### PR TITLE
no-duplicate-variable: treat function arguments as vars

### DIFF
--- a/src/rules/noDuplicateVariableRule.ts
+++ b/src/rules/noDuplicateVariableRule.ts
@@ -27,12 +27,6 @@ class NoDuplicateVariableWalker extends Lint.ScopeAwareRuleWalker<ScopeInfo> {
         return new ScopeInfo();
     }
 
-    fail(ident: ts.Identifier): void {
-        var failureString = Rule.FAILURE_STRING + ident.text + "'";
-        this.addFailure(this.createFailure(ident.getStart(),
-            ident.getWidth(), failureString));
-    }
-
     public visitParameterDeclaration(node: ts.ParameterDeclaration): void {
         // Treat parameters as var.
         var propertyName = node.name;
@@ -40,7 +34,7 @@ class NoDuplicateVariableWalker extends Lint.ScopeAwareRuleWalker<ScopeInfo> {
         var currentScope = this.getCurrentScope();
 
         if (currentScope.varNames.indexOf(variableName) >= 0) {
-            this.fail(node.name);
+            this.addFailureOnIdentifier(node.name);
         } else {
             currentScope.varNames.push(variableName);
         }
@@ -57,11 +51,11 @@ class NoDuplicateVariableWalker extends Lint.ScopeAwareRuleWalker<ScopeInfo> {
 
         if (currentScope.varNames.indexOf(variableName) >= 0) {
             // if there was a previous var declaration with the same name, this declaration is invalid
-            this.fail(propertyName);
+            this.addFailureOnIdentifier(propertyName);
         } else if (!declarationIsLet) {
             if (currentScope.letNames.indexOf(variableName) >= 0) {
                 // if we're a var, and someone previously declared a let with the same name, this declaration is invalid
-                this.fail(propertyName);
+                this.addFailureOnIdentifier(propertyName);
             } else {
                 currentScope.varNames.push(variableName);
             }
@@ -71,6 +65,13 @@ class NoDuplicateVariableWalker extends Lint.ScopeAwareRuleWalker<ScopeInfo> {
 
         super.visitVariableDeclaration(node);
     }
+
+    private addFailureOnIdentifier(ident: ts.Identifier): void {
+        var failureString = Rule.FAILURE_STRING + ident.text + "'";
+        this.addFailure(this.createFailure(ident.getStart(),
+            ident.getWidth(), failureString));
+    }
+
 }
 
 class ScopeInfo {

--- a/test/files/rules/duplicate-variable.test.ts
+++ b/test/files/rules/duplicate-variable.test.ts
@@ -93,3 +93,13 @@ function letTesting() {
     }
     var f = 4;
 }
+
+// failure: two arguments have the same name.
+function testArguments1(arg: number, arg: number): void {
+}
+
+// failure: local var/let declarations shadow arguments.
+function testArguments2(x: number, y: number): void {
+    var x = 1;
+    let y = 2;
+}

--- a/test/rules/noDuplicateVariableRuleTests.ts
+++ b/test/rules/noDuplicateVariableRuleTests.ts
@@ -30,7 +30,10 @@ describe("<no-duplicate-variable>", () => {
             Lint.Test.createFailure(fileName, [82, 13], [82, 14], NoDuplicateVariableRule.FAILURE_STRING + "a'"),
             Lint.Test.createFailure(fileName, [85, 13], [85, 14], NoDuplicateVariableRule.FAILURE_STRING + "d'"),
             Lint.Test.createFailure(fileName, [91, 13], [91, 14], NoDuplicateVariableRule.FAILURE_STRING + "e'"),
-            Lint.Test.createFailure(fileName, [94, 9], [94, 10], NoDuplicateVariableRule.FAILURE_STRING + "f'")
+            Lint.Test.createFailure(fileName, [94, 9], [94, 10], NoDuplicateVariableRule.FAILURE_STRING + "f'"),
+            Lint.Test.createFailure(fileName, [98, 38], [98, 41], NoDuplicateVariableRule.FAILURE_STRING + "arg'"),
+            Lint.Test.createFailure(fileName, [103, 9], [103, 10], NoDuplicateVariableRule.FAILURE_STRING + "x'"),
+            Lint.Test.createFailure(fileName, [104, 9], [104, 10], NoDuplicateVariableRule.FAILURE_STRING + "y'")
         ];
 
         var actualFailures = Lint.Test.applyRuleOnFile(fileName, NoDuplicateVariableRule);


### PR DESCRIPTION
This way we can detect duplicate arguments in function declarations, or
if a var/let shadows one of the function arguments.