### PR TITLE
Identify multiline literals with single property correctly.

### DIFF
--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -53,7 +53,7 @@ class TrailingCommaWalker extends Lint.RuleWalker {
     private lintNode(node: ts.Node) {
         const child = node.getChildAt(1);
         if (child != null && child.kind === ts.SyntaxKind.SyntaxList) {
-            const isMultiline = child.getText().match(/\n|\r/);
+            const isMultiline = node.getText().match(/\n|\r/);
             const option = this.getOption(isMultiline ? "multiline" : "singleline");
             const grandChildren = child.getChildren();
 

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -14,6 +14,15 @@ var x = [{
 }];
 ~   [missing trailing comma]
 
+var s = {
+    sA: 6,
+};
+
+var t = {
+    tA: 7
+        ~ [missing trailing comma]
+}
+
 var y = {
     yA: 42,
     yB: 24,
@@ -24,6 +33,15 @@ var z = {
     zTwo: 1
           ~ [missing trailing comma]
 };
+
+var ss = [
+    6,
+];
+
+var tt = [
+    7
+    ~ [missing trailing comma]
+];
 
 var yy = [
     42,
@@ -49,6 +67,15 @@ var cc = [42, 24,];
 var dd = [2, 1];
 
 var {
+    sA,
+} = s;
+
+var {
+    tA
+     ~ [missing trailing comma]
+} = t;
+
+var {
     yA,
     yB,
 } = y;
@@ -58,6 +85,15 @@ var {
     zTwo
        ~ [missing trailing comma]
 } = z;
+
+var [
+    ssA,
+] = ss;
+
+var [
+    ttA
+      ~ [missing trailing comma]
+] = tt;
 
 var [
     yyA,
@@ -77,6 +113,15 @@ var {dOne, dTwo} = d;
 var [ccA, ccB,] = cc;
 
 var [ddOne, ddTwo] = dd;
+
+import {
+    ClassS,
+} from "module";
+
+import {
+    ClassT
+         ~ [missing trailing comma]
+} from "module";
 
 import {
     ClassV,

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -14,6 +14,15 @@ var x = [{
     c: (a + b)
 }];
 
+var s = {
+    sA: 6,
+         ~ [trailing comma]
+};
+
+var t = {
+    tA: 7
+}
+
 var y = {
     yA: 42,
     yB: 24,
@@ -24,6 +33,15 @@ var z = {
     zOne: 2,
     zTwo: 1
 };
+
+var ss = [
+    6,
+     ~ [trailing comma]
+];
+
+var tt = [
+    7
+];
 
 var yy = [
     42,
@@ -49,6 +67,15 @@ var cc = [42, 24,];
 var dd = [2, 1];
 
 var {
+    sA,
+      ~ [trailing comma]
+} = s;
+
+var {
+    tA
+} = t;
+
+var {
     yA,
     yB,
       ~ [trailing comma]
@@ -58,6 +85,15 @@ var {
     zOne,
     zTwo
 } = z;
+
+var [
+    ssA,
+       ~ [trailing comma]
+] = ss;
+
+var [
+    ttA
+] = tt;
 
 var [
     yyA,
@@ -77,6 +113,15 @@ var {dOne, dTwo} = d;
 var [ccA, ccB,] = cc;
 
 var [ddOne, ddTwo] = dd;
+
+import {
+    ClassS,
+          ~ [trailing comma]
+} from "module";
+
+import {
+    ClassT
+} from "module";
 
 import {
     ClassV,

--- a/test/rules/trailing-comma/singleline-always/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-always/test.ts.lint
@@ -12,6 +12,14 @@ var x = [{
     c: (a + b)
 }];
 
+var s = {
+    sA: 6,
+};
+
+var t = {
+    tA: 7
+}
+
 var y = {
     yA: 42,
     yB: 24,
@@ -21,6 +29,14 @@ var z = {
     zOne: 2,
     zTwo: 1
 };
+
+var ss = [
+    6,
+];
+
+var tt = [
+    7
+];
 
 var yy = [
     42,
@@ -49,6 +65,14 @@ var dd = [2, 1];
              ~   [missing trailing comma]
 
 var {
+    sA,
+} = s;
+
+var {
+    tA
+} = t;
+
+var {
     yA,
     yB,
 } = y;
@@ -57,6 +81,14 @@ var {
     zOne,
     zTwo
 } = z;
+
+var [
+    ssA,
+] = ss;
+
+var [
+    ttA
+] = tt;
 
 var [
     yyA,
@@ -77,6 +109,14 @@ var [ccA, ccB,] = cc;
 
 var [ddOne, ddTwo] = dd;
                 ~        [missing trailing comma]
+
+import {
+    ClassS,
+} from "module";
+
+import {
+    ClassT
+} from "module";
 
 import {
     ClassV,

--- a/test/rules/trailing-comma/singleline-never/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-never/test.ts.lint
@@ -12,6 +12,14 @@ var x = [{
     c: (a + b)
 }];
 
+var s = {
+    sA: 6,
+};
+
+var t = {
+    tA: 7
+}
+
 var y = {
     yA: 42,
     yB: 24,
@@ -21,6 +29,14 @@ var z = {
     zOne: 2,
     zTwo: 1
 };
+
+var ss = [
+    6,
+];
+
+var tt = [
+    7
+];
 
 var yy = [
     42,
@@ -49,6 +65,14 @@ var cc = [42, 24,];
 var dd = [2, 1];
 
 var {
+    sA,
+} = s;
+
+var {
+    tA
+} = t;
+
+var {
     yA,
     yB,
 } = y;
@@ -57,6 +81,14 @@ var {
     zOne,
     zTwo
 } = z;
+
+var [
+    ssA,
+] = ss;
+
+var [
+    ttA
+] = tt;
 
 var [
     yyA,
@@ -77,6 +109,14 @@ var [ccA, ccB,] = cc;
              ~        [trailing comma]
 
 var [ddOne, ddTwo] = dd;
+
+import {
+    ClassS,
+} from "module";
+
+import {
+    ClassT
+} from "module";
 
 import {
     ClassV,


### PR DESCRIPTION
This PR addresses https://github.com/palantir/tslint/issues/856. It's only a one line fix, but quite a few test cases were added to cover the various flavors of multiline literals.