### PR TITLE
Add tests for semicolon rule on ES6 module syntax

### DIFF
--- a/test/files/rules/semicolon.test.ts
+++ b/test/files/rules/semicolon.test.ts
@@ -48,3 +48,7 @@ interface ITest {
     bar: number
     baz: boolean; // no error
 }
+
+import {Router} from 'aurelia-router'; // no error
+
+import {Controller} from 'my-lib' // error

--- a/test/rules/semicolonRuleTests.ts
+++ b/test/rules/semicolonRuleTests.ts
@@ -28,7 +28,7 @@ describe("<semicolon>", () => {
     });
 
     it("warns on all statements", () => {
-        assert.equal(actualFailures.length, 19);
+        assert.equal(actualFailures.length, 20);
     });
 
     it("warns on variable statements", () => {
@@ -84,5 +84,9 @@ describe("<semicolon>", () => {
     it("warns on interface declaration", () => {
         Lint.Test.assertContainsFailure(actualFailures, createFailure([47, 17], [47, 17]));
         Lint.Test.assertContainsFailure(actualFailures, createFailure([48, 16], [48, 16]));
+    });
+
+    it("warns on import statement", () => {
+        Lint.Test.assertContainsFailure(actualFailures, createFailure([54, 34], [54, 34]));
     });
 });


### PR DESCRIPTION
This prevents regressions on #441 