### PR TITLE
Remove typedef 'catchClause' from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ A sample configuration file with all options is available [here](https://github.
 * `triple-equals` enforces === and !== in favor of == and !=.
 * `typedef` enforces type definitions to exist. Rule options:
     * `"callSignature"` checks return type of functions
-    * `"catchClause"` checks type in exception catch blocks
     * `"indexSignature"` checks index type specifier of indexers
     * `"parameter"` checks type specifier of parameters
     * `"propertySignature"` checks return types of interface properties


### PR DESCRIPTION
I remover the code from typedef last week, but forgot to update the readme.
(See below reason why I removed the code)
5.11
The variable introduced by a ‘catch’ clause of a ‘try’ statement is always of type Any. It is not possible to include a type annotation in a ‘catch’ clause.
