### PR TITLE
Cleanup language service host

### DIFF
--- a/src/language/languageServiceHost.ts
+++ b/src/language/languageServiceHost.ts
@@ -21,14 +21,7 @@ module Lint {
             getCurrentDirectory: () => "",
             getDefaultLibFileName: () => "lib.d.ts",
             getScriptFileNames: () => [fileName],
-            getScriptSnapshot: () => {
-                return {
-                    getChangeRange: (oldSnapshot) => undefined,
-                    getLength: () => source.length,
-                    getLineStartPositions: () => ts.computeLineStarts(source),
-                    getText: (start, end) => source.substring(start, end)
-                };
-            },
+            getScriptSnapshot: () => ts.ScriptSnapshot.fromString(source),
             getScriptVersion: () => "1",
             log: (message) => { /* */ }
         };

--- a/typings/typescriptServicesScanner.d.ts
+++ b/typings/typescriptServicesScanner.d.ts
@@ -1,7 +1,6 @@
 /// <reference path="./typescriptServices.d.ts" />
 
 declare module ts {
-    function computeLineStarts(text: string): number[];
     /** Creates a scanner over a (possibly unspecified) range of a piece of text. */
     function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean, languageVariant: ts.LanguageVariant, text?: string, onError?: ErrorCallback, start?: number, length?: number): Scanner;
 }


### PR DESCRIPTION
computeLineStarts is an impl detail we shouldn't be using:
https://github.com/Microsoft/TypeScript/issues/4057#issuecomment-130120572