### PR TITLE
Improve unreachable rule for unbraced conditionals (#83 and #31)

### DIFF
--- a/src/rules/noUnreachableRule.ts
+++ b/src/rules/noUnreachableRule.ts
@@ -60,6 +60,27 @@ class UnreachableWalker extends Lint.RuleWalker {
         this.hasReturned = false;
     }
 
+    public visitIfStatement(node: TypeScript.IfStatementSyntax): void {
+        this.hasReturned = false;
+        super.visitIfStatement(node);
+        this.hasReturned = false;
+    }
+
+    public visitElseClause(node: TypeScript.ElseClauseSyntax): void {
+        this.hasReturned = false;
+        super.visitElseClause(node);
+        this.hasReturned = false;
+    }
+
+    public visitOptionalNode(node: TypeScript.SyntaxNode): void {
+        if (node != null && node.kind() === TypeScript.SyntaxKind.ElseClause) {
+            // if we're an else clause then we're in the middle of processing an if statement
+            // and thus we want to disregard the case where the previous statement ended with a return
+            this.hasReturned = false;
+        }
+        super.visitOptionalNode(node);
+    }
+
     public visitBreakStatement(node: TypeScript.BreakStatementSyntax): void {
         super.visitBreakStatement(node);
         this.hasReturned = true;

--- a/test/files/rules/nounreachable.test.ts
+++ b/test/files/rules/nounreachable.test.ts
@@ -51,3 +51,18 @@ switch (x) {
         i = 4;
         break;
 }
+
+function f4() {
+    var x = 3;
+    if (x === 4) return;
+    else x = 4;
+    var y = 7;
+}
+
+function f5() {
+    var x = 3;
+    if (x === 4) x = 5;
+    else return;
+    var y = 7;
+}
+


### PR DESCRIPTION
There should no longer be false positives for if and else statements
without braces that end in return (and similar statments) for the
no-unreachable rule.
