### PR TITLE
Fix issue #324 windows line endings not respected

### DIFF
--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -45,7 +45,10 @@ class JsdocWalker extends Lint.SkippableTokenAwareRuleWalker {
 
     private findFailuresForJsdocComment(commentText: string, startingPosition: number, sourceFile: ts.SourceFile) {
         var currentPosition = startingPosition;
-        var lines = commentText.split("\n");
+        // the file may be different depending on the OS it was originally authored on
+        // can't rely on require('os').EOL or process.platform as that is the execution env
+        // regex is: split optionally on \r\n, but alwasy split on \n if no \r exists
+        var lines = commentText.split(/\r?\n/);
         var jsdocPosition = currentPosition;
         var firstLine = lines[0];
 

--- a/test/files/rules/jsdoc-windows.test.ts
+++ b/test/files/rules/jsdoc-windows.test.ts
@@ -1,0 +1,10 @@
+/**
+ * MyClass
+ *
+ * Does classy things and impresses everyone. Quite a debonair class indeed.
+ *
+ * This file has all windows line endings "\r\n" and valid jsdoc.
+ */
+class MyClass {
+   
+}

--- a/test/rules/jsdocFormatRuleTests.ts
+++ b/test/rules/jsdocFormatRuleTests.ts
@@ -42,4 +42,10 @@ describe("<jsdoc-format>", () => {
         Lint.Test.assertContainsFailure(actualFailures, expectedFailure7);
         assert.lengthOf(actualFailures, 7);
     });
+
+    it("ensures jsdoc commments can have have windows line endings", () => {
+        var fileName = "rules/jsdoc-windows.test.ts";
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, JsdocFormatRule);
+        assert.lengthOf(actualFailures, 0);
+    });
 });


### PR DESCRIPTION
I came across this issue today as I was putting tslint rules into place on our code base. All of our development occurs on windows, and I was surprised to see so many jsdoc formatting errors. I dug in and found that #324 exactly described what was happening.

After digging further I found that the `jsdocFormatRule` did not support windows line endings! How funny for a TypeScript library I thought :)

I've gone ahead and implemented a fix. The reason I'm solving this with a regular expression and not detecting the host OS with `require('os').EOL` or `process.platform`, is because the line ending is dependent on where the file was originally authored, not where tslint is running.

Let me know if you would like me to update any comments, test, code for this PR.

Cheers!
