### PR TITLE
Comments on the beginning of the file are invalid

### DIFF
--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -53,8 +53,8 @@ class JsdocWalker extends Lint.RuleWalker {
                 return;
             }
 
-            // Correct position for comments on the start of the file
-            if (currentPosition == 1) {
+            // Fix position for comments on the start of the file
+            if (currentPosition === 1) {
                 currentPosition = 0;
             }
 
@@ -82,7 +82,7 @@ class JsdocWalker extends Lint.RuleWalker {
             // followed by the end of the string
             var endBlockCommentMatch = lastLine.match(/^\s*\*\/$/);
             if (endBlockCommentMatch == null) {
-                this.addFailureAt(jsdocPosition, lastLine.length,  Rule.FORMAT_FAILURE_STRING);
+                this.addFailureAt(jsdocPosition, lastLine.length, Rule.FORMAT_FAILURE_STRING);
             }
             var lastAsteriskIndex = lastLine.indexOf("*");
             if (lastAsteriskIndex !== indexToMatch) {

--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -52,6 +52,13 @@ class JsdocWalker extends Lint.RuleWalker {
                 }
                 return;
             }
+
+            // Correct position for comments on the start of the file
+            if (currentPosition == 1) {
+                currentPosition = 0;
+            }
+
+
             // the -1 is necessary because character is 1-indexed, but indexOf is 0-indexed
             var indexToMatch = firstLine.indexOf("**") + sourceFile.getLineAndCharacterFromPosition(currentPosition).character - 1;
             // all lines but the first and last


### PR DESCRIPTION
    /**
     * jsdoc at start of file
     */ 

Above command is invalid according jsdocFormatRule.ts. 
Pull request for the change i made to fix it. It is probably a HACK but i am not able to find the cause.
     