### PR TITLE
Config: Search in Home directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "optimist": "~0.6.0",
-    "underscore.string": "~2.3.3"
+    "underscore.string": "~2.3.3",
+    "findup-sync": "~0.1.2"
   },
   "devDependencies": {
     "chai": "~1.7.2",


### PR DESCRIPTION
Cc: https://github.com/madskristensen/WebEssentials2013/issues/699

In JsHint and JSCS (with a [recent commit](https://github.com/mdevils/node-jscs/commit/1248aa1db499b3845b8e46414df4f8b8255b17e0)), they search for configuration file (`.jshintrc` and `.jscsrc`; JSON file with comments) in HOME directory as a fall back; if none found in the current folder's ancestry (till the drive's root). 

This PR enables the same for `tslint.json`.

**Points to ponder:**
- <del>They also allow embedding configuration in `package.json`, where package.json has precedence over other formats. (see the discussion [here](https://github.com/mdevils/node-jscs/commit/1248aa1db499b3845b8e46414df4f8b8255b17e0#commitcomment-5503300))</del>
- Please consider making your _default_ configuration file name consistent with other linters, i.e. `.tslintrc` (now that VS introduced native support for JSON and `jshintrc` and `jscsrc`'s content type inherits JSON via Web Essentials).

---

<h3> Edit:</h3>


Now, `package.json` of form:

``` json
{
  "tslintConfig": {}
}
```

is supported; with `tslintConfig` as embedded resource.
