### PR TITLE
AbstractFormatter and AbstractRule are now abstract classes

### DIFF
--- a/lib/tslint.d.ts
+++ b/lib/tslint.d.ts
@@ -92,10 +92,10 @@ declare module Lint {
     }
 }
 declare module Lint {
-    class ScopeAwareRuleWalker<T> extends RuleWalker {
+    abstract class ScopeAwareRuleWalker<T> extends RuleWalker {
         private scopeStack;
         constructor(sourceFile: ts.SourceFile, options?: any);
-        createScope(): T;
+        abstract createScope(): T;
         getCurrentScope(): T;
         getAllScopes(): T[];
         getCurrentDepth(): number;
@@ -106,8 +106,8 @@ declare module Lint {
     }
 }
 declare module Lint.Formatters {
-    class AbstractFormatter implements Lint.IFormatter {
-        format(failures: Lint.RuleFailure[]): string;
+    abstract class AbstractFormatter implements Lint.IFormatter {
+        abstract format(failures: Lint.RuleFailure[]): string;
     }
 }
 declare module Lint {
@@ -120,12 +120,12 @@ declare module Lint {
     function createLanguageService(fileName: string, source: string): ts.LanguageService;
 }
 declare module Lint.Rules {
-    class AbstractRule implements Lint.IRule {
+    abstract class AbstractRule implements Lint.IRule {
         private value;
         private options;
         constructor(ruleName: string, value: any, disabledIntervals: Lint.IDisabledInterval[]);
         getOptions(): Lint.IOptions;
-        apply(sourceFile: ts.SourceFile): RuleFailure[];
+        abstract apply(sourceFile: ts.SourceFile): RuleFailure[];
         applyWithWalker(walker: Lint.RuleWalker): RuleFailure[];
         isEnabled(): boolean;
     }
@@ -189,10 +189,10 @@ declare module Lint {
     function isNodeFlagSet(node: ts.Node, flagToCheck: ts.NodeFlags): boolean;
 }
 declare module Lint {
-    class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalker<T> {
+    abstract class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalker<T> {
         private blockScopeStack;
         constructor(sourceFile: ts.SourceFile, options?: any);
-        createBlockScope(): U;
+        abstract createBlockScope(): U;
         getCurrentBlockScope(): U;
         onBlockScopeStart(): void;
         getCurrentBlockDepth(): number;

--- a/src/language/formatter/abstractFormatter.ts
+++ b/src/language/formatter/abstractFormatter.ts
@@ -15,9 +15,7 @@
  */
 
 module Lint.Formatters {
-    export class AbstractFormatter implements Lint.IFormatter {
-        public format(failures: Lint.RuleFailure[]): string {
-            throw Lint.abstract();
-        }
+    export abstract class AbstractFormatter implements Lint.IFormatter {
+        public abstract format(failures: Lint.RuleFailure[]): string;
     }
 }

--- a/src/language/rule/abstractRule.ts
+++ b/src/language/rule/abstractRule.ts
@@ -15,7 +15,7 @@
  */
 
 module Lint.Rules {
-    export class AbstractRule implements Lint.IRule {
+    export abstract class AbstractRule implements Lint.IRule {
         private value: any;
         private options: Lint.IOptions;
 
@@ -38,11 +38,7 @@ module Lint.Rules {
             return this.options;
         }
 
-        /* tslint:disable:no-unused-variable */
-        public apply(sourceFile: ts.SourceFile): RuleFailure[] {
-            throw Lint.abstract();
-        }
-        /* tslint:enable:no-unused-variable */
+        public abstract apply(sourceFile: ts.SourceFile): RuleFailure[];
 
         public applyWithWalker(walker: Lint.RuleWalker): RuleFailure[] {
             walker.walk(walker.getSourceFile());

--- a/src/language/walker/blockScopeAwareRuleWalker.ts
+++ b/src/language/walker/blockScopeAwareRuleWalker.ts
@@ -19,7 +19,7 @@ module Lint {
      * An AST walker that is aware of block scopes in addition to regular scopes. Block scopes
      * are a superset of regular scopes (new block scopes are created more frequently in a program).
      */
-    export class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalker<T> {
+    export abstract class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalker<T> {
         private blockScopeStack: U[];
 
         constructor(sourceFile: ts.SourceFile, options?: any) {
@@ -29,9 +29,7 @@ module Lint {
             this.blockScopeStack = [this.createBlockScope()];
         }
 
-        public createBlockScope(): U {
-            throw Lint.abstract();
-        }
+        public abstract createBlockScope(): U;
 
         public getCurrentBlockScope(): U {
             return this.blockScopeStack[this.blockScopeStack.length - 1];

--- a/src/language/walker/scopeAwareRuleWalker.ts
+++ b/src/language/walker/scopeAwareRuleWalker.ts
@@ -15,7 +15,7 @@
  */
 
 module Lint {
-    export class ScopeAwareRuleWalker<T> extends RuleWalker {
+    export abstract class ScopeAwareRuleWalker<T> extends RuleWalker {
         private scopeStack: T[];
 
         constructor(sourceFile: ts.SourceFile, options?: any) {
@@ -25,9 +25,7 @@ module Lint {
             this.scopeStack = [this.createScope()];
         }
 
-        public createScope(): T {
-            throw Lint.abstract();
-        }
+        public abstract createScope(): T;
 
         public getCurrentScope(): T {
             return this.scopeStack[this.scopeStack.length - 1];


### PR DESCRIPTION
refs #631

Don't think this breaks custom rules. Feel free to close if this isn't something you want:)

**edit: I did keep the `Lint.abstract();` in `utils.ts` because removing that would change the api**; it isn't used though