### PR TITLE
New rule to prohibit use of 'any' for type declarations

### DIFF
--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference path="../../lib/tslint.d.ts" />
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "Type decoration of 'any' is forbidden.";
+
+    public apply(syntaxTree: TypeScript.SyntaxTree): Lint.RuleFailure[] {
+        return this.applyWithWalker(<Lint.RuleWalker>(new NoAnyWalker(syntaxTree, this.getOptions())));
+    }
+}
+
+class NoAnyWalker extends Lint.RuleWalker {
+
+    public visitToken(token : TypeScript.ISyntaxToken): void {
+        this.handleToken(token);
+        super.visitToken(token);
+    }
+
+    private handleToken(token: TypeScript.ISyntaxToken) {
+        if (token.kind() === TypeScript.SyntaxKind.AnyKeyword) {
+            var position = this.position() + token.leadingTriviaWidth();
+            this.addFailure(this.createFailure(position, token.width(), Rule.FAILURE_STRING));
+        }
+    }
+}

--- a/test/files/rules/noAny.test.ts
+++ b/test/files/rules/noAny.test.ts
@@ -1,0 +1,5 @@
+var x: any;
+
+/*tslint:disable:no-any */
+var y: any;
+/*tslint:enable:no-any */

--- a/test/rules/noAnyRuleTests.ts
+++ b/test/rules/noAnyRuleTests.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/// <reference path='../references.ts' />
+
+describe("<no-any>", () => {
+    var fileName = "rules/noAny.test.ts";
+    var NoAnyRule = Lint.Test.getRule("no-any");
+
+    it("var declaration with type of 'any' should not be allowed", () => {
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, NoAnyRule);
+        var expectedFailure = Lint.Test.createFailure(fileName, [1, 8], [1, 11], "Type decoration of 'any' is forbidden.");
+
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+});


### PR DESCRIPTION
To ensure that we actually _type_ as much as possible we plan to prohibit use of any without an explicit disable and a comment as to why _any_ must be used.
