### PR TITLE
Switch off conflicting rules in sample.json

### DIFF
--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -44,7 +44,7 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
-    "no-inferrable-types": true,
+    "no-inferrable-types": false,
     "no-internal-module": true,
     "no-require-imports": true,
     "no-string-literal": true,


### PR DESCRIPTION
This doesn't address the issue of the presence of conflicting rules, but anyone using the sample config be default will have a workable config.