### PR TITLE
Bug fix for multiple files

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -137,14 +137,14 @@ if ("help" in argv) {
 }
 
 var processFile = (file: string) => {
-    var contents;
+    var contents: string;
     try {
         contents = fs.readFileSync(file, "utf8");
-    } catch(e) {
+    } catch (e) {
         console.error("Unable to open file: " + file);
         process.exit(1);
     }
-    
+
     var configuration = Lint.Configuration.findConfiguration(argv.c, file);
 
     if (configuration === undefined) {


### PR DESCRIPTION
Previously when multiple files would be provided (via multiple -f), the check on line 139 (if (!fs.existsSync(argv.f)) {) would fail, as argv.f would just be concatenated and would return false
