### PR TITLE
Skip checking indentation inside multi-line comments

### DIFF
--- a/src/rules/indentRule.ts
+++ b/src/rules/indentRule.ts
@@ -49,8 +49,14 @@ class IndentWalker extends Lint.RuleWalker {
             return;
         }
 
+        let endOfComment = -1;
         const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, node.text);
         for (let lineStart of node.getLineStarts()) {
+            if (lineStart < endOfComment) {
+                // skip checking lines inside multi-line comments
+                continue;
+            }
+
             scanner.setTextPos(lineStart);
 
             let currentScannedType = scanner.scan();
@@ -66,6 +72,11 @@ class IndentWalker extends Lint.RuleWalker {
 
                 fullLeadingWhitespace += scanner.getTokenText();
                 currentScannedType = scanner.scan();
+            }
+
+            const commentRanges = ts.getTrailingCommentRanges(node.text, lineStart);
+            if (commentRanges) {
+                endOfComment = commentRanges[commentRanges.length - 1].end;
             }
 
             if (currentScannedType === ts.SyntaxKind.SingleLineCommentTrivia

--- a/test/files/rules/indentwith_tabs.test.ts
+++ b/test/files/rules/indentwith_tabs.test.ts
@@ -1,5 +1,8 @@
 // valid code
 module TestModule {
+	/**
+	 * Some documentation
+	 */
 	var func = () => {
 		console.warn("hi");
 	};

--- a/test/rules/indentRuleTests.ts
+++ b/test/rules/indentRuleTests.ts
@@ -37,45 +37,45 @@ describe("<indent>", () => {
         });
 
         it("enforces variable indentation", () => {
-            expectFailure(Lint.Test.createFailure(fileName, [58, 1], [58, 5], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [62, 1], [62, 9], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [66, 1], [66, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [61, 1], [61, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [65, 1], [65, 9], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [69, 1], [69, 5], failureStringTabs));
         });
 
         it("enforces class method indentation", () => {
-            expectFailure(Lint.Test.createFailure(fileName, [68, 1], [68, 5], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [69, 1], [69, 8], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [70, 1], [70, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [71, 1], [71, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [72, 1], [72, 8], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [73, 1], [73, 5], failureStringTabs));
         });
 
         it("enforces object literal indentation", () => {
-            expectFailure(Lint.Test.createFailure(fileName, [74, 1], [74, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [77, 1], [77, 5], failureStringTabs));
         });
 
         it("enforces enum indentation", () => {
-            expectFailure(Lint.Test.createFailure(fileName, [80, 1], [80, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [83, 1], [83, 5], failureStringTabs));
         });
 
         it("enforces switch indentation", () => {
-            expectFailure(Lint.Test.createFailure(fileName, [88, 1], [88, 5], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [89, 1], [89, 9], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [90, 1], [90, 9], failureStringTabs));
             expectFailure(Lint.Test.createFailure(fileName, [91, 1], [91, 5], failureStringTabs));
             expectFailure(Lint.Test.createFailure(fileName, [92, 1], [92, 9], failureStringTabs));
             expectFailure(Lint.Test.createFailure(fileName, [93, 1], [93, 9], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [94, 1], [94, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [95, 1], [95, 9], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [96, 1], [96, 9], failureStringTabs));
         });
 
         it("enforces control blocks indentation", () => {
-            expectFailure(Lint.Test.createFailure(fileName, [97, 1], [97, 5], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [101, 1], [101, 5], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [105, 1], [105, 5], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [109, 1], [109, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [100, 1], [100, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [104, 1], [104, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [108, 1], [108, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [112, 1], [112, 5], failureStringTabs));
         });
 
         it("enforces array literal indentation", () => {
-            expectFailure(Lint.Test.createFailure(fileName, [113, 1], [113, 5], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [119, 1], [119, 9], failureStringTabs));
-            expectFailure(Lint.Test.createFailure(fileName, [121, 1], [121, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [116, 1], [116, 5], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [122, 1], [122, 9], failureStringTabs));
+            expectFailure(Lint.Test.createFailure(fileName, [124, 1], [124, 5], failureStringTabs));
         });
     });
 

--- a/test/rules/indentRuleTests.ts
+++ b/test/rules/indentRuleTests.ts
@@ -32,6 +32,10 @@ describe("<indent>", () => {
             actualFailures = Lint.Test.applyRuleOnFile(fileName, IndentRule, [true, "tabs"]);
         });
 
+        it("doesn't fail good code", () => {
+            assert.lengthOf(actualFailures, 21);
+        });
+
         it("enforces variable indentation", () => {
             expectFailure(Lint.Test.createFailure(fileName, [58, 1], [58, 5], failureStringTabs));
             expectFailure(Lint.Test.createFailure(fileName, [62, 1], [62, 9], failureStringTabs));
@@ -81,6 +85,10 @@ describe("<indent>", () => {
 
         before(() => {
             actualFailures = Lint.Test.applyRuleOnFile(fileName, IndentRule, [true, "spaces"]);
+        });
+
+        it("doesn't fail good code", () => {
+            assert.lengthOf(actualFailures, 21);
         });
 
         it("enforces variable indentation", () => {


### PR DESCRIPTION
Eventually a full implementation of [smart-tabs](http://www.emacswiki.org/emacs/SmartTabs) would be nice, but the only case I've seen failing so far is using an initial space to align the asterisks in a multi-line comment. This allows that use-case (along with other multi-line comment formats) by simply turning off indentation checking inside multi-line comments.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/323)
<!-- Reviewable:end -->
