### PR TITLE
header rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A sample configuration file with all options is available [here](https://github.
 * `curly` enforces braces for `if`/`for`/`do`/`while` statements.
 * `eofline` enforces the file to end with a newline.
 * `forin` enforces a `for ... in` statement to be filtered with an `if` statement.*
+* `header` enforces file having a header at the top. Required option is the pattern that should match the first line.
 * `indent` enforces consistent indentation levels (currently disabled).
 * `interface-name` enforces the rule that interface names must begin with a capital 'I'
 * `jsdoc-format` enforces basic format rules for jsdoc comments -- comments starting with `/**`

--- a/src/rules/headerRule.ts
+++ b/src/rules/headerRule.ts
@@ -17,8 +17,8 @@
 /// <reference path='../../lib/tslint.d.ts' />
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static NOT_FOUND_FAILURE_STRING = "no header found at the start of the file"
-    public static WHITESPACE_FAILURE_STRING = "whitespace found at the start of the file instead of a header"
+    public static NOT_FOUND_FAILURE_STRING = "no header found at the start of the file";
+    public static WHITESPACE_FAILURE_STRING = "whitespace found at the start of the file instead of a header";
     public static PATTERN_FAILURE_STRING = "header must match expression provided";
 
     public apply(syntaxTree: TypeScript.SyntaxTree): Lint.RuleFailure[] {
@@ -33,7 +33,7 @@ class HeaderWalker extends Lint.RuleWalker {
     private pattern: RegExp;
 
     constructor(syntaxTree: TypeScript.SyntaxTree, options: Lint.IOptions) {
-        super(syntaxTree, options)
+        super(syntaxTree, options);
         this.pattern = new RegExp(options.ruleArguments[0]);
     }
 
@@ -52,7 +52,7 @@ class HeaderWalker extends Lint.RuleWalker {
                         break;
                     case TypeScript.SyntaxKind.MultiLineCommentTrivia:
                         var fullText = triviaItem.fullText();
-                        var text = fullText.replace(/\n\s*\*\/$|^(\/\*\n|\s*\* ?)/gm, '');
+                        var text = fullText.replace(/\n\s*\*\/$|^(\/\*\n|\s*\* ?)/gm, "");
                         if (!this.pattern.test(text)) {
                             this.addFailureAt(this.position(), fullText.length, Rule.PATTERN_FAILURE_STRING);
                         }

--- a/src/rules/headerRule.ts
+++ b/src/rules/headerRule.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/// <reference path='../../lib/tslint.d.ts' />
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static NOT_FOUND_FAILURE_STRING = "no header found at the start of the file"
+    public static WHITESPACE_FAILURE_STRING = "whitespace found at the start of the file instead of a header"
+    public static PATTERN_FAILURE_STRING = "header must match expression provided";
+
+    public apply(syntaxTree: TypeScript.SyntaxTree): Lint.RuleFailure[] {
+        var options = this.getOptions();
+        return this.applyWithWalker(new HeaderWalker(syntaxTree, this.getOptions()));
+    }
+}
+
+class HeaderWalker extends Lint.RuleWalker {
+    private firstToken = true;
+    private firstTrivia = true;
+    private pattern: RegExp;
+
+    constructor(syntaxTree: TypeScript.SyntaxTree, options: Lint.IOptions) {
+        super(syntaxTree, options)
+        this.pattern = new RegExp(options.ruleArguments[0]);
+    }
+
+    public visitToken(token: TypeScript.ISyntaxToken): void {
+        var options = this.getOptions();
+        if (this.firstToken) {
+            this.firstToken = false;
+            var trivia = token.leadingTrivia().toArray();
+            trivia.forEach((triviaItem) => {
+                if (!this.firstTrivia) { return; }
+                this.firstTrivia = false;
+                switch (triviaItem.kind()) {
+                    case TypeScript.SyntaxKind.WhitespaceTrivia:
+                    case TypeScript.SyntaxKind.NewLineTrivia:
+                        this.addFailureAt(0, 0, Rule.WHITESPACE_FAILURE_STRING);
+                        break;
+                    case TypeScript.SyntaxKind.MultiLineCommentTrivia:
+                        var fullText = triviaItem.fullText();
+                        var text = fullText.replace(/\n\s*\*\/$|^(\/\*\n|\s*\* ?)/gm, '');
+                        if (!this.pattern.test(text)) {
+                            this.addFailureAt(this.position(), fullText.length, Rule.PATTERN_FAILURE_STRING);
+                        }
+                        break;
+                    default:
+                        this.addFailureAt(0, 0, Rule.NOT_FOUND_FAILURE_STRING);
+                }
+            });
+            if (!trivia.length) {
+                this.addFailureAt(0, 0, Rule.NOT_FOUND_FAILURE_STRING);
+            }
+        }
+        super.visitToken(token);
+    }
+
+    private addFailureAt(currentPosition: number, width: number, failureString: string) {
+        var failure = this.createFailure(currentPosition, width, failureString);
+        this.addFailure(failure);
+    }
+}

--- a/test/files/rules/header1.test.ts
+++ b/test/files/rules/header1.test.ts
@@ -1,0 +1,17 @@
+function hello() {}
+
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/

--- a/test/files/rules/header2.test.ts
+++ b/test/files/rules/header2.test.ts
@@ -1,0 +1,18 @@
+
+/*
+ * Copyright 2014 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+var a = 1 + 2;

--- a/test/files/rules/header3.test.ts
+++ b/test/files/rules/header3.test.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2010 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+function a(b, c) {
+    return 42;
+}

--- a/test/files/rules/header4.test.ts
+++ b/test/files/rules/header4.test.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+function a(b, c) {
+    return 42;
+}

--- a/test/rules/headerRuleTests.ts
+++ b/test/rules/headerRuleTests.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/// <reference path='../references.ts' />
+
+describe("<header>", () => {
+    var HeaderRule = Lint.Test.getRule("header");
+    var options = [true, "Copyright 2014 Palantir Technologies, Inc."];
+
+    it("forbids the first token from not including the header", () => {
+        var fileName = "rules/header1.test.ts";
+        var expectedFailure = Lint.Test.createFailuresOnFile(fileName, HeaderRule.NOT_FOUND_FAILURE_STRING)([1, 1], [1, 1]);
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, HeaderRule, options);
+        assert.lengthOf(actualFailures, 1);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+
+    it("forbids whitespace from showing up before a possible header", () => {
+        var fileName = "rules/header2.test.ts";
+        var expectedFailure = Lint.Test.createFailuresOnFile(fileName, HeaderRule.WHITESPACE_FAILURE_STRING)([1, 1], [1, 1]);
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, HeaderRule, options);
+        assert.lengthOf(actualFailures, 1);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+
+    it("ensures a header that matches a given pattern is included at the top of the file", () => {
+        var fileName3 = "rules/header3.test.ts";
+        var expectedFailure3 = Lint.Test.createFailuresOnFile(fileName3, HeaderRule.PATTERN_FAILURE_STRING)([1, 1], [15, 3]);
+        var actualFailures3 = Lint.Test.applyRuleOnFile(fileName3, HeaderRule, options);
+        actualFailures3.forEach(function(f) { console.log(f); });
+        assert.lengthOf(actualFailures3, 1);
+        Lint.Test.assertContainsFailure(actualFailures3, expectedFailure3);
+
+        var fileName4 = "rules/header4.test.ts";
+        var actualFailures4 = Lint.Test.applyRuleOnFile(fileName4, HeaderRule, options);
+        assert.lengthOf(actualFailures4, 0);
+    });
+});


### PR DESCRIPTION
Takes care of #155

Not sure if this needs a walker, is there a better way to access only the first token?

And as of now, only headers in multiline comments `/* */` will be accepted, should it also allow several lines of single line comments?