### PR TITLE
Added assert for use strict rule

### DIFF
--- a/test/rules/useStrictRuleTests.ts
+++ b/test/rules/useStrictRuleTests.ts
@@ -25,6 +25,7 @@ describe("<use-strict>", () => {
     before(() => {
         var options = [true, "check-function", "check-module"];
         actualFailures = Lint.Test.applyRuleOnFile(fileName, UseStrictRule, options);
+        assert.lengthOf(actualFailures, 2);
     });
 
     it("enforces checks for 'use strict' in functions", () => {


### PR DESCRIPTION
False positives could be missed by the test because it uses assertContains failure
