### PR TITLE
bug fix: don't issue typedef variable-declaration warning with for-in statements

### DIFF
--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -96,7 +96,9 @@ class TypedefWalker extends Lint.RuleWalker {
     }
 
     public visitVariableDeclaration(node: ts.VariableDeclaration) {
-        this.checkTypeAnnotation("variable-declaration", node.name.getEnd(), node.type, node.name);
+        if (node.parent.kind !== ts.SyntaxKind.ForInStatement) {
+            this.checkTypeAnnotation("variable-declaration", node.name.getEnd(), node.type, node.name);
+        }
         super.visitVariableDeclaration(node);
     }
 

--- a/test/files/rules/typedef.test.ts
+++ b/test/files/rules/typedef.test.ts
@@ -53,3 +53,7 @@ class ConstructorUnTyped {
 function anotherNoTypesFn(a, b) {
     return b;
 }
+
+function forInFn(): void {
+    for (var p in []) {}
+}


### PR DESCRIPTION
This fix prevents tslint from issuing the typedef variable-declaration warning when declaring an iteration variable within for-in statements. 
e.g
```typescript
for (var p in [1, 2]) {
// "p" cannot have a type annotation.
}
```
Type annotations cannot be used for variable declarations within a for-in statement. 