### PR TITLE
Improve use-strict rule to work for module declarations with more than one identifier

### DIFF
--- a/src/rules/useStrictRule.ts
+++ b/src/rules/useStrictRule.ts
@@ -34,13 +34,16 @@ class UseStrictWalker extends Lint.ScopeAwareRuleWalker<{}> {
     }
 
     public visitModuleDeclaration(node: ts.ModuleDeclaration) {
-        // current depth is 2: global scope and the scope created by this module
-        if (this.getCurrentDepth() === 2
-                && !Lint.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
+        if (!Lint.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
                 && this.hasOption(UseStrictWalker.OPTION_CHECK_MODULE)
                 && node.body != null
                 && node.body.kind === ts.SyntaxKind.ModuleBlock) {
-            this.handleBlock(node, <ts.Block> node.body);
+            let firstModuleDeclaration = getFirstInModuleDeclarationsChain(node);
+            let hasOnlyModuleDeclarationParents = firstModuleDeclaration.parent.kind === ts.SyntaxKind.SourceFile;
+
+            if (hasOnlyModuleDeclarationParents) {
+                this.handleBlock(firstModuleDeclaration, <ts.Block> node.body);
+            }
         }
 
         super.visitModuleDeclaration(node);
@@ -77,4 +80,14 @@ class UseStrictWalker extends Lint.ScopeAwareRuleWalker<{}> {
             this.addFailure(this.createFailure(node.getStart(), node.getFirstToken().getWidth(), Rule.FAILURE_STRING));
         }
     }
+}
+
+function getFirstInModuleDeclarationsChain(node: ts.ModuleDeclaration): ts.ModuleDeclaration {
+    let current = node;
+
+    while (current.parent.kind === ts.SyntaxKind.ModuleDeclaration) {
+        current = <ts.ModuleDeclaration> current.parent;
+    }
+
+    return current;
 }

--- a/test/files/rules/usestrict.test.ts
+++ b/test/files/rules/usestrict.test.ts
@@ -26,6 +26,11 @@ module TestNoUseStrictModule {
     var i = 3;
 }
 
+module TestNoUseStrictModule.Namespaced.AndAgain {
+    // hello
+    var i = 3;
+}
+
 function checkDepth() {
     "use strict";
 

--- a/test/rules/useStrictRuleTests.ts
+++ b/test/rules/useStrictRuleTests.ts
@@ -22,7 +22,7 @@ describe("<use-strict>", () => {
     before(() => {
         const options = [true, "check-function", "check-module"];
         actualFailures = Lint.Test.applyRuleOnFile(fileName, UseStrictRule, options);
-        assert.lengthOf(actualFailures, 2);
+        assert.lengthOf(actualFailures, 3);
     });
 
     it("enforces checks for 'use strict' in functions", () => {
@@ -32,6 +32,11 @@ describe("<use-strict>", () => {
 
     it("enforces checks for 'use strict' in modules", () => {
         const expectedFailures = Lint.Test.createFailure(fileName, [24, 1], [24, 7], UseStrictRule.FAILURE_STRING);
+        Lint.Test.assertContainsFailure(actualFailures, expectedFailures);
+    });
+
+    it("enforces checks for 'use strict' in module declaration with more than one identifier", () => {
+        const expectedFailures = Lint.Test.createFailure(fileName, [29, 1], [29, 7], UseStrictRule.FAILURE_STRING);
         Lint.Test.assertContainsFailure(actualFailures, expectedFailures);
     });
 });


### PR DESCRIPTION
This will make it work for code like this:

```
module A.B.C {
  // use strict required here
}
```

Fixes #544 