### PR TITLE
Various fixes to one-line rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ A sample configuration file with all options is available [here](https://github.
 * `one-line` enforces the specified tokens to be on the same line as the expression preceding it. Rule options:
   * `"check-catch"` checks that `catch` is on the same line as the closing brace for `try`.
   * `"check-else"` checks that `else` is on the same line as the closing brace for `if`.
+  * `"check-finally"` checks that `finally` is on the same line as the closing brace for the preceding `try` or `catch`.
   * `"check-open-brace"` checks that an open brace falls on the same line as its preceding expression.
   * `"check-whitespace"` checks preceding whitespace for the specified tokens.
 * `quotemark` enforces consistent single or double quoted string literals. Rule options (at least one of `"double"` or `"single"` is required):

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -75,6 +75,7 @@
       "check-open-brace",
       "check-catch",
       "check-else",
+      "check-finally",
       "check-whitespace"
     ],
     "quotemark": [

--- a/test/rules/one-line/all/test.ts.lint
+++ b/test/rules/one-line/all/test.ts.lint
@@ -67,6 +67,33 @@ catch (e)
 ~ [misplaced opening brace]
     throw(e);
 }
+finally
+~~~~~~~ [misplaced 'finally']
+{
+~ [misplaced opening brace]
+    // do something
+}
+
+try {
+    foo();
+}
+finally
+~~~~~~~ [misplaced 'finally']
+{
+~ [misplaced opening brace]
+    bar();
+}
+
+try{
+   ~ [missing whitespace]
+    foo();
+} catch(e){
+          ~ [missing whitespace]
+    bar();
+} finally{
+         ~ [missing whitespace]
+    baz();
+}
 
 while(x < 10){
              ~ [missing whitespace]

--- a/test/rules/one-line/all/tslint.json
+++ b/test/rules/one-line/all/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"]
+    "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-finally", "check-whitespace"]
   }
 }

--- a/test/rules/one-line/none/test.ts.lint
+++ b/test/rules/one-line/none/test.ts.lint
@@ -55,6 +55,26 @@ catch (e)
 {
     throw(e);
 }
+finally
+{
+    // do something
+}
+
+try {
+    foo();
+}
+finally
+{
+    bar();
+}
+
+try{
+    foo();
+} catch(e){
+    bar();
+} finally{
+    baz();
+}
 
 while(x < 10){
     x++;

--- a/tslint.json
+++ b/tslint.json
@@ -46,6 +46,7 @@
       "check-open-brace",
       "check-catch",
       "check-else",
+      "check-finally",
       "check-whitespace"
     ],
     "quotemark": [true, "double", "avoid-escape"],


### PR DESCRIPTION
* Correctly check for space between catch and opening brace (fixes #925)
* Add `check-finally` option
* Check opening brace of finally blocks