### PR TITLE
Cleanup

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -71,14 +71,16 @@ export function findConfiguration(configFile: string, inputFileLocation: string)
 
 function getHomeDir() {
     const environment = global.process.env;
-    const paths = [environment.USERPROFILE, environment.HOME, environment.HOMEPATH, environment.HOMEDRIVE + environment.HOMEPATH];
+    const paths = [
+        environment.USERPROFILE,
+        environment.HOME,
+        environment.HOMEPATH,
+        environment.HOMEDRIVE + environment.HOMEPATH
+    ];
 
-    for (const homeIndex in paths) {
-        if (paths.hasOwnProperty(homeIndex)) {
-            const homePath = paths[homeIndex];
-            if (homePath && fs.existsSync(homePath)) {
-                return homePath;
-            }
+    for (const homePath of paths) {
+        if (homePath != null && fs.existsSync(homePath)) {
+            return homePath;
         }
     }
 }

--- a/src/enableDisableRules.ts
+++ b/src/enableDisableRules.ts
@@ -1,18 +1,19 @@
 /*
-* Copyright 2014 Palantir Technologies, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as Lint from "./lint";
 import {SkippableTokenAwareRuleWalker} from "./language/walker/skippableTokenAwareRuleWalker";
 import * as ts from "typescript";
@@ -23,6 +24,7 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
     public visitSourceFile(node: ts.SourceFile) {
         super.visitSourceFile(node);
         const scan = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text);
+
         Lint.scanAllTokens(scan, (scanner: ts.Scanner) => {
             const startPos = scanner.getStartPos();
             if (this.tokensToSkipStartEndMap[startPos] != null) {
@@ -41,29 +43,28 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
     }
 
     private handlePossibleTslintSwitch(commentText: string, startingPosition: number) {
-        const currentPosition = startingPosition;
         // regex is: start of string followed by "/*" followed by any amount of whitespace followed by "tslint:"
         if (commentText.match(/^\/\*\s*tslint:/)) {
             const commentTextParts = commentText.split(":");
             // regex is: start of string followed by either "enable" or "disable"
             // followed by either whitespace or end of string
             const enableOrDisableMatch = commentTextParts[1].match(/^(enable|disable)(\s|$)/);
+
             if (enableOrDisableMatch != null) {
                 const isEnabled = enableOrDisableMatch[1] === "enable";
-                const position = currentPosition;
                 let rulesList = ["all"];
                 if (commentTextParts.length > 2) {
                     rulesList = commentTextParts[2].split(/\s+/);
                 }
-                rulesList.forEach((ruleToAdd) => {
+                for (const ruleToAdd of rulesList) {
                     if (!(ruleToAdd in this.enableDisableRuleMap)) {
                         this.enableDisableRuleMap[ruleToAdd] = [];
                     }
                     this.enableDisableRuleMap[ruleToAdd].push({
                         isEnabled: isEnabled,
-                        position: position
+                        position: startingPosition
                     });
-                });
+                }
             }
         }
     }

--- a/src/formatterLoader.ts
+++ b/src/formatterLoader.ts
@@ -1,18 +1,18 @@
 /*
-* Copyright 2013 Palantir Technologies, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import * as fs from "fs";
 import * as path from "path";
@@ -22,15 +22,15 @@ const moduleDirectory = path.dirname(module.filename);
 const CORE_FORMATTERS_DIRECTORY = path.resolve(moduleDirectory, ".", "formatters");
 
 export function findFormatter(name: string, formattersDirectory?: string) {
-    if (typeof(name) === "function") {
+    if (typeof name === "function") {
         return name;
     }
 
-    const camelizedName = camelize(name + "Formatter");
+    const camelizedName = camelize(`${name}Formatter`);
 
     // first check for core formatters
     let Formatter = loadFormatter(CORE_FORMATTERS_DIRECTORY, camelizedName);
-    if (Formatter) {
+    if (Formatter != null) {
         return Formatter;
     }
 
@@ -50,7 +50,7 @@ function loadFormatter(...paths: string[]) {
     const formatterPath = paths.reduce((p, c) => path.join(p, c), "");
     const fullPath = path.resolve(moduleDirectory, formatterPath);
 
-    if (fs.existsSync(fullPath + ".js")) {
+    if (fs.existsSync(`${fullPath}.js`)) {
         const formatterModule = require(fullPath);
         return formatterModule.Formatter;
     }

--- a/src/formatters/jsonFormatter.ts
+++ b/src/formatters/jsonFormatter.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as Lint from "../lint";
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 

--- a/src/formatters/pmdFormatter.ts
+++ b/src/formatters/pmdFormatter.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as Lint from "../lint";
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 

--- a/src/formatters/pmdFormatter.ts
+++ b/src/formatters/pmdFormatter.ts
@@ -26,8 +26,8 @@ export class Formatter extends AbstractFormatter {
                 .replace(/&/g, "&amp;")
                 .replace(/</g, "&lt;")
                 .replace(/>/g, "&gt;")
-                .replace(/\'/g, "&#39;")
-                .replace(/\"/g, "&quot;");
+                .replace(/'/g, "&#39;")
+                .replace(/"/g, "&quot;");
 
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
 

--- a/src/formatters/proseFormatter.ts
+++ b/src/formatters/proseFormatter.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as Lint from "../lint";
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 

--- a/src/formatters/verboseFormatter.ts
+++ b/src/formatters/verboseFormatter.ts
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
+
 import * as Lint from "../lint";
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 
@@ -27,7 +28,7 @@ export class Formatter extends AbstractFormatter {
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
             const positionTuple = "[" + (lineAndCharacter.line + 1) + ", " + (lineAndCharacter.character + 1) + "]";
 
-            return "(" + ruleName + ") " + fileName + positionTuple + ": " + failureString;
+            return `(${ruleName}) ${fileName}${positionTuple}: ${failureString}`;
         });
 
         return outputLines.join("\n") + "\n";

--- a/src/language/formatter/abstractFormatter.ts
+++ b/src/language/formatter/abstractFormatter.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as Lint from "../../lint";
 
 export abstract class AbstractFormatter implements Lint.IFormatter {

--- a/src/language/formatter/formatter.ts
+++ b/src/language/formatter/formatter.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as Lint from "../../lint";
 
 export interface IFormatter {

--- a/src/language/languageServiceHost.ts
+++ b/src/language/languageServiceHost.ts
@@ -17,18 +17,16 @@
 import * as Lint from "../lint";
 import * as ts from "typescript";
 
-export function createLanguageServiceHost(fileName: string, source: string) {
-    const host: ts.LanguageServiceHost = {
+export function createLanguageServiceHost(fileName: string, source: string): ts.LanguageServiceHost {
+    return {
         getCompilationSettings: () => Lint.createCompilerOptions(),
         getCurrentDirectory: () => "",
         getDefaultLibFileName: () => "lib.d.ts",
         getScriptFileNames: () => [fileName],
-        getScriptSnapshot: (name) => ts.ScriptSnapshot.fromString(name === fileName ? source : ""),
+        getScriptSnapshot: (name: string) => ts.ScriptSnapshot.fromString(name === fileName ? source : ""),
         getScriptVersion: () => "1",
-        log: (message) => { /* */ }
+        log: () => { /* */ }
     };
-
-    return host;
 }
 
 export function createLanguageService(fileName: string, source: string) {

--- a/src/language/rule/abstractRule.ts
+++ b/src/language/rule/abstractRule.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import * as ts from "typescript";
 import * as Lint from "../../lint";
 import {RuleWalker} from "../walker/ruleWalker";
-import * as ts from "typescript";
 
 export abstract class AbstractRule implements Lint.IRule {
     private value: any;

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../../lint";
 
 export interface IOptions {
     ruleArguments?: any[];

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as Lint from "../lint";
-import * as ts from "typescript";
 import * as path from "path";
+import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export function getSourceFile(fileName: string, source: string): ts.SourceFile {
     const normalizedName = path.normalize(fileName).replace(/\\/g, "/");
@@ -71,8 +71,8 @@ export function scanAllTokens(scanner: ts.Scanner, callback: (s: ts.Scanner) => 
 }
 
 /**
-* @returns true if any modifier kinds passed along exist in the given modifiers array
-*/
+ * @returns true if any modifier kinds passed along exist in the given modifiers array
+ */
 export function hasModifier(modifiers: ts.ModifiersArray, ...modifierKinds: ts.SyntaxKind[]) {
     if (modifiers == null || modifierKinds == null) {
         return false;
@@ -84,9 +84,9 @@ export function hasModifier(modifiers: ts.ModifiersArray, ...modifierKinds: ts.S
 }
 
 /**
-* Determines if the appropriate bit in the parent (VariableDeclarationList) is set,
-* which indicates this is a "let" or "const".
-*/
+ * Determines if the appropriate bit in the parent (VariableDeclarationList) is set,
+ * which indicates this is a "let" or "const".
+ */
 export function isBlockScopedVariable(node: ts.VariableDeclaration | ts.VariableStatement): boolean {
     const parentNode = (node.kind === ts.SyntaxKind.VariableDeclaration)
         ? (<ts.VariableDeclaration> node).parent
@@ -110,8 +110,8 @@ export function isBlockScopedBindingElement(node: ts.BindingElement): boolean {
 }
 
 /**
-* Bitwise check for node flags.
-*/
+ * Bitwise check for node flags.
+ */
 export function isNodeFlagSet(node: ts.Node, flagToCheck: ts.NodeFlags): boolean {
     /* tslint:disable:no-bitwise */
     return (node.flags & flagToCheck) !== 0;

--- a/src/language/walker/blockScopeAwareRuleWalker.ts
+++ b/src/language/walker/blockScopeAwareRuleWalker.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ScopeAwareRuleWalker} from "./scopeAwareRuleWalker";
+
 import * as ts from "typescript";
+import {ScopeAwareRuleWalker} from "./scopeAwareRuleWalker";
 
 /**
-* An AST walker that is aware of block scopes in addition to regular scopes. Block scopes
-* are a superset of regular scopes (new block scopes are created more frequently in a program).
-*/
+ * An AST walker that is aware of block scopes in addition to regular scopes. Block scopes
+ * are a superset of regular scopes (new block scopes are created more frequently in a program).
+ */
 export abstract class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalker<T> {
     private blockScopeStack: U[];
 

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import * as ts from "typescript";
 import * as Lint from "../../lint";
 import {SyntaxWalker} from "./syntaxWalker";
-import * as ts from "typescript";
 
 export class RuleWalker extends SyntaxWalker {
     private limit: number;

--- a/src/language/walker/scopeAwareRuleWalker.ts
+++ b/src/language/walker/scopeAwareRuleWalker.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {RuleWalker} from "./ruleWalker";
+
 import * as ts from "typescript";
+import {RuleWalker} from "./ruleWalker";
 
 export abstract class ScopeAwareRuleWalker<T> extends RuleWalker {
     private scopeStack: T[];

--- a/src/language/walker/skippableTokenAwareRuleWalker.ts
+++ b/src/language/walker/skippableTokenAwareRuleWalker.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import * as ts from "typescript";
 import * as Lint from "../../lint";
 import {RuleWalker} from "./ruleWalker";
-import * as ts from "typescript";
 
 export class SkippableTokenAwareRuleWalker extends RuleWalker {
     protected tokensToSkipStartEndMap: {[start: number]: number};

--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -315,10 +315,6 @@ export class SyntaxWalker {
                 this.visitArrayLiteralExpression(<ts.ArrayLiteralExpression> node);
                 break;
 
-            case ts.SyntaxKind.BindingElement:
-                this.visitBindingElement(<ts.BindingElement> node);
-                break;
-
             case ts.SyntaxKind.ArrowFunction:
                 this.visitArrowFunction(<ts.FunctionLikeDeclaration> node);
                 break;

--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as ts from "typescript";
 
 export class SyntaxWalker {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as configuration from "./configuration";
 import * as formatters from "./formatters";
 import * as linter from "./tslint";
 import * as rules from "./rules";
-
+import {RuleFailure} from "./language/rule/rule";
 
 export * from "./language/rule/rule";
 export * from "./enableDisableRules";
@@ -17,8 +33,6 @@ export var Configuration = configuration;
 export var Formatters = formatters;
 export var Linter = linter;
 export var Rules = rules;
-
-import {RuleFailure} from "./language/rule/rule";
 
 export interface LintResult {
     failureCount: number;

--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -1,18 +1,18 @@
 /*
-* Copyright 2013 Palantir Technologies, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import * as fs from "fs";
 import * as path from "path";

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -76,12 +76,12 @@ class AlignWalker extends Lint.RuleWalker {
             return;
         }
 
-        let prevPos = this.getPosition(nodes[0]);
+        let prevPos = getPosition(nodes[0]);
         const alignToColumn = prevPos.character;
 
         // skip first node in list
         for (let node of nodes.slice(1)) {
-            const curPos = this.getPosition(node);
+            const curPos = getPosition(node);
             if (curPos.line !== prevPos.line && curPos.character !== alignToColumn) {
                 this.addFailure(this.createFailure(node.getStart(), node.getWidth(), kind + Rule.FAILURE_STRING_SUFFIX));
                 break;
@@ -90,7 +90,8 @@ class AlignWalker extends Lint.RuleWalker {
         }
     }
 
-    private getPosition(node: ts.Node): SourcePosition {
-        return node.getSourceFile().getLineAndCharacterOfPosition(node.getStart());
-    }
+}
+
+function getPosition(node: ts.Node): SourcePosition {
+    return node.getSourceFile().getLineAndCharacterOfPosition(node.getStart());
 }

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as Lint from "../lint";
 import * as ts from "typescript";
 

--- a/src/rules/banRule.ts
+++ b/src/rules/banRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_PART = "function invocation disallowed: ";
@@ -23,9 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         const options = this.getOptions();
         const banFunctionWalker = new BanFunctionWalker(sourceFile, options);
         const functionsToBan = options.ruleArguments;
-        functionsToBan.forEach((functionToBan) => {
-            banFunctionWalker.addBannedFunction(functionToBan);
-        });
+        functionsToBan.forEach((f) => banFunctionWalker.addBannedFunction(f));
         return this.applyWithWalker(banFunctionWalker);
     }
 }
@@ -40,8 +39,8 @@ export class BanFunctionWalker extends Lint.RuleWalker {
     public visitCallExpression(node: ts.CallExpression) {
         const expression = node.expression;
 
-        if (expression.kind === ts.SyntaxKind.PropertyAccessExpression &&
-            expression.getChildCount() >= 3) {
+        if (expression.kind === ts.SyntaxKind.PropertyAccessExpression
+                && expression.getChildCount() >= 3) {
 
             const firstToken = expression.getFirstToken();
             const secondToken = expression.getChildAt(1);
@@ -51,14 +50,16 @@ export class BanFunctionWalker extends Lint.RuleWalker {
             const thirdText = thirdToken.getFullText();
 
             if (secondToken.kind === ts.SyntaxKind.DotToken) {
-                this.bannedFunctions.forEach((bannedFunction) => {
+                for (const bannedFunction of this.bannedFunctions) {
                     if (firstText === bannedFunction[0] && thirdText === bannedFunction[1]) {
-                        const failure = this.createFailure(expression.getStart(),
-                                                         expression.getWidth(),
-                                                         Rule.FAILURE_STRING_PART + firstText + "." + thirdText);
+                        const failure = this.createFailure(
+                            expression.getStart(),
+                            expression.getWidth(),
+                            `${Rule.FAILURE_STRING_PART}${firstText}.${thirdText}`
+                        );
                         this.addFailure(failure);
                     }
-                });
+                }
             }
         }
 

--- a/src/rules/classNameRule.ts
+++ b/src/rules/classNameRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     static FAILURE_STRING = "name must be in pascal case";

--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 const OPTION_SPACE = "check-space";
 const OPTION_LOWERCASE = "check-lowercase";

--- a/src/rules/curlyRule.ts
+++ b/src/rules/curlyRule.ts
@@ -31,7 +31,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class CurlyWalker extends Lint.RuleWalker {
     public visitForInStatement(node: ts.ForInStatement) {
-        if (!this.isStatementBraced(node.statement)) {
+        if (!isStatementBraced(node.statement)) {
             this.addFailureForNode(node, Rule.FOR_FAILURE_STRING);
         }
 
@@ -39,7 +39,7 @@ class CurlyWalker extends Lint.RuleWalker {
     }
 
     public visitForOfStatement(node: ts.ForInStatement) {
-        if (!this.isStatementBraced(node.statement)) {
+        if (!isStatementBraced(node.statement)) {
             this.addFailureForNode(node, Rule.FOR_FAILURE_STRING);
         }
 
@@ -47,7 +47,7 @@ class CurlyWalker extends Lint.RuleWalker {
     }
 
     public visitForStatement(node: ts.ForStatement) {
-        if (!this.isStatementBraced(node.statement)) {
+        if (!isStatementBraced(node.statement)) {
             this.addFailureForNode(node, Rule.FOR_FAILURE_STRING);
         }
 
@@ -55,7 +55,7 @@ class CurlyWalker extends Lint.RuleWalker {
     }
 
     public visitIfStatement(node: ts.IfStatement) {
-        if (!this.isStatementBraced(node.thenStatement)) {
+        if (!isStatementBraced(node.thenStatement)) {
             this.addFailure(this.createFailure(
                 node.getStart(),
                 node.thenStatement.getEnd() - node.getStart(),
@@ -65,7 +65,7 @@ class CurlyWalker extends Lint.RuleWalker {
 
         if (node.elseStatement != null
                 && node.elseStatement.kind !== ts.SyntaxKind.IfStatement
-                && !this.isStatementBraced(node.elseStatement)) {
+                && !isStatementBraced(node.elseStatement)) {
 
             // find the else keyword to place the error appropriately
             const elseKeywordNode = node.getChildren().filter((child) => child.kind === ts.SyntaxKind.ElseKeyword)[0];
@@ -81,7 +81,7 @@ class CurlyWalker extends Lint.RuleWalker {
     }
 
     public visitDoStatement(node: ts.DoStatement) {
-        if (!this.isStatementBraced(node.statement)) {
+        if (!isStatementBraced(node.statement)) {
             this.addFailureForNode(node, Rule.DO_FAILURE_STRING);
         }
 
@@ -89,18 +89,18 @@ class CurlyWalker extends Lint.RuleWalker {
     }
 
     public visitWhileStatement(node: ts.WhileStatement) {
-        if (!this.isStatementBraced(node.statement)) {
+        if (!isStatementBraced(node.statement)) {
             this.addFailureForNode(node, Rule.WHILE_FAILURE_STRING);
         }
 
         super.visitWhileStatement(node);
     }
 
-    private isStatementBraced(node: ts.Statement) {
-        return node.kind === ts.SyntaxKind.Block;
-    }
-
     private addFailureForNode(node: ts.Node, failure: string) {
         this.addFailure(this.createFailure(node.getStart(), node.getWidth(), failure));
     }
+}
+
+function isStatementBraced(node: ts.Statement) {
+    return node.kind === ts.SyntaxKind.Block;
 }

--- a/src/rules/curlyRule.ts
+++ b/src/rules/curlyRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static DO_FAILURE_STRING = "do statements must be braced";
@@ -55,7 +56,11 @@ class CurlyWalker extends Lint.RuleWalker {
 
     public visitIfStatement(node: ts.IfStatement) {
         if (!this.isStatementBraced(node.thenStatement)) {
-            this.addFailure(this.createFailure(node.getStart(), node.thenStatement.getEnd() - node.getStart(), Rule.IF_FAILURE_STRING));
+            this.addFailure(this.createFailure(
+                node.getStart(),
+                node.thenStatement.getEnd() - node.getStart(),
+                Rule.IF_FAILURE_STRING
+            ));
         }
 
         if (node.elseStatement != null
@@ -65,11 +70,11 @@ class CurlyWalker extends Lint.RuleWalker {
             // find the else keyword to place the error appropriately
             const elseKeywordNode = node.getChildren().filter((child) => child.kind === ts.SyntaxKind.ElseKeyword)[0];
 
-            this.addFailure(
-                this.createFailure(elseKeywordNode.getStart(),
+            this.addFailure(this.createFailure(
+                elseKeywordNode.getStart(),
                 node.elseStatement.getEnd() - elseKeywordNode.getStart(),
-                Rule.ELSE_FAILURE_STRING)
-            );
+                Rule.ELSE_FAILURE_STRING
+            ));
         }
 
         super.visitIfStatement(node);

--- a/src/rules/eoflineRule.ts
+++ b/src/rules/eoflineRule.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as Lint from "../lint";
 import * as ts from "typescript";
 

--- a/src/rules/forinRule.ts
+++ b/src/rules/forinRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "for (... in ...) statements must be filtered with an if statement";

--- a/src/rules/indentRule.ts
+++ b/src/rules/indentRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 const OPTION_USE_TABS = "tabs";
 const OPTION_USE_SPACES = "spaces";

--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     static FAILURE_STRING = "interface name must be a capitalized I";

--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static ALIGNMENT_FAILURE_STRING = "asterisks in jsdoc must be aligned";

--- a/src/rules/labelPositionRule.ts
+++ b/src/rules/labelPositionRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "unexpected label on statement";

--- a/src/rules/labelUndefinedRule.ts
+++ b/src/rules/labelUndefinedRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "undefined label: '";

--- a/src/rules/maxLineLengthRule.ts
+++ b/src/rules/maxLineLengthRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "exceeds maximum line length of ";

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     static FAILURE_STRING = "default access modifier on member/method not allowed";

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "type decoration of 'any' is forbidden";

--- a/src/rules/noArgRule.ts
+++ b/src/rules/noArgRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "access forbidden to arguments property";

--- a/src/rules/noBitwiseRule.ts
+++ b/src/rules/noBitwiseRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "forbidden bitwise operation";

--- a/src/rules/noConditionalAssignmentRule.ts
+++ b/src/rules/noConditionalAssignmentRule.ts
@@ -70,12 +70,12 @@ class NoConditionalAssignmentWalker extends Lint.RuleWalker {
     }
 
     private checkForAssignment(expression: ts.BinaryExpression) {
-        if (this.isAssignmentToken(expression.operatorToken)) {
+        if (isAssignmentToken(expression.operatorToken)) {
             this.addFailure(this.createFailure(expression.getStart(), expression.getWidth(), Rule.FAILURE_STRING));
         }
     }
+}
 
-    private isAssignmentToken(token: ts.Node) {
-        return token.kind >= ts.SyntaxKind.FirstAssignment && token.kind <= ts.SyntaxKind.LastAssignment;
-    }
+function isAssignmentToken(token: ts.Node) {
+    return token.kind >= ts.SyntaxKind.FirstAssignment && token.kind <= ts.SyntaxKind.LastAssignment;
 }

--- a/src/rules/noConditionalAssignmentRule.ts
+++ b/src/rules/noConditionalAssignmentRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "assignment in conditional: ";

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     static FAILURE_STRING = "consecutive blank lines are disallowed";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new BlankLinesWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new NoConsecutiveBlankLinesWalker(sourceFile, this.getOptions()));
     }
 }
 
-class BlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
+class NoConsecutiveBlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
     public visitSourceFile(node: ts.SourceFile) {
         super.visitSourceFile(node);
 

--- a/src/rules/noConsoleRule.ts
+++ b/src/rules/noConsoleRule.ts
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
-import * as ts from "typescript";
 
-import BanRule = require("./banRule");
+import * as ts from "typescript";
+import * as Lint from "../lint";
+import * as BanRule from "./banRule";
 
 export class Rule extends BanRule.Rule {
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options = this.getOptions();
         const consoleBanWalker = new BanRule.BanFunctionWalker(sourceFile, this.getOptions());
-        for (let option of options.ruleArguments) {
+        for (const option of options.ruleArguments) {
             consoleBanWalker.addBannedFunction(["console", option]);
         }
         return this.applyWithWalker(consoleBanWalker);
     }
-  }
+}

--- a/src/rules/noConstructRule.ts
+++ b/src/rules/noConstructRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "undesirable constructor use";
@@ -40,7 +41,6 @@ class NoConstructWalker extends Lint.RuleWalker {
                 this.addFailure(failure);
             }
         }
-
         super.visitNewExpression(node);
     }
 }

--- a/src/rules/noConstructorVarsRule.ts
+++ b/src/rules/noConstructorVarsRule.ts
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_PART = " cannot be declared in the constructor";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoConstructorVariableDeclarationsWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new NoConstructorVarsWalker(sourceFile, this.getOptions()));
     }
 }
 
-export class NoConstructorVariableDeclarationsWalker extends Lint.RuleWalker {
-
+export class NoConstructorVarsWalker extends Lint.RuleWalker {
     public visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
         const parameters = node.parameters;
         for (let parameter of parameters) {

--- a/src/rules/noDebuggerRule.ts
+++ b/src/rules/noDebuggerRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "use of debugger statements is disallowed";

--- a/src/rules/noDuplicateKeyRule.ts
+++ b/src/rules/noDuplicateKeyRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "duplicate key '";

--- a/src/rules/noDuplicateVariableRule.ts
+++ b/src/rules/noDuplicateVariableRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "duplicate variable: '";

--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "block is empty";

--- a/src/rules/noEvalRule.ts
+++ b/src/rules/noEvalRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "forbidden eval";

--- a/src/rules/noInternalModuleRule.ts
+++ b/src/rules/noInternalModuleRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "forbidden internal module";

--- a/src/rules/noInternalModuleRule.ts
+++ b/src/rules/noInternalModuleRule.ts
@@ -37,13 +37,14 @@ class NoInternalModuleWalker extends Lint.RuleWalker {
         // an internal module declaration is not a namespace or a nested declaration
         // for external modules, node.name.kind will be a LiteralExpression instead of Identifier
         return !Lint.isNodeFlagSet(node, ts.NodeFlags.Namespace)
-            && !this.isNestedDeclaration(node)
+            && !isNestedDeclaration(node)
             && node.name.kind === ts.SyntaxKind.Identifier;
     }
+}
 
-    private isNestedDeclaration(node: ts.ModuleDeclaration) {
-        // in a declaration expression like 'module a.b.c' - 'a' is the top level module declaration node and 'b' and 'c' are nested
-        // therefore we can depend that a node's position will only match with its name's position for nested nodes
-        return node.name.pos === node.pos;
-    }
+function isNestedDeclaration(node: ts.ModuleDeclaration) {
+    // in a declaration expression like 'module a.b.c' - 'a' is the top level module declaration node and 'b' and 'c'
+    // are nested therefore we can depend that a node's position will only match with its name's position for nested
+    // nodes
+    return node.name.pos === node.pos;
 }

--- a/src/rules/noRequireImportsRule.ts
+++ b/src/rules/noRequireImportsRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "require() style import is forbidden";

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "shadowed variable: '";

--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -35,18 +35,18 @@ class NoStringLiteralWalker extends Lint.RuleWalker {
             const unquotedAccessorText = accessorText.substring(1, accessorText.length - 1);
 
             // only create a failure if the identifier is valid, in which case there's no need to use string literals
-            if (this.isValidIdentifier(unquotedAccessorText)) {
+            if (isValidIdentifier(unquotedAccessorText)) {
                 this.addFailure(this.createFailure(argument.getStart(), argument.getWidth(), Rule.FAILURE_STRING));
             }
         }
 
         super.visitElementAccessExpression(node);
     }
+}
 
-    private isValidIdentifier(token: string) {
-        const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, token);
-        scanner.scan();
-        // if we scanned to the end of the token, we can check if the scanned item was an identifier
-        return scanner.getTokenText() === token && scanner.isIdentifier();
-    }
+function isValidIdentifier(token: string) {
+    const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, token);
+    scanner.scan();
+    // if we scanned to the end of the token, we can check if the scanned item was an identifier
+    return scanner.getTokenText() === token && scanner.isIdentifier();
 }

--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "object access via string literals is disallowed";

--- a/src/rules/noSwitchCaseFallThroughRule.ts
+++ b/src/rules/noSwitchCaseFallThroughRule.ts
@@ -35,18 +35,21 @@ export class NoSwitchCaseFallThroughWalker extends Lint.RuleWalker {
             const kind = child.kind;
             if (kind === ts.SyntaxKind.CaseClause) {
                 const switchClause = <ts.CaseClause> child;
-                isFallingThrough = this.fallsThrough(switchClause.statements);
+                isFallingThrough = fallsThrough(switchClause.statements);
                 // no break statements and no statements means the fallthrough is expected.
                 // last item doesn't need a break
                 if (isFallingThrough && switchClause.statements.length > 0 && ((switchClauses.length - 1) > i)) {
-                    if (!this.fallThroughAllowed(switchClauses[i + 1])) {
-                        this.addFailure(this.createFailure(child.getEnd(), 1,
-                            Rule.FAILURE_STRING_PART + "'case'"));
+                    if (!isFallThroughAllowed(switchClauses[i + 1])) {
+                        this.addFailure(this.createFailure(
+                            child.getEnd(),
+                            1,
+                            `${Rule.FAILURE_STRING_PART}'case'`
+                        ));
                     }
                 }
             } else {
                 // case statement falling through a default
-                if (isFallingThrough && !this.fallThroughAllowed(child)) {
+                if (isFallingThrough && !isFallThroughAllowed(child)) {
                     const failureString = Rule.FAILURE_STRING_PART + "'default'";
                     this.addFailure(this.createFailure(switchClauses[i - 1].getEnd(), 1, failureString));
                 }
@@ -54,28 +57,28 @@ export class NoSwitchCaseFallThroughWalker extends Lint.RuleWalker {
         });
         super.visitSwitchStatement(node);
     }
+}
 
-    private fallThroughAllowed(nextCaseOrDefaultStatement: ts.Node) {
-        const sourceFileText = nextCaseOrDefaultStatement.getSourceFile().text;
-        const firstChild = nextCaseOrDefaultStatement.getChildAt(0);
-        const commentRanges = ts.getLeadingCommentRanges(sourceFileText, firstChild.getFullStart());
-        if (commentRanges != null) {
-            for (let commentRange of commentRanges) {
-                const commentText = sourceFileText.substring(commentRange.pos, commentRange.end);
-                if (commentText === "/* falls through */") {
-                    return true;
-                }
+function fallsThrough(statements: ts.NodeArray<ts.Statement>) {
+    return !statements.some((statement) => {
+        return statement.kind === ts.SyntaxKind.BreakStatement
+            || statement.kind === ts.SyntaxKind.ThrowStatement
+            || statement.kind === ts.SyntaxKind.ReturnStatement
+            || statement.kind === ts.SyntaxKind.ContinueStatement;
+    });
+}
+
+function isFallThroughAllowed(nextCaseOrDefaultStatement: ts.Node) {
+    const sourceFileText = nextCaseOrDefaultStatement.getSourceFile().text;
+    const firstChild = nextCaseOrDefaultStatement.getChildAt(0);
+    const commentRanges = ts.getLeadingCommentRanges(sourceFileText, firstChild.getFullStart());
+    if (commentRanges != null) {
+        for (let commentRange of commentRanges) {
+            const commentText = sourceFileText.substring(commentRange.pos, commentRange.end);
+            if (commentText === "/* falls through */") {
+                return true;
             }
         }
-        return false;
     }
-
-    private fallsThrough(statements: ts.NodeArray<ts.Statement>) {
-        return !statements.some((statement) => {
-            return statement.kind === ts.SyntaxKind.BreakStatement
-                || statement.kind === ts.SyntaxKind.ThrowStatement
-                || statement.kind === ts.SyntaxKind.ReturnStatement
-                || statement.kind === ts.SyntaxKind.ContinueStatement;
-        });
-    }
+    return false;
 }

--- a/src/rules/noSwitchCaseFallThroughRule.ts
+++ b/src/rules/noSwitchCaseFallThroughRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_PART = "expected a 'break' before ";

--- a/src/rules/noTrailingWhitespaceRule.ts
+++ b/src/rules/noTrailingWhitespaceRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "trailing whitespace";
@@ -45,7 +46,7 @@ class NoTrailingWhitespaceWalker extends Lint.SkippableTokenAwareRuleWalker {
                     const failure = this.createFailure(lastSeenWhitespacePosition, width, Rule.FAILURE_STRING);
                     this.addFailure(failure);
                 }
-               lastSeenWasWhitespace = false;
+                lastSeenWasWhitespace = false;
             } else if (scanner.getToken() === ts.SyntaxKind.WhitespaceTrivia) {
                 lastSeenWasWhitespace = true;
                 lastSeenWhitespacePosition = scanner.getStartPos();

--- a/src/rules/noUnreachableRule.ts
+++ b/src/rules/noUnreachableRule.ts
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "unreachable code";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new UnreachableWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new NoUnreachableWalker(sourceFile, this.getOptions()));
     }
 }
 
-class UnreachableWalker extends Lint.RuleWalker {
+class NoUnreachableWalker extends Lint.RuleWalker {
     private hasReturned: boolean;
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {

--- a/src/rules/noUnusedExpressionRule.ts
+++ b/src/rules/noUnusedExpressionRule.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as Lint from "../lint";
 import * as ts from "typescript";
 
@@ -20,11 +21,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "expected an assignment or function call";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new UnusedExpressionWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new NoUnusedExpressionWalker(sourceFile, this.getOptions()));
     }
 }
 
-class UnusedExpressionWalker extends Lint.RuleWalker {
+class NoUnusedExpressionWalker extends Lint.RuleWalker {
     private expressionIsUnused: boolean;
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 const OPTION_REACT = "react";
 const OPTION_CHECK_PARAMETERS = "check-parameters";
@@ -128,9 +129,9 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
     }
 
     public visitNamedImports(node: ts.NamedImports) {
-        node.elements.forEach((namedImport: ts.ImportSpecifier) => {
+        for (const namedImport of node.elements) {
             this.validateReferencesForVariable(namedImport.name.text, namedImport.name.getStart());
-        });
+        }
         super.visitNamedImports(node);
     }
 

--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_PREFIX = "variable '";

--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "forbidden var keyword";

--- a/src/rules/noVarRequiresRule.ts
+++ b/src/rules/noVarRequiresRule.ts
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "require statement not part of an import statement";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const requiresWalker = new RequiresWalker(sourceFile, this.getOptions());
+        const requiresWalker = new NoVarRequiresWalker(sourceFile, this.getOptions());
         return this.applyWithWalker(requiresWalker);
     }
 }
 
-class RequiresWalker extends Lint.ScopeAwareRuleWalker<{}> {
+class NoVarRequiresWalker extends Lint.ScopeAwareRuleWalker<{}> {
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);
     }

--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "unsorted key '";

--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 const OPTION_BRACE = "check-open-brace";
 const OPTION_CATCH = "check-catch";

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -58,7 +58,7 @@ class QuotemarkWalker extends Lint.RuleWalker {
         this.avoidEscape = ruleArguments.indexOf("avoid-escape") > 0;
     }
 
-    protected visitStringLiteral(node: ts.StringLiteral) {
+    public visitStringLiteral(node: ts.StringLiteral) {
         const text = node.getText();
         const width = node.getWidth();
         const position = node.getStart();

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 enum QuoteMark {
     SINGLE_QUOTES,
@@ -35,11 +36,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new QuoteWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new QuotemarkWalker(sourceFile, this.getOptions()));
     }
 }
 
-class QuoteWalker extends Lint.RuleWalker {
+class QuotemarkWalker extends Lint.RuleWalker {
     private quoteMark = QuoteMark.DOUBLE_QUOTES;
     private avoidEscape: boolean;
 

--- a/src/rules/radixRule.ts
+++ b/src/rules/radixRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "missing radix parameter";

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "missing semicolon";
@@ -89,15 +90,12 @@ class SemicolonWalker extends Lint.RuleWalker {
 
     private checkSemicolonAt(node: ts.Node) {
         const children = node.getChildren(this.getSourceFile());
-        for (let child of children) {
-            if (child.kind === ts.SyntaxKind.SemicolonToken) {
-                return;
-            }
-        }
+        const hasSemicolon = children.some((child) => child.kind === ts.SyntaxKind.SemicolonToken);
 
-        // no semicolon token was found, so add a failure at the given position
-        const sourceFile = this.getSourceFile();
-        const position = node.getStart(sourceFile) + node.getWidth(sourceFile);
-        this.addFailure(this.createFailure(Math.min(position, this.getLimit()), 0, Rule.FAILURE_STRING));
+        if (!hasSemicolon) {
+            const sourceFile = this.getSourceFile();
+            const position = node.getStart(sourceFile) + node.getWidth(sourceFile);
+            this.addFailure(this.createFailure(Math.min(position, this.getLimit()), 0, Rule.FAILURE_STRING));
+        }
     }
 }

--- a/src/rules/switchDefaultRule.ts
+++ b/src/rules/switchDefaultRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "switch statement doesn't include a 'default' case";

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_NEVER = "trailing comma";

--- a/src/rules/tripleEqualsRule.ts
+++ b/src/rules/tripleEqualsRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 const OPTION_ALLOW_NULL_CHECK = "allow-null-check";
 
@@ -50,7 +51,7 @@ class ComparisonWalker extends Lint.RuleWalker {
         }
     }
 
-    private isExpressionAllowed(node: ts.BinaryExpression): boolean {
+    private isExpressionAllowed(node: ts.BinaryExpression) {
         const nullKeyword = ts.SyntaxKind.NullKeyword;
 
         return this.hasOption(OPTION_ALLOW_NULL_CHECK)

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "missing type declaration";

--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "missing type declaration";
-
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new TypedefWhitespaceWalker(sourceFile, this.getOptions()));
     }

--- a/src/rules/useStrictRule.ts
+++ b/src/rules/useStrictRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "missing 'use strict'";

--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 const BANNED_KEYWORDS = ["any", "Number", "number", "String", "string", "Boolean", "boolean", "Undefined", "undefined"];
 

--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -92,7 +92,7 @@ class VariableNameWalker extends Lint.RuleWalker {
     private handleVariableNameFormat(name: ts.Identifier) {
         const variableName = name.text;
 
-        if (this.shouldCheckFormat && !this.isCamelCase(variableName) && !this.isUpperCase(variableName)) {
+        if (this.shouldCheckFormat && !this.isCamelCase(variableName) && !isUpperCase(variableName)) {
             this.addFailure(this.createFailure(name.getStart(), name.getWidth(), Rule.FORMAT_FAILURE));
         }
     }
@@ -121,8 +121,8 @@ class VariableNameWalker extends Lint.RuleWalker {
         }
         return firstCharacter === firstCharacter.toLowerCase() && middle.indexOf("_") === -1;
     }
+}
 
-    private isUpperCase(name: string) {
-        return name === name.toUpperCase();
-    }
+function isUpperCase(name: string) {
+    return name === name.toUpperCase();
 }

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Lint from "../lint";
+
 import * as ts from "typescript";
+import * as Lint from "../lint";
 
 const OPTION_BRANCH = "check-branch";
 const OPTION_DECL = "check-decl";

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import * as Linter from "./tslint";
 import * as fs from "fs";
 import * as optimist from "optimist";
+import * as Linter from "./tslint";
+
 let processed = optimist
     .usage("Usage: $0 [options] [file ...]")
     .check((argv: any) => {
@@ -63,7 +64,7 @@ let processed = optimist
 const argv = processed.argv;
 
 let outputStream: any;
-if (argv.o !== undefined) {
+if (argv.o != null) {
     outputStream = fs.createWriteStream(argv.o, {
         flags: "w+",
         mode: 420
@@ -72,7 +73,7 @@ if (argv.o !== undefined) {
     outputStream = process.stdout;
 }
 
-if (argv.v !== undefined) {
+if (argv.v != null) {
     outputStream.write(Linter.VERSION + "\n");
     process.exit(0);
 }
@@ -140,15 +141,15 @@ if (argv.c && !fs.existsSync(argv.c)) {
 
 const processFile = (file: string) => {
     if (!fs.existsSync(file)) {
-        console.error("Unable to open file: " + file);
+        console.error(`Unable to open file: ${file}`);
         process.exit(1);
     }
 
     const contents = fs.readFileSync(file, "utf8");
     const configuration = Linter.findConfiguration(argv.c, file);
 
-    if (configuration === undefined) {
-        console.error("unable to find tslint configuration");
+    if (configuration == null) {
+        console.error("Unable to find tslint configuration");
         process.exit(1);
     }
 

--- a/src/tslint.ts
+++ b/src/tslint.ts
@@ -48,13 +48,12 @@ class Linter {
         const rulesDirectory = this.getRelativePath(this.options.rulesDirectory);
         const configuration = this.options.configuration.rules;
         const configuredRules = Lint.loadRules(configuration, enableDisableRuleMap, rulesDirectory);
-        for (let rule of configuredRules) {
-            if (rule.isEnabled()) {
-                const ruleFailures = rule.apply(sourceFile);
-                for (let ruleFailure of ruleFailures) {
-                    if (!this.containsRule(failures, ruleFailure)) {
-                        failures.push(ruleFailure);
-                    }
+        const enabledRules = configuredRules.filter((r) => r.isEnabled());
+        for (let rule of enabledRules) {
+            const ruleFailures = rule.apply(sourceFile);
+            for (let ruleFailure of ruleFailures) {
+                if (!this.containsRule(failures, ruleFailure)) {
+                    failures.push(ruleFailure);
                 }
             }
         }
@@ -66,7 +65,7 @@ class Linter {
         if (Formatter) {
             formatter = new Formatter();
         } else {
-            throw new Error("formatter '" + this.options.formatter + "' not found");
+            throw new Error(`formatter '${this.options.formatter}' not found`);
         }
 
         const output = formatter.format(failures);
@@ -79,11 +78,9 @@ class Linter {
     }
 
     private getRelativePath(directory: string): string {
-        if (directory) {
+        if (directory != null) {
             return path.relative(moduleDirectory, directory);
         }
-
-        return undefined;
     }
 
     private containsRule(rules: Lint.RuleFailure[], rule: Lint.RuleFailure) {


### PR DESCRIPTION
- whitespace fixes
- some import reordering
- `for ... of` loops
- remove implicit type coercion to bool
- convert methods to private helper functions when possible (all static methods)
- rename walker classes to match file names
- some more random issues