### PR TITLE
Add a test for templated strings in jsdoc rule

### DIFF
--- a/test/files/rules/jsdoc.test.ts
+++ b/test/files/rules/jsdoc.test.ts
@@ -59,4 +59,11 @@ one  *
 
 }
 
-
+// Regression test: jsdoc rule shouldn't look inside template strings (https://github.com/palantir/tslint/issues/332)
+function makeHeader(pkg: Package) {
+    return [
+        `\t/**`,
+        `\t * ${pkg.name} v${pkg.version}`,
+        `\t */`
+    ].join("\r\n");
+}


### PR DESCRIPTION
Adds verification for #332

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/482)
<!-- Reviewable:end -->
