### PR TITLE
Added rule to enforce vertical alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Supported Rules
 
 A sample configuration file with all options is available [here](https://github.com/palantir/tslint/blob/master/docs/sample.tslint.json).
 
+* `align` enforces vertical alignment. Rule options:
+  * `"parameters"` checks alignment of function parameters.
+  * `"arguments"` checks alignment of function call arguments.
+  * `"statements"` checks alignment of statements.
 * `ban` bans the use of specific functions. Options are ["object", "function"] pairs that ban the use of object.function()
 * `class-name` enforces PascalCased class and interface names.
 * `comment-format` enforces rules for single-line comments. Rule options:

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -1,5 +1,9 @@
 {
   "rules": {
+  "align": [true,
+        "parameters",
+        "arguments",
+        "statements"],
     "ban": false,
     "class-name": true,
     "comment-format": [true,

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING_SUFFIX = " are not aligned";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        var alignWalker = new AlignWalker(sourceFile, this.getOptions());
+        return this.applyWithWalker(alignWalker);
+    }
+}
+
+type SourcePosition = {
+    line: number;
+    character: number;
+}
+
+class AlignWalker extends Lint.RuleWalker {
+    public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
+        this.checkParameters(node.parameters);
+        super.visitFunctionDeclaration(node);
+    }
+
+    public visitFunctionExpression(node: ts.FunctionExpression) {
+        this.checkParameters(node.parameters);
+        super.visitFunctionExpression(node);
+    }
+
+    public visitCallExpression(node: ts.CallExpression) {
+        this.checkArguments(node.arguments);
+        super.visitCallExpression(node);
+    }
+
+    public visitBlock(node: ts.Block) {
+        this.checkStatements(node.statements);
+        super.visitBlock(node);
+    }
+
+    private checkParameters(parameters: ts.Node[]) {
+        this.checkAlignment("parameters", parameters);
+    }
+
+    private checkArguments(arguments: ts.Node[]) {
+        this.checkAlignment("arguments", arguments);
+    }
+
+    private checkStatements(statements: ts.Node[]) {
+        this.checkAlignment("statements", statements);
+    }
+
+    private checkAlignment(kind: string, nodes: ts.Node[]) {
+        if (nodes.length === 0 || !this.hasOption(kind)) {
+            return;
+        }
+        var prevPos = this.getPosition(nodes[0]);
+        var alignToColumn = prevPos.character;
+        for (var index = 1; index < nodes.length; index++) {
+            var node = nodes[index];
+            var curPos = this.getPosition(node);
+            if (curPos.line !== prevPos.line && curPos.character !== alignToColumn) {
+                this.addFailure(this.createFailure(node.getStart(),
+                                                   node.getWidth(),
+                                                   kind + Rule.FAILURE_STRING_SUFFIX));
+                break; // exit loop.
+            }
+            prevPos = curPos;
+        }
+    }
+
+    private getPosition(node: ts.Node): SourcePosition {
+        return node.getSourceFile().getLineAndCharacterFromPosition(node.getStart());
+    }
+}

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -15,6 +15,10 @@
 */
 
 export class Rule extends Lint.Rules.AbstractRule {
+    public static PARAMETERS_OPTION = "parameters";
+    public static ARGUMENTS_OPTION = "arguments";
+    public static STATEMENTS_OPTION = "statements";
+
     public static FAILURE_STRING_SUFFIX = " are not aligned";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -30,35 +34,23 @@ type SourcePosition = {
 
 class AlignWalker extends Lint.RuleWalker {
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-        this.checkParameters(node.parameters);
+        this.checkAlignment(Rule.PARAMETERS_OPTION, node.parameters);
         super.visitFunctionDeclaration(node);
     }
 
     public visitFunctionExpression(node: ts.FunctionExpression) {
-        this.checkParameters(node.parameters);
+        this.checkAlignment(Rule.PARAMETERS_OPTION, node.parameters);
         super.visitFunctionExpression(node);
     }
 
     public visitCallExpression(node: ts.CallExpression) {
-        this.checkArguments(node.arguments);
+        this.checkAlignment(Rule.ARGUMENTS_OPTION, node.arguments);
         super.visitCallExpression(node);
     }
 
     public visitBlock(node: ts.Block) {
-        this.checkStatements(node.statements);
+        this.checkAlignment(Rule.STATEMENTS_OPTION, node.statements);
         super.visitBlock(node);
-    }
-
-    private checkParameters(parameters: ts.Node[]) {
-        this.checkAlignment("parameters", parameters);
-    }
-
-    private checkArguments(arguments: ts.Node[]) {
-        this.checkAlignment("arguments", arguments);
-    }
-
-    private checkStatements(statements: ts.Node[]) {
-        this.checkAlignment("statements", statements);
     }
 
     private checkAlignment(kind: string, nodes: ts.Node[]) {

--- a/test/files/rules/align.test.ts
+++ b/test/files/rules/align.test.ts
@@ -1,0 +1,135 @@
+function invalidParametersAlignment1(a: number,
+b: number) {
+    var i = 0;
+}
+
+function invalidParametersAlignment2(a: number, b: number,
+c: number) {
+    var i = 0;
+}
+
+function invalidParametersAlignment3(a: number,
+                             b: number,
+                           c: number) {
+    var i = 0;
+}
+
+class C1 {
+    function invalidParametersAlignment(a: number,
+                           b: number)
+    {
+    }
+}
+
+class InvalidAlignmentInConstructor {
+    function constructor(a: number,
+                                 str: string)
+    {
+    }
+}
+
+var invalidParametersAlignment4 = function(xxx: foo,
+                              yyy: bar) { return true; }
+
+function validParametersAlignment1(a: number, b: number) {
+    var i = 0;
+}
+
+function validParametersAlignment2(a: number, b: number,
+                                   c: number) {
+    var i = 0;
+}
+
+function validParametersAlignment3(a: number,
+                                   b: number,
+                                   c: number) {
+    var i = 0;
+}
+
+function validParametersAlignment4(
+      a: number,
+      b: number,
+      c: number) {
+    var i = 0;
+}
+
+var validParametersAlignment6 = function(xxx: foo,
+                                         yyy: bar) { return true; }
+
+
+///////
+
+void invalidArgumentsAlignment1()
+{
+    f(10,
+    'abcd', 0);
+}
+
+void invalidArgumentsAlignment2()
+{
+    f(10,
+      'abcd',
+        0);
+}
+
+void validArgumentsAlignment1()
+{
+    f(101, 'xyz', 'abc');
+}
+
+void validArgumentsAlignment2()
+{
+    f(1,
+      2,
+      3,
+      4);
+}
+
+void validArgumentsAlignment3()
+{
+    f(
+        1,
+        2,
+        3,
+        4);
+}
+
+void validArgumentsAlignment3()
+{
+    f(1, 2,
+      3, 4);
+}
+
+////////
+
+void invalidStatementsAlignment1()
+{
+    var i = 0;
+    var j = 0;
+     var k = 1;
+}
+
+void invalidStatementsAlignment1()
+{
+    var i = 0;
+    {
+        var j = 0;
+       var k = 1;
+    }
+}
+
+void validStatementsAlignment1()
+{
+    var i = 0;
+    var j = 0;
+    var k = 1;
+}
+
+void validStatementsAlignment2()
+{
+    var i = 0;
+    {
+        var j = 0;
+        var k = 1;
+    }
+}

--- a/test/rules/alignRuleTests.ts
+++ b/test/rules/alignRuleTests.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+///<reference path='../references.ts' />
+
+describe("<align, enabled>", () => {
+
+    it("ensures that parameters in function signatures are aligned", () => {
+        var fileName = "rules/align.test.ts";
+        var AlignRule = Lint.Test.getRule("align");
+        var options = [true, "parameters"];
+        var failureString = "parameters" + AlignRule.FAILURE_STRING_SUFFIX;
+        var failure = Lint.Test.createFailuresOnFile(fileName, failureString);
+        var expectedFailures = [
+            failure([2, 1], [2, 10]),
+            failure([7, 1], [7, 10]),
+            failure([12, 30], [12, 39]),
+            failure([19, 28], [19, 37]),
+            failure([26, 34], [26, 45]),
+            failure([32, 31], [32, 39])
+        ];
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, AlignRule, options);
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
+    });
+
+    it("ensures that arguments in function calls are aligned", () => {
+        var fileName = "rules/align.test.ts";
+        var AlignRule = Lint.Test.getRule("align");
+        var options = [true, "arguments"];
+        var failureString = "arguments" + AlignRule.FAILURE_STRING_SUFFIX;
+        var failure = Lint.Test.createFailuresOnFile(fileName, failureString);
+        var expectedFailures = [
+            failure([65, 5], [65, 11]),
+            failure([72, 9], [72, 10])
+        ];
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, AlignRule, options);
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
+    });
+
+    it("ensures that statements at the same nesting level are aligned", () => {
+        var fileName = "rules/align.test.ts";
+        var AlignRule = Lint.Test.getRule("align");
+        var options = [true, "statements"];
+        var failureString = "statements" + AlignRule.FAILURE_STRING_SUFFIX;
+        var failure = Lint.Test.createFailuresOnFile(fileName, failureString);
+        var expectedFailures = [
+            failure([109, 6], [109, 16]),
+            failure([117, 8], [117, 18])
+        ];
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, AlignRule, options);
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
+    });
+});
+

--- a/test/rules/alignRuleTests.ts
+++ b/test/rules/alignRuleTests.ts
@@ -21,8 +21,8 @@ describe("<align, enabled>", () => {
     it("ensures that parameters in function signatures are aligned", () => {
         var fileName = "rules/align.test.ts";
         var AlignRule = Lint.Test.getRule("align");
-        var options = [true, "parameters"];
-        var failureString = "parameters" + AlignRule.FAILURE_STRING_SUFFIX;
+        var options = [true, AlignRule.PARAMETERS_OPTION];
+        var failureString = AlignRule.PARAMETERS_OPTION + AlignRule.FAILURE_STRING_SUFFIX;
         var failure = Lint.Test.createFailuresOnFile(fileName, failureString);
         var expectedFailures = [
             failure([2, 1], [2, 10]),
@@ -39,8 +39,8 @@ describe("<align, enabled>", () => {
     it("ensures that arguments in function calls are aligned", () => {
         var fileName = "rules/align.test.ts";
         var AlignRule = Lint.Test.getRule("align");
-        var options = [true, "arguments"];
-        var failureString = "arguments" + AlignRule.FAILURE_STRING_SUFFIX;
+        var options = [true, AlignRule.ARGUMENTS_OPTION];
+        var failureString = AlignRule.ARGUMENTS_OPTION + AlignRule.FAILURE_STRING_SUFFIX;
         var failure = Lint.Test.createFailuresOnFile(fileName, failureString);
         var expectedFailures = [
             failure([65, 5], [65, 11]),
@@ -53,8 +53,8 @@ describe("<align, enabled>", () => {
     it("ensures that statements at the same nesting level are aligned", () => {
         var fileName = "rules/align.test.ts";
         var AlignRule = Lint.Test.getRule("align");
-        var options = [true, "statements"];
-        var failureString = "statements" + AlignRule.FAILURE_STRING_SUFFIX;
+        var options = [true, AlignRule.STATEMENTS_OPTION];
+        var failureString = AlignRule.STATEMENTS_OPTION + AlignRule.FAILURE_STRING_SUFFIX;
         var failure = Lint.Test.createFailuresOnFile(fileName, failureString);
         var expectedFailures = [
             failure([109, 6], [109, 16]),


### PR DESCRIPTION
This is a new rule that checks for vertical alignment for one of the three options: "parameters", "arguments" and "statements".