### PR TITLE
Fix #493: avoid checking class names for default exports

### DIFF
--- a/src/rules/classNameRule.ts
+++ b/src/rules/classNameRule.ts
@@ -24,9 +24,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NameWalker extends Lint.RuleWalker {
     public visitClassDeclaration(node: ts.ClassDeclaration) {
-        const className = node.name.getText();
-        if (!this.isPascalCased(className)) {
-            this.addFailureAt(node.name.getStart(), node.name.getWidth());
+        // classes declared as default exports will be unnamed
+        if (node.name != null) {
+            const className = node.name.getText();
+            if (!this.isPascalCased(className)) {
+                this.addFailureAt(node.name.getStart(), node.name.getWidth());
+            }
         }
 
         super.visitClassDeclaration(node);
@@ -41,7 +44,7 @@ class NameWalker extends Lint.RuleWalker {
         super.visitInterfaceDeclaration(node);
     }
 
-    private isPascalCased(name: string): boolean {
+    private isPascalCased(name: string) {
         if (name.length <= 0) {
             return true;
         }

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -174,5 +174,5 @@ const processFile = (file: string) => {
 const files = argv._;
 
 for (const file of files) {
-        processFile(file);
+    processFile(file);
 }

--- a/test/files/rules/classname.test.ts
+++ b/test/files/rules/classname.test.ts
@@ -9,3 +9,7 @@ class invalidClassName {
 class Another_Invalid_Class_Name {
 
 }
+
+export default class {
+    // should not fail
+}

--- a/test/references.ts
+++ b/test/references.ts
@@ -14,5 +14,7 @@
  * limitations under the License.
  */
 
-// attach chai.assert to the global object
-global.assert = require("chai").assert;
+/* tslint:disable:no-var-keyword */
+var assert: Chai.Assert = require("chai").assert;
+global.assert = assert;
+/* tslint:enable:no-var-keyword */


### PR DESCRIPTION
- add a variable declaration for "assert" to fix atom-typescript compilation
- small indentation fix in tslint-cli.ts

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/494)
<!-- Reviewable:end -->
