### PR TITLE
Implement a "react" option for the no-unused-variable rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ A sample configuration file with all options is available [here](https://github.
 * `no-unused-variable` disallows unused imports, variables, functions and private class members.
     * `"check-parameters"` disallows unused function and constructor parameters.
         * NOTE: this option is experimental and does not work with classes that use abstract method declarations, among other things. Use at your own risk.
+    * `"react"` relaxes the rule for a namespace import named `React` (from either the module `"react"` or `"react/addons"`) to also consider JSX expressions
+      uses of the import
 * `no-use-before-declare` disallows usage of variables before their declaration.
 * `no-var-keyword` disallows usage of the `var` keyword, use `let` or `const` instead.
 * `no-var-requires` disallows the use of require statements except in import statements, banning the use of forms such as `var module = require("module")`

--- a/test/files/rules/nounusedvariable-react1-react.test.tsx
+++ b/test/files/rules/nounusedvariable-react1-react.test.tsx
@@ -1,0 +1,3 @@
+import * as React from "react";
+
+console.log(<div></div>);

--- a/test/files/rules/nounusedvariable-react1-react_addons.test.tsx
+++ b/test/files/rules/nounusedvariable-react1-react_addons.test.tsx
@@ -1,0 +1,3 @@
+import * as React from "react/addons";
+
+console.log(<div></div>);

--- a/test/files/rules/nounusedvariable-react2-react.test.tsx
+++ b/test/files/rules/nounusedvariable-react2-react.test.tsx
@@ -1,0 +1,3 @@
+import * as React from "react";
+
+export class MyComponent extends React.Component<{}, {}> {}

--- a/test/files/rules/nounusedvariable-react2-react_addons.test.tsx
+++ b/test/files/rules/nounusedvariable-react2-react_addons.test.tsx
@@ -1,0 +1,3 @@
+import * as React from "react/addons";
+
+export class MyComponent extends React.Component<{}, {}> {}

--- a/test/files/rules/nounusedvariable-react3-react.test.tsx
+++ b/test/files/rules/nounusedvariable-react3-react.test.tsx
@@ -1,0 +1,1 @@
+import * as React from "react";

--- a/test/files/rules/nounusedvariable-react3-react_addons.test.tsx
+++ b/test/files/rules/nounusedvariable-react3-react_addons.test.tsx
@@ -1,0 +1,1 @@
+import * as React from "react/addons";

--- a/test/rules/noUnusedVariableRuleTests.ts
+++ b/test/rules/noUnusedVariableRuleTests.ts
@@ -113,4 +113,66 @@ describe("<no-unused-variable>", () => {
 
         assert.lengthOf(actualFailures, 0);
     });
+
+    describe("with react option", () => {
+        describe("set", () => {
+            function shared(importModuleName: string) {
+                const suffix = moduleNameToFilenameSuffix(importModuleName);
+                describe("importing \"${importModuleName}\"", () => {
+                    it("should not fail if only JSX present", () => {
+                        pass(`rules/nounusedvariable-react1-${suffix}.test.tsx`, true);
+                    });
+
+                    it("should not fail if React namespace is used", () => {
+                        pass(`rules/nounusedvariable-react2-${suffix}.test.tsx`, true);
+                    });
+
+                    it("should fail if neither JSX nor React namespace is seen", () => {
+                        fail(`rules/nounusedvariable-react3-${suffix}.test.tsx`, true);
+                    });
+                });
+            }
+
+            shared("react");
+            shared("react/addons");
+        });
+
+        describe("not set", () => {
+            function shared(importModuleName: string) {
+                const suffix = moduleNameToFilenameSuffix(importModuleName);
+                describe("importing \"${importModuleName}\"", () => {
+                    it("should fail if only JSX present", () => {
+                        fail(`rules/nounusedvariable-react1-${suffix}.test.tsx`, false);
+                    });
+
+                    it("should not fail if React namespace is used", () => {
+                        pass(`rules/nounusedvariable-react2-${suffix}.test.tsx`, false);
+                    });
+
+                    it("should fail if neither JSX nor React namespace is seen", () => {
+                        fail(`rules/nounusedvariable-react3-${suffix}.test.tsx`, false);
+                    });
+                });
+            }
+
+            shared("react");
+            shared("react/addons");
+        });
+
+        function pass(fileName: string, isReactOptionSet: boolean) {
+            const actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule, isReactOptionSet ? [true, "react"] : [true]);
+            assert.lengthOf(actualFailures, 0);
+        }
+
+        function fail(fileName: string, isReactOptionSet: boolean) {
+            const failure1 = Lint.Test.createFailuresOnFile(fileName, Rule.FAILURE_STRING + "'React'")([1, 13], [1, 18]);
+            const actualFailures = Lint.Test.applyRuleOnFile(fileName, Rule, isReactOptionSet ? [true, "react"] : [true]);
+            assert.lengthOf(actualFailures, 1);
+            Lint.Test.assertContainsFailure(actualFailures, failure1);
+        }
+
+        function moduleNameToFilenameSuffix(moduleName: string): string {
+            return moduleName.replace(/\//g, "_");
+        }
+    });
 });


### PR DESCRIPTION
Addresses #698 

```
"no-unused-variable", [true, "react"],
```

With such a valid option, the following is __not__ an error:

```typescript
import * as React from "react";

let x = <span></span>;
console.log(x);
```

Thoughts/comments?