### PR TITLE
Correctly find = token for variable declarations in one-line rule.

### DIFF
--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -127,7 +127,7 @@ class OneLineWalker extends Lint.RuleWalker {
     public visitVariableDeclaration(node: ts.VariableDeclaration) {
         const initializer = node.initializer;
         if (initializer != null && initializer.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-            const equalsToken = node.getChildAt(1);
+            const equalsToken = node.getChildren().filter((n) => n.kind === ts.SyntaxKind.EqualsToken)[0];
             const openBraceToken = initializer.getChildAt(0);
             this.handleOpeningBrace(equalsToken, openBraceToken);
         }

--- a/test/files/rules/oneline.test.ts
+++ b/test/files/rules/oneline.test.ts
@@ -89,3 +89,13 @@ function longFunctionNameWithLotsOfParams<T>(
     z: number,
     a: T) {
 }
+
+let geoConfig: {
+    maximumAge?: number;
+    timeout?: number;
+    enableHighAccuracy?: boolean;
+} = {
+    maximumAge: 3000,
+    timeout: 5000,
+    enableHighAccuracy: false
+};


### PR DESCRIPTION
Fixes #935