### PR TITLE
Spread tests

### DIFF
--- a/test/files/rules/nounusedvariable-var.test.ts
+++ b/test/files/rules/nounusedvariable-var.test.ts
@@ -30,3 +30,12 @@ export function testDestructuring() {
 }
 
 export var [foo, bar] = [1, 2];
+
+export function testUnusedSpread() {
+  var a = [1, 2]; // 1 failure
+  var b = [3, 4];
+  var c = [...b, 5]; // make sure we see that b is being used
+
+  return c;
+
+}

--- a/test/files/rules/typedef.test.ts
+++ b/test/files/rules/typedef.test.ts
@@ -58,6 +58,10 @@ function forInFn(): void {
     for (var p in []) {}
 }
 
+function spreadFunction(...n) : number {
+  return ns[0];
+}
+
 class NoReturnTypeForSetAccessor {
     set name(value: string) {
     }

--- a/test/files/rules/varname.test.ts
+++ b/test/files/rules/varname.test.ts
@@ -21,8 +21,12 @@ export function functionWithInvalidParamNames (bad_name, AnotherOne) { // 2 fail
 }
 
 let { foo, bar } = { foo: 1, bar: 2 };
-let [ InvalidFoo, invalid_bar ] =  [1, 2]; // 2 failures
+let [ InvalidFoo, invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 3 failures
 
 export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 2 failures
     //
+}
+
+export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
+  //
 }

--- a/test/rules/noUnusedVariableRuleTests.ts
+++ b/test/rules/noUnusedVariableRuleTests.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-describe.only("<no-unused-variable>", () => {
+describe("<no-unused-variable>", () => {
     it("restricts unused imports", () => {
         var fileName = "rules/nounusedvariable-imports.test.ts";
         var Rule = Lint.Test.getRule("no-unused-variable");

--- a/test/rules/noUnusedVariableRuleTests.ts
+++ b/test/rules/noUnusedVariableRuleTests.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-describe("<no-unused-variable>", () => {
+describe.only("<no-unused-variable>", () => {
     it("restricts unused imports", () => {
         var fileName = "rules/nounusedvariable-imports.test.ts";
         var Rule = Lint.Test.getRule("no-unused-variable");
@@ -42,15 +42,17 @@ describe("<no-unused-variable>", () => {
         var failure3 = Lint.Test.createFailuresOnFile(fileName, Rule.FAILURE_STRING + "'b'")([23, 13], [23, 14]);
         var failure4 = Lint.Test.createFailuresOnFile(fileName, Rule.FAILURE_STRING + "'d'")([26, 10], [26, 11]);
         var failure5 = Lint.Test.createFailuresOnFile(fileName, Rule.FAILURE_STRING + "'e'")([26, 13], [26, 14]);
+        var failure6 = Lint.Test.createFailuresOnFile(fileName, Rule.FAILURE_STRING + "'a'")([35, 7] , [35, 8 ]);
 
         var actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule);
 
-        assert.lengthOf(actualFailures, 5);
+        assert.lengthOf(actualFailures, 6);
         Lint.Test.assertContainsFailure(actualFailures, failure1);
         Lint.Test.assertContainsFailure(actualFailures, failure2);
         Lint.Test.assertContainsFailure(actualFailures, failure3);
         Lint.Test.assertContainsFailure(actualFailures, failure4);
         Lint.Test.assertContainsFailure(actualFailures, failure5);
+        Lint.Test.assertContainsFailure(actualFailures, failure6);
     });
 
     it("restricts unused functions", () => {

--- a/test/rules/typedefRuleTests.ts
+++ b/test/rules/typedefRuleTests.ts
@@ -30,7 +30,7 @@ describe("<typedef, not enabled>", () => {
     });
 });
 
-describe("<typedef, enabled>", () => {
+describe.only("<typedef, enabled>", () => {
     const fileName = "rules/typedef.test.ts";
     const TypedefRule = Lint.Test.getRule("typedef");
     let actualFailures: Lint.RuleFailure[];
@@ -112,8 +112,12 @@ describe("<typedef, enabled>", () => {
             [53, 31],
             [53, 32],
             "expected parameter: 'b' to have a typedef");
+        const expectedFailure6 = Lint.Test.createFailure(fileName,
+              [61, 29],
+              [61, 30],
+              "expected parameter: 'n' to have a typedef");
 
-        assertFailures(expectedFailure1, expectedFailure2, expectedFailure3, expectedFailure4, expectedFailure5);
+        assertFailures(expectedFailure1, expectedFailure2, expectedFailure3, expectedFailure4, expectedFailure5, expectedFailure6);
     });
 
     it("enforces typedef in property declaration", () => {

--- a/test/rules/typedefRuleTests.ts
+++ b/test/rules/typedefRuleTests.ts
@@ -30,7 +30,7 @@ describe("<typedef, not enabled>", () => {
     });
 });
 
-describe.only("<typedef, enabled>", () => {
+describe("<typedef, enabled>", () => {
     const fileName = "rules/typedef.test.ts";
     const TypedefRule = Lint.Test.getRule("typedef");
     let actualFailures: Lint.RuleFailure[];

--- a/test/rules/variableNameRuleTests.ts
+++ b/test/rules/variableNameRuleTests.ts
@@ -31,8 +31,10 @@ describe("<variable-name>", () => {
             createFailure([19, 58], [19, 68]),
             createFailure([24, 7], [24, 17]),
             createFailure([24, 19], [24, 30]),
+            createFailure([24, 35], [24, 46]),
             createFailure([26, 56], [26, 69]),
             createFailure([26, 71], [26, 84]),
+            createFailure([30, 43], [30, 54]),
         ];
 
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, VariableNameRule);


### PR DESCRIPTION
Add test cases that make sure the TypeDef, UnusedVariable and VariableName rules work with spread syntax. This should allow us to close #369.

I haven't added tests for DuplicateVariable because DuplicateVariable doesn't support destructuring yet (#425).
