### PR TITLE
'learn more' button goes to 404

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,7 +17,7 @@
       <h2 class="project-tagline">{{page.subtitle}}</h2>
     {% endif %}
     <a href="https://github.com/palantir/tslint" class="btn">View on GitHub</a>
-    <a href="usage" class="btn">Learn More</a>
+    <a href="{{site.baseurl}}/usage/cli" class="btn">Learn More</a>
     <a href="https://github.com/palantir/tslint/tarball/master" class="btn">Download .tar.gz</a>
   </section>
   {% endif %}


### PR DESCRIPTION
Update href to be coherent with the "the full usage guide" link.