### PR TITLE
Tighten imports across core sources

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -34,28 +34,7 @@ const DEFAULT_CONFIG = {
         "semicolon": true
     }
 };
-
 const moduleDirectory = path.dirname(module.filename);
-
-export function getRulesDirectories(directories: string | string[]): string[] {
-    let rulesDirectories: string[] = [];
-
-    if (directories != null) {
-        if (typeof directories === "string") {
-            rulesDirectories = [getRelativePath(<string>directories)];
-        } else {
-            rulesDirectories = (<string[]>directories).map((dir) => getRelativePath(dir));
-        }
-    }
-
-    return rulesDirectories;
-}
-
-export function getRelativePath(directory: string): string {
-    if (directory != null) {
-        return path.relative(moduleDirectory, directory);
-    }
-}
 
 export function findConfiguration(configFile: string, inputFileLocation: string): any {
     if (configFile == null) {
@@ -105,4 +84,24 @@ function getHomeDir() {
             return homePath;
         }
     }
+}
+
+export function getRelativePath(directory: string): string {
+    if (directory != null) {
+        return path.relative(moduleDirectory, directory);
+    }
+}
+
+export function getRulesDirectories(directories: string | string[]): string[] {
+    let rulesDirectories: string[] = [];
+
+    if (directories != null) {
+        if (typeof directories === "string") {
+            rulesDirectories = [getRelativePath(<string>directories)];
+        } else {
+            rulesDirectories = (<string[]>directories).map((dir) => getRelativePath(dir));
+        }
+    }
+
+    return rulesDirectories;
 }

--- a/src/enableDisableRules.ts
+++ b/src/enableDisableRules.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import * as ts from "typescript";
 import * as Lint from "./lint";
 import {SkippableTokenAwareRuleWalker} from "./language/walker/skippableTokenAwareRuleWalker";
-import * as ts from "typescript";
 
 export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
     public enableDisableRuleMap: {[rulename: string]: Lint.IEnableDisablePosition[]} = {};

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export * from "./language/formatter/abstractFormatter";
 export * from "./formatters/index";

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export * from "./jsonFormatter";
 export * from "./pmdFormatter";
 export * from "./proseFormatter";

--- a/src/formatters/jsonFormatter.ts
+++ b/src/formatters/jsonFormatter.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as Lint from "../lint";
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
+import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
-    public format(failures: Lint.RuleFailure[]): string {
+    public format(failures: RuleFailure[]): string {
         const failuresJSON = failures.map((failure) => failure.toJson());
         return JSON.stringify(failuresJSON);
     }

--- a/src/formatters/pmdFormatter.ts
+++ b/src/formatters/pmdFormatter.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as Lint from "../lint";
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
+import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
-    public format(failures: Lint.RuleFailure[]): string {
+    public format(failures: RuleFailure[]): string {
         let output = "<pmd version=\"tslint\">";
 
         for (let failure of failures) {

--- a/src/formatters/proseFormatter.ts
+++ b/src/formatters/proseFormatter.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import * as Lint from "../lint";
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
+import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
-    public format(failures: Lint.RuleFailure[]): string {
-        const outputLines = failures.map((failure: Lint.RuleFailure) => {
+    public format(failures: RuleFailure[]): string {
+        const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();
             const failureString = failure.getFailure();
 

--- a/src/formatters/verboseFormatter.ts
+++ b/src/formatters/verboseFormatter.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import * as Lint from "../lint";
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
+import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
-    public format(failures: Lint.RuleFailure[]): string {
-
-        const outputLines = failures.map((failure: Lint.RuleFailure) => {
+    public format(failures: RuleFailure[]): string {
+        const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();
             const failureString = failure.getFailure();
             const ruleName = failure.getRuleName();

--- a/src/language/formatter/abstractFormatter.ts
+++ b/src/language/formatter/abstractFormatter.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import * as Lint from "../../lint";
+import {RuleFailure} from "../rule/rule";
+import {IFormatter} from "./formatter";
 
-export abstract class AbstractFormatter implements Lint.IFormatter {
-    public abstract format(failures: Lint.RuleFailure[]): string;
+export abstract class AbstractFormatter implements IFormatter {
+    public abstract format(failures: RuleFailure[]): string;
 }

--- a/src/language/formatter/formatter.ts
+++ b/src/language/formatter/formatter.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as Lint from "../../lint";
+import {RuleFailure} from "../rule/rule";
 
 export interface IFormatter {
-    format(failures: Lint.RuleFailure[]): string;
+    format(failures: RuleFailure[]): string;
 }

--- a/src/language/languageServiceHost.ts
+++ b/src/language/languageServiceHost.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import * as Lint from "../lint";
 import * as ts from "typescript";
+import {createCompilerOptions} from "./utils";
 
 export function createLanguageServiceHost(fileName: string, source: string): ts.LanguageServiceHost {
     return {
-        getCompilationSettings: () => Lint.createCompilerOptions(),
+        getCompilationSettings: () => createCompilerOptions(),
         getCurrentDirectory: () => "",
         getDefaultLibFileName: () => "lib.d.ts",
         getScriptFileNames: () => [fileName],
@@ -30,6 +30,6 @@ export function createLanguageServiceHost(fileName: string, source: string): ts.
 }
 
 export function createLanguageService(fileName: string, source: string) {
-    const languageServiceHost = Lint.createLanguageServiceHost(fileName, source);
+    const languageServiceHost = createLanguageServiceHost(fileName, source);
     return ts.createLanguageService(languageServiceHost);
 }

--- a/src/language/rule/abstractRule.ts
+++ b/src/language/rule/abstractRule.ts
@@ -15,14 +15,15 @@
  */
 
 import * as ts from "typescript";
-import * as Lint from "../../lint";
+import {IOptions} from "../../lint";
 import {RuleWalker} from "../walker/ruleWalker";
+import {IRule, IDisabledInterval, RuleFailure} from "./rule";
 
-export abstract class AbstractRule implements Lint.IRule {
+export abstract class AbstractRule implements IRule {
     private value: any;
-    private options: Lint.IOptions;
+    private options: IOptions;
 
-    constructor(ruleName: string, value: any, disabledIntervals: Lint.IDisabledInterval[]) {
+    constructor(ruleName: string, value: any, disabledIntervals: IDisabledInterval[]) {
         let ruleArguments: any[] = [];
 
         if (Array.isArray(value) && value.length > 1) {
@@ -37,13 +38,13 @@ export abstract class AbstractRule implements Lint.IRule {
         };
     }
 
-    public getOptions(): Lint.IOptions {
+    public getOptions(): IOptions {
         return this.options;
     }
 
-    public abstract apply(sourceFile: ts.SourceFile): Lint.RuleFailure[];
+    public abstract apply(sourceFile: ts.SourceFile): RuleFailure[];
 
-    public applyWithWalker(walker: RuleWalker): Lint.RuleFailure[] {
+    public applyWithWalker(walker: RuleWalker): RuleFailure[] {
         walker.walk(walker.getSourceFile());
         return walker.getFailures();
     }

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -15,12 +15,12 @@
  */
 
 import * as ts from "typescript";
-import * as Lint from "../../lint";
+import {RuleWalker} from "../walker/ruleWalker";
 
 export interface IOptions {
     ruleArguments?: any[];
     ruleName: string;
-    disabledIntervals: Lint.IDisabledInterval[];
+    disabledIntervals: IDisabledInterval[];
 }
 
 export interface IDisabledInterval {
@@ -32,7 +32,7 @@ export interface IRule {
     getOptions(): IOptions;
     isEnabled(): boolean;
     apply(sourceFile: ts.SourceFile): RuleFailure[];
-    applyWithWalker(walker: Lint.RuleWalker): RuleFailure[];
+    applyWithWalker(walker: RuleWalker): RuleFailure[];
 }
 
 export class RuleFailurePosition {
@@ -73,8 +73,8 @@ export class RuleFailurePosition {
 export class RuleFailure {
     private sourceFile: ts.SourceFile;
     private fileName: string;
-    private startPosition: Lint.RuleFailurePosition;
-    private endPosition: Lint.RuleFailurePosition;
+    private startPosition: RuleFailurePosition;
+    private endPosition: RuleFailurePosition;
     private failure: string;
     private ruleName: string;
 

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -16,7 +16,7 @@
 
 import * as path from "path";
 import * as ts from "typescript";
-import * as Lint from "../lint";
+import {IDisabledInterval, RuleFailure} from "./rule/rule";
 
 export function getSourceFile(fileName: string, source: string): ts.SourceFile {
     const normalizedName = path.normalize(fileName).replace(/\\/g, "/");
@@ -50,7 +50,7 @@ export function createCompilerOptions(): ts.CompilerOptions {
     };
 }
 
-export function doesIntersect(failure: Lint.RuleFailure, disabledIntervals: Lint.IDisabledInterval[]) {
+export function doesIntersect(failure: RuleFailure, disabledIntervals: IDisabledInterval[]) {
     return disabledIntervals.some((interval) => {
         const maxStart = Math.max(interval.startPosition, failure.getStartPosition().getPosition());
         const minEnd = Math.min(interval.endPosition, failure.getEndPosition().getPosition());

--- a/src/language/walker/index.ts
+++ b/src/language/walker/index.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export * from "./blockScopeAwareRuleWalker";
 export * from "./ruleWalker";
 export * from "./scopeAwareRuleWalker";

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -15,19 +15,21 @@
  */
 
 import * as ts from "typescript";
-import * as Lint from "../../lint";
+import {IOptions} from "../../lint";
+import {IDisabledInterval, RuleFailure} from "../rule/rule";
+import {doesIntersect} from "../utils";
 import {SyntaxWalker} from "./syntaxWalker";
 
 export class RuleWalker extends SyntaxWalker {
     private limit: number;
     private position: number;
     private options: any[];
-    private failures: Lint.RuleFailure[];
+    private failures: RuleFailure[];
     private sourceFile: ts.SourceFile;
-    private disabledIntervals: Lint.IDisabledInterval[];
+    private disabledIntervals: IDisabledInterval[];
     private ruleName: string;
 
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+    constructor(sourceFile: ts.SourceFile, options: IOptions) {
         super();
 
         this.position = 0;
@@ -43,7 +45,7 @@ export class RuleWalker extends SyntaxWalker {
         return this.sourceFile;
     }
 
-    public getFailures(): Lint.RuleFailure[] {
+    public getFailures(): RuleFailure[] {
         return this.failures;
     }
 
@@ -67,20 +69,20 @@ export class RuleWalker extends SyntaxWalker {
         this.position += node.getFullWidth();
     }
 
-    public createFailure(start: number, width: number, failure: string): Lint.RuleFailure {
+    public createFailure(start: number, width: number, failure: string): RuleFailure {
         const from = (start > this.limit) ? this.limit : start;
         const to = ((start + width) > this.limit) ? this.limit : (start + width);
-        return new Lint.RuleFailure(this.sourceFile, from, to, failure, this.ruleName);
+        return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName);
     }
 
-    public addFailure(failure: Lint.RuleFailure) {
+    public addFailure(failure: RuleFailure) {
         // don't add failures for a rule if the failure intersects an interval where that rule is disabled
-        if (!this.existsFailure(failure) && !Lint.doesIntersect(failure, this.disabledIntervals)) {
+        if (!this.existsFailure(failure) && !doesIntersect(failure, this.disabledIntervals)) {
             this.failures.push(failure);
         }
     }
 
-    private existsFailure(failure: Lint.RuleFailure) {
+    private existsFailure(failure: RuleFailure) {
         return this.failures.some((f) => f.equals(failure));
     }
 }

--- a/src/language/walker/skippableTokenAwareRuleWalker.ts
+++ b/src/language/walker/skippableTokenAwareRuleWalker.ts
@@ -15,13 +15,13 @@
  */
 
 import * as ts from "typescript";
-import * as Lint from "../../lint";
+import {IOptions} from "../../lint";
 import {RuleWalker} from "./ruleWalker";
 
 export class SkippableTokenAwareRuleWalker extends RuleWalker {
     protected tokensToSkipStartEndMap: {[start: number]: number};
 
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+    constructor(sourceFile: ts.SourceFile, options: IOptions) {
         super(sourceFile, options);
         this.tokensToSkipStartEndMap = {};
     }

--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -17,8 +17,8 @@
 import * as fs from "fs";
 import * as path from "path";
 import {camelize, strLeft, strRight} from "underscore.string";
-import * as Lint from "./lint";
 import {getRulesDirectories} from "./configuration";
+import {IRule, IDisabledInterval} from "./language/rule/rule";
 
 const moduleDirectory = path.dirname(module.filename);
 const CORE_RULES_DIRECTORY = path.resolve(moduleDirectory, ".", "rules");
@@ -29,9 +29,9 @@ export interface IEnableDisablePosition {
 }
 
 export function loadRules(ruleConfiguration: {[name: string]: any},
-                          enableDisableRuleMap: {[rulename: string]: Lint.IEnableDisablePosition[]},
-                          rulesDirectories?: string | string[]): Lint.IRule[] {
-    const rules: Lint.IRule[] = [];
+                          enableDisableRuleMap: {[rulename: string]: IEnableDisablePosition[]},
+                          rulesDirectories?: string | string[]): IRule[] {
+    const rules: IRule[] = [];
     for (const ruleName in ruleConfiguration) {
         if (ruleConfiguration.hasOwnProperty(ruleName)) {
             const ruleValue = ruleConfiguration[ruleName];
@@ -110,13 +110,13 @@ function loadRule(...paths: string[]) {
 }
 
 /*
-    * We're assuming both lists are already sorted top-down so compare the tops, use the smallest of the two,
-    * and build the intervals that way.
-    */
+ * We're assuming both lists are already sorted top-down so compare the tops, use the smallest of the two,
+ * and build the intervals that way.
+ */
 function buildDisabledIntervalsFromSwitches(ruleSpecificList: IEnableDisablePosition[], allList: IEnableDisablePosition[]) {
     let isCurrentlyDisabled = false;
     let disabledStartPosition: number;
-    const disabledIntervalList: Lint.IDisabledInterval[] = [];
+    const disabledIntervalList: IDisabledInterval[] = [];
     let i = 0;
     let j = 0;
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,1 +1,17 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export * from "./language/rule/abstractRule";


### PR DESCRIPTION
This change reduces usage of `import * as Lint` in favor of more granular imports. This reduces cyclical dependencies between our modules.