### PR TITLE
Fix #612

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ A sample configuration file with all options is available [here](https://github.
 * `label-undefined` checks that labels are defined before usage.
 * `max-line-length` sets the maximum length of a line.
 * `member-access` enforces using explicit visibility on class members
+    * `"check-accessor"` enforces explicit visibility on accessors (can only be public)
+    * `"check-constructor"` enforces explicit visibility on constructors (can only be public)
 * `member-ordering` enforces member ordering. Rule options:
     * `public-before-private` All public members must be declared before private members
     * `static-before-instance` All static members must be declared before instance members

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ A sample configuration file with all options is available [here](https://github.
 * `label-undefined` checks that labels are defined before usage.
 * `max-line-length` sets the maximum length of a line.
 * `member-access` enforces using explicit visibility on class members
-    * `"check-accessor"` enforces explicit visibility on accessors (can only be public)
+    * `"check-accessor"` enforces explicit visibility on get/set accessors (can only be public)
     * `"check-constructor"` enforces explicit visibility on constructors (can only be public)
 * `member-ordering` enforces member ordering. Rule options:
     * `public-before-private` All public members must be declared before private members

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -26,17 +26,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 export class MemberAccessWalker extends Lint.RuleWalker {
-    private validateConstructors: boolean;
-    private validateAccessors: boolean;
-
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);
-        this.validateConstructors = this.hasOption("check-constructor");
-        this.validateAccessors = this.hasOption("check-accessor");
     }
 
     public visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
-        if (this.validateConstructors) {
+        if (this.hasOption("check-constructor")) {
             // constructor is only allowed to have public or nothing, but the compiler will catch this
             this.validateVisibilityModifiers(node);
         }
@@ -51,10 +46,11 @@ export class MemberAccessWalker extends Lint.RuleWalker {
 
     public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
         this.validateVisibilityModifiers(node);
+        super.visitMethodDeclaration(node);
     }
 
     public visitGetAccessor(node: ts.AccessorDeclaration) {
-        if (this.validateAccessors) {
+        if (this.hasOption("check-accessor")) {
             this.validateVisibilityModifiers(node);
         }
         super.visitGetAccessor(node);

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -46,7 +46,7 @@ export class MemberAccessWalker extends Lint.RuleWalker {
 
     public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
         this.validateVisibilityModifiers(node);
-        super.visitMethodDeclaration(node);
+        super.visitPropertyDeclaration(node);
     }
 
     public visitGetAccessor(node: ts.AccessorDeclaration) {
@@ -57,7 +57,7 @@ export class MemberAccessWalker extends Lint.RuleWalker {
     }
 
     public visitSetAccessor(node: ts.AccessorDeclaration) {
-        if (this.validateAccessors) {
+        if (this.hasOption("check-accessor")) {
             this.validateVisibilityModifiers(node);
         }
         super.visitSetAccessor(node);

--- a/test/files/rules/memberaccess-accessor.test.ts
+++ b/test/files/rules/memberaccess-accessor.test.ts
@@ -1,0 +1,17 @@
+class Members {
+    get g() {
+        return 1;
+    }
+    set s(o: any) {}
+
+    public get publicG() {
+        return 1;
+    }
+    public set publicS(o: any) {}
+}
+
+const obj = {
+    get g() {
+        return 1;
+    }
+};

--- a/test/files/rules/memberaccess-constructor.test.ts
+++ b/test/files/rules/memberaccess-constructor.test.ts
@@ -1,0 +1,9 @@
+class ContructorsNoAccess {
+    constructor(i: number);
+    constructor(o: any) {}
+}
+
+class ContructorsAccess {
+    public constructor(i: number);
+    public constructor(o: any) {}
+}

--- a/test/files/rules/memberaccess.test.ts
+++ b/test/files/rules/memberaccess.test.ts
@@ -1,18 +1,32 @@
-class Foo {
-    constructor() {
-    }
+declare class AmbientNoAccess {
+    a(): number;
+}
 
-    public w: number;
-    private x: number;
-    protected y: number;
-    z: number;
+declare class AmbientAccess {
+    public a(): number;
+}
 
-    public barW(): any {
-    }
-    private barX(): any {
-    }
-    protected barY(): any {
-    }
-    barZ(): any {
+class Members {
+    i: number;
+
+    public nPublic: number;
+    protected nProtected: number;
+    private nPrivate: number;
+
+    noAccess(x: number): number;
+    noAccess(o: any): any {}
+
+    public access(x: number): number;
+    public access(o: any): any {}
+}
+
+const obj = {
+    func() {}
+};
+
+function main() {
+    class A {
+        i: number;
+        public n: number;
     }
 }

--- a/test/rules/memberAccessTests.ts
+++ b/test/rules/memberAccessTests.ts
@@ -16,14 +16,48 @@
 import * as Lint from "../lint";
 
 describe("<member-access>", () => {
-    it("enforces using explicit visibility on class members", () => {
-        let fileName = "rules/memberaccess.test.ts";
-        let MemberAccessRule = Lint.Test.getRule("member-access");
-        let actualFailures = Lint.Test.applyRuleOnFile(fileName, MemberAccessRule);
 
-        Lint.Test.assertFailuresEqual(actualFailures, [
-            Lint.Test.createFailure(fileName, [8, 5], [8, 15], MemberAccessRule.FAILURE_STRING),
-            Lint.Test.createFailure(fileName, [16, 5], [17, 6], MemberAccessRule.FAILURE_STRING)
-        ]);
+    it("ensures that class properties have access modifiers", () => {
+        const fileName = "rules/memberaccess.test.ts";
+        const expectedFailures = [
+            [[2, 5], [2, 17]],
+            [[10, 5], [10, 15]],
+            [[16, 5], [16, 33]],
+            [[17, 5], [17, 29]],
+            [[29, 9], [29, 19]]
+        ];
+
+        checkFile(fileName, expectedFailures);
     });
+
+    it("ensures that constructors have access modifiers", () => {
+        const fileName = "rules/memberaccess-constructor.test.ts";
+        const expectedFailures = [
+            [[2, 5], [2, 28]],
+            [[3, 5], [3, 27]]
+        ];
+        const options = [true, "check-constructor"];
+
+        checkFile(fileName, expectedFailures, options);
+    });
+
+    it("ensures that accessors have access modifiers", () => {
+        const fileName = "rules/memberaccess-accessor.test.ts";
+        const expectedFailures = [
+            [[2, 5], [4, 6]],
+            [[5, 5], [5, 21]]
+        ];
+        const options = [true, "check-accessor"];
+
+        checkFile(fileName, expectedFailures, options);
+    });
+
+    function checkFile(fileName: string, expectedFailures: number[][][], options: any[] = [true]) {
+        const MemberAccessRule = Lint.Test.getRule("member-access");
+        const createFailure = Lint.Test.createFailuresOnFile(fileName, MemberAccessRule.FAILURE_STRING);
+        const expectedFileFailures = expectedFailures.map(failure => createFailure(failure[0], failure[1]));
+
+        const actualFailures = Lint.Test.applyRuleOnFile(fileName, MemberAccessRule, options);
+        Lint.Test.assertFailuresEqual(actualFailures, expectedFileFailures);
+    }
 });

--- a/test/rules/memberAccessTests.ts
+++ b/test/rules/memberAccessTests.ts
@@ -16,7 +16,6 @@
 import * as Lint from "../lint";
 
 describe("<member-access>", () => {
-
     it("ensures that class properties have access modifiers", () => {
         const fileName = "rules/memberaccess.test.ts";
         const expectedFailures = [
@@ -27,7 +26,7 @@ describe("<member-access>", () => {
             [[29, 9], [29, 19]]
         ];
 
-        checkFile(fileName, expectedFailures);
+        assertFailuresInFile(fileName, expectedFailures);
     });
 
     it("ensures that constructors have access modifiers", () => {
@@ -38,7 +37,7 @@ describe("<member-access>", () => {
         ];
         const options = [true, "check-constructor"];
 
-        checkFile(fileName, expectedFailures, options);
+        assertFailuresInFile(fileName, expectedFailures, options);
     });
 
     it("ensures that accessors have access modifiers", () => {
@@ -49,10 +48,10 @@ describe("<member-access>", () => {
         ];
         const options = [true, "check-accessor"];
 
-        checkFile(fileName, expectedFailures, options);
+        assertFailuresInFile(fileName, expectedFailures, options);
     });
 
-    function checkFile(fileName: string, expectedFailures: number[][][], options: any[] = [true]) {
+    function assertFailuresInFile(fileName: string, expectedFailures: number[][][], options: any[] = [true]) {
         const MemberAccessRule = Lint.Test.getRule("member-access");
         const createFailure = Lint.Test.createFailuresOnFile(fileName, MemberAccessRule.FAILURE_STRING);
         const expectedFileFailures = expectedFailures.map(failure => createFailure(failure[0], failure[1]));


### PR DESCRIPTION
Fixes member-access checking for object literals and nested objects, #612 