### PR TITLE
member-ordering-rule ignores object literal shorthand methods

### DIFF
--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -65,7 +65,10 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
     }
 
     public visitMethodDeclaration(node: ts.MethodDeclaration) {
-        this.checkModifiersAndSetPrevious(node, getModifiers(true, node.modifiers));
+        if (node.parent.kind !== ts.SyntaxKind.ObjectLiteralExpression) {
+            this.checkModifiersAndSetPrevious(node, getModifiers(true, node.modifiers));
+        }
+
         super.visitMethodDeclaration(node);
     }
 

--- a/test/files/rules/memberordering-private.test.ts
+++ b/test/files/rules/memberordering-private.test.ts
@@ -1,7 +1,7 @@
 class Foo {
     private x: number;
     private bar(): any {
-        var bla: { a: string } = {a: '1'};
+        var bla: { a: string, b: () => void } = { a: '1', b() {} };
     }
     y: number;
 }


### PR DESCRIPTION
This MR should fix first issue described in #714.