### PR TITLE
Make src/tslint.ts a commonjs-style module instead of an ES6 module.

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,6 +1,8 @@
-import * as formatters from "./formatters";
 import * as configuration from "./configuration";
+import * as formatters from "./formatters";
+import * as linter from "./tslint";
 import * as rules from "./rules";
+
 
 export * from "./language/rule/rule";
 export * from "./enableDisableRules";
@@ -11,8 +13,9 @@ export * from "./language/languageServiceHost";
 export * from "./language/walker";
 export * from "./language/formatter/formatter";
 
-export var Formatters = formatters;
 export var Configuration = configuration;
+export var Formatters = formatters;
+export var Linter = linter;
 export var Rules = rules;
 
 import {RuleFailure} from "./language/rule/rule";
@@ -30,5 +33,3 @@ export interface ILinterOptions {
     formattersDirectory: string;
     rulesDirectory: string;
 }
-
-export {default as Linter} from "./tslint";

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Linter from "./tslint";
+import * as Linter from "./tslint";
 import * as fs from "fs";
 import * as optimist from "optimist";
 let processed = optimist

--- a/src/tslint.ts
+++ b/src/tslint.ts
@@ -19,7 +19,7 @@ import * as path from "path";
 import {findConfiguration as config} from "./configuration";
 const moduleDirectory = path.dirname(module.filename);
 
-export default class Linter {
+class Linter {
     public static VERSION = "2.5.1";
     public static findConfiguration = config;
 
@@ -90,3 +90,6 @@ export default class Linter {
         return rules.some((r) => r.equals(rule));
     }
 }
+
+namespace Linter {}
+export = Linter;


### PR DESCRIPTION
Reverts 'tslint' back to being an old-style module so it works better with CommonJS. 