### PR TITLE
Add Undefined to List of Banned Var Names

### DIFF
--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -16,7 +16,7 @@
 import * as Lint from "../lint";
 import * as ts from "typescript";
 
-const BANNED_KEYWORDS = ["any", "Number", "number", "String", "string", "Boolean", "boolean", "undefined"];
+const BANNED_KEYWORDS = ["any", "Number", "number", "String", "string", "Boolean", "boolean", "Undefined", "undefined"];
 
 const OPTION_LEADING_UNDERSCORE = "allow-leading-underscore";
 const OPTION_TRAILING_UNDERSCORE = "allow-trailing-underscore";


### PR DESCRIPTION
See #748 

(No tests added because we don't really need to test that every term in the list is banned)