### PR TITLE
Added rule for enforcing 'default' case in 'switch' statement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ A sample configuration file with all options is available [here](https://github.
 * `quotemark` enforces consistent single or double quoted string literals.
 * `radix` enforces the radix parameter of `parseInt`
 * `semicolon` enforces semicolons at the end of every statement.
+* `switch-default` enforces a `default` case in `switch` statements.
 * `triple-equals` enforces === and !== in favor of == and !=.
 * `typedef` enforces type definitions to exist. Rule options:
     * `"call-signature"` checks return type of functions

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -58,6 +58,7 @@
     "quotemark": [true, "double"],
     "radix": true,
     "semicolon": true,
+    "switch-default": true,
     "triple-equals": [true, "allow-null-check"],
     "typedef": [true,
         "call-signature",

--- a/src/rules/switchDefaultRule.ts
+++ b/src/rules/switchDefaultRule.ts
@@ -25,13 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 export class SwitchDefaultWalker extends Lint.RuleWalker {
 
     public visitSwitchStatement(node: ts.SwitchStatement) {
-        var hasDefaultCase = false;
-        var switchClauses = node.clauses;
-        switchClauses.forEach((child, i) => {
-            if (child.kind === ts.SyntaxKind.DefaultClause) {
-                hasDefaultCase = true;
-            }
-        });
+        var hasDefaultCase = node.clauses.some((clause) =>
+                                               clause.kind === ts.SyntaxKind.DefaultClause);
         if (!hasDefaultCase) {
             this.addFailure(this.createFailure(node.getStart(),
                                                node.getWidth(),

--- a/src/rules/switchDefaultRule.ts
+++ b/src/rules/switchDefaultRule.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "Switch statement doesn't include a 'default' case";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new SwitchDefaultWalker(sourceFile, this.getOptions()));
+    }
+}
+
+export class SwitchDefaultWalker extends Lint.RuleWalker {
+
+    public visitSwitchStatement(node: ts.SwitchStatement) {
+        var hasDefaultCase = false;
+        var switchClauses = node.clauses;
+        switchClauses.forEach((child, i) => {
+            if (child.kind === ts.SyntaxKind.DefaultClause) {
+                hasDefaultCase = true;
+            }
+        });
+        if (!hasDefaultCase) {
+            this.addFailure(this.createFailure(node.getStart(),
+                                               node.getWidth(),
+                                               Rule.FAILURE_STRING));
+        }
+        super.visitSwitchStatement(node);
+    }
+}

--- a/src/rules/switchDefaultRule.ts
+++ b/src/rules/switchDefaultRule.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Palantir Technologies, Inc.
+ * Copyright 2015 Palantir Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 */
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "Switch statement doesn't include a 'default' case";
+    public static FAILURE_STRING = "switch statement doesn't include a 'default' case";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new SwitchDefaultWalker(sourceFile, this.getOptions()));

--- a/test/files/rules/switchdefault.test.ts
+++ b/test/files/rules/switchdefault.test.ts
@@ -1,0 +1,49 @@
+
+switch (foo) {
+case 1:
+    bar();
+    break;
+}
+
+switch (foo) {
+case 1:
+    bar();
+    break;
+case 2:
+    bar();
+    break;
+case 3:
+    bar();
+    break;
+}
+
+// valid
+switch (foo) {
+case 1:
+    bar();
+    break;
+default:
+    break;
+}
+
+// valid
+switch (foo) {
+default:
+    bar();
+    break;
+case 1:
+    bar();
+    break;
+}
+
+// valid
+switch (foo) {
+case 1:
+    bar();
+    break;
+default:
+    break;
+case 2:
+    break;
+}
+

--- a/test/rules/switchDefaultRuleTests.ts
+++ b/test/rules/switchDefaultRuleTests.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/// <reference path='../references.ts' />
+
+describe("<switch-default>", () => {
+    it("Switch default", () => {
+        var fileName = "rules/switchdefault.test.ts";
+        var Rule = Lint.Test.getRule("switch-default");
+        var failureString = Rule.FAILURE_STRING;
+        var failure = Lint.Test.createFailuresOnFile(fileName, failureString);
+        var expectedFailures = [
+            failure([2, 1], [6, 2]),
+            failure([8, 1], [18, 2])
+        ];
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule);
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
+    });
+});

--- a/test/rules/switchDefaultRuleTests.ts
+++ b/test/rules/switchDefaultRuleTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Palantir Technologies, Inc.
+ * Copyright 2015 Palantir Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This new rule checks that a 'default' case is present in a 'switch'.
I made it a new rule but it could be an option of a "switch" rule with "no-switch-case-fall-through" made also an option of "switch". 