### PR TITLE
Remove node 0.10 from appveyor and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-    - "0.10"
     - "0.12"
     - "4.2"
     - "5.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: "0.10"
   - nodejs_version: "0.12"
   - nodejs_version: "4.2"
   - nodejs_version: "5.0"


### PR DESCRIPTION
This resolves #835 

I also added a new line to the end of the appveyor config so it matches the other files in the project.