### PR TITLE
add typedef whitespace rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Supported Rules
 * `radix` enforces the radix parameter of `parseInt`
 * `semicolon` enforces semicolons at the end of every statement.
 * `triple-equals` enforces === and !== in favor of == and !=.
+* `typedef-whitespace` enforces spacing whitespace for type definitions. Each rule option requires a value of `"space"` or `"nospace"`
+   to require a space or no space before the type specifier's colon. Rule options:
+    * `"callSignature"` checks return type of functions
+    * `"catchClause"` checks type in exception catch blocks
+    * `"indexSignature"` checks index type specifier of indexers
+    * `"parameter"` checks type specifier of parameters
+    * `"propertySignature"` checks return types of interface properties
+    * `"variableDeclarator"` checks variable declarations
 * `variable-name` allows only camelCased or UPPER_CASED variable names. Rule options:
 	* `"allow-leading-underscore"` allows underscores at the beginnning.
 * `whitespace` enforces spacing whitespace. Rule options:

--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference path="../../lib/tslint.d.ts" />
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "missing type declaration";
+
+    public apply(syntaxTree: TypeScript.SyntaxTree): Lint.RuleFailure[] {
+        return this.applyWithWalker(<Lint.RuleWalker>(new TypedefWhitespaceWalker(syntaxTree, this.getOptions())));
+    }
+}
+
+class TypedefWhitespaceWalker extends Lint.RuleWalker {
+
+    public visitCallSignature(node: TypeScript.CallSignatureSyntax): void {
+        this.checkSpace("callSignature", node, node.typeAnnotation);
+
+        super.visitCallSignature(node);
+    }
+
+    public visitCatchClause(node: TypeScript.CatchClauseSyntax): void {
+        this.checkSpace("catchClause", node, node.typeAnnotation);
+
+        super.visitCatchClause(node);
+    }
+
+    public visitGetAccessorPropertyAssignment(node: TypeScript.GetAccessorPropertyAssignmentSyntax): void {
+        // TODO: The following check was not accurate/working.  Since the notation
+        //       is esoteric, this subrule is marked as not implemented until
+        //       the functionality is needed and the bugs worked out. 
+        //this.checkSpace("getAccessorPropertyAssignment", node, node.typeAnnotation);
+
+        this.addNotImplementedFailure("getAccessorPropertyAssignment");
+
+        super.visitGetAccessorPropertyAssignment(node);
+    }
+
+    public visitGetMemberAccessorDeclaration(node: TypeScript.GetMemberAccessorDeclarationSyntax): void {
+        // TODO: The following check was not accurate/working.  Since the notation
+        //       is esoteric, this subrule is marked as not implemented until
+        //       the functionality is needed and the bugs worked out. 
+        //this.checkSpace("getMemberAccessorDeclaration", node, node.typeAnnotation);
+
+        this.addNotImplementedFailure("getMemberAccessorDeclaration");
+
+        super.visitGetMemberAccessorDeclaration(node);
+    }
+
+    public visitIndexSignature(node: TypeScript.IndexSignatureSyntax): void {
+        this.checkSpace("indexSignature", node, node.typeAnnotation);
+
+        super.visitIndexSignature(node);
+    }
+
+    public visitParameter(node: TypeScript.ParameterSyntax): void {
+        this.checkSpace("parameter", node, node.typeAnnotation);
+
+        super.visitParameter(node);
+    }
+
+    public visitPropertySignature(node: TypeScript.PropertySignatureSyntax): void {
+        this.checkSpace("propertySignature", node, node.typeAnnotation);
+
+        super.visitPropertySignature(node);
+    }
+
+    public visitVariableDeclarator(node: TypeScript.VariableDeclaratorSyntax): void {
+        this.checkSpace("variableDeclarator", node, node.typeAnnotation);
+
+        super.visitVariableDeclarator(node);
+    }
+
+    public checkSpace(option: string, node: TypeScript.SyntaxNode, typeAnnotation: TypeScript.TypeAnnotationSyntax) : void {
+        if (this.hasOption(option) && typeAnnotation) {
+            var typeAnnotationChildIndex = this.getTypeAnnotationIndex(node),
+                preceedingChild = this.findPreceedingChild(node, typeAnnotationChildIndex),
+                hasLeadingWhitespace = this.hasLeadingWhitespace(preceedingChild.trailingTrivia());
+
+            if (hasLeadingWhitespace !== (this.getOption(option) === "space")) {
+                this.addFailure(
+                    this.createFailure(
+                        this.positionAfter(preceedingChild),
+                        1,
+                        "expected " + this.getOption(option) + " in " + option + "."
+                    )
+                );
+            }
+        }
+    }
+
+    private addNotImplementedFailure(option: string) : void {
+        if (this.hasOption(option)) {
+            this.addFailure(this.createFailure(0, 1, option + " not implemented."));
+        }
+    }
+
+    public hasOption(option: string): boolean {
+        var allOptions = this.getOptions();
+        if (!allOptions || allOptions.length === 0) {
+            return false;
+        }
+
+        var options = allOptions[0];
+
+        if (!options) {
+            return false;
+        }
+
+        return !!options[option];
+    }
+
+    private getOption(option: string): string {
+        var allOptions = this.getOptions();
+        if (!allOptions || allOptions.length === 0) {
+            return undefined;
+        }
+
+        var options = allOptions[0];
+
+        return options[option];
+    }
+
+    private getTypeAnnotationIndex(node: TypeScript.SyntaxNode): number {
+        var index = 0,
+            current = node.childAt(index);
+
+        while (!(current instanceof TypeScript.TypeAnnotationSyntax)) {
+            index++;
+            current = node.childAt(index);
+        }
+        return index;
+    }
+
+    private findPreceedingChild(node: TypeScript.SyntaxNode, startIndex: number): TypeScript.ISyntaxElement {
+        var preceedingChild,
+            offset = 0;
+
+        while (!preceedingChild) {
+            offset++;
+            preceedingChild = node.childAt(startIndex - offset);
+        }
+        return preceedingChild;
+    }
+
+    private hasLeadingWhitespace(trivia: TypeScript.ISyntaxTriviaList): boolean {
+        if (trivia.count() < 1) {
+            return false;
+        } else {
+            var kind = trivia.syntaxTriviaAt(0).kind();
+            if (kind !== TypeScript.SyntaxKind.WhitespaceTrivia && kind !== TypeScript.SyntaxKind.NewLineTrivia) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/test/files/rules/typedefWhitespace.test.ts
+++ b/test/files/rules/typedefWhitespace.test.ts
@@ -1,0 +1,65 @@
+var noPreceedingSpaceObjectLiteralWithPropertyGetter = {
+    Prop: "some property",
+    
+    get Prop(): string {
+        return Prop;
+    }
+};
+
+var withPreceedingSpaceObjectLiteralWithPropertyGetter = {
+    Prop: "some property",
+
+    get Prop() : string {
+        return Prop;
+    }
+};
+
+interface NoPreceedingSpaceInterface {
+    Prop: string;
+}
+
+interface WithPreceedingSpaceInterface {
+    Prop : string;
+}
+
+var noPreceedingSpacesFn = function (a: number, b: number): number {
+    var c: number = a + b;
+    var d: number = a - b;
+
+    try {
+        return c / d;
+    } catch (ex: Exception) {
+        console.log(ex);
+    }
+};
+
+var withPreceedingSpacesFn = function (a : number, b : number) : number {
+    var c : number = a + b;
+    var d : number = a - b;
+
+    try {
+        return c / d;
+    } catch (ex : Exception) {
+        console.log(ex);
+    }
+};
+
+class NoPreceedingSpacesClass {
+    [index: number]: string
+
+    Prop: string = "some property";
+
+    public get name(): string {
+        return "some name";
+    }
+}
+
+class WithPreceedingSpacesClass {
+    [index : number] : string
+
+    Prop : string = "some property";
+
+    public get name() : string {
+        return "some name";
+    }
+}

--- a/test/rules/typedefWhitespaceRuleTests.ts
+++ b/test/rules/typedefWhitespaceRuleTests.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/// <reference path='../references.ts' />
+
+describe("<typedefWhitespace, not enabled>", () => {
+    var fileName = "rules/typedefWhitespace.test.ts";
+    var TypedefWhitespaceRule = Lint.Test.getRule("typedefWhitespace");
+
+    it("enforces rules only when enabled (unspecified)", () => {
+        var failures = Lint.Test.applyRuleOnFile(fileName, TypedefWhitespaceRule);
+        assert.equal(failures.length, 0);
+    });
+
+    it("enforces rules only when enabled (disabled)", () => {
+        var options = [false];
+
+        var failures = Lint.Test.applyRuleOnFile(fileName, TypedefWhitespaceRule, options);
+        assert.equal(failures.length, 0);
+    });
+});
+
+describe("<typedefWhitespace, not implemented>", () => {
+    var failures;
+    var fileName = "rules/typedefWhitespace.test.ts";
+    var TypedefWhitespaceRule = Lint.Test.getRule("typedefWhitespace");
+
+    before(() => {
+        var options = [true,
+            {
+                "getAccessorPropertyAssignment": "space",
+                "getMemberAccessorDeclaration": "space",
+            }
+        ];
+        failures = Lint.Test.applyRuleOnFile(fileName, TypedefWhitespaceRule, options);
+        console.log(failures);
+    });
+
+    it("get accessor property assignment not implemented", () => {
+        var notImplementedFailure = Lint.Test.createFailure(fileName, [1, 1], [1, 2], "getAccessorPropertyAssignment not implemented.");
+        Lint.Test.assertContainsFailure(failures, notImplementedFailure);
+    });
+
+    it("get member accessor declaration not implemented", () => {
+        var notImplementedFailure = Lint.Test.createFailure(fileName, [1, 1], [1, 2], "getMemberAccessorDeclaration not implemented.");
+        Lint.Test.assertContainsFailure(failures, notImplementedFailure);
+    });
+});
+
+describe("<typedefWhitespace, required>", () => {
+    var actualFailures;
+    var fileName = "rules/typedefWhitespace.test.ts";
+    var TypedefWhitespaceRule = Lint.Test.getRule("typedefWhitespace");
+
+    before(() => {
+        var options = [true,
+            {
+                "callSignature": "space",
+                "catchClause": "space",
+                "indexSignature": "space",
+                "parameter": "space",
+                "propertySignature": "space",
+                "variableDeclarator": "space"
+            }
+        ];
+        actualFailures = Lint.Test.applyRuleOnFile(fileName, TypedefWhitespaceRule, options);
+    });
+
+    it("enforces whitespace in call signatures", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [25, 59], [25, 60], "expected space in callSignature.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces whitespace in catch clauses", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [31, 9], [31, 10], "expected space in catchClause.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces whitespace in indexSignature", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [48, 2], [48, 3], "expected space in indexSignature.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces whitespace in parameter", () => {
+        var expectedFailure1 = Lint.Test.createFailure(fileName, [25, 39], [25, 40], "expected space in parameter.");
+        var expectedFailure2 = Lint.Test.createFailure(fileName, [25, 50], [25, 51], "expected space in parameter.");
+        var expectedFailure3 = Lint.Test.createFailure(fileName, [48, 11], [48, 12], "expected space in parameter.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure1);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure2);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure3);
+    });
+
+    it("enforces whitespace in propertySignature", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [18, 9], [18, 10], "expected space in propertySignature.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces whitespace in variable declarator", () => {
+        var expectedFailure1 = Lint.Test.createFailure(fileName, [26, 10], [26, 11], "expected space in variableDeclarator.");
+        var expectedFailure2 = Lint.Test.createFailure(fileName, [27, 10], [27, 11], "expected space in variableDeclarator.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure1);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure2);
+    });
+});
+
+describe("<typedefWhitespace, not allowed>", () => {
+    var actualFailures;
+    var fileName = "rules/typedefWhitespace.test.ts";
+    var TypedefWhitespaceRule = Lint.Test.getRule("typedefWhitespace");
+
+    before(() => {
+        var options = [true,
+            {
+                "callSignature": "nospace",
+                "catchClause": "nospace",
+                "indexSignature": "nospace",
+                "parameter": "nospace",
+                "propertySignature": "nospace",
+                "variableDeclarator": "nospace"
+            }
+        ];
+        actualFailures = Lint.Test.applyRuleOnFile(fileName, TypedefWhitespaceRule, options);
+    });
+
+    it("enforces no whitespace in call signatures", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [36, 64], [36, 65], "expected nospace in callSignature.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces no whitespace in catch clauses", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [42, 10], [42, 11], "expected nospace in catchClause.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces no whitespace in indexSignature", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [58, 3], [58, 4], "expected nospace in indexSignature.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces no whitespace in parameter", () => {
+        var expectedFailure1 = Lint.Test.createFailure(fileName, [36, 42], [36, 43], "expected nospace in parameter.");
+        var expectedFailure2 = Lint.Test.createFailure(fileName, [36, 54], [36, 55], "expected nospace in parameter.");
+        var expectedFailure3 = Lint.Test.createFailure(fileName, [58, 12], [58, 13], "expected nospace in parameter.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure1);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure2);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure3);
+    });
+
+    it("enforces no whitespace in propertySignature", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [22, 10], [22, 11], "expected nospace in propertySignature.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces no whitespace in variable declarator", () => {
+        var expectedFailure1 = Lint.Test.createFailure(fileName, [37, 11], [37, 12], "expected nospace in variableDeclarator.");
+        var expectedFailure2 = Lint.Test.createFailure(fileName, [38, 11], [38, 12], "expected nospace in variableDeclarator.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure1);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure2);
+    });
+});


### PR DESCRIPTION
adds typedef whitespace rule.

enforced whitespace before colon when specifying a type.

options usage explained in readme.
