### PR TITLE
unused variable rule shouldn't error on abstract methods with parameters

### DIFF
--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -193,7 +193,13 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
             }
         }
 
+        // skip checking parameter declarations for abstract methods
+        // They can't have a body so parameters are always unused
+        if (Lint.hasModifier(node.modifiers, ts.SyntaxKind.AbstractKeyword)) {
+            this.skipParameterDeclaration = true;
+        }
         super.visitMethodDeclaration(node);
+        this.skipParameterDeclaration = false;
     }
 
     private validateReferencesForVariable(name: string, position: number) {

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -193,8 +193,7 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
             }
         }
 
-        // skip checking parameter declarations for abstract methods
-        // They can't have a body so parameters are always unused
+        // abstract methods can't have a body so their parameters are always unused
         if (Lint.hasModifier(node.modifiers, ts.SyntaxKind.AbstractKeyword)) {
             this.skipParameterDeclaration = true;
         }

--- a/test/files/rules/nounusedvariable-parameter.test.ts
+++ b/test/files/rules/nounusedvariable-parameter.test.ts
@@ -56,3 +56,7 @@ export class DestructuringTests {
         return;
     }
 }
+
+abstract class AbstractTest {
+    abstract foo(x);
+}


### PR DESCRIPTION
fixes #663