### PR TITLE
Fix error when no default configuration exists

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -45,7 +45,7 @@ module Lint.Configuration {
         }
 
         var defaultPath = path.join(homeDir, CONFIG_FILENAME);
-        if (!fs.existsSync(defaultPath)) defaultPath = undefined;
+        if (!fs.existsSync(defaultPath)) { defaultPath = undefined; }
 
         configFile = findup(CONFIG_FILENAME, { cwd: inputFileLocation, nocase: true }) || defaultPath;
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -45,6 +45,7 @@ module Lint.Configuration {
         }
 
         var defaultPath = path.join(homeDir, CONFIG_FILENAME);
+        if (!fs.existsSync(defaultPath)) defaultPath = undefined;
 
         configFile = findup(CONFIG_FILENAME, { cwd: inputFileLocation, nocase: true }) || defaultPath;
 


### PR DESCRIPTION
Will now return undefined for getConfiguration calls.

I was using tslint programatically in http://www.bithound.io/ I have a case where I want to check if the user has a default config in their repo. My servers do not have a default config in the home dir. This fixes that.