### PR TITLE
Forbid var keyword in for, for-in, and for-of loops

### DIFF
--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -36,4 +36,26 @@ class NoVarKeywordWalker extends Lint.RuleWalker {
 
         super.visitVariableStatement(node);
     }
+
+    public visitForStatement(node: ts.ForStatement) {
+        this.handleInitializerNode(node.initializer);
+        super.visitForStatement(node);
+    }
+
+    public visitForInStatement(node: ts.ForInStatement) {
+        this.handleInitializerNode(node.initializer);
+        super.visitForInStatement(node);
+    }
+
+    public visitForOfStatement(node: ts.ForOfStatement) {
+        this.handleInitializerNode(node.initializer);
+        super.visitForOfStatement(node);
+    }
+
+    private handleInitializerNode(node: ts.VariableDeclarationList | ts.Expression) {
+        if (node && node.kind === ts.SyntaxKind.VariableDeclarationList &&
+                !(Lint.isNodeFlagSet(node, ts.NodeFlags.Let) || Lint.isNodeFlagSet(node, ts.NodeFlags.Const))) {
+            this.addFailure(this.createFailure(node.getStart(), "var".length, Rule.FAILURE_STRING));
+        }
+    }
 }

--- a/test/files/rules/novarkeyword.test.ts
+++ b/test/files/rules/novarkeyword.test.ts
@@ -9,6 +9,10 @@ var i, // failure
 
 var [a, b] = [1, 2]; // failure
 
+for (var n; false;); // failure
+for (var n1 in foo); // failure
+for (var n2 of foo); // failure
+
 declare var tmp2: any;
 
 let bar;
@@ -22,3 +26,10 @@ module quz {
 }
 
 let [x, y] = [1, 2];
+
+for (n; false;);
+for (let n; false;);
+for (let name in foo);
+for (let name of foo);
+for (const name in foo);
+for (const name of foo);

--- a/test/rules/noVarKeywordRuleTests.ts
+++ b/test/rules/noVarKeywordRuleTests.ts
@@ -26,6 +26,9 @@ describe("<no-var-keyword>", () => {
             createFailure([4, 5], [4, 8]),
             createFailure([7, 1], [7, 4]),
             createFailure([10, 1], [10, 4]),
+            createFailure([12, 6], [12, 9]),
+            createFailure([13, 6], [13, 9]),
+            createFailure([14, 6], [14, 9]),
         ];
         const actualFailures = Lint.Test.applyRuleOnFile(fileName, NoVarKeywordRule);
 


### PR DESCRIPTION
no-var-keyword currently only prevents the `var` keyword in a block. This PR ensures var keywords are also correctly forbidden in for loop initializers.