### PR TITLE
Update noEmptyRule for AccessModifier

### DIFF
--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -52,9 +52,8 @@ class BlockWalker extends Lint.RuleWalker {
             for (var j = 0; param.modifiers != null && j < param.modifiers.length; j++) {
                 var modifier = param.modifiers[j].kind;
 
-                if (modifier === ts.SyntaxKind.PublicKeyword || modifier === ts.SyntaxKind.PrivateKeyword) {
+                if (this.isAccessModifier(param.modifiers[j].kind)) {
                     isSkipped = true;
-
                     this.ignoredBlocks.push(node.body);
 
                     break;
@@ -67,5 +66,18 @@ class BlockWalker extends Lint.RuleWalker {
         }
 
         super.visitConstructorDeclaration(node);
+    }
+
+    private isAccessModifier(modifier: string): boolean {
+        if (modifier === ts.SyntaxKind.PrivateKeyword) {
+            return true;
+        }
+        if (modifier === ts.SyntaxKind.ProtectedKeyword) {
+            return true;
+        }
+        if (modifier === ts.SyntaxKind.PublicKeyword) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -69,8 +69,8 @@ class BlockWalker extends Lint.RuleWalker {
     }
 
     private isPropertyAccessModifier(modifier: string): boolean {
-        return modifier === ts.SyntaxKind.PrivateKeyword ||
-            modifier === ts.SyntaxKind.ProtectedKeyword ||
-            modifier === ts.SyntaxKind.PublicKeyword;
+        return modifier === ts.SyntaxKind.PrivateKeyword
+            || modifier === ts.SyntaxKind.ProtectedKeyword
+            || modifier === ts.SyntaxKind.PublicKeyword;
     }
 }

--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -52,7 +52,7 @@ class BlockWalker extends Lint.RuleWalker {
             for (var j = 0; param.modifiers != null && j < param.modifiers.length; j++) {
                 var modifier = param.modifiers[j].kind;
 
-                if (this.isAccessModifier(param.modifiers[j].kind)) {
+                if (this.isPropertyAccessModifier(param.modifiers[j].kind)) {
                     isSkipped = true;
                     this.ignoredBlocks.push(node.body);
 
@@ -68,16 +68,9 @@ class BlockWalker extends Lint.RuleWalker {
         super.visitConstructorDeclaration(node);
     }
 
-    private isAccessModifier(modifier: string): boolean {
-        if (modifier === ts.SyntaxKind.PrivateKeyword) {
-            return true;
-        }
-        if (modifier === ts.SyntaxKind.ProtectedKeyword) {
-            return true;
-        }
-        if (modifier === ts.SyntaxKind.PublicKeyword) {
-            return true;
-        }
-        return false;
+    private isPropertyAccessModifier(modifier: string): boolean {
+        return modifier === ts.SyntaxKind.PrivateKeyword ||
+            modifier === ts.SyntaxKind.ProtectedKeyword ||
+            modifier === ts.SyntaxKind.PublicKeyword;
     }
 }

--- a/test/files/rules/noempty.test.ts
+++ b/test/files/rules/noempty.test.ts
@@ -21,6 +21,11 @@ class testClass {
 }
 
 class testClass2 {
+    constructor(protected allowed: any) {
+    }
+}
+
+class testClass3 {
     constructor(notAllowed: any) {
     }
 }

--- a/test/rules/noEmptyRuleTests.ts
+++ b/test/rules/noEmptyRuleTests.ts
@@ -45,7 +45,7 @@ describe("<no-empty>", () => {
     });
 
     it("forbids empty constructors", () => {
-        var expectedFailure = createFailure([24, 34], [25, 6]);
+        var expectedFailure = createFailure([29, 34], [30, 6]);
         Lint.Test.assertContainsFailure(actualFailures, expectedFailure);
     });
 


### PR DESCRIPTION
## Update noEmptyRule.

```typescript
class testClass {
    constructor(protected allowed: any) {
    }
}
```
^^
Access modifier : `protected`
is not allowed to have empty blocks.
So I created function : `isAccessModifier(modifier: string)`. 
As a result, empty blocks will be ignored when using `protected` .

## Versions
- tslint
2.2.0-beta

- typescript
1.5.0

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/402)
<!-- Reviewable:end -->
