### PR TITLE
compile all files using the right tsconfig.json

### DIFF
--- a/.settings/settings.json
+++ b/.settings/settings.json
@@ -13,9 +13,9 @@
 		".git",
 		".tscache",
 		"bower_components",
-        "bin",
+                "bin",
 		"build",
-        "lib",
+                "lib",
 		"node_modules"
 	]
 }

--- a/.settings/settings.json
+++ b/.settings/settings.json
@@ -13,6 +13,7 @@
 		".git",
 		".tscache",
 		"bower_components",
+        "bin",
 		"build",
         "lib",
 		"node_modules"

--- a/.settings/tasks.json
+++ b/.settings/tasks.json
@@ -6,23 +6,14 @@
 // ${fileExtname}: the current opened file's extension
 // ${cwd}: the current working directory of the spawned process
 
-// A task runner that calls the Typescipt compiler (tsc) and compiles based on a tsconfig.json file
+// A task runner that calls scripts/tsc-wrapper.js. The wrapper script traverses
+// up the file system until a valid `tsconfig.json` is found, and runs `tsc` from
+// node_modules with that path as the root
 {
 	"version": "0.1.0",
-	
-	// The command is tsc. Assumes that tsc has been installed using npm install -g typescript
-	"command": "${workspaceRoot}/node_modules/typescript/bin/tsc",
-	
-	// The command is a shell script
+	"command": "${workspaceRoot}/scripts/tsc-wrapper.js",
 	"isShellCommand": true,
-
-	// Show the output window only if unrecognized errors occur. 
 	"showOutput": "silent",
-	
-	// Tell the tsc compiler to use the tsconfig.json from the open folder.
-	"args": ["-p", "${fileDirname}"],
-	
-	// use the standard tsc problem matcher to find compile problems
-	// in the output.
+	"args": ["${workspaceRoot}", "${fileDirname}"],
 	"problemMatcher": "$tsc"
 }

--- a/scripts/tsc-wrapper.js
+++ b/scripts/tsc-wrapper.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/* global process */
+
+var execSync = require("child_process").execSync;
+var findup = require("findup-sync");
+var path = require("path");
+var spawnSync = require("child_process").spawnSync;
+
+/* print a buffer to a stream */ 
+function print(buffer, stream) {
+    if (buffer != null) {
+        var output = buffer.toString("utf8");
+        stream.write(output);
+    }
+}
+
+var argv = process.argv;
+if (argv.length < 4) {
+    console.error("insufficient arguments to tsc wrapper");
+    process.exit(1);
+}
+
+var workspacePath = argv[2];
+var filePath = argv[3];
+
+var configPath = path.dirname(findup("tsconfig.json", { cwd: filePath, nocase: true }));
+if (configPath == null) {
+    console.error("tsconfig.json not found");
+    process.exit(2);
+}
+
+var tscPath = path.join(workspacePath, "node_modules", "typescript", "bin", "tsc");
+var tsc = spawnSync(tscPath, ["-p", configPath]);
+
+print(tsc.stdout, process.stdout);
+print(tsc.stderr, process.stderr);
+process.exit(tsc.status);

--- a/test/formatters/externalFormatterTest.ts
+++ b/test/formatters/externalFormatterTest.ts
@@ -17,13 +17,14 @@
 describe("External Formatter", () => {
     var TEST_FILE = "formatters/externalFormatter.test.ts";
     var TEST_MODULE = "../test/files/formatters/simple";
-    var sourceFile, formatter;
+    var sourceFile: ts.SourceFile, formatter: Lint.IFormatter;
 
     before(function() {
         var Formatter = Lint.Test.getFormatter(TEST_MODULE);
         sourceFile = Lint.Test.getSourceFile(TEST_FILE);
         formatter = new Formatter();
     });
+
     it("formats failures", () => {
         var maxPosition = sourceFile.getFullWidth();
 
@@ -52,7 +53,7 @@ describe("External Formatter", () => {
         assert.equal(result, "");
     });
 
-    function getPositionString(line, character) {
+    function getPositionString(line: number, character: number) {
         return "[" + line + ", " + character + "]";
     }
 });

--- a/test/ruleDisableEnableTests.ts
+++ b/test/ruleDisableEnableTests.ts
@@ -28,7 +28,7 @@ describe("Enable and Disable Rules", () => {
         var relativePath = path.join("test", "files", "rules/enabledisable.test.ts");
         var source = fs.readFileSync(relativePath, "utf8");
 
-        var options = {
+        var options: Lint.ILinterOptions = {
             formatter: "json",
             configuration: validConfiguration,
             rulesDirectory: null,
@@ -49,12 +49,11 @@ describe("Enable and Disable Rules", () => {
         var expectedFailure5 = quotemarkFailure([10, 13], [10, 19]);
         var expectedFailure6 = quotemarkFailure([16, 13], [16, 19]);
 
-
         var ll = new Lint.Linter(relativePath, source, options);
         var result = ll.lint();
         var parsedResult = JSON.parse(result.output);
         var actualFailures: Lint.RuleFailure[] = [];
-        parsedResult.forEach((failure) => {
+        parsedResult.forEach((failure: any) => {
             var startArray = [failure.startPosition.line + 1, failure.startPosition.character + 1];
             var endArray = [failure.endPosition.line + 1, failure.endPosition.character + 1];
             actualFailures.push(Lint.Test.createFailure("rules/enabledisable.test.ts", startArray, endArray, failure.failure));

--- a/test/rules/noVarKeywordRuleTests.ts
+++ b/test/rules/noVarKeywordRuleTests.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
 */
 
-/// <reference path='../references.ts' />
-
 describe("<no-var-keyword>", () => {
     it("disallows use of creating variables with 'var'", () => {
         var fileName = "rules/novarkeyword.test.ts";

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -5,14 +5,18 @@
         "noImplicitAny": true,
         "sourceMap": false,
         "target": "es5",
-        "out": "../build/tslint-tests.js"
+        "out": "build/tslint-tests.js"
     },
     "filesGlob": [
         "../typings/*.d.ts",
         "../lib/tslint.d.ts",
         "./typings/*.ts",
-        "./**/*.ts",
-        "!./files/**/*"
+        "./references.ts",
+        "./helper.ts",
+        "./ruleDisableEnableTests.ts",
+        "./ruleLoaderTests.ts",
+        "./formatters/*.ts",
+        "./rules/*.ts"
     ],
     "files": [
         "../typings/node.d.ts",
@@ -21,16 +25,15 @@
         "../lib/tslint.d.ts",
         "./typings/chai.d.ts",
         "./typings/mocha.d.ts",
-        "./chaiAssert.ts",
+        "./references.ts",
+        "./helper.ts",
+        "./ruleDisableEnableTests.ts",
+        "./ruleLoaderTests.ts",
         "./formatters/externalFormatterTest.ts",
         "./formatters/jsonFormatterTests.ts",
         "./formatters/pmdFormatterTests.ts",
         "./formatters/proseFormatterTests.ts",
         "./formatters/verboseFormatterTests.ts",
-        "./helper.ts",
-        "./references.ts",
-        "./ruleDisableEnableTests.ts",
-        "./ruleLoaderTests.ts",
         "./rules/alignRuleTests.ts",
         "./rules/banRuleTests.ts",
         "./rules/classNameRuleTests.ts",


### PR DESCRIPTION
- tsc-wrapper.js is just a wrapper on top of tsc for VS Code,
  that walks up the dirtree until a tsconfig.json is found and
  compiles at that path. necessary for tasks.json configuration
- test compilation will also work with this, but there's an issue with
  test/tsconfig.json