### PR TITLE
Show an error instead of a stacktrace when a file doesn't exist.

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -142,6 +142,11 @@ if (configuration === undefined) {
     process.exit(1);
 }
 
+if (!fs.existsSync(argv.f)) {
+    console.error("Unable to open file: " + argv.f);
+    process.exit(1);
+}
+
 var file = argv.f;
 var contents = fs.readFileSync(file, "utf8");
 


### PR DESCRIPTION
Show a nice error instead of a stacktrace. Makes it easier to see what is actually wrong.
Note: if this is something you guys don't want, just cancel the PR :)

Note: I did not check if it is a directory because I might want to implement the closed #134 if you guys want me to? I will add a question to that issue right after this one :)
