### PR TITLE
Add typescript definition info to packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   "peerDependencies": {
     "typescript": ">=1.7.3"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "typescript": {
+    "definition": "lib/tslint.d.ts"
+  }
 }


### PR DESCRIPTION
This allows tools like tsd to auto-pull definition files from the node_modules folder