### PR TITLE
shorten error string

### DIFF
--- a/src/rules/noSwitchCaseFallThroughRule.ts
+++ b/src/rules/noSwitchCaseFallThroughRule.ts
@@ -15,7 +15,7 @@
 */
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING_PART = "Expected a 'break' before ";
+    public static FAILURE_STRING_PART = "expected a 'break' before ";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new NoSwitchCaseFallThroughWalker(sourceFile, this.getOptions()));

--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -19,7 +19,7 @@
 var OPTION_LEADING_UNDERSCORE = "no-var-keyword";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "use of the var-keyword is disallowed, use 'let' or 'const' instead";
+    public static FAILURE_STRING = "forbidden var keyword";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         var noVarKeywordWalker = new NoVarKeywordWalker(sourceFile, this.getOptions());


### PR DESCRIPTION
- the no-var-keyword error is too verbose, the convention
  elsewhere is "forbidden blah" (no-eval, no-bitwise) which is
  succint enough. detailed rule information is available on the
  readme.