### PR TITLE
Move to a peer dependency for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "dependencies": {
     "findup-sync": "~0.2.1",
     "optimist": "~0.6.0",
-    "underscore.string": "~3.1.1",
-    "typescript": "next"
+    "underscore.string": "~3.1.1"
   },
   "devDependencies": {
     "chai": "^3.0.0",
@@ -37,6 +36,9 @@
     "grunt-tslint": "latest",
     "mocha": "^2.2.5",
     "tslint": "latest"
+  },
+  "peerDependencies": {
+    "typescript": ">=1.7.0 || >=1.7.0-dev.20151003 || >=1.8.0-dev"
   },
   "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "grunt-ts": "^5.1.0",
     "grunt-tslint": "latest",
     "mocha": "^2.2.5",
-    "tslint": "latest"
+    "tslint": "latest",
+    "typescript": "next"
   },
   "peerDependencies": {
     "typescript": ">=1.7.0 || >=1.7.0-dev.20151003 || >=1.8.0-dev"


### PR DESCRIPTION
Accept all versions of 1.7.0-dev after the jsx spread bugfix, accept all versions of 1.8.0-dev, accept any release versions >= 1.7.0