### PR TITLE
Resolve #471, add tests for spread operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
     - "0.10"
-    - "0.12.3"
+    - "0.12"

--- a/src/rules/noDuplicateVariableRule.ts
+++ b/src/rules/noDuplicateVariableRule.ts
@@ -32,7 +32,6 @@ class NoDuplicateVariableWalker extends Lint.BlockScopeAwareRuleWalker<{}, Scope
     }
 
     public visitBindingElement(node: ts.BindingElement) {
-        // #471: handle node.dotdotToken?
         const isSingleVariable = node.name.kind === ts.SyntaxKind.Identifier;
         const isBlockScoped = Lint.isBlockScopedBindingElement(node);
 

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -32,7 +32,6 @@ class NoShadowedVariableWalker extends Lint.BlockScopeAwareRuleWalker<ScopeInfo,
     }
 
     public visitBindingElement(node: ts.BindingElement) {
-        // #471: handle node.dotDotDotToken?
         const isSingleVariable = node.name.kind === ts.SyntaxKind.Identifier;
         const isBlockScoped = Lint.isBlockScopedBindingElement(node);
 

--- a/test/files/rules/no-duplicate-variable.test.ts
+++ b/test/files/rules/no-duplicate-variable.test.ts
@@ -156,4 +156,7 @@ function testDestructuring() {
         var a; // not a failure; caught by no-shadowed-variable
         return b;
     }
+
+    var [x, y3] = myFunc(); // failure
+    var [x3, ...y] = [1, 2, 3, 4]; // failure
 }

--- a/test/files/rules/no-shadowed-variable.test.ts
+++ b/test/files/rules/no-shadowed-variable.test.ts
@@ -93,5 +93,7 @@ function testDestructuring(x: number) {
     function anotherInnerFunc() {
         var [{x}] = [{x: 1}];   // failure
         let [[y]] = [[2]];      // failure
+        var [foo, ...bar] = [1, 2, 3, 4];
+        var [...z] = [1, 2, 3, 4]; // failure
     }
 }

--- a/test/rules/noDuplicateVariableRuleTests.ts
+++ b/test/rules/noDuplicateVariableRuleTests.ts
@@ -26,7 +26,9 @@ describe("<no-duplicate-variable>", () => {
             createFailure([22, 9], [22, 19]),
             createFailure([26, 5], [26, 15]),
             Lint.Test.createFailure(fileName, [141, 13], [141, 14], NoDuplicateVariableRule.FAILURE_STRING + "z'"),
-            Lint.Test.createFailure(fileName, [153, 11], [153, 13], NoDuplicateVariableRule.FAILURE_STRING + "a2'")
+            Lint.Test.createFailure(fileName, [153, 11], [153, 13], NoDuplicateVariableRule.FAILURE_STRING + "a2'"),
+            Lint.Test.createFailure(fileName, [160, 10], [160, 11], NoDuplicateVariableRule.FAILURE_STRING + "x'"),
+            Lint.Test.createFailure(fileName, [161, 17], [161, 18], NoDuplicateVariableRule.FAILURE_STRING + "y'")
         ];
 
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, NoDuplicateVariableRule);

--- a/test/rules/noShadowedVariableRuleTests.ts
+++ b/test/rules/noShadowedVariableRuleTests.ts
@@ -39,7 +39,8 @@ describe("<no-shadowed-variable>", () => {
             Lint.Test.createFailure(fileName, [89, 14], [89, 15], NoShadowedVariableRule.FAILURE_STRING + "y'"),
             Lint.Test.createFailure(fileName, [90, 16], [90, 17], NoShadowedVariableRule.FAILURE_STRING + "z'"),
             Lint.Test.createFailure(fileName, [94, 15], [94, 16], NoShadowedVariableRule.FAILURE_STRING + "x'"),
-            Lint.Test.createFailure(fileName, [95, 15], [95, 16], NoShadowedVariableRule.FAILURE_STRING + "y'")
+            Lint.Test.createFailure(fileName, [95, 15], [95, 16], NoShadowedVariableRule.FAILURE_STRING + "y'"),
+            Lint.Test.createFailure(fileName, [97, 17], [97, 18], NoShadowedVariableRule.FAILURE_STRING + "z'")
         ];
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, NoShadowedVariableRule);
 


### PR DESCRIPTION
Turns out we don't need to look at node.dotDotToken for BindingElements.
It's literally just a text token. We don't need it for any linting rule
right now, but might in the future.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/486)
<!-- Reviewable:end -->
