### PR TITLE
tslint-cli uses a default configuration if none is found

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -48,7 +48,11 @@ module Lint.Configuration {
 
         configFile = findup(CONFIG_FILENAME, { cwd: inputFileLocation, nocase: true }) || defaultPath;
 
-        return configFile ? JSON.parse(fs.readFileSync(configFile, "utf8")) : undefined;
+        if (fs.existsSync(configFile)) {
+            return JSON.parse(fs.readFileSync(configFile, "utf8"));
+        } else {
+            return getDefaultConfiguration();
+        }
     }
 
     function getHomeDir() {
@@ -64,5 +68,23 @@ module Lint.Configuration {
                 }
             }
         }
+    }
+
+    function getDefaultConfiguration(): any {
+        return {
+            "rules": {
+                "curly": true,
+                "indent": [true, 4],
+                "no-duplicate-key": true,
+                "no-duplicate-variable": true,
+                "no-empty": true,
+                "no-eval": true,
+                "no-trailing-whitespace": true,
+                "no-unreachable": true,
+                "no-use-before-declare": true,
+                "quotemark": [true, "double"],
+                "semicolon": true
+            }
+        };
     }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,7 +19,22 @@ module Lint.Configuration {
     var path = require("path");
     var findup = require("findup-sync");
 
-    var CONFIG_FILENAME = "tslint.json";
+    const CONFIG_FILENAME = "tslint.json";
+    const DEFAULT_CONFIG = {
+        "rules": {
+            "curly": true,
+            "indent": [true, 4],
+            "no-duplicate-key": true,
+            "no-duplicate-variable": true,
+            "no-empty": true,
+            "no-eval": true,
+            "no-trailing-whitespace": true,
+            "no-unreachable": true,
+            "no-use-before-declare": true,
+            "quotemark": [true, "double"],
+            "semicolon": true
+        }
+    };
 
     export function findConfiguration(configFile: string, inputFileLocation: string): any {
         if (configFile) {
@@ -51,7 +66,7 @@ module Lint.Configuration {
         if (fs.existsSync(configFile)) {
             return JSON.parse(fs.readFileSync(configFile, "utf8"));
         } else {
-            return getDefaultConfiguration();
+            return DEFAULT_CONFIG;
         }
     }
 
@@ -68,23 +83,5 @@ module Lint.Configuration {
                 }
             }
         }
-    }
-
-    function getDefaultConfiguration(): any {
-        return {
-            "rules": {
-                "curly": true,
-                "indent": [true, 4],
-                "no-duplicate-key": true,
-                "no-duplicate-variable": true,
-                "no-empty": true,
-                "no-eval": true,
-                "no-trailing-whitespace": true,
-                "no-unreachable": true,
-                "no-use-before-declare": true,
-                "quotemark": [true, "double"],
-                "semicolon": true
-            }
-        };
     }
 }


### PR DESCRIPTION
The default options enabled are:

curly: true,
indent: [true, 4],
no-duplicate-key: true,
no-duplicate-variable: true,
no-empty: true,
no-eval: true,
no-trailing-whitespace: true,
no-unreachable: true,
no-use-before-declare: true,
quotemark: [true, "double"],
semicolon: true