### PR TITLE
walk interface and reset previous state for member-ordering rules

### DIFF
--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -62,12 +62,13 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
     }
 
     public visitClassDeclaration(node: ts.ClassDeclaration): void {
-        this.previous = {
-            isMethod: false,
-            isPrivate: false,
-            isInstance: false
-        };
+        this.resetPreviousModifiers();
         super.visitClassDeclaration(node);
+    }
+
+    public visitInterfaceDeclaration(node: ts.InterfaceDeclaration): void {
+        this.resetPreviousModifiers();
+        super.visitInterfaceDeclaration(node);
     }
 
     public visitMethodDeclaration(node: ts.MethodDeclaration): void {
@@ -82,6 +83,14 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
 
     public visitTypeLiteral(node: ts.TypeLiteralNode) {
         // don't call super from here -- we want to skip the property declarations in type literals
+    }
+
+    private resetPreviousModifiers(): void {
+        this.previous = {
+            isMethod: false,
+            isPrivate: false,
+            isInstance: false
+        };
     }
 
     private checkAndSetModifiers(node: ts.Declaration, current: IModifiers): void {

--- a/test/files/rules/memberordering-method.test.ts
+++ b/test/files/rules/memberordering-method.test.ts
@@ -1,3 +1,17 @@
+// ensure that Bar and Baz do not get conflated
+interface Bar {
+    x(): void;
+}
+
+interface Baz {
+    y: number;
+}
+
+interface BarBaz {
+    x(): void;
+    y: number;
+}
+
 class Foo {
     x(): void {}
     y: number;

--- a/test/rules/memberOrderingRuleTests.ts
+++ b/test/rules/memberOrderingRuleTests.ts
@@ -41,9 +41,12 @@ describe("<member-ordering>", () => {
         ]);
 
         Lint.Test.assertFailuresEqual(actualFailures, [
-            Lint.Test.createFailure(fileName, [3, 5], [3, 15],
+            Lint.Test.createFailure(fileName, [12, 5], [12, 15],
                     "Declaration of public instance member variable not allowed " +
-                    "to appear after declaration of public instance member function")
+                    "to appear after declaration of public instance member function"),
+            Lint.Test.createFailure(fileName, [17, 5], [17, 15],
+                    "Declaration of public instance member variable not allowed " +
+                    "to appear after declaration of public instance member function"),
         ]);
     });
 


### PR DESCRIPTION
This change introduces resetting the previous `IModifiers` state when
visiting an interface declaration.  Without doing so, subsequent
interface declarations would be conflated as if they were the same
interface when using the `variables-before-functions` rule option.

Version `1.2.0` did not have this problem and `2.1.0` introduced this
regression.  The `memberordering-method.test.ts` has been updated
appropriately to test for this regression and an additional test has
been provided to ensure that interface declarations should trigger
similarly to class declarations.