### PR TITLE
Fixes nesting bug in noDuplicateKeyRule.

### DIFF
--- a/test/files/rules/dupkey.test.ts
+++ b/test/files/rules/dupkey.test.ts
@@ -25,6 +25,12 @@ var z = {
     b: "a"
 };
 
+var interspersed = {
+    duplicated: 1,
+    newContext: {},
+    duplicated: 2
+};
+
 var n = {
     constructor: function () {},
     hasOwnProperty: function () {}

--- a/test/rules/noDuplicateKeyRuleTests.ts
+++ b/test/rules/noDuplicateKeyRuleTests.ts
@@ -25,10 +25,12 @@ describe("<no-duplicate-key>", () => {
         var actualFailures = Lint.Test.applyRuleOnFile(fileName, NoDuplicateKeyRule);
         var createFailure1 = Lint.Test.createFailuresOnFile(fileName, failureString + "axa'");
         var createFailure2 = Lint.Test.createFailuresOnFile(fileName, failureString + "bd'");
+        var createFailure3 = Lint.Test.createFailuresOnFile(fileName, failureString + "duplicated'");
         var expectedFailures = [
             createFailure1([10, 5], [10, 8]),
             createFailure2([13, 5], [13, 7]),
-            createFailure1([14, 5], [14, 8])
+            createFailure1([14, 5], [14, 8]),
+            createFailure3([31, 5], [31, 15])
         ];
 
         Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);


### PR DESCRIPTION
This pull request addresses an issue where the noDuplicateKeyRule fails to detect duplicate object literal properties when interspersed by a nested object literal.
