### PR TITLE
Move installation & usage higher up in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,103 @@ TSLint [![NPM version](https://badge.fury.io/js/tslint.png)](http://badge.fury.i
 
 A linter for the TypeScript language.
 
+Installation
+------------
+
+##### CLI
+
+```sudo npm install tslint -g```
+
+##### Library
+
+```npm install tslint```
+
+Usage
+-----
+
+Please first ensure that the TypeScript source files compile correctly.
+
+##### CLI
+
+    usage: tslint
+
+	Options:
+	  -c, --config  		 configuration file
+	  -f, --file    		 file to lint                 [required]
+	  -o, --out     		 output file
+      -r, --rules-dir   	 rules directory
+      -s, --formatters-dir   formatters directory
+	  -t, --format  		 output format (prose, json)  [default: "prose"]
+
+By default, configuration is loaded from `tslint.json`, if it exists in the current path, or the user's home directory, in that order.
+
+tslint accepts the following commandline options:
+
+    -f, --file:
+        The location of the TypeScript file that you wish to lint. This
+        option is required. Muliptle files are processed consecutively.
+
+    -c, --config:
+        The location of the configuration file that tslint will use to
+        determine which rules are activated and what options to provide
+        to the rules. If no option is specified, the config file named
+        tslint.json is used, so long as it exists in the path.
+        The format of the file is { rules: { /* rules list */ } },
+        where /* rules list */ is a key: value comma-seperated list of
+        rulename: rule-options pairs. Rule-options can be either a
+        boolean true/false value denoting whether the rule is used or not,
+        or a list [boolean, ...] where the boolean provides the same role
+        as in the non-list case, and the rest of the list are options passed
+        to the rule that will determine what it checks for (such as number
+        of characters for the max-line-length rule, or what functions to ban
+        for the ban rule).
+
+    -o, --out:
+        A filename to output the results to. By default, tslint outputs to
+        stdout, which is usually the console where you're running it from.
+
+    -r, --rules-dir:
+        An additional rules directory, for user-created rules.
+        tslint will always check its default rules directory, in
+        node_modules/tslint/build/rules, before checking the user-provided
+        rules directory, so rules in the user-provided rules directory
+        with the same name as the base rules will not be loaded.
+
+    -s, --formatters-dir:
+        An additional formatters directory, for user-created formatters.
+        Formatters are files that will format the tslint output, before
+        writing it to stdout or the file passed in --out. The default
+        directory, node_modules/tslint/build/formatters, will always be
+        checked first, so user-created formatters with the same names
+        as the base formatters will not be loaded.
+
+    -t, --format:
+        The formatter to use to format the results of the linter before
+        outputting it to stdout or the file passed in --out. The core
+        formatters are prose (human readable) and json (machine readable),
+        and prose is the default if this option is not used. Additional
+        formatters can be added and used if the --formatters-dir option
+        is set.
+
+    --help:
+        Prints this help message.
+
+##### Library
+
+```javascript
+var options = {
+	formatter: "json",
+	configuration: configuration,
+	rulesDirectory: "customRules/",
+	formattersDirectory: "customFormatters/"
+};
+
+var Linter = require("tslint");
+
+var ll = new Linter(fileName, contents, options);
+var result = ll.lint();
+```
+
 Supported Rules
 -----
 
@@ -192,103 +289,6 @@ export class Formatter extends Lint.Formatters.AbstractFormatter {
 ```
 
 Such custom formatters can also be written in Javascript. Additionally, formatter files are always named with the suffix `Formatter`, and referenced from TSLint without its suffix.
-
-Installation
-------------
-
-##### CLI
-
-```sudo npm install tslint -g```
-
-##### Library
-
-```npm install tslint```
-
-Usage
------
-
-Please first ensure that the TypeScript source files compile correctly.
-
-##### CLI
-
-    usage: tslint
-
-	Options:
-	  -c, --config  		 configuration file
-	  -f, --file    		 file to lint                 [required]
-	  -o, --out     		 output file
-      -r, --rules-dir   	 rules directory
-      -s, --formatters-dir   formatters directory
-	  -t, --format  		 output format (prose, json)  [default: "prose"]
-
-By default, configuration is loaded from `tslint.json`, if it exists in the current path, or the user's home directory, in that order.
-
-tslint accepts the following commandline options:
-
-    -f, --file:
-        The location of the TypeScript file that you wish to lint. This
-        option is required. Muliptle files are processed consecutively.
-
-    -c, --config:
-        The location of the configuration file that tslint will use to
-        determine which rules are activated and what options to provide
-        to the rules. If no option is specified, the config file named
-        tslint.json is used, so long as it exists in the path.
-        The format of the file is { rules: { /* rules list */ } },
-        where /* rules list */ is a key: value comma-seperated list of
-        rulename: rule-options pairs. Rule-options can be either a
-        boolean true/false value denoting whether the rule is used or not,
-        or a list [boolean, ...] where the boolean provides the same role
-        as in the non-list case, and the rest of the list are options passed
-        to the rule that will determine what it checks for (such as number
-        of characters for the max-line-length rule, or what functions to ban
-        for the ban rule).
-
-    -o, --out:
-        A filename to output the results to. By default, tslint outputs to
-        stdout, which is usually the console where you're running it from.
-
-    -r, --rules-dir:
-        An additional rules directory, for user-created rules.
-        tslint will always check its default rules directory, in
-        node_modules/tslint/build/rules, before checking the user-provided
-        rules directory, so rules in the user-provided rules directory
-        with the same name as the base rules will not be loaded.
-
-    -s, --formatters-dir:
-        An additional formatters directory, for user-created formatters.
-        Formatters are files that will format the tslint output, before
-        writing it to stdout or the file passed in --out. The default
-        directory, node_modules/tslint/build/formatters, will always be
-        checked first, so user-created formatters with the same names
-        as the base formatters will not be loaded.
-
-    -t, --format:
-        The formatter to use to format the results of the linter before
-        outputting it to stdout or the file passed in --out. The core
-        formatters are prose (human readable) and json (machine readable),
-        and prose is the default if this option is not used. Additional
-        formatters can be added and used if the --formatters-dir option
-        is set.
-
-    --help:
-        Prints this help message.
-
-##### Library
-
-```javascript
-var options = {
-	formatter: "json",
-	configuration: configuration,
-	rulesDirectory: "customRules/",
-	formattersDirectory: "customFormatters/"
-};
-
-var Linter = require("tslint");
-
-var ll = new Linter(fileName, contents, options);
-var result = ll.lint();
-```
 
 Development
 -----------


### PR DESCRIPTION
I found myself looking for installation and usage first, so I thought it'd be nice to move that to the top.
