### PR TITLE
Oneline rule: allow exception for multiline expression.

### DIFF
--- a/test/files/rules/oneline.test.ts
+++ b/test/files/rules/oneline.test.ts
@@ -65,3 +65,40 @@ function f():
 
     return 5;
 }
+
+if (cond1 &&
+    cond2)
+ {
+    i++;
+ }
+
+ if (cond1 &&
+     cond2)
+{
+    i++;
+}
+
+// valid
+if (cond1 &&
+    cond2 &&
+    cond3)
+{
+    i++;
+}
+
+// valid
+while (cond1 &&
+       cond2)
+{
+    count++;
+}
+
+// valid
+for (var i = 0;
+     i < length;
+     i++)
+{
+    count++;
+}
+     
+

--- a/test/rules/oneLineRuleTests.ts
+++ b/test/rules/oneLineRuleTests.ts
@@ -28,7 +28,7 @@ describe("<one-line>", () => {
     before(() => {
         var options = [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"];
         actualFailures = Lint.Test.applyRuleOnFile(fileName, OneLineRule, options);
-        assert.lengthOf(actualFailures, 13);
+        assert.lengthOf(actualFailures, 15);
     });
 
     it("enforces rules only when enabled", () => {
@@ -100,4 +100,15 @@ describe("<one-line>", () => {
         var expectedFailure = Lint.Test.createFailure(fileName, [59, 14], [59, 15], whitespaceFailure);
         Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
     });
+
+    it("enforces vertical alignment of if and brace", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [71, 2], [71, 3], braceFailure);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
+    it("enforces vertical alignment of if and brace", () => {
+        var expectedFailure = Lint.Test.createFailure(fileName, [77, 1], [77, 2], braceFailure);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
+    });
+
 });


### PR DESCRIPTION
This is a change to the one-line rule that fits the coding style standard at my work place.
I don't think it is an uncommon pattern since it is the second company where I have seen this. So, here it is in case you want to integrate it in tslint in some way.

For an 'if', 'while' or 'for' statement when the expression spans over multiple lines it may be difficult to see where the expression ends. For example with an 'if' statement and a 4 space identation the expression and the 'then' statements are aligned. Example:

if (cond1 &&
    cond2 &&
    cond3 &&) {
    blah;
}

In this situation it is desirable to tolerate the placement of the opening brace on a different line aligned with the start of the statement:

if (cond1 &&
    cond2 &&
    cond3 &&) 
{
    foo();
}

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/335)
<!-- Reviewable:end -->
