### PR TITLE
Fix for no-internal-module rule

### DIFF
--- a/test/files/rules/nointernalmodule.test.ts
+++ b/test/files/rules/nointernalmodule.test.ts
@@ -11,3 +11,42 @@ declare module "hoge" {
 }
 declare module 'fuga' {
 }
+
+namespace foo.bar {
+}
+namespace foo.bar.baz {
+}
+namespace foo {
+    namespace bar.baz {
+    }
+}
+
+namespace foo.bar {
+    module baz {
+        namespace buzz {
+        }
+    }
+}
+
+module foo.bar {
+    namespace baz {
+        module buzz {
+        }
+    }
+}
+
+namespace name.namespace {
+}
+namespace namespace.name {
+}
+
+// intentionally malformed for test cases, do not format
+declare module declare
+.dec{}
+declare  module dec . declare  {
+}
+
+module  mod.module{}
+module module.mod
+{
+}

--- a/test/rules/noInternalModuleTests.ts
+++ b/test/rules/noInternalModuleTests.ts
@@ -23,7 +23,14 @@ describe("<no-internal-module>", () => {
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, NoInternalModule);
         const expectedFailures = [
             Lint.Test.createFailure(fileName, [4, 1], [4, 15], failureString),
-            Lint.Test.createFailure(fileName, [7, 1], [7, 24], failureString)
+            Lint.Test.createFailure(fileName, [7, 1], [7, 24], failureString),
+            Lint.Test.createFailure(fileName, [25, 5], [28, 6], failureString),
+            Lint.Test.createFailure(fileName, [31, 1], [36, 2], failureString),
+            Lint.Test.createFailure(fileName, [33, 9], [33, 32], failureString),
+            Lint.Test.createFailure(fileName, [44, 1], [44, 30], failureString),
+            Lint.Test.createFailure(fileName, [46, 1], [46, 35], failureString),
+            Lint.Test.createFailure(fileName, [49, 1], [49, 21], failureString),
+            Lint.Test.createFailure(fileName, [50, 1], [50, 22], failureString)
         ];
 
         Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);


### PR DESCRIPTION
Fix proposal for issue #600 

**Personal note:** I think the better approach to fixing this issue is to have the nodes representing the nested sub-paths in the namespace have the correct flag type `ts.NodeFlags.Namespace` instead of having to recurse for their parent which has it. Currently they have `ts.NodeFlags.Export` as their `flags` property's value. However, I wanted to limit the fix to the rule's definition file, and think this is the best solution without having to tamper into the node walker internals.