### PR TITLE
Fix indent rule in sample tslint.json

### DIFF
--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -13,7 +13,7 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "indent": [true, 4],
+    "indent": [true, "spaces"],
     "interface-name": true,
     "jsdoc-format": true,
     "label-position": true,


### PR DESCRIPTION
The indent rule in the sample is incorrect as of `2.4.2` and `master`

Valid options are:

```
"indent": [true, "spaces"]

OR

"indent": [true, "tabs"]
```

I guess in future the third option would be a number? But hopefully this fixes things for now.