### PR TITLE
Update grunt ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-mocha-test": "~0.6.2",
-    "grunt-ts": "~1.12.1",
+    "grunt-ts": "~4.1.0",
     "grunt-tslint": "~2.0.0",
     "typescript": "1.5.0-beta"
   },


### PR DESCRIPTION
I had an error in one of my (currently custom) rules but it wasn't working.
After some minutes testing I noticed a message from grunt-ts with the following:

> 1 non-emit-preventing type warning
> Type errors only.

So this PR updates grunt-ts so that it is an error now because of the `failontypeerrors` options (seems that the default has the right value)
https://github.com/TypeStrong/grunt-ts#grunt-ts-gruntfilejs-options

Feel free to close if this isn't something you want at this point :)

Edit: oops, let me rebase this... one commit shouldn't be here :( **done**

To clarify, after this PR errors like calling a method with invalid parameters is an error (which is not the case currently)