### PR TITLE
Fixes #293

### DIFF
--- a/lib/tslint.d.ts
+++ b/lib/tslint.d.ts
@@ -97,6 +97,7 @@ declare module Lint {
         protected visitSetAccessor(node: ts.AccessorDeclaration): void;
         protected visitSourceFile(node: ts.SourceFile): void;
         protected visitSwitchStatement(node: ts.SwitchStatement): void;
+        protected visitTemplateExpression(node: ts.TemplateExpression): void;
         protected visitThrowStatement(node: ts.ThrowStatement): void;
         protected visitTryBlock(node: ts.Block): void;
         protected visitTryStatement(node: ts.TryStatement): void;

--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -210,6 +210,10 @@ module Lint {
             this.walkChildren(node);
         }
 
+        protected visitTemplateExpression(node: ts.TemplateExpression) {
+            this.walkChildren(node);
+        }
+
         protected visitThrowStatement(node: ts.ThrowStatement) {
             this.walkChildren(node);
         }
@@ -430,6 +434,10 @@ module Lint {
 
                 case ts.SyntaxKind.SwitchStatement:
                     this.visitSwitchStatement(<ts.SwitchStatement> node);
+                    break;
+
+                case ts.SyntaxKind.TemplateExpression:
+                    this.visitTemplateExpression(<ts.TemplateExpression> node);
                     break;
 
                 case ts.SyntaxKind.ThrowStatement:

--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -44,6 +44,7 @@ class CommentWalker extends Lint.RuleWalker {
                 scanner.setTextPos(this.tokensToSkipStartEndMap[startPos]);
                 return;
             }
+
             if (scanner.getToken() === ts.SyntaxKind.SingleLineCommentTrivia) {
                 var commentText = scanner.getTokenText();
                 var startPosition = scanner.getTokenPos() + 2;
@@ -65,27 +66,25 @@ class CommentWalker extends Lint.RuleWalker {
     }
 
     public visitRegularExpressionLiteral(node: ts.Node) {
-        if (node.getStart() < node.getEnd()) {
-            // only add to the map nodes whose end comes after their start, to prevent infinite loops
-            this.tokensToSkipStartEndMap[node.getStart()] = node.getEnd();
-        }
+        this.addTokenToSkipFromNode(node);
         super.visitRegularExpressionLiteral(node);
     }
 
     public visitIdentifier(node: ts.Identifier) {
-        if (node.getStart() < node.getEnd()) {
-            // only add to the map nodes whose end comes after their start, to prevent infinite loops
-            this.tokensToSkipStartEndMap[node.getStart()] = node.getEnd();
-        }
+        this.addTokenToSkipFromNode(node);
         super.visitIdentifier(node);
     }
 
     public visitTemplateExpression(node: ts.TemplateExpression) {
+        this.addTokenToSkipFromNode(node);
+        super.visitTemplateExpression(node);
+    }
+
+     public addTokenToSkipFromNode(node: ts.Node) {
         if (node.getStart() < node.getEnd()) {
             // only add to the map nodes whose end comes after their start, to prevent infinite loops
             this.tokensToSkipStartEndMap[node.getStart()] = node.getEnd();
         }
-        super.visitTemplateExpression(node);
     }
 
     private startsWithSpace(commentText: string): boolean {

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -57,7 +57,7 @@ class WhitespaceWalker extends Lint.RuleWalker {
 
             if (this.tokensToSkipStartEndMap[startPos] != null) {
                 // tokens to skip are places where the scanner gets confused about what the token is, without the proper context
-                // (specifically, regex and identifiers). So skip those tokens.
+                // (specifically, regex, identifiers, and templates). So skip those tokens.
                 scanner.setTextPos(this.tokensToSkipStartEndMap[startPos]);
                 return;
             }
@@ -109,6 +109,14 @@ class WhitespaceWalker extends Lint.RuleWalker {
             this.tokensToSkipStartEndMap[node.getStart()] = node.getEnd();
         }
         super.visitIdentifier(node);
+    }
+
+    public visitTemplateExpression(node: ts.TemplateExpression) {
+        if (node.getStart() < node.getEnd()) {
+            // only add to the map nodes whose end comes after their start, to prevent infinite loops
+            this.tokensToSkipStartEndMap[node.getStart()] = node.getEnd();
+        }
+        super.visitTemplateExpression(node);
     }
 
     // check for spaces between the operator symbol (except in the case of comma statements)

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -96,27 +96,25 @@ class WhitespaceWalker extends Lint.RuleWalker {
     }
 
     public visitRegularExpressionLiteral(node: ts.Node) {
-        if (node.getStart() < node.getEnd()) {
-            // only add to the map nodes whose end comes after their start, to prevent infinite loops
-            this.tokensToSkipStartEndMap[node.getStart()] = node.getEnd();
-        }
+        this.addTokenToSkipFromNode(node);
         super.visitRegularExpressionLiteral(node);
     }
 
     public visitIdentifier(node: ts.Identifier) {
-        if (node.getStart() < node.getEnd()) {
-            // only add to the map nodes whose end comes after their start, to prevent infinite loops
-            this.tokensToSkipStartEndMap[node.getStart()] = node.getEnd();
-        }
+        this.addTokenToSkipFromNode(node);
         super.visitIdentifier(node);
     }
 
     public visitTemplateExpression(node: ts.TemplateExpression) {
+        this.addTokenToSkipFromNode(node);
+        super.visitTemplateExpression(node);
+    }
+
+    public addTokenToSkipFromNode(node: ts.Node) {
         if (node.getStart() < node.getEnd()) {
             // only add to the map nodes whose end comes after their start, to prevent infinite loops
             this.tokensToSkipStartEndMap[node.getStart()] = node.getEnd();
         }
-        super.visitTemplateExpression(node);
     }
 
     // check for spaces between the operator symbol (except in the case of comma statements)

--- a/test/files/rules/comment.test.ts
+++ b/test/files/rules/comment.test.ts
@@ -11,3 +11,5 @@ class Clazz { // this comment is correct
 
 //#region test
 //#endregion
+
+`${location.protocol}//${location.hostname}`


### PR DESCRIPTION
Comment format rule should skip templates (and other things). And the
whitespace rule should skip templates too.