### PR TITLE
Automatic tslint.json generation with --init command

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,8 +19,8 @@ import * as fs from "fs";
 import * as path from "path";
 import * as findup from "findup-sync";
 
-const CONFIG_FILENAME = "tslint.json";
-const DEFAULT_CONFIG = {
+export const CONFIG_FILENAME = "tslint.json";
+export const DEFAULT_CONFIG = {
     "rules": {
         "curly": true,
         "indent": [true, 4],

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,17 +22,33 @@ import * as findup from "findup-sync";
 export const CONFIG_FILENAME = "tslint.json";
 export const DEFAULT_CONFIG = {
     "rules": {
-        "curly": true,
-        "indent": [true, 4],
-        "no-duplicate-key": true,
+        "class-name": true,
+        "comment-format": [true, "check-space"],
+        "indent": [true, "spaces"],
         "no-duplicate-variable": true,
-        "no-empty": true,
         "no-eval": true,
+        "no-internal-module": true,
         "no-trailing-whitespace": true,
-        "no-unreachable": true,
-        "no-use-before-declare": true,
+        "no-var-keyword": true,
+        "one-line": [true, "check-open-brace", "check-whitespace"],
         "quotemark": [true, "double"],
-        "semicolon": true
+        "semicolon": true,
+        "triple-equals": [true, "allow-null-check"],
+        "typedef-whitespace": [true, {
+            "call-signature": "nospace",
+            "index-signature": "nospace",
+            "parameter": "nospace",
+            "property-declaration": "nospace",
+            "variable-declaration": "nospace"
+        }],
+        "variable-name": [true, "ban-keywords"],
+        "whitespace": [true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type"
+        ],
     }
 };
 const moduleDirectory = path.dirname(module.filename);

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -44,7 +44,7 @@ let processed = optimist
         },
         "i": {
             alias: "init",
-            describe: "generate a tslint.json config file in the cwd"
+            describe: "generate a tslint.json config file in the current working directory"
         },
         "o": {
             alias: "out",
@@ -91,7 +91,7 @@ if (argv.i != null) {
         process.exit(1);
     }
 
-    const tslintJSON = JSON.stringify(DEFAULT_CONFIG, undefined, "   ");
+    const tslintJSON = JSON.stringify(DEFAULT_CONFIG, undefined, "    ");
     fs.writeFileSync(CONFIG_FILENAME, tslintJSON);
     process.exit(0);
 }

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -19,13 +19,13 @@ import * as fs from "fs";
 import * as glob from "glob";
 import * as optimist from "optimist";
 import * as Linter from "./tslint";
-import {getRulesDirectories} from "./configuration";
+import {CONFIG_FILENAME, DEFAULT_CONFIG, getRulesDirectories} from "./configuration";
 
 let processed = optimist
     .usage("Usage: $0 [options] [file ...]")
     .check((argv: any) => {
         // at least one of file, help, version or unqualified argument must be present
-        if (!(argv.h || argv.v || argv._.length > 0)) {
+        if (!(argv.h || argv.i || argv.v || argv._.length > 0)) {
             throw "Missing files";
         }
 
@@ -41,6 +41,10 @@ let processed = optimist
         "h": {
             alias: "help",
             describe: "display detailed help"
+        },
+        "i": {
+            alias: "init",
+            describe: "generate a tslint.json config file in the cwd"
         },
         "o": {
             alias: "out",
@@ -81,6 +85,17 @@ if (argv.v != null) {
     process.exit(0);
 }
 
+if (argv.i != null) {
+    if (fs.existsSync(CONFIG_FILENAME)) {
+        console.error(`Cannot generate ${CONFIG_FILENAME}: file already exists`);
+        process.exit(1);
+    }
+
+    const tslintJSON = JSON.stringify(DEFAULT_CONFIG, undefined, "   ");
+    fs.writeFileSync(CONFIG_FILENAME, tslintJSON);
+    process.exit(0);
+}
+
 if ("help" in argv) {
     outputStream.write(processed.help());
     const outputString = `
@@ -100,6 +115,9 @@ tslint accepts the following commandline options:
         to the rule that will determine what it checks for (such as number
         of characters for the max-line-length rule, or what functions to ban
         for the ban rule).
+
+    -i, --init:
+        Generates a tslint.json config file in the current working directory.
 
     -o, --out:
         A filename to output the results to. By default, tslint outputs to

--- a/test/check-bin.sh
+++ b/test/check-bin.sh
@@ -19,8 +19,7 @@ expectOut () {
   expect=$2
   msg=$3
 
-  if [ $expect != $actual ]
-  then
+  if [ $expect != $actual ]; then
     echo "$msg: expected $expect got $actual"
     num_failures=$(expr $num_failures + 1)
   fi
@@ -43,8 +42,27 @@ expectOut $? 0 "tslint with valid arguments did not exit correctly"
 ./bin/tslint src/configuration.ts -f src/formatterLoader.ts
 expectOut $? 1 "tslint with -f flag did not exit correctly"
 
-if [ $num_failures != 0 ]
-then
+# make sure tslint --init generates a file
+cd ./bin
+if [ -f tslint.json ]; then
+  rm tslint.json
+fi
+
+./tslint --init
+if [ ! -f tslint.json ]; then
+  echo "--init failed, tslint.json not created"
+  num_failures=$(expr $num_failures + 1)
+fi
+expectOut $? 0 "tslint with --init flag did not exit correctly"
+
+# should fail since tslint.json already exists
+./tslint --init
+expectOut $? 1 "tslint with --init flag did not exit correctly when tslint.json already exists"
+
+rm tslint.json
+cd ..
+
+if [ $num_failures != 0 ]; then
   echo "Failed $num_failures tests"
   exit 1
 else

--- a/tslint.json
+++ b/tslint.json
@@ -52,6 +52,13 @@
     "radix": true,
     "semicolon": true,
     "triple-equals": [true, "allow-null-check"],
+    "typedef-whitespace": [true, {
+      "call-signature": "nospace",
+      "index-signature": "nospace",
+      "parameter": "nospace",
+      "property-declaration": "nospace",
+      "variable-declaration": "nospace"
+    }],
     "variable-name": false,
     "whitespace": [true,
       "check-branch",


### PR DESCRIPTION
Implements #717 

A simple implementation of a feature to generate a tslint.json file for users. This PR is very limited in scope - there are lots of ways for this to be improved in the future.

This feature intentionally isn't added to the README yet, that can be done once a better default configuration is settled on.