### PR TITLE
no-unused-variable option leading-underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A sample configuration file with all options is available [here](https://github.
 * `no-unused-variable` disallows unused imports, variables, functions and private class members.
     * `"check-parameters"` disallows unused function and constructor parameters.
         * NOTE: this option is experimental and does not work with classes that use abstract method declarations, among other things. Use at your own risk.
+    * `"ignore-underscore"` variables which have a leading underscore (including just underscore itself) are exempt from this check.
 * `no-use-before-declare` disallows usage of variables before their declaration.
 * `no-var-requires` disallows the use of require statements except in import statements, banning the use of forms such as `var module = require("module")`
 * `one-line` enforces the specified tokens to be on the same line as the expression preceding it. Rule options:

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -15,6 +15,7 @@
 */
 
 var OPTION_CHECK_PARAMETERS = "check-parameters";
+var OPTION_IGNORE_UNDERSCORE = "ignore-underscore";
 
 /// <reference path='../../lib/tslint.d.ts' />
 
@@ -157,6 +158,12 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
     }
 
     private validateReferencesForVariable(name: string, position: number) {
+        if (this.hasOption(OPTION_IGNORE_UNDERSCORE)) {
+            if (name.charAt(0) === "_") {
+                return;
+            }
+        }
+
         var references = this.languageService.getReferencesAtPosition("file.ts", position);
         if (references.length <= 1) {
             var failureString = Rule.FAILURE_STRING + "'" + name + "'";

--- a/test/files/rules/nounusedvariable-parameter.test.ts
+++ b/test/files/rules/nounusedvariable-parameter.test.ts
@@ -34,3 +34,6 @@ export function func6(...args: number[]) {
 export function func7(f: (x: number) => number) {
     return f;
 }
+
+export function func8(_x: number) {
+}

--- a/test/files/rules/nounusedvariable-var.test.ts
+++ b/test/files/rules/nounusedvariable-var.test.ts
@@ -3,6 +3,8 @@ var x = 3;
 var y = x;
 var z;
 
+var _a;
+
 export var abcd = 3;
 
 class ABCD {

--- a/test/rules/noUnusedVariableRuleTests.ts
+++ b/test/rules/noUnusedVariableRuleTests.ts
@@ -35,7 +35,7 @@ describe("<no-unused-variable>", () => {
         var failureString = Rule.FAILURE_STRING + "'y'";
         var failure = Lint.Test.createFailuresOnFile(fileName, failureString)([3, 5], [3, 6]);
 
-        var actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule);
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule, [true, "ignore-underscore"]);
 
         assert.lengthOf(actualFailures, 1);
         Lint.Test.assertContainsFailure(actualFailures, failure);
@@ -77,7 +77,7 @@ describe("<no-unused-variable>", () => {
         var failure3 = Lint.Test.createFailuresOnFile(fileName, Rule.FAILURE_STRING + "'y'")([9, 35], [9, 36]);
         var failure4 = Lint.Test.createFailuresOnFile(fileName, Rule.FAILURE_STRING + "'x'")([18, 25], [18, 26]);
 
-        var actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule, [true, "check-parameters"]);
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule, [true, "check-parameters", "ignore-underscore"]);
 
         assert.lengthOf(actualFailures, 4);
 


### PR DESCRIPTION
With this option tslint ignores unused variables when they have a leading
underscore. This is useful to selectively ignore the warning.

See #314.