### PR TITLE
Config: Switch var positions for home slection

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -53,7 +53,7 @@ module Lint.Configuration {
 
     function getHomeDir() {
         var environment = global.process.env;
-        var paths = [environment.HOME, environment.USERPROFILE, environment.HOMEPATH, environment.HOMEDRIVE + environment.HOMEPATH];
+        var paths = [environment.USERPROFILE, environment.HOME, environment.HOMEPATH, environment.HOMEDRIVE + environment.HOMEPATH];
 
         for (var homeIndex in paths) {
             if (paths.hasOwnProperty(homeIndex)) {


### PR DESCRIPTION
On new Windows versions, the user home is resolved with `process.env.USERPROFILE` and `process.env.HOME` is set to the (default) user's home, which may be different than that of the current user.

This commit changes the sequence, to locate the  `tslint.json` file.
