### PR TITLE
add typedef rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Supported Rules
 * `radix` enforces the radix parameter of `parseInt`
 * `semicolon` enforces semicolons at the end of every statement.
 * `triple-equals` enforces === and !== in favor of == and !=.
+* `typedef` enforces type definitions to exist. Rule options:
+    * `"callSignature"` checks return type of functions
+    * `"catchClause"` checks type in exception catch blocks
+    * `"indexSignature"` checks index type specifier of indexers
+    * `"getAccessorPropertyAssignment"` checks get accessor assignments on object literals
+    * `"getMemberAccessorDeclaration"` checks get member accessor declarations on classes
+    * `"parameter"` checks type specifier of parameters
+    * `"propertySignature"` checks return types of interface properties
+    * `"variableDeclarator"` checks variable declarations
 * `variable-name` allows only camelCased or UPPER_CASED variable names. Rule options:
 	* `"allow-leading-underscore"` allows underscores at the beginnning.
 * `whitespace` enforces spacing whitespace. Rule options:

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference path="../../lib/tslint.d.ts" />
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "missing type declaration";
+
+    public apply(syntaxTree: TypeScript.SyntaxTree): Lint.RuleFailure[] {
+        return this.applyWithWalker(<Lint.RuleWalker>(new TypedefWalker(syntaxTree, this.getOptions())));
+    }
+}
+
+class TypedefWalker extends Lint.RuleWalker {
+
+    public visitCallSignature(node: TypeScript.CallSignatureSyntax): void {
+        this.checkTypeAnnotation("callSignature", node, node.typeAnnotation);
+
+        super.visitCallSignature(node);
+    }
+
+    public visitCatchClause(node: TypeScript.CatchClauseSyntax): void {
+        this.checkTypeAnnotation("catchClause", node, node.typeAnnotation, node.identifier);
+
+        super.visitCatchClause(node);
+    }
+
+    public visitGetAccessorPropertyAssignment(node: TypeScript.GetAccessorPropertyAssignmentSyntax): void {
+        this.checkTypeAnnotation("getAccessorPropertyAssignment", node, node.typeAnnotation, node.propertyName);
+
+        super.visitGetAccessorPropertyAssignment(node);
+    }
+
+    public visitGetMemberAccessorDeclaration(node: TypeScript.GetMemberAccessorDeclarationSyntax): void {
+        this.checkTypeAnnotation("getMemberAccessorDeclaration", node, node.typeAnnotation, node.propertyName);
+
+        super.visitGetMemberAccessorDeclaration(node);
+    }
+
+    public visitIndexSignature(node: TypeScript.IndexSignatureSyntax): void {
+        this.checkTypeAnnotation("indexSignature", node, node.typeAnnotation);
+
+        super.visitIndexSignature(node);
+    }
+
+    public visitParameter(node: TypeScript.ParameterSyntax): void {
+        this.checkTypeAnnotation("parameter", node, node.typeAnnotation, node.identifier);
+        super.visitParameter(node);
+    }
+
+    public visitPropertySignature(node: TypeScript.PropertySignatureSyntax): void {
+        this.checkTypeAnnotation("propertySignature", node, node.typeAnnotation, node.propertyName);
+
+        super.visitPropertySignature(node);
+    }
+
+    public visitVariableDeclarator(node: TypeScript.VariableDeclaratorSyntax): void {
+        this.checkTypeAnnotation("variableDeclarator", node, node.typeAnnotation, node.identifier);
+
+        super.visitVariableDeclarator(node);
+    }
+
+    public checkTypeAnnotation(
+        option: string,
+        node: TypeScript.SyntaxNode,
+        typeAnnotation: TypeScript.TypeAnnotationSyntax,
+        name?: TypeScript.ISyntaxToken) : void {
+        if (this.hasOption(option) && !typeAnnotation) {
+            var name = name ? ": '" + name.text() + "'" : "";
+            this.addFailure(
+                this.createFailure(
+                    this.positionAfter(node),
+                    1,
+                    "expected " + option + name + " to have a typedef."
+                )
+            );
+        }
+    }
+}

--- a/test/files/rules/typedef.test.ts
+++ b/test/files/rules/typedef.test.ts
@@ -1,0 +1,34 @@
+var NoTypeObjectLiteralWithPropertyGetter = {
+    Prop: "some property",
+
+    get Prop() {
+        return Prop;
+    }
+};
+
+interface NoTypeInterface {
+    Prop;
+}
+
+var NoTypesFn = function (
+    a,
+    b) {
+    var c = a + b;
+    var d = a - b;
+
+    try {
+        return c / d;
+    } catch (ex) {
+        console.log(ex);
+    }
+};
+
+class NoTypesClass {
+    [index]
+
+    Prop = "some property";
+
+    public get name() {
+        return "some name";
+    }
+}

--- a/test/rules/typedefRuleTests.ts
+++ b/test/rules/typedefRuleTests.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/// <reference path='../references.ts' />
+
+describe("<typedef, not enabled>", () => {
+    var fileName = "rules/typedef.test.ts";
+    var TypedefRule = Lint.Test.getRule("typedef");
+
+    it("enforces rules only when enabled (unspecified)", () => {
+        var failures = Lint.Test.applyRuleOnFile(fileName, TypedefRule);
+        assert.equal(failures.length, 0);
+    });
+
+    it("enforces rules only when enabled (disabled)", () => {
+        var options = [false];
+
+        var failures = Lint.Test.applyRuleOnFile(fileName, TypedefRule, options);
+        assert.equal(failures.length, 0);
+    });
+});
+
+describe("<typedef, enabled>", () => {
+    var actualFailures;
+    var fileName = "rules/typedef.test.ts";
+    var TypedefRule = Lint.Test.getRule("typedef");
+
+    before(() => {
+        var options = [true,
+            "callSignature",
+            "catchClause",
+            "indexSignature",
+            "getAccessorPropertyAssignment",
+            "getMemberAccessorDeclaration",
+            "parameter",
+            "propertySignature",
+            "variableDeclarator"
+        ];
+        actualFailures = Lint.Test.applyRuleOnFile(fileName, TypedefRule, options);
+    });
+
+    it("enforces typedef in call signatures", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [15, 8], [15, 9], "expected callSignature to have a typedef.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces typedef in catch clauses", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [24, 1], [24, 2], "expected catchClause: 'ex' to have a typedef.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces typedef in get accessor property assignment", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName,
+            [7, 1],
+            [7, 2],
+            "expected getAccessorPropertyAssignment: 'Prop' to have a typedef.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces typedef in get member accessor declaration", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName,
+            [34, 1],
+            [34, 2],
+            "expected getMemberAccessorDeclaration: 'name' to have a typedef.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces typedef in indexSignature", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [28, 1], [28, 2], "expected indexSignature to have a typedef.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces typedef in parameter", () => {
+        var expectedFailure1 = Lint.Test.createFailure(fileName, [14, 6], [14, 7], "expected parameter: 'a' to have a typedef.");
+        var expectedFailure2 = Lint.Test.createFailure(fileName, [15, 6], [15, 7], "expected parameter: 'b' to have a typedef.");
+        var expectedFailure3 = Lint.Test.createFailure(fileName, [27, 11], [27, 12], "expected parameter: 'index' to have a typedef.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure1);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure2);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure3);
+    });
+
+    it("enforces typedef in propertySignature", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [10, 9], [10, 10], "expected propertySignature: 'Prop' to have a typedef.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces typedef in variable declarator", () => {
+        var expectedFailure1 = Lint.Test.createFailure(fileName,
+            [7, 2],
+            [7, 3],
+            "expected variableDeclarator: 'NoTypeObjectLiteralWithPropertyGetter' to have a typedef.");
+        var expectedFailure2 = Lint.Test.createFailure(fileName,
+            [24, 2],
+            [24, 3],
+            "expected variableDeclarator: 'NoTypesFn' to have a typedef.");
+        var expectedFailure3 = Lint.Test.createFailure(fileName,
+            [16, 18],
+            [16, 19],
+            "expected variableDeclarator: 'c' to have a typedef.");
+        var expectedFailure4 = Lint.Test.createFailure(fileName,
+            [17, 18],
+            [17, 19],
+            "expected variableDeclarator: 'd' to have a typedef.");
+        var expectedFailure5 = Lint.Test.createFailure(fileName,
+            [29, 27],
+            [29, 28],
+            "expected variableDeclarator: 'Prop' to have a typedef.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure1);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure2);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure3);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure4);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure5);
+    });
+});


### PR DESCRIPTION
adds typedef rule

enforces that types are defined in various places where they are able to be defined.

options usage explained in readme
