### PR TITLE
Fix various bugs with align-rule

### DIFF
--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -33,6 +33,11 @@ type SourcePosition = {
 }
 
 class AlignWalker extends Lint.RuleWalker {
+    public visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
+        this.checkAlignment(Rule.PARAMETERS_OPTION, node.parameters);
+        super.visitConstructorDeclaration(node);
+    }
+
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
         this.checkAlignment(Rule.PARAMETERS_OPTION, node.parameters);
         super.visitFunctionDeclaration(node);
@@ -41,6 +46,11 @@ class AlignWalker extends Lint.RuleWalker {
     public visitFunctionExpression(node: ts.FunctionExpression) {
         this.checkAlignment(Rule.PARAMETERS_OPTION, node.parameters);
         super.visitFunctionExpression(node);
+    }
+
+    public visitMethodDeclaration(node: ts.MethodDeclaration) {
+        this.checkAlignment(Rule.PARAMETERS_OPTION, node.parameters);
+        super.visitMethodDeclaration(node);
     }
 
     public visitCallExpression(node: ts.CallExpression) {
@@ -59,7 +69,7 @@ class AlignWalker extends Lint.RuleWalker {
     }
 
     private checkAlignment(kind: string, nodes: ts.Node[]) {
-        if (nodes.length === 0 || !this.hasOption(kind)) {
+        if (nodes == null || nodes.length === 0 || !this.hasOption(kind)) {
             return;
         }
 

--- a/test/files/rules/align.test.ts
+++ b/test/files/rules/align.test.ts
@@ -15,14 +15,14 @@ function invalidParametersAlignment3(a: number,
 }
 
 class C1 {
-    function invalidParametersAlignment(a: number,
+    invalidParametersAlignment(a: number,
                            b: number)
     {
     }
 }
 
 class InvalidAlignmentInConstructor {
-    function constructor(a: number,
+    constructor(a: number,
                                  str: string)
     {
     }
@@ -59,22 +59,22 @@ var validParametersAlignment6 = function(xxx: foo,
 
 ///////
 
-void invalidArgumentsAlignment1()
+function invalidArgumentsAlignment1()
 {
     f(10,
     'abcd', 0);
 }
 
-void invalidArgumentsAlignment2()
+function invalidArgumentsAlignment2()
 {
     f(10,
       'abcd',
         0);
 }
 
-class foo {
-    function constructor(a: number,
-                         str: string)
+class Foo {
+    constructor(a: number,
+                str: string)
     {
     }
 }
@@ -82,12 +82,12 @@ class foo {
 var invalidConstructorArgsAlignment = new foo(10,
              "abcd");
 
-void validArgumentsAlignment1()
+function validArgumentsAlignment1()
 {
     f(101, 'xyz', 'abc');
 }
 
-void validArgumentsAlignment2()
+function validArgumentsAlignment2()
 {
     f(1,
       2,
@@ -95,7 +95,7 @@ void validArgumentsAlignment2()
       4);
 }
 
-void validArgumentsAlignment3()
+function validArgumentsAlignment3()
 {
     f(
         1,
@@ -104,7 +104,7 @@ void validArgumentsAlignment3()
         4);
 }
 
-void validArgumentsAlignment3()
+function validArgumentsAlignment3()
 {
     f(1, 2,
       3, 4);
@@ -112,14 +112,14 @@ void validArgumentsAlignment3()
 
 ////////
 
-void invalidStatementsAlignment1()
+function invalidStatementsAlignment1()
 {
     var i = 0;
     var j = 0;
      var k = 1;
 }
 
-void invalidStatementsAlignment1()
+function invalidStatementsAlignment1()
 {
     var i = 0;
     {
@@ -128,18 +128,22 @@ void invalidStatementsAlignment1()
     }
 }
 
-void validStatementsAlignment1()
+function validStatementsAlignment1()
 {
     var i = 0;
     var j = 0;
     var k = 1;
 }
 
-void validStatementsAlignment2()
+function validStatementsAlignment2()
 {
     var i = 0;
     {
         var j = 0;
         var k = 1;
     }
+}
+
+function shouldntCrash() {
+  let f = new Foo;
 }


### PR DESCRIPTION
* Align rule won't crash on new expression without parens
* Align rule now checks constructor and method declarations
* Align rule test file now uses valid/normal TS syntax