### PR TITLE
Restore CLI functionality

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,12 @@
 "use strict";
 
+var checkBinTest;
+if (process.platform  === "win32") {
+    checkBinTest = [];
+} else {
+    checkBinTest = ["run:test"];
+}
+
 module.exports = function (grunt) {
     // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
     grunt.initConfig({
@@ -33,6 +40,12 @@ module.exports = function (grunt) {
                     reporter: "spec"
                 },
                 src: ["build/tslint-tests.js"]
+            }
+        },
+
+        run: {
+            test: {
+                cmd: "./test/check-bin.sh"
             }
         },
 
@@ -72,8 +85,10 @@ module.exports = function (grunt) {
             bin: {
                 src: [
                     "typings/*.d.ts",
+                    "src/language/walker/syntaxWalker.ts",
                     "src/language/**/*.ts",
-                    "src/*.ts",
+                    "src/!(tslint-cli).ts",
+                    "src/tslint-cli.ts"
                 ],
                 out: "bin/tslint-cli.js"
             },
@@ -138,13 +153,15 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-concat");
     grunt.loadNpmTasks("grunt-jscs");
     grunt.loadNpmTasks("grunt-mocha-test");
+    grunt.loadNpmTasks("grunt-run");
     grunt.loadNpmTasks("grunt-tslint");
     grunt.loadNpmTasks("grunt-ts");
 
     // register custom tasks
     grunt.registerTask("core", ["clean:core", "ts:core", "concat:core", "ts:core_rules", "ts:core_formatters"]);
     grunt.registerTask("bin", ["clean:bin", "ts:bin", "tslint:src", "concat:bin"]);
-    grunt.registerTask("test", ["clean:test", "ts:test", "tslint:test", "concat:test", "mochaTest"]);
+    grunt.registerTask("test", ["clean:test", "ts:test", "tslint:test", "concat:test", "mochaTest"]
+                                  .concat(checkBinTest));
 
     // create default task
     grunt.registerTask("default", ["jscs", "core", "bin", "test"]);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-contrib-concat": "~0.5.0",
     "grunt-jscs": "~1.8.0",
     "grunt-mocha-test": "~0.6.2",
+    "grunt-run": "^0.3.0",
     "grunt-ts": "~4.1.0",
     "grunt-tslint": "~2.0.0",
     "typescript": "1.5.0-beta"

--- a/test/check-bin.sh
+++ b/test/check-bin.sh
@@ -1,0 +1,46 @@
+# Copyright 2014 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Checking tslint binary"
+# make sure calling tslint with no args exits correctly.
+./bin/tslint
+out=$?
+if [ $out != 1 ]
+then
+  echo "tslint with no args did not exit with a 1, got $out"
+  exit 1
+fi
+
+
+
+# make sure calling tslint with a good file exits correctly.
+./bin/tslint -f src/configuration.ts
+out=$?
+if [ $out != 0 ]
+then
+  echo "tslint with a good file did not exit with a 0, got $out"
+  exit 1
+fi
+
+
+# make sure calling tslint with a bad file exits correctly
+./bin/tslint -f test/files/rules/ban.test.ts -c tslint.json
+out=$?
+if [ $out != 2 ]
+then
+  echo "tslint with a bad file did not exit with a 2, got $out"
+  exit 1
+fi
+
+echo "Done!"


### PR DESCRIPTION
This fixes issue #424. 

The code generated by grunt tried to derive RuleWalker from SyntaxWalker before
loading SyntaxWalker. This was causing tslint-cli to crash.

The fix simply explicitly references syntaxWalker.ts from ruleWalker.ts.