### PR TITLE
Improve handling of paths to custom rules directories

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -18,8 +18,15 @@
 import * as fs from "fs";
 import * as glob from "glob";
 import * as optimist from "optimist";
+import * as path from "path";
 import * as Linter from "./tslint";
-import {CONFIG_FILENAME, DEFAULT_CONFIG, getRulesDirectories} from "./configuration";
+import {
+    CONFIG_FILENAME,
+    DEFAULT_CONFIG,
+    findConfigurationPath,
+    getRulesDirectories,
+    loadConfigurationFromPath
+} from "./configuration";
 
 let processed = optimist
     .usage("Usage: $0 [options] [file ...]")
@@ -167,14 +174,13 @@ const processFile = (file: string) => {
     }
 
     const contents = fs.readFileSync(file, "utf8");
-    const configuration = Linter.findConfiguration(argv.c, file);
+    const configurationPath = findConfigurationPath(argv.c, file);
+    const configuration = loadConfigurationFromPath(configurationPath);
 
-    if (configuration == null) {
-        console.error("Unable to find tslint configuration");
-        process.exit(1);
-    }
+    // if configurationPath is null, this will be set to ".", which is the current directory and is fine
+    const configurationDir = path.dirname(configurationPath);
 
-    const rulesDirectories = getRulesDirectories(configuration.rulesDirectory);
+    const rulesDirectories = getRulesDirectories(configuration.rulesDirectory, configurationDir);
 
     if (argv.r != null) {
         rulesDirectories.push(argv.r);

--- a/test/config/tslint-custom-rules-with-dir.json
+++ b/test/config/tslint-custom-rules-with-dir.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": "../files/custom-rules/",
+  "rules": {
+    "always-fail": true
+  }
+}

--- a/test/config/tslint-custom-rules.json
+++ b/test/config/tslint-custom-rules.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "always-fail": true
+  }
+}

--- a/test/files/custom-rules/alwaysFailRule.js
+++ b/test/files/custom-rules/alwaysFailRule.js
@@ -1,0 +1,27 @@
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var Lint = require("tslint/lib/lint");
+var Rule = (function (_super) {
+    __extends(Rule, _super);
+    function Rule() {
+        _super.apply(this, arguments);
+    }
+    Rule.prototype.apply = function (sourceFile) {
+        return this.applyWithWalker(new AlwaysFailWalker(sourceFile, this.getOptions()));
+    };
+    return Rule;
+})(Lint.Rules.AbstractRule);
+exports.Rule = Rule;
+var AlwaysFailWalker = (function (_super) {
+    __extends(AlwaysFailWalker, _super);
+    function AlwaysFailWalker() {
+        _super.apply(this, arguments);
+    }
+    AlwaysFailWalker.prototype.visitSourceFile = function (node) {
+        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), "failure"));
+    };
+    return AlwaysFailWalker;
+})(Lint.RuleWalker);

--- a/test/ruleLoaderTests.ts
+++ b/test/ruleLoaderTests.ts
@@ -17,8 +17,7 @@
 import {loadRules} from "./lint";
 
 describe("Rule Loader", () => {
-    const path = require("path");
-    const rulesDirectory = path.join(global.process.cwd(), "build/rules");
+    const RULES_DIRECTORY = "build/src/rules";
 
     it("loads core rules", () => {
         const validConfiguration: {[name: string]: any} = {
@@ -29,7 +28,7 @@ describe("Rule Loader", () => {
             "no-debugger": true
         };
 
-        const rules = loadRules(validConfiguration, {}, rulesDirectory);
+        const rules = loadRules(validConfiguration, {}, RULES_DIRECTORY);
         assert.equal(rules.length, 5);
     });
 
@@ -39,7 +38,7 @@ describe("Rule Loader", () => {
             "invalidConfig2": false
         };
 
-        const rules = loadRules(invalidConfiguration, {}, rulesDirectory);
+        const rules = loadRules(invalidConfiguration, {}, RULES_DIRECTORY);
         assert.deepEqual(rules, []);
     });
 
@@ -51,7 +50,7 @@ describe("Rule Loader", () => {
             "eofline-": true
         };
 
-        const rules = loadRules(invalidConfiguration, {}, rulesDirectory);
+        const rules = loadRules(invalidConfiguration, {}, RULES_DIRECTORY);
         assert.deepEqual(rules, []);
     });
 
@@ -64,7 +63,7 @@ describe("Rule Loader", () => {
             "no-debugger": true
         };
 
-        const rules = loadRules(validConfiguration, {}, [rulesDirectory]);
+        const rules = loadRules(validConfiguration, {}, [RULES_DIRECTORY]);
         assert.equal(rules.length, 5);
     });
 });


### PR DESCRIPTION
New behavior:

* Throw an error if the rules directory supplied does not exist
* If rules directory is supplied in a tslint.json or package.json file, look for directory relative to .json file.
* If rules directory is supplied via CLI, look for directory relative to CWD.

Fixes #910