### PR TITLE
Do not check return type for set accessors since they don't have one.

### DIFF
--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -104,7 +104,10 @@ class TypedefWalker extends Lint.RuleWalker {
 
     private handleCallSignature(node: ts.FunctionLikeDeclaration) {
         var location = (node.parameters != null) ? node.parameters.end : null;
-        this.checkTypeAnnotation("call-signature", location, node.type, node.name);
+        // Set accessors don't have a return type.
+        if (node.kind !== ts.SyntaxKind.SetAccessor) {
+            this.checkTypeAnnotation("call-signature", location, node.type, node.name);
+        }
     }
 
     private checkTypeAnnotation(option: string,

--- a/test/files/rules/typedef.test.ts
+++ b/test/files/rules/typedef.test.ts
@@ -57,3 +57,8 @@ function anotherNoTypesFn(a, b) {
 function forInFn(): void {
     for (var p in []) {}
 }
+
+class NoReturnTypeForSetAccessor {
+    set name(value: string) {
+    }
+}


### PR DESCRIPTION
This change prevents tslint from reporting a defect for the absence of a return type in a set accessor signature.