### PR TITLE
Add a relax option "escape" for quotemark

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,10 @@ A sample configuration file with all options is available [here](https://github.
   * `"check-else"` checks that `else` is on the same line as the closing brace for `if`
   * `"check-open-brace"` checks that an open brace falls on the same line as its preceding expression.
   * `"check-whitespace"` checks preceding whitespace for the specified tokens.
-* `quotemark` enforces consistent single or double quoted string literals. Rule options (one is required):
+* `quotemark` enforces consistent single or double quoted string literals. Rule options (at least one of `"double"` or `"single"` is required):
     * `"single"` enforces single quotes
     * `"double"` enforces double quotes
+    * `"avoid-escape"` allows you to use the "other" quotemark in cases where escaping would normally be required. For example, `[true, "double", "avoid-escape"]` would not report a failure on the string literal `'Hello "World"'`.
 * `radix` enforces the radix parameter of `parseInt`
 * `semicolon` enforces semicolons at the end of every statement.
 * `sort-object-literal-keys` checks that keys in object literals are declared in alphabetical order

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -62,7 +62,7 @@
         "check-else",
         "check-whitespace"
     ],
-    "quotemark": [true, "double"],
+    "quotemark": [true, "double", "avoid-escape"],
     "radix": true,
     "semicolon": true,
     "sort-object-literal-keys": true,

--- a/test/files/rules/quotemark.test.ts
+++ b/test/files/rules/quotemark.test.ts
@@ -1,2 +1,4 @@
 var single = 'single';
     var doublee = "married";
+var singleWithinDouble = "'singleWithinDouble'";
+var doubleWithinSingle = '"doubleWithinSingle"';

--- a/test/rules/quotemarkRuleTests.ts
+++ b/test/rules/quotemarkRuleTests.ts
@@ -22,14 +22,38 @@ describe("<quotemark>", () => {
 
     it("enforces single quotes", () => {
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, QuoteMarkRule, [true, "single"]);
+        const expectedFailures = [
+            Lint.Test.createFailure(fileName, [2, 19], [2, 28], singleFailureString),
+            Lint.Test.createFailure(fileName, [3, 26], [3, 48], singleFailureString)
+        ];
+
+        assert.equal(actualFailures.length, 2);
+        assert.isTrue(actualFailures[0].equals(expectedFailures[0]));
+        assert.isTrue(actualFailures[1].equals(expectedFailures[1]));
+    });
+
+    it("enforces double quotes", () => {
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, QuoteMarkRule, [true, "double"]);
+        const expectedFailures = [
+          Lint.Test.createFailure(fileName, [1, 14], [1, 22], doubleFailureString),
+          Lint.Test.createFailure(fileName, [4, 26], [4, 48], doubleFailureString)
+        ];
+
+        assert.equal(actualFailures.length, 2);
+        assert.isTrue(actualFailures[0].equals(expectedFailures[0]));
+        assert.isTrue(actualFailures[1].equals(expectedFailures[1]));
+    });
+
+    it("enforces single quotes but allow other quote marks to avoid having to escape", () => {
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, QuoteMarkRule, [true, "single", "avoid-escape"]);
         const expectedFailure = Lint.Test.createFailure(fileName, [2, 19], [2, 28], singleFailureString);
 
         assert.equal(actualFailures.length, 1);
         assert.isTrue(actualFailures[0].equals(expectedFailure));
     });
 
-    it("enforces double quotes", () => {
-        const actualFailures = Lint.Test.applyRuleOnFile(fileName, QuoteMarkRule, [true, "double"]);
+    it("enforces double quotes but allow other quote marks to avoid having to escape", () => {
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, QuoteMarkRule, [true, "double", "avoid-escape"]);
         const expectedFailure = Lint.Test.createFailure(fileName, [1, 14], [1, 22], doubleFailureString);
 
         assert.equal(actualFailures.length, 1);


### PR DESCRIPTION
This rule allow to use "other" quote mark for escaping.
It is similar to the "escape" option of JSCS or the "avoid-escape" option of ESLint.

This option is explained on [JSCS - validateQuoteMarks rule](http://jscs.info/rule/validateQuoteMarks.html):

> Allow the "other" quote mark to be used, but only to avoid having to escape.

and also on [Rule quotes - ESLint - Pluggable JavaScript linter](http://eslint.org/docs/rules/quotes):

> The third parameter enables an exception to the rule to avoid escaping quotes.

Related #543