### PR TITLE
Use node 0.12 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
-  nodejs_version: "0.10"
+  matrix:
+  - nodejs_version: "0.10"
+  - nodejs_version: "0.12"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
This will allow appveyor to run the tests on both node 0.10 and 0.12 just like they do on travis