### PR TITLE
Don't check `declared` vars in the unused-variable-rule

### DIFF
--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -93,9 +93,10 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
         this.skipParameterDeclaration = false;
     }
 
-    // skip exported variables
+    // skip exported and declared variables
     public visitVariableStatement(node: ts.VariableStatement): void {
-        if (this.hasModifier(node.modifiers, ts.SyntaxKind.ExportKeyword)) {
+        if (this.hasModifier(node.modifiers, ts.SyntaxKind.ExportKeyword)
+            || this.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)) {
             this.skipVariableDeclaration = true;
         }
 

--- a/test/files/rules/nounusedvariable-var.test.ts
+++ b/test/files/rules/nounusedvariable-var.test.ts
@@ -16,3 +16,5 @@ try {
 } catch (e) {
   // e is unused but that's still ok
 }
+
+declare var tmp: any;


### PR DESCRIPTION
fix #190 
`declare var x: any;`

^^ Above code isn't an error anymore wen x isn't used