### PR TITLE
Added rule to sort object literal keys alphabetically

### DIFF
--- a/src/rules/sortObjectLiteralKeysRule.ts
+++ b/src/rules/sortObjectLiteralKeysRule.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "unsorted key '";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new SortedKeyWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class SortedKeyWalker extends Lint.RuleWalker {
+    private lastSortedKeyStack: string[] = [];
+    private sortedStateStack: boolean[] = [];
+
+    public visitObjectLiteralExpression(node: ts.ObjectLiteralExpression): void {
+        this.lastSortedKeyStack.push(""); // Char code 0; every string should be >= to this
+        this.sortedStateStack.push(true); // Sorted state is always initially true
+        super.visitObjectLiteralExpression(node);
+        this.lastSortedKeyStack.pop();
+        this.sortedStateStack.pop();
+    }
+
+    public visitPropertyAssignment(node: ts.PropertyAssignment): void {
+        var sortedState = this.sortedStateStack[this.sortedStateStack.length - 1];
+        if (sortedState) {
+            var lastSortedKey = this.lastSortedKeyStack[this.lastSortedKeyStack.length - 1];
+            var keyNode = node.name;
+            if (keyNode.kind === ts.SyntaxKind.Identifier) {
+                var key = (<ts.Identifier> keyNode).text;
+                if (key < lastSortedKey) {
+                    var failureString = Rule.FAILURE_STRING + key + "'";
+                    this.addFailure(this.createFailure(keyNode.getStart(), keyNode.getWidth(), failureString));
+                    this.sortedStateStack[this.sortedStateStack.length - 1] = false;
+                } else {
+                    this.lastSortedKeyStack[this.lastSortedKeyStack.length - 1] = key;
+                }
+            }
+        }
+        super.visitPropertyAssignment(node);
+    }
+}

--- a/test/files/rules/sortedkey.test.ts
+++ b/test/files/rules/sortedkey.test.ts
@@ -38,24 +38,42 @@ var failC = {
     }
 };
 
-var passD = {};
+var passD = {
+    a: 1,
+    b: {
+        aa: 1,
+        bb: 2
+    },
+    c: 3
+};
 
-var passE = {
+var failD = {
+    a: 1,
+    c: {
+        aa: 1,
+        bb: 2
+    },
+    b: 3
+};
+
+var passE = {};
+
+var passF = {
     asdf: [1, 2, 3],
     sdfa: {}
 };
 
-var failE = {
+var failF = {
     sdfa: {},
     asdf: [1, 2, 3]
 };
 
-var passF = {
+var passG = {
     asdfn: function () {},
     sdafn: function () {}
 };
 
-var failF = {
+var failG = {
     sdafn: function () {},
     asdfn: function () {}
 };

--- a/test/files/rules/sortedkey.test.ts
+++ b/test/files/rules/sortedkey.test.ts
@@ -1,0 +1,61 @@
+var passA = {
+    a: 1,
+    b: 2
+};
+
+var failA = {
+    b: 1,
+    a: 2
+};
+
+var passB = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4
+};
+
+var failB = {
+    c: 3,
+    a: 1,
+    b: 2,
+    d: 4
+};
+
+var passC = {
+    a: 1,
+    b: {
+        aa: 1,
+        bb: 2
+    }
+};
+
+var failC = {
+    a: 1,
+    b: {
+        bb: 2,
+        aa: 1
+    }
+};
+
+var passD = {};
+
+var passE = {
+    asdf: [1, 2, 3],
+    sdfa: {}
+};
+
+var failE = {
+    sdfa: {},
+    asdf: [1, 2, 3]
+};
+
+var passF = {
+    asdfn: function () {},
+    sdafn: function () {}
+};
+
+var failF = {
+    sdafn: function () {},
+    asdfn: function () {}
+};

--- a/test/rules/sortObjectLiteralKeysRuleTests.ts
+++ b/test/rules/sortObjectLiteralKeysRuleTests.ts
@@ -16,22 +16,24 @@
 
 describe("<sort-object-literal-keys>", () => {
     it("forbids unsorted keys in object literals", () => {
-        var fileName = "rules/sortedkey.test.ts";
-        var SortedKeyRule = Lint.Test.getRule("sort-object-literal-keys");
-        var failureString = SortedKeyRule.FAILURE_STRING;
+        const fileName = "rules/sortedkey.test.ts";
+        const SortedKeyRule = Lint.Test.getRule("sort-object-literal-keys");
+        const failureString = SortedKeyRule.FAILURE_STRING;
 
-        var actualFailures = Lint.Test.applyRuleOnFile(fileName, SortedKeyRule);
-        var createFailure1 = Lint.Test.createFailuresOnFile(fileName, failureString + "a'");
-        var createFailure2 = Lint.Test.createFailuresOnFile(fileName, failureString + "a'");
-        var createFailure3 = Lint.Test.createFailuresOnFile(fileName, failureString + "aa'");
-        var createFailure4 = Lint.Test.createFailuresOnFile(fileName, failureString + "asdf'");
-        var createFailure5 = Lint.Test.createFailuresOnFile(fileName, failureString + "asdfn'");
-        var expectedFailures = [
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, SortedKeyRule);
+        const createFailure1 = Lint.Test.createFailuresOnFile(fileName, failureString + "a'");
+        const createFailure2 = Lint.Test.createFailuresOnFile(fileName, failureString + "a'");
+        const createFailure3 = Lint.Test.createFailuresOnFile(fileName, failureString + "aa'");
+        const createFailure4 = Lint.Test.createFailuresOnFile(fileName, failureString + "b'");
+        const createFailure5 = Lint.Test.createFailuresOnFile(fileName, failureString + "asdf'");
+        const createFailure6 = Lint.Test.createFailuresOnFile(fileName, failureString + "asdfn'");
+        const expectedFailures = [
             createFailure1([8, 5], [8, 6]),
             createFailure2([20, 5], [20, 6]),
             createFailure3([37, 9], [37, 11]),
-            createFailure4([50, 5], [50, 9]),
-            createFailure5([60, 5], [60, 10])
+            createFailure4([56, 5], [56, 6]),
+            createFailure5([68, 5], [68, 9]),
+            createFailure6([78, 5], [78, 10])
         ];
 
         Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);

--- a/test/rules/sortObjectLiteralKeysRuleTests.ts
+++ b/test/rules/sortObjectLiteralKeysRuleTests.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("<sort-object-literal-keys>", () => {
+    it("forbids unsorted keys in object literals", () => {
+        var fileName = "rules/sortedkey.test.ts";
+        var SortedKeyRule = Lint.Test.getRule("sort-object-literal-keys");
+        var failureString = SortedKeyRule.FAILURE_STRING;
+
+        var actualFailures = Lint.Test.applyRuleOnFile(fileName, SortedKeyRule);
+        var createFailure1 = Lint.Test.createFailuresOnFile(fileName, failureString + "a'");
+        var createFailure2 = Lint.Test.createFailuresOnFile(fileName, failureString + "a'");
+        var createFailure3 = Lint.Test.createFailuresOnFile(fileName, failureString + "aa'");
+        var createFailure4 = Lint.Test.createFailuresOnFile(fileName, failureString + "asdf'");
+        var createFailure5 = Lint.Test.createFailuresOnFile(fileName, failureString + "asdfn'");
+        var expectedFailures = [
+            createFailure1([8, 5], [8, 6]),
+            createFailure2([20, 5], [20, 6]),
+            createFailure3([37, 9], [37, 11]),
+            createFailure4([50, 5], [50, 9]),
+            createFailure5([60, 5], [60, 10])
+        ];
+
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
+    });
+});


### PR DESCRIPTION
This rule lints an object literal's keys and validates that the user has declared them in alphabetical order. 