### PR TITLE
Better test failure messages

### DIFF
--- a/test/helper.ts
+++ b/test/helper.ts
@@ -81,6 +81,8 @@ module Lint.Test {
             }
         }
 
-        assert.fail(needle, haystack, "expected failure not found");
+        var line = needle.getStartPosition().getLineAndCharacter().line() + 1,
+            character =  needle.getStartPosition().getLineAndCharacter().character() + 1;
+        assert(false, "expected failure not found on [" + line + ", " + character + "]");
     }
 }


### PR DESCRIPTION
Added a bit of useful information for test error messages. Changed from: 

```
  1) <indent-with> on a tab-indented file enforces array literal indentation:

  AssertionError: [object Object]
      at Function.assert.fail (/Users/fonda/work/tslint/node_modules/chai/lib/chai/interface/assert.js:58:11)
```

to

```
  1) <indent-with> on a tab-indented file enforces array literal indentation:
     AssertionError: expected failure not found on [114, 1]
```
