### PR TITLE
Check in Eclipse settings to improve dev experience

### DIFF
--- a/.project
+++ b/.project
@@ -5,8 +5,14 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>com.palantir.typescript.typeScriptBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>com.palantir.typescript.typeScriptNature</nature>
 	</natures>
 	<filteredResources>
 		<filter>

--- a/.settings/com.palantir.typescript.prefs
+++ b/.settings/com.palantir.typescript.prefs
@@ -1,0 +1,13 @@
+build.path.exportedFolder=src
+build.path.sourceFolder=src,test
+compiler.codeGenTarget=ECMASCRIPT5
+compiler.compileOnSave=false
+compiler.generateDeclarationFiles=false
+compiler.mapSourceFiles=false
+compiler.moduleGenTarget=SYNCHRONOUS
+compiler.noImplicitAny=false
+compiler.noLib=false
+compiler.outputDirOption=
+compiler.outputFileOption=
+compiler.removeComments=false
+eclipse.preferences.version=1


### PR DESCRIPTION
Hi @ashwinr,

The `.project` file that's currently checked in doesn't enable the TypeScript builder or set up source folders, so I get a bunch of errors when first setting up. Is there any reason why we shouldn't just check those files in?
