### PR TITLE
Add support for ES6 bare imports

### DIFF
--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -57,7 +57,8 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
             const importClause = node.importClause;
 
             // named imports & namespace imports handled by other walker methods
-            if (importClause.name != null) {
+            // importClause will be null for bare imports
+            if (importClause != null && importClause.name != null) {
                 const variableIdentifier = importClause.name;
                 this.validateReferencesForVariable(variableIdentifier.text, variableIdentifier.getStart());
             }

--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -42,14 +42,13 @@ class NoUseBeforeDeclareWalker extends Lint.ScopeAwareRuleWalker<VisitedVariable
     }
 
     public visitImportDeclaration(node: ts.ImportDeclaration) {
-        if (node.importClause != null) {
-            const importClause = node.importClause;
+        const importClause = node.importClause;
 
-            // named imports & namespace imports handled by other walker methods
-            if (importClause.name != null) {
-                const variableIdentifier = importClause.name;
-                this.validateUsageForVariable(variableIdentifier.text, variableIdentifier.getStart());
-            }
+        // named imports & namespace imports handled by other walker methods
+        // importClause will be null for bare imports
+        if (importClause != null && importClause.name != null) {
+            const variableIdentifier = importClause.name;
+            this.validateUsageForVariable(variableIdentifier.text, variableIdentifier.getStart());
         }
 
         super.visitImportDeclaration(node);

--- a/test/files/rules/nounusedvariable-imports.test.ts
+++ b/test/files/rules/nounusedvariable-imports.test.ts
@@ -22,3 +22,5 @@ import defaultExport, { namedExport } from "libD"; // failure on 'defaultExport'
 bar.someFunc();
 baz();
 namedExport();
+
+import "jquery";

--- a/test/files/rules/nousebeforedeclare.test.ts
+++ b/test/files/rules/nousebeforedeclare.test.ts
@@ -42,3 +42,4 @@ import { default as foo1 } from "lib";
 import foo2 from "lib";
 import _, { map, foldl } from "underscore";
 import * as foo3 from "lib";
+import "lib";

--- a/test/files/rules/whitespace.test.ts
+++ b/test/files/rules/whitespace.test.ts
@@ -68,3 +68,4 @@ export function each(obj, iterator, context) {
 }
 
 export {each as forEach};
+import "libE";


### PR DESCRIPTION
Fixes #451

This affects the following rules:

- `no-unused-variable`
- `no-use-before-declare`
- `whitespace` (it was already handled here, but I added a regression test)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/468)
<!-- Reviewable:end -->
