### PR TITLE
Fix indentation/typos

### DIFF
--- a/test/check-bin.sh
+++ b/test/check-bin.sh
@@ -29,7 +29,7 @@ expectOut () {
 echo "Checking tslint binary"
 # make sure calling tslint with no args exits correctly.
 ./bin/tslint
-expectOut $? 1  "tslint with not args did not exit correctly"
+expectOut $? 1  "tslint with no args did not exit correctly"
 
 # make sure calling tslint with a good file exits correctly.
 ./bin/tslint src/configuration.ts
@@ -37,11 +37,11 @@ expectOut $? 0 "tslint with a good file did not exit correctly"
 
 # make sure calling tslint without the -f flag exits correctly
 ./bin/tslint src/configuration.ts src/formatterLoader.ts
-expectOut $? 0 "tslint with no did not exit correctly"
+expectOut $? 0 "tslint without -f flag did not exit correctly"
 
-# make sure calling tslint the -f flag exits correctly
+# make sure calling tslint with the -f flag exits correctly
 ./bin/tslint src/configuration.ts -f src/formatterLoader.ts
-expectOut $? 1 "tslint with no did not exit correctly"
+expectOut $? 1 "tslint with -f flag did not exit correctly"
 
 if [ $num_failures != 0 ]
 then

--- a/test/check-bin.sh
+++ b/test/check-bin.sh
@@ -37,7 +37,7 @@ expectOut $? 0 "tslint with a good file did not exit correctly"
 
 # make sure calling tslint without the -f flag exits correctly
 ./bin/tslint src/configuration.ts src/formatterLoader.ts
-expectOut $? 0 "tslint without -f flag did not exit correctly"
+expectOut $? 0 "tslint with valid arguments did not exit correctly"
 
 # make sure calling tslint with the -f flag exits correctly
 ./bin/tslint src/configuration.ts -f src/formatterLoader.ts

--- a/test/rules/classNameRuleTests.ts
+++ b/test/rules/classNameRuleTests.ts
@@ -21,8 +21,8 @@ describe("<class-name>", () => {
     it("ensures class names are always pascal-cased", () => {
         const createFailure = Lint.Test.createFailuresOnFile(fileName, ClassNameRule.FAILURE_STRING);
         const expectedFailures = [
-          createFailure([5, 7], [5, 23]),
-          createFailure([9, 7], [9, 33])
+            createFailure([5, 7], [5, 23]),
+            createFailure([9, 7], [9, 33])
         ];
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, ClassNameRule);
 


### PR DESCRIPTION
Fix the indentation from PR #579, also fix  a few other typos in `check-bin.sh`.