### PR TITLE
Ignore unused variables in type literals

### DIFF
--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -85,6 +85,12 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
         this.skipVariableDeclaration = false;
     }
 
+    public visitFunctionType(node: ts.Node): void {
+        this.skipParameterDeclaration = true;
+        super.visitFunctionType(node);
+        this.skipParameterDeclaration = false;
+    }
+
     // check function declarations (skipping exports)
     public visitFunctionDeclaration(node: ts.FunctionDeclaration): void {
         var variableName = node.name.text;
@@ -98,19 +104,6 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
 
     public visitParameterDeclaration(node: ts.ParameterDeclaration): void {
         var variableName = node.name.text;
-
-        // Skip parameters in type literals. We don't want to generate
-        // warnings about unused variables in those.
-        if (node.parent && node.parent.symbol) {
-
-            // Similar code which checks presence of a bit is also present in
-            // noDuplicateVariableRule.ts. Does TypeScript or tslint provide
-            // any helpers to test presence of bits?
-            var symbolFlags = node.parent.symbol.flags;
-            if ((Math.floor(symbolFlags / ts.SymbolFlags.TypeLiteral) % 2) === 1) {
-                return;
-            }
-        }
 
         if (!this.hasModifier(node.modifiers, ts.SyntaxKind.PublicKeyword)
             && !this.skipParameterDeclaration && this.hasOption(OPTION_CHECK_PARAMETERS)) {

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -99,6 +99,19 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
     public visitParameterDeclaration(node: ts.ParameterDeclaration): void {
         var variableName = node.name.text;
 
+        // Skip parameters in type literals. We don't want to generate
+        // warnings about unused variables in those.
+        if (node.parent && node.parent.symbol) {
+
+            // Similar code which checks presence of a bit is also present in
+            // noDuplicateVariableRule.ts. Does TypeScript or tslint provide
+            // any helpers to test presence of bits?
+            var symbolFlags = node.parent.symbol.flags;
+            if ((Math.floor(symbolFlags / ts.SymbolFlags.TypeLiteral) % 2) === 1) {
+                return;
+            }
+        }
+
         if (!this.hasModifier(node.modifiers, ts.SyntaxKind.PublicKeyword)
             && !this.skipParameterDeclaration && this.hasOption(OPTION_CHECK_PARAMETERS)) {
             this.validateReferencesForVariable(variableName, node.name.getStart());

--- a/test/files/rules/nounusedvariable-parameter.test.ts
+++ b/test/files/rules/nounusedvariable-parameter.test.ts
@@ -30,3 +30,7 @@ export interface ITestMapInterface {
 export function func6(...args: number[]) {
     return args;
 }
+
+export function func7(f: (x: number) => number) {
+    return f;
+}


### PR DESCRIPTION
I ran into a false positive when `no-unused-variables` is enabled together with the `check-parameters` option.

```javascript
function func(f: (x: number) => void) {
    f(42);
}
```

tslint claimed that `x` is unused. That is a correct observation, though in such cases we actually want to ignore these warnings.