### PR TITLE
Fixes #292

### DIFF
--- a/lib/tslint.d.ts
+++ b/lib/tslint.d.ts
@@ -101,6 +101,7 @@ declare module Lint {
         protected visitTryBlock(node: ts.Block): void;
         protected visitTryStatement(node: ts.TryStatement): void;
         protected visitTypeAssertionExpression(node: ts.TypeAssertion): void;
+        protected visitTypeLiteral(node: ts.TypeLiteralNode): void;
         protected visitVariableDeclaration(node: ts.VariableDeclaration): void;
         protected visitVariableStatement(node: ts.VariableStatement): void;
         protected visitWhileStatement(node: ts.WhileStatement): void;

--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -226,6 +226,10 @@ module Lint {
             this.walkChildren(node);
         }
 
+        protected visitTypeLiteral(node: ts.TypeLiteralNode) {
+            this.walkChildren(node);
+        }
+
         protected visitVariableDeclaration(node: ts.VariableDeclaration) {
             this.walkChildren(node);
         }
@@ -442,6 +446,10 @@ module Lint {
 
                 case ts.SyntaxKind.TypeAssertionExpression:
                     this.visitTypeAssertionExpression(<ts.TypeAssertion> node);
+                    break;
+
+                case ts.SyntaxKind.TypeLiteral:
+                    this.visitTypeLiteral(<ts.TypeLiteralNode> node);
                     break;
 
                 case ts.SyntaxKind.VariableDeclaration:

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -80,6 +80,10 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
         super.visitPropertyDeclaration(node);
     }
 
+    public visitTypeLiteral(node: ts.TypeLiteralNode) {
+        // don't call super from here -- we want to skip the property declarations in type literals
+    }
+
     private checkAndSetModifiers(node: ts.Declaration, current: IModifiers): void {
         if (!this.canAppearAfter(this.previous, current)) {
             var message = "Declaration of " + toString(current) +

--- a/test/files/rules/memberordering-private.test.ts
+++ b/test/files/rules/memberordering-private.test.ts
@@ -1,4 +1,7 @@
 class Foo {
     private x: number;
+    private bar(): any {
+        var bla: { a: string } = {a: '1'};
+    }
     y: number;
 }

--- a/test/rules/memberOrderingRuleTests.ts
+++ b/test/rules/memberOrderingRuleTests.ts
@@ -26,9 +26,9 @@ describe("<member-ordering>", () => {
         ]);
 
         Lint.Test.assertFailuresEqual(actualFailures, [
-            Lint.Test.createFailure(fileName, [3, 5], [3, 15],
+            Lint.Test.createFailure(fileName, [6, 5], [6, 15],
                 "Declaration of public instance member variable not allowed " +
-                "to appear after declaration of private instance member variable")
+                "to appear after declaration of private instance member function")
         ]);
     });
 


### PR DESCRIPTION
Member ordering rule should not be considering type literals. So
skip them.