### PR TITLE
JSON format outputs a line delimited JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ Just like rules, additional formatters can also be supplied to TSLint via `--for
 
 export class Formatter extends Lint.Formatters.AbstractFormatter {
     public format(failures: Lint.RuleFailure[]): string {
-        var failuresJSON = failures.map((failure: Lint.RuleFailure) => failure.toJson());
-        return JSON.stringify(failuresJSON);
+        const failuresJSON = failures.map((failure) => failure.toJson());
+        return JSON.stringify(failuresJSON) + "\n";
     }
 }
 ```

--- a/src/formatters/jsonFormatter.ts
+++ b/src/formatters/jsonFormatter.ts
@@ -17,6 +17,6 @@
 export class Formatter extends Lint.Formatters.AbstractFormatter {
     public format(failures: Lint.RuleFailure[]): string {
         const failuresJSON = failures.map((failure) => failure.toJson());
-        return JSON.stringify(failuresJSON);
+        return JSON.stringify(failuresJSON) + "\n";
     }
 }


### PR DESCRIPTION
This PR is a solution of #379 .

Currently, if designate json to format and multiple files, output of tslint is not a JSON.

I propose the line delimited JSON.
The line delimited JSON is machine readable than currently.