### PR TITLE
Fixed issue when typescript language services do not return references

### DIFF
--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -61,13 +61,15 @@ class NoUseBeforeDeclareWalker extends Lint.RuleWalker {
 
     private validateUsageForVariable(name: string, position: number) {
         var references = this.languageService.getReferencesAtPosition(this.fileName, position);
-        references.forEach((reference) => {
-            var referencePosition = reference.textSpan.start();
-            if (this.classStartPosition <= referencePosition && referencePosition < position) {
-                var failureString = Rule.FAILURE_STRING_PREFIX + name + Rule.FAILURE_STRING_POSTFIX;
-                var failure = this.createFailure(referencePosition, name.length, failureString);
-                this.addFailure(failure);
-            }
-        });
+        if (references) {
+            references.forEach((reference) => {
+                var referencePosition = reference.textSpan.start();
+                if (this.classStartPosition <= referencePosition && referencePosition < position) {
+                    var failureString = Rule.FAILURE_STRING_PREFIX + name + Rule.FAILURE_STRING_POSTFIX;
+                    var failure = this.createFailure(referencePosition, name.length, failureString);
+                    this.addFailure(failure);
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Since TypeScript 1.3 the typescript language services return no references for the following statement which I currently use in a project:
`export import Foo = require('./foo');`
I tried disabling this rule `/* tslint:disable:no-use-before-declare */` and also tried disabling tslint altogether for the file which was failing `/* tslint:disable */` but tslint called the method nevertheless and failed at calling the method forEach of undefined because `references` is not defined.
