### PR TITLE
Implemented optional trailing underscore for variableNameRule.ts

### DIFF
--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -15,6 +15,7 @@
  */
 
 const OPTION_LEADING_UNDERSCORE = "allow-leading-underscore";
+const OPTION_TRAILING_UNDERSCORE = "allow-trailing-underscore";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "variable name must be in camelcase or uppercase";
@@ -71,15 +72,19 @@ class VariableNameWalker extends Lint.RuleWalker {
 
     private isCamelCase(name: string) {
         const firstCharacter = name.charAt(0);
-        const rest = name.substring(1);
+        const lastCharacter = name.charAt(name.length - 1);
+        const middle = name.substr(1, name.length - 2);
 
         if (name.length <= 0) {
             return true;
-        } else if (!this.hasOption(OPTION_LEADING_UNDERSCORE) && firstCharacter === "_") {
+        }
+        if (!this.hasOption(OPTION_LEADING_UNDERSCORE) && firstCharacter === "_") {
             return false;
         }
-
-        return firstCharacter === firstCharacter.toLowerCase() && rest.indexOf("_") === -1;
+        if (!this.hasOption(OPTION_TRAILING_UNDERSCORE) && lastCharacter === "_") {
+            return false;
+        }
+        return firstCharacter === firstCharacter.toLowerCase() && middle.indexOf("_") === -1;
     }
 
     private isUpperCase(name: string) {

--- a/test/files/rules/varname.test.ts
+++ b/test/files/rules/varname.test.ts
@@ -32,3 +32,4 @@ export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
 }
 
 let optionallyValid_ = "bar";
+let _$httpBackend_ = "leading and trailing";

--- a/test/files/rules/varname.test.ts
+++ b/test/files/rules/varname.test.ts
@@ -30,3 +30,5 @@ export function anotherFunctionWithInvalidParamNames ([first_element, SecondElem
 export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
   //
 }
+
+let optionallyValid_ = "bar";

--- a/test/rules/variableNameRuleTests.ts
+++ b/test/rules/variableNameRuleTests.ts
@@ -35,6 +35,7 @@ describe("<variable-name>", () => {
             createFailure([26, 56], [26, 69]),
             createFailure([26, 71], [26, 84]),
             createFailure([30, 43], [30, 54]),
+            createFailure([34, 5], [34, 21])
         ];
 
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, VariableNameRule);
@@ -49,6 +50,22 @@ describe("<variable-name>", () => {
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, VariableNameRule, options);
         const optionallyValidFailures = [
             createFailure([8, 13], [8, 29])
+        ];
+
+        // none of the optionally valid names should appear in the failures list
+        assert.isFalse(actualFailures.some((failure) => {
+            return optionallyValidFailures.some((f) => f.equals(failure));
+        }));
+    });
+
+    it("ensures trailing underscores can optionally be legal", () => {
+        const options = [true,
+            "allow-trailing-underscore"
+        ];
+
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, VariableNameRule, options);
+        const optionallyValidFailures = [
+            createFailure([34, 5], [34, 21])
         ];
 
         // none of the optionally valid names should appear in the failures list

--- a/test/rules/variableNameRuleTests.ts
+++ b/test/rules/variableNameRuleTests.ts
@@ -35,7 +35,8 @@ describe("<variable-name>", () => {
             createFailure([26, 56], [26, 69]),
             createFailure([26, 71], [26, 84]),
             createFailure([30, 43], [30, 54]),
-            createFailure([34, 5], [34, 21])
+            createFailure([34, 5], [34, 21]),
+            createFailure([35, 5], [35, 19])
         ];
 
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, VariableNameRule);
@@ -66,6 +67,23 @@ describe("<variable-name>", () => {
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, VariableNameRule, options);
         const optionallyValidFailures = [
             createFailure([34, 5], [34, 21])
+        ];
+
+        // none of the optionally valid names should appear in the failures list
+        assert.isFalse(actualFailures.some((failure) => {
+            return optionallyValidFailures.some((f) => f.equals(failure));
+        }));
+    });
+
+    it("ensures leading & trailing underscores can optionally be legal", () => {
+        const options = [true,
+            "allow-leading-underscore",
+            "allow-trailing-underscore"
+        ];
+
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, VariableNameRule, options);
+        const optionallyValidFailures = [
+            createFailure([35, 5], [35, 19])
         ];
 
         // none of the optionally valid names should appear in the failures list


### PR DESCRIPTION
When implementing AngularJS tests the inject methods recommends parameters to follow the convention "\_paramName\_", eg "\_$httpBackend\_".

The respective rule was missing in TSLint, which is now implemented by adding the option "allow-trailing-underscore" to "variable-name".

Cheers