### PR TITLE
Fix duplicate key rule incorrectly warns when defining properties that exist on Object.prototype

### DIFF
--- a/src/rules/noDuplicateKeyRule.ts
+++ b/src/rules/noDuplicateKeyRule.ts
@@ -27,9 +27,9 @@ class NoDuplicateKeyWalker extends Lint.RuleWalker {
     private objectKeys;
 
     public visitObjectLiteralExpression(node: TypeScript.ObjectLiteralExpressionSyntax): void {
-        this.objectKeys = {};
+        this.objectKeys = Object.create(null);
         super.visitObjectLiteralExpression(node);
-        this.objectKeys = {};
+        this.objectKeys = Object.create(null);
     }
 
     public visitSimplePropertyAssignment(node: TypeScript.SimplePropertyAssignmentSyntax): void {

--- a/test/files/rules/dupkey.test.ts
+++ b/test/files/rules/dupkey.test.ts
@@ -24,3 +24,8 @@ var z = {
     a: 1,
     b: "a"
 };
+
+var n = {
+    constructor: function () {},
+    hasOwnProperty: function () {}
+};


### PR DESCRIPTION
Given an object literal:

``` ts
{
  constructor: function () {},
  hasOwnProperty: function () {}
}
```

The following incorrect warnings will be emitted:

duplicate key 'constructor'
duplicate key 'hasOwnProperty'

This PR fixes this issue. Includes a revision to the dupkey tests.

Please let me know if you have a CLA or anything that needs signing.
