### PR TITLE
Improvements to forInRule and varNameRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Supported Rules
 * `semicolon` enforces semicolons at the end of every statement.
 * `sub` disallows object access via string literals.
 * `trailing` disallows trailing whitespace at the end of a line.
-* `varname` allows only camelCased or UPPER_CASED variable names.
+* `varname` allows only camelCased or UPPER_CASED variable names. Rule options:
+	* `"allow-inner-underscore"` allows underscores inside variable names
+	* `"allow-leading-underscore"` allows underscores at the beginnning of variable names
 * `whitespace` enforces spacing whitespace. Rule options:
 	* `"check-branch"` checks branching statements (`if`/`else`/`for`/`while`) are followed by whitespace
 	* `"check-decl"`checks that variable declarations have whitespace around the equals token

--- a/src/rules/eqeqeqRule.ts
+++ b/src/rules/eqeqeqRule.ts
@@ -32,7 +32,7 @@ module Lint.Rules {
     class ComparisonWalker extends Lint.RuleWalker {
         private options: any;
 
-        constructor(syntaxTree: TypeScript.SyntaxTree, options: any) {
+        constructor(syntaxTree: TypeScript.SyntaxTree, options?: any) {
             super(syntaxTree);
             this.options = options;
         }
@@ -40,7 +40,7 @@ module Lint.Rules {
         public visitBinaryExpression(node: TypeScript.BinaryExpressionSyntax): void {
             var position = this.positionAfter(node.left);
 
-            if (!isExpressionAllowed(node)) {
+            if (!this.isExpressionAllowed(node)) {
                 this.handleOperatorToken(position, node.operatorToken);
             }
             super.visitBinaryExpression(node);

--- a/test/files/rules/forin.test.ts
+++ b/test/files/rules/forin.test.ts
@@ -15,4 +15,16 @@ function a() {
             console.log("k");
         }
     }
+    
+    for (var m in obj) {
+        if (!obj.hasOwnProperty(m)) {
+            continue;
+        }
+        console.log("m");
+    }
+    
+    for (var n in obj) {
+        if (!obj.hasOwnProperty(n)) continue;
+        console.log("m");
+    }
 }

--- a/test/files/rules/varname.test.ts
+++ b/test/files/rules/varname.test.ts
@@ -5,10 +5,13 @@ var invalid_name2 = " ";
 
 class Test {
     private Invalid_name3 = "how";
+    private _optionallyValid = "are";
 }
 
 function test() {
     () => {
-        var InVaLiDnAmE4 = "are";
+        var InVaLiDnAmE4 = "you";
     };
 }
+
+declare var DeclaresAreValid: any;

--- a/test/rules/forInRuleTests.ts
+++ b/test/rules/forInRuleTests.ts
@@ -22,9 +22,9 @@ describe("<forin>", () => {
         var failureString = Lint.Rules.ForInRule.FAILURE_STRING;
         var firstFailure = Lint.Test.createFailure(fileName, [2, 5], [4, 6], failureString);
         var secondFailure = Lint.Test.createFailure(fileName, [6, 5], [11, 6], failureString);
+        var expectedFailures = [firstFailure, secondFailure];
         var actualFailures = Lint.Test.applyRuleOnFile(fileName, "forin");
-
-        Lint.Test.assertContainsFailure(actualFailures, firstFailure);
-        Lint.Test.assertContainsFailure(actualFailures, secondFailure);
+        
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
     });
 });

--- a/test/rules/varNameRuleTests.ts
+++ b/test/rules/varNameRuleTests.ts
@@ -26,10 +26,47 @@ describe("<varname>", () => {
             createFailure([3, 5], [3, 17]),
             createFailure([4, 5], [4, 18]),
             createFailure([7, 13], [7, 26]),
-            createFailure([12, 13], [12, 25])
+            createFailure([8, 13], [8, 29]),
+            createFailure([13, 13], [13, 25])
         ];
 
         var actualFailures = Lint.Test.applyRuleOnFile(fileName, "varname");
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
+    });
+    it("ensures leading underscores can optionally be legal", () => {
+        var fileName = "rules/varname.test.ts";
+        var failureString = Lint.Rules.VarNameRule.FAILURE_STRING;
+
+        var createFailure = Lint.Test.createFailuresOnFile(fileName, failureString);
+        var expectedFailures = [
+            createFailure([3, 5], [3, 17]),
+            createFailure([4, 5], [4, 18]),
+            createFailure([7, 13], [7, 26]),
+            createFailure([13, 13], [13, 25])
+        ];
+        var options = [true,
+            "allow-leading-underscore"
+        ];
+
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, "varname", options);
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
+    });
+    it("ensures inner underscores can optionally be legal", () => {
+        var fileName = "rules/varname.test.ts";
+        var failureString = Lint.Rules.VarNameRule.FAILURE_STRING;
+
+        var createFailure = Lint.Test.createFailuresOnFile(fileName, failureString);
+        var expectedFailures = [
+            createFailure([3, 5], [3, 17]),
+            createFailure([7, 13], [7, 26]),
+            createFailure([8, 13], [8, 29]),
+            createFailure([13, 13], [13, 25])
+        ];
+        var options = [true,
+            "allow-inner-underscore"
+        ];
+
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, "varname", options);
         Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
     });
 });

--- a/test/typings/chai.d.ts
+++ b/test/typings/chai.d.ts
@@ -5,26 +5,26 @@
 
 declare module chai {
     interface Equality {
-        (expected: any, message?: string): bool;
+        (expected: any, message?: string): boolean;
     }
 
     interface Property {
-        (name: string, value?: any, message?: string): bool;
+        (name: string, value?: any, message?: string): boolean;
     }
 
     interface NumberComparer {
-        (value: number, message?: string): bool;
+        (value: number, message?: string): boolean;
     }
 
     interface Eql {
-        (value: any, message?: string): bool;
+        (value: any, message?: string): boolean;
     }
 
     interface Include {
-        (value: Object, message?: string): bool;
-        (value: string, message?: string): bool;
-        (value: number, message?: string): bool;
-        keys(...names: string[]): bool;
+        (value: Object, message?: string): boolean;
+        (value: string, message?: string): boolean;
+        (value: number, message?: string): boolean;
+        keys(...names: string[]): boolean;
     }
 
     interface Throw {
@@ -34,8 +34,8 @@ declare module chai {
     }
 
     interface TypeComparison {
-        (type: string, message?: string): bool;
-        instanceof(type: Object): bool;
+        (type: string, message?: string): boolean;
+        instanceof(type: Object): boolean;
     }
 
     interface NumericComparison {
@@ -49,7 +49,7 @@ declare module chai {
     }
 
     interface Length extends NumericComparison {
-        (value: number, message?: string): bool;
+        (value: number, message?: string): boolean;
     }
 
     interface Deep {
@@ -61,32 +61,32 @@ declare module chai {
         property: Property;
         deep: Deep;
         length: Length;
-        ownProperty(name: string, message?: string): bool;
-        string(value: string, message?: string): bool;
-        keys(...values: string[]): bool;
+        ownProperty(name: string, message?: string): boolean;
+        string(value: string, message?: string): boolean;
+        keys(...values: string[]): boolean;
     }
 
     interface At {
-        least(value: number, message?: string): bool;
-        gte(value: number, message?: string): bool;
-        most(value: number, message?: string): bool;
-        lte(value: number, message?: string): bool;
+        least(value: number, message?: string): boolean;
+        gte(value: number, message?: string): boolean;
+        most(value: number, message?: string): boolean;
+        lte(value: number, message?: string): boolean;
     }
 
     interface Be extends NumericComparison {
-        ok: bool;
-        true: bool;
-        false: bool;
-        null: bool;
-        undefined: bool;
-        empty: bool;
-        arguments: bool;
+        ok: boolean;
+        true: boolean;
+        false: boolean;
+        null: boolean;
+        undefined: boolean;
+        empty: boolean;
+        arguments: boolean;
         an: TypeComparison;
         at: At;
 
-        a(type: string, message?: string): bool;
-        within(start: number, finish: number, message?: string): bool;
-        closeTo(expected: number, delta: number, message?: string): bool;
+        a(type: string, message?: string): boolean;
+        within(start: number, finish: number, message?: string): boolean;
+        closeTo(expected: number, delta: number, message?: string): boolean;
     }
 
     interface To {
@@ -95,7 +95,7 @@ declare module chai {
         deep: Deep;
         have: Have;
 
-        exist: bool;
+        exist: boolean;
 
         equal: Equality;
 
@@ -106,7 +106,7 @@ declare module chai {
         eql: Eql;
         eqls: Eql;
 
-        match(value: RegExp, message?: string): bool;
+        match(value: RegExp, message?: string): boolean;
 
         respondTo(method: string, message?: string);
         satisfy(matcher: Function, message?: string);


### PR DESCRIPTION
Improved for..in filtering to accept the if() continue; pattern.  Added new options to the varname rule and added ignoring declared vars.   Fixed compilation bug in eqeqeqRule and usage of bool in chai.d.ts.
