### PR TITLE
Fix false positive on no-switch-case-fall-through

### DIFF
--- a/src/rules/noSwitchCaseFallThroughRule.ts
+++ b/src/rules/noSwitchCaseFallThroughRule.ts
@@ -72,7 +72,8 @@ export class NoSwitchCaseFallThroughWalker extends Lint.RuleWalker {
         return !statements.some((statement) => {
             return statement.kind === ts.SyntaxKind.BreakStatement
                 || statement.kind === ts.SyntaxKind.ThrowStatement
-                || statement.kind === ts.SyntaxKind.ReturnStatement;
+                || statement.kind === ts.SyntaxKind.ReturnStatement
+                || statement.kind === ts.SyntaxKind.ContinueStatement;
         });
     }
 }

--- a/test/files/rules/switchdefault.test.ts
+++ b/test/files/rules/switchdefault.test.ts
@@ -47,3 +47,13 @@ case 2:
     break;
 }
 
+// valid
+baz:
+while (true){
+    switch(foo) {
+    case 1:
+        bar();
+        continue baz;
+    default:
+    }
+}


### PR DESCRIPTION
Fix #509

NoSwitchCaseFallThroughWalker didn't realize continue statements
would break out of case block.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/palantir/tslint/510)
<!-- Reviewable:end -->
