### PR TITLE
Split variable decleration rules in to regular and member variants

### DIFF
--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -55,10 +55,21 @@ class TypedefWalker extends Lint.RuleWalker {
         super.visitPropertySignature(node);
     }
 
-    public visitVariableDeclarator(node: TypeScript.VariableDeclaratorSyntax): void {
-        this.checkTypeAnnotation("variableDeclarator", node, node.typeAnnotation, node.propertyName);
+    public visitVariableDeclaration(node: TypeScript.VariableDeclarationSyntax): void {
+        for (var i = 0, n = node.variableDeclarators.childCount(); i < n; i++) {
+            var item = <TypeScript.VariableDeclaratorSyntax>node.variableDeclarators.childAt(i);
+            this.checkTypeAnnotation("variableDeclarator", node, item.typeAnnotation, item.propertyName);
+        }
 
-        super.visitVariableDeclarator(node);
+        super.visitVariableDeclaration(node);
+    }
+
+    public visitMemberVariableDeclaration(node: TypeScript.MemberVariableDeclarationSyntax): void {
+        var variableDeclarator =  node.variableDeclarator;
+        this.checkTypeAnnotation("memberVariableDeclarator", variableDeclarator, variableDeclarator.typeAnnotation,
+            variableDeclarator.propertyName);
+
+        super.visitMemberVariableDeclaration(node);
     }
 
     public checkTypeAnnotation(option: string,

--- a/test/files/rules/typedef.test.ts
+++ b/test/files/rules/typedef.test.ts
@@ -13,8 +13,8 @@ interface NoTypeInterface {
 var NoTypesFn = function (
     a,
     b) {
-    var c = a + b;
-    var d = a - b;
+    var c = a + b,
+        d = a - b;
 
     try {
         return c / d;

--- a/test/rules/typedefRuleTests.ts
+++ b/test/rules/typedefRuleTests.ts
@@ -45,7 +45,8 @@ describe("<typedef, enabled>", () => {
             "indexSignature",
             "parameter",
             "propertySignature",
-            "variableDeclarator"
+            "variableDeclarator",
+            "memberVariableDeclarator"
         ];
         actualFailures = Lint.Test.applyRuleOnFile(fileName, TypedefRule, options);
     });
@@ -97,8 +98,8 @@ describe("<typedef, enabled>", () => {
             [24, 3],
             "expected variableDeclarator: 'NoTypesFn' to have a typedef.");
         var expectedFailure3 = Lint.Test.createFailure(fileName,
-            [16, 18],
-            [16, 19],
+            [17, 18],
+            [17, 19],
             "expected variableDeclarator: 'c' to have a typedef.");
         var expectedFailure4 = Lint.Test.createFailure(fileName,
             [17, 18],
@@ -107,7 +108,7 @@ describe("<typedef, enabled>", () => {
         var expectedFailure5 = Lint.Test.createFailure(fileName,
             [29, 27],
             [29, 28],
-            "expected variableDeclarator: 'Prop' to have a typedef.");
+            "expected memberVariableDeclarator: 'Prop' to have a typedef.");
 
         Lint.Test.assertContainsFailure(actualFailures, expectedFailure1);
         Lint.Test.assertContainsFailure(actualFailures, expectedFailure2);


### PR DESCRIPTION
In my code, I tend to use implicit typing (inference) on local variables, but I like to have clearly defined types on class members. I made a small tweak to tslint to allow you to specify the rules for member variables and other types of declarations separately.

To do this, we need to handle walking VariableDeclaration and MemberVariableDeclaration separately in the rule, which requires a slight tweak to the way normal variables are handled. As you can see, we now loop through the list of declarators and check each individually as we are walking through the root declaration node.

I also tweaked the test slightly to test for variable lists in the form var x = y, z = a, since we are now walking the declarator list ourselves rather than visiting each declarator.
