### PR TITLE
Better support for globs in cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "findup-sync": "~0.2.1",
+    "glob": "^6.0.1",
     "optimist": "~0.6.0",
     "underscore.string": "~3.1.1"
   },

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from "fs";
+import * as glob from "glob";
 import * as optimist from "optimist";
 import * as Linter from "./tslint";
 import {getRulesDirectories} from "./configuration";
@@ -179,5 +180,5 @@ const processFile = (file: string) => {
 const files = argv._;
 
 for (const file of files) {
-    processFile(file);
+    glob.sync(file).forEach(processFile);
 }

--- a/tsd.json
+++ b/tsd.json
@@ -22,6 +22,9 @@
     },
     "optimist/optimist.d.ts": {
       "commit": "98d3168c2c570352a3a7393788e2ec9fbb08ade6"
+    },
+    "glob/glob.d.ts": {
+      "commit": "fb2b3b1e068c9ff7d8f9b0851c08d37d96c95c38"
     }
   }
 }

--- a/typings/glob/glob.d.ts
+++ b/typings/glob/glob.d.ts
@@ -1,0 +1,112 @@
+// Type definitions for Glob 5.0.10
+// Project: https://github.com/isaacs/node-glob
+// Definitions by: vvakame <https://github.com/vvakame/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+/// <reference path="../minimatch/minimatch.d.ts" />
+
+declare module "glob" {
+
+	import events = require("events");
+	import fs = require('fs');
+	import minimatch = require("minimatch");
+
+	function G(pattern: string, cb: (err: Error, matches: string[]) => void): void;
+	function G(pattern: string, options: G.IOptions, cb: (err: Error, matches: string[]) => void): void;
+
+	module G {
+		function sync(pattern: string, options?: IOptions): string[];
+
+		function hasMagic(pattern: string, options?: IOptions): boolean;
+
+		var Glob: IGlobStatic;
+		var GlobSync: IGlobSyncStatic;
+
+		interface IOptions extends minimatch.IOptions {
+			cwd?: string;
+			root?: string;
+			dot?: boolean;
+			nomount?: boolean;
+			mark?: boolean;
+			nosort?: boolean;
+			stat?: boolean;
+			silent?: boolean;
+			strict?: boolean;
+			cache?: { [path: string]: any /* boolean | string | string[] */ };
+			statCache?: { [path: string]: fs.Stats };
+			symlinks?: any;
+			sync?: boolean;
+			nounique?: boolean;
+			nonull?: boolean;
+			debug?: boolean;
+			nobrace?: boolean;
+			noglobstar?: boolean;
+			noext?: boolean;
+			nocase?: boolean;
+			matchBase?: any;
+			nodir?: boolean;
+			ignore?: any; /* string | string[] */
+			follow?: boolean;
+			realpath?: boolean;
+			nonegate?: boolean;
+			nocomment?: boolean;
+
+			/** Deprecated. */
+			globDebug?: boolean;
+		}
+
+		interface IGlobStatic extends events.EventEmitter {
+			new (pattern: string, cb?: (err: Error, matches: string[]) => void): IGlob;
+			new (pattern: string, options: IOptions, cb?: (err: Error, matches: string[]) => void): IGlob;
+			prototype: IGlob;
+		}
+
+		interface IGlobSyncStatic {
+			new (pattern: string, options?: IOptions): IGlobBase
+			prototype: IGlobBase;
+		}
+
+		interface IGlobBase {
+			minimatch: minimatch.IMinimatch;
+			options: IOptions;
+			aborted: boolean;
+			cache: { [path: string]: any /* boolean | string | string[] */ };
+			statCache: { [path: string]: fs.Stats };
+			symlinks: { [path: string]: boolean };
+			realpathCache: { [path: string]: string };
+			found: string[];
+		}
+
+		interface IGlob extends IGlobBase, events.EventEmitter {
+			pause(): void;
+			resume(): void;
+			abort(): void;
+
+			/** Deprecated. */
+			EOF: any;
+			/** Deprecated. */
+			paused: boolean;
+			/** Deprecated. */
+			maxDepth: number;
+			/** Deprecated. */
+			maxLength: number;
+			/** Deprecated. */
+			changedCwd: boolean;
+			/** Deprecated. */
+			cwd: string;
+			/** Deprecated. */
+			root: string;
+			/** Deprecated. */
+			error: any;
+			/** Deprecated. */
+			matches: string[];
+			/** Deprecated. */
+			log(...args: any[]): void;
+			/** Deprecated. */
+			emitMatch(m: any): void;
+		}
+	}
+
+	export = G;
+}

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -4,3 +4,4 @@
 /// <reference path="findup-sync/findup-sync.d.ts" />
 /// <reference path="minimatch/minimatch.d.ts" />
 /// <reference path="optimist/optimist.d.ts" />
+/// <reference path="glob/glob.d.ts" />


### PR DESCRIPTION
Related to #692. Potentially fixed glob issues in windows.

This makes the cli accept a glob as a string and expand it.

It solves a problem with "arguments list is too large" when using regular globs.