### PR TITLE
fix semicolon rule

### DIFF
--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -83,10 +83,12 @@ class SemicolonWalker extends Lint.RuleWalker {
     }
 
     public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
-        for (let member of node.members) {
-            this.checkSemicolonAt(member);
+        if (node.members) {
+            for (let member of node.members) {
+                this.checkSemicolonAt(member);
+            }
+            super.visitInterfaceDeclaration(node);
         }
-        super.visitInterfaceDeclaration(node);
     }
 
     private checkSemicolonAt(node: ts.Node) {


### PR DESCRIPTION
I don't think this is a legitimate fix. It just illustrates the issue:
semicolonRule - TypeError: Cannot read property 'length' of undefined #50