### PR TITLE
fix member ordering regression w.r.t. interfaces

### DIFF
--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -70,6 +70,15 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
         super.visitClassDeclaration(node);
     }
 
+    public visitInterfaceDeclaration(node: ts.InterfaceDeclaration): void {
+        this.previous = {
+            isMethod: false,
+            isPrivate: false,
+            isInstance: false
+        };
+        super.visitInterfaceDeclaration(node);
+    }
+
     public visitMethodDeclaration(node: ts.MethodDeclaration): void {
         this.checkAndSetModifiers(node, getModifiers(true, node.modifiers));
         super.visitMethodDeclaration(node);

--- a/test/files/rules/memberordering-method.test.ts
+++ b/test/files/rules/memberordering-method.test.ts
@@ -2,3 +2,13 @@ class Foo {
     x(): void {}
     y: number;
 }
+
+class Bar {
+    x(): void {}
+}
+
+interface IBar {
+    x: number;
+    y(): void;
+    z: number;
+}

--- a/test/rules/memberOrderingRuleTests.ts
+++ b/test/rules/memberOrderingRuleTests.ts
@@ -39,9 +39,11 @@ describe("<member-ordering>", () => {
             true,
             "variables-before-functions"
         ]);
-
         Lint.Test.assertFailuresEqual(actualFailures, [
             Lint.Test.createFailure(fileName, [3, 5], [3, 15],
+                    "Declaration of public instance member variable not allowed " +
+                    "to appear after declaration of public instance member function"),
+            Lint.Test.createFailure(fileName, [13, 5], [13, 15],
                     "Declaration of public instance member variable not allowed " +
                     "to appear after declaration of public instance member function")
         ]);

--- a/test/rules/memberOrderingRuleTests.ts
+++ b/test/rules/memberOrderingRuleTests.ts
@@ -39,6 +39,7 @@ describe("<member-ordering>", () => {
             true,
             "variables-before-functions"
         ]);
+
         Lint.Test.assertFailuresEqual(actualFailures, [
             Lint.Test.createFailure(fileName, [3, 5], [3, 15],
                     "Declaration of public instance member variable not allowed " +


### PR DESCRIPTION
This addresses a regression introduced by same commit (b269886) that caused #292. Basically, the member ordering rule needs to be aware of interface definitions. Currently, a property declaration within an interface triggers an error if a previously defined class contains methods.