### PR TITLE
Config: Findup should start from input file dir

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -21,13 +21,13 @@ module Lint.Configuration {
 
     var CONFIG_FILENAME = "tslint.json";
 
-    export function findConfiguration(configFile: string): any {
+    export function findConfiguration(configFile: string, inputFileLocation: string): any {
         if (configFile) {
             return JSON.parse(fs.readFileSync(configFile, "utf8"));
         }
 
-        // First look for package.json
-        configFile = findup("package.json", { nocase: true });
+        // First look for package.json from input file location
+        configFile = findup("package.json", { cwd: inputFileLocation, nocase: true });
 
         if (configFile) {
             var content = require(configFile);
@@ -46,7 +46,7 @@ module Lint.Configuration {
 
         var defaultPath = path.join(homeDir, CONFIG_FILENAME);
 
-        configFile = findup(CONFIG_FILENAME, { nocase: true }) || defaultPath;
+        configFile = findup(CONFIG_FILENAME, { cwd: inputFileLocation, nocase: true }) || defaultPath;
 
         return configFile ? JSON.parse(fs.readFileSync(configFile, "utf8")) : undefined;
     }

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -136,12 +136,6 @@ if ("help" in argv) {
     process.exit(0);
 }
 
-var configuration = Lint.Configuration.findConfiguration(argv.c);
-if (configuration === undefined) {
-    console.error("unable to find tslint configuration");
-    process.exit(1);
-}
-
 if (!fs.existsSync(argv.f)) {
     console.error("Unable to open file: " + argv.f);
     process.exit(1);
@@ -149,6 +143,12 @@ if (!fs.existsSync(argv.f)) {
 
 var processFile = (file: string) => {
     var contents = fs.readFileSync(file, "utf8");
+    var configuration = Lint.Configuration.findConfiguration(argv.c, file);
+
+    if (configuration === undefined) {
+        console.error("unable to find tslint configuration");
+        process.exit(1);
+    }
 
     var linter = new Lint.Linter(file, contents, {
         configuration: configuration,
@@ -156,6 +156,7 @@ var processFile = (file: string) => {
         rulesDirectory: argv.r,
         formattersDirectory: argv.s
     });
+
     var lintResult = linter.lint();
 
     if (lintResult.failureCount > 0) {


### PR DESCRIPTION
Currently, when the configuration file is not provided by user, the discovery mechanism starts the search from current directory (`process.cwd()`) instead of the location of file-to-lint. This commit fixes the issue.
