### PR TITLE
(bugfix) use strict statement should not always require semicolon #351

### DIFF
--- a/src/rules/useStrictRule.ts
+++ b/src/rules/useStrictRule.ts
@@ -69,13 +69,11 @@ class UseStrictWalker extends Lint.ScopeAwareRuleWalker<{}> {
         if (block.statements != null && block.statements.length > 0) {
             var firstStatement = block.statements[0];
 
-            if (firstStatement.kind === ts.SyntaxKind.ExpressionStatement && firstStatement.getChildCount() === 2) {
+            if (firstStatement.kind === ts.SyntaxKind.ExpressionStatement) {
                 var firstChild = firstStatement.getChildAt(0);
-                var secondChild = firstStatement.getChildAt(1);
 
                 if (firstChild.kind === ts.SyntaxKind.StringLiteral &&
-                        (<ts.StringLiteralExpression> firstChild).text === UseStrictWalker.USE_STRICT_STRING &&
-                        secondChild.kind === ts.SyntaxKind.SemicolonToken) {
+                        (<ts.StringLiteralExpression> firstChild).text === UseStrictWalker.USE_STRICT_STRING) {
                     isFailure = false;
                 }
             }

--- a/test/files/rules/semicolon.test.ts
+++ b/test/files/rules/semicolon.test.ts
@@ -31,3 +31,8 @@ import v = require("i")
 module M {
     export var x
 }
+
+function useStrictMissingSemicolon() {
+    "use strict"
+    return null;
+}

--- a/test/files/rules/usestrict.test.ts
+++ b/test/files/rules/usestrict.test.ts
@@ -47,3 +47,8 @@ declare module foo {
     export class bar {
     }
 }
+
+function shouldPassUseStrictRule(): string {
+    "use strict"
+    return "This is a test"
+}

--- a/test/rules/semicolonRuleTests.ts
+++ b/test/rules/semicolonRuleTests.ts
@@ -30,7 +30,7 @@ describe("<semicolon>", () => {
     });
 
     it("warns on all statements", () => {
-        assert.equal(actualFailures.length, 14);
+        assert.equal(actualFailures.length, 15);
     });
 
     it("warns on variable statements", () => {
@@ -72,5 +72,9 @@ describe("<semicolon>", () => {
     it("warns on import and export statements", () => {
         Lint.Test.assertContainsFailure(actualFailures, createFailure([30, 24], [30, 24]));
         Lint.Test.assertContainsFailure(actualFailures, createFailure([32, 17], [32, 17]));
+    });
+
+    it("warns on use strict statements", () => {
+        Lint.Test.assertContainsFailure(actualFailures, createFailure([36, 17], [36, 17]));
     });
 });


### PR DESCRIPTION
fixes #351 