### PR TITLE
Add all-caps rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A sample configuration file with all options is available [here](https://github.
   * `"parameters"` checks alignment of function parameters.
   * `"arguments"` checks alignment of function call arguments.
   * `"statements"` checks alignment of statements.
+* `all-caps` ensures that all-caps variable names are const.
 * `ban` bans the use of specific functions. Options are ["object", "function"] pairs that ban the use of object.function()
 * `class-name` enforces PascalCased class and interface names.
 * `comment-format` enforces rules for single-line comments. Rule options:

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -4,6 +4,7 @@
         "parameters",
         "arguments",
         "statements"],
+    "all-caps": true,
     "ban": false,
     "class-name": true,
     "comment-format": [true,

--- a/src/rules/allCapsRule.ts
+++ b/src/rules/allCapsRule.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "all-caps variables must be const";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new AllCapsWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class AllCapsWalker extends Lint.RuleWalker {
+    public visitVariableDeclaration(node: ts.VariableDeclaration) {
+        const variableName = node.name.getText();
+        const isConst = Lint.isNodeFlagSet(node.parent, ts.NodeFlags.Const);
+        if (!isConst && this.isUpperCase(variableName)) {
+            this.addFailure(this.createFailure(node.name.getStart(), node.name.getWidth(), Rule.FAILURE_STRING));
+        }
+
+        super.visitVariableDeclaration(node);
+    }
+
+    private isUpperCase(name: string) {
+        return name === name.toUpperCase();
+    }
+}

--- a/src/rules/tsconfig.json
+++ b/src/rules/tsconfig.json
@@ -17,6 +17,7 @@
         "../../typings/node.d.ts",
         "../../typings/typescriptServices.d.ts",
         "./alignRule.ts",
+        "./allCapsRule.ts",
         "./banRule.ts",
         "./classNameRule.ts",
         "./commentFormatRule.ts",

--- a/test/files/rules/allcaps.test.ts
+++ b/test/files/rules/allcaps.test.ts
@@ -1,0 +1,19 @@
+// lowercase names shouldn't fail
+const a;
+let b;
+var c;
+var d, e;
+var f = 1;
+var g = 2,
+    h = 3;
+
+// const shouldn't fail
+const A;
+
+// all of these should fail
+let B;
+var C;
+var D, E;
+var F = 1;
+var G = 2,
+    H = 3;

--- a/test/rules/allCapsRuleTests.ts
+++ b/test/rules/allCapsRuleTests.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("<all-caps>", () => {
+    const AllCapsRule = Lint.Test.getRule("all-caps");
+    const fileName = "rules/allcaps.test.ts";
+
+    it("ensures all-caps variables are always const", () => {
+        const createFailure = Lint.Test.createFailuresOnFile(fileName, AllCapsRule.FAILURE_STRING);
+        const expectedFailures = [
+            createFailure([14, 5], [14, 6]),
+            createFailure([15, 5], [15, 6]),
+            createFailure([16, 5], [16, 6]),
+            createFailure([16, 8], [16, 9]),
+            createFailure([17, 5], [17, 6]),
+            createFailure([18, 5], [18, 6]),
+            createFailure([19, 5], [19, 6]),
+        ];
+
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, AllCapsRule);
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFailures);
+    });
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -36,6 +36,7 @@
         "./formatters/proseFormatterTests.ts",
         "./formatters/verboseFormatterTests.ts",
         "./rules/alignRuleTests.ts",
+        "./rules/allCapsRuleTests.ts",
         "./rules/banRuleTests.ts",
         "./rules/classNameRuleTests.ts",
         "./rules/commentFormatRuleTests.ts",


### PR DESCRIPTION
Addresses #604.

Enforces the use of `const` for all-caps variable names. For example:

    let PI = 3.1415926535; // bad
    const SECONDS_IN_A_DAY = 86400; // good
