### PR TITLE
Use explicit exports for formatters.

### DIFF
--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-export * from "./jsonFormatter";
-export * from "./pmdFormatter";
-export * from "./proseFormatter";
-export * from "./verboseFormatter";
+export { Formatter as JsonFormatter } from "./jsonFormatter";
+export { Formatter as PmdFormatter } from "./pmdFormatter";
+export { Formatter as ProseFormatter } from "./proseFormatter";
+export { Formatter as VerboseFormatter } from "./verboseFormatter";


### PR DESCRIPTION
Since all of the formatters are named `Formatter`, this is going to break in TypeScript 1.8 and we noticed it when nightlies weren't getting published.