### PR TITLE
Add support for var destructuring & named exports to no-use-before-declare rule

### DIFF
--- a/src/rules/noDuplicateVariableRule.ts
+++ b/src/rules/noDuplicateVariableRule.ts
@@ -36,6 +36,7 @@ class NoDuplicateVariableWalker extends Lint.BlockScopeAwareRuleWalker<{}, Scope
         const isSingleVariable = node.name.kind === ts.SyntaxKind.Identifier;
         const isBlockScoped = Lint.isBlockScopedBindingElement(node);
 
+        // duplicate-variable errors for block-scoped vars are caught by tsc
         if (isSingleVariable && !isBlockScoped) {
             this.handleSingleVariableIdentifier(<ts.Identifier> node.name);
         }

--- a/test/files/rules/nousebeforedeclare.test.ts
+++ b/test/files/rules/nousebeforedeclare.test.ts
@@ -43,3 +43,18 @@ import foo2 from "lib";
 import _, { map, foldl } from "underscore";
 import * as foo3 from "lib";
 import "lib";
+
+export default function () {
+    //
+};
+
+export {
+    undeclaredA, // failure
+    undeclaredB, // tsc error
+    undeclaredC, // tsc error
+    testUndeclaredImports
+};
+
+var undeclaredA = 42;
+let { undeclaredB } = { undeclaredB: 43 };
+const [ undeclaredC, [undeclaredD] ] = [ 1, [2] ];

--- a/test/rules/noUseBeforeDeclareRuleTests.ts
+++ b/test/rules/noUseBeforeDeclareRuleTests.ts
@@ -20,7 +20,7 @@ describe("<no-use-before-declare>", () => {
 
     it("restricts usage before declaration", () => {
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule);
-        assert.equal(actualFailures.length, 7);
+        assert.equal(actualFailures.length, 8);
     });
 
     it("restricts usage of imports before declaration", () => {
@@ -47,6 +47,13 @@ describe("<no-use-before-declare>", () => {
 
         Lint.Test.assertContainsFailure(actualFailures, failure1);
         Lint.Test.assertContainsFailure(actualFailures, failure2);
+    });
+
+    it("restricts exporting variables before declaration", () => {
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule);
+        const failure1 = Lint.Test.createFailuresOnFile(fileName, makeFailureString("undeclaredA"))([52, 5], [52, 16]);
+
+        Lint.Test.assertContainsFailure(actualFailures, failure1);
     });
 
     function makeFailureString(varName: string) {


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/472)
<!-- Reviewable:end -->
