### PR TITLE
Identify spaces before function return type colons correctly.

### DIFF
--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -26,20 +26,17 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class TypedefWhitespaceWalker extends Lint.RuleWalker {
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-        const positionBeforeColon = this.positionBeforeColon(node);
-        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon(node));
         super.visitFunctionDeclaration(node);
     }
 
     public visitFunctionExpression(node: ts.FunctionExpression) {
-        const positionBeforeColon = this.positionBeforeColon(node);
-        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon(node));
         super.visitFunctionExpression(node);
     }
 
     public visitGetAccessor(node: ts.AccessorDeclaration) {
-        const positionBeforeColon = this.positionBeforeColon(node);
-        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon(node));
         super.visitGetAccessor(node);
     }
 
@@ -54,14 +51,12 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
     }
 
     public visitMethodDeclaration(node: ts.MethodDeclaration) {
-        const positionBeforeColon = this.positionBeforeColon(node);
-        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon(node));
         super.visitMethodDeclaration(node);
     }
 
     public visitMethodSignature(node: ts.SignatureDeclaration) {
-        const positionBeforeColon = this.positionBeforeColon(node);
-        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon(node));
         super.visitMethodSignature(node);
     }
 
@@ -81,8 +76,7 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
     }
 
     public visitSetAccessor(node: ts.AccessorDeclaration) {
-        const positionBeforeColon = this.positionBeforeColon(node);
-        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon(node));
         super.visitSetAccessor(node);
     }
 
@@ -125,15 +119,9 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
         const options = allOptions[0];
         return options[option];
     }
+}
 
-    private positionBeforeColon(node: ts.FunctionDeclaration | ts.FunctionExpression | ts.AccessorDeclaration |
-                                        ts.MethodDeclaration | ts.SignatureDeclaration | ts.AccessorDeclaration) {
-        const children = node.getChildren();
-        for (let i = 0; i < children.length; ++i) {
-            if (children[i].getText() === ":") {
-                return children[i].pos;
-            }
-        }
-        return 0;
-    }
+function positionBeforeColon(node: ts.Node): number {
+    const colon = node.getChildren().filter((c) => c.kind === ts.SyntaxKind.ColonToken)[0];
+    return colon == null ? -1 : colon.pos;
 }

--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -26,17 +26,20 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class TypedefWhitespaceWalker extends Lint.RuleWalker {
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-        this.checkSpace("call-signature", node, node.type, node.parameters.end + 1);
+        const positionBeforeColon = this.positionBeforeColon(node);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
         super.visitFunctionDeclaration(node);
     }
 
     public visitFunctionExpression(node: ts.FunctionExpression) {
-        this.checkSpace("call-signature", node, node.type, node.parameters.end + 1);
+        const positionBeforeColon = this.positionBeforeColon(node);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
         super.visitFunctionExpression(node);
     }
 
     public visitGetAccessor(node: ts.AccessorDeclaration) {
-        this.checkSpace("call-signature", node, node.type, node.parameters.end + 1);
+        const positionBeforeColon = this.positionBeforeColon(node);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
         super.visitGetAccessor(node);
     }
 
@@ -51,12 +54,14 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
     }
 
     public visitMethodDeclaration(node: ts.MethodDeclaration) {
-        this.checkSpace("call-signature", node, node.type, node.parameters.end + 1);
+        const positionBeforeColon = this.positionBeforeColon(node);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
         super.visitMethodDeclaration(node);
     }
 
     public visitMethodSignature(node: ts.SignatureDeclaration) {
-        this.checkSpace("call-signature", node, node.type, node.parameters.end + 1);
+        const positionBeforeColon = this.positionBeforeColon(node);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
         super.visitMethodSignature(node);
     }
 
@@ -76,7 +81,8 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
     }
 
     public visitSetAccessor(node: ts.AccessorDeclaration) {
-        this.checkSpace("call-signature", node, node.type, node.parameters.end + 1);
+        const positionBeforeColon = this.positionBeforeColon(node);
+        this.checkSpace("call-signature", node, node.type, positionBeforeColon);
         super.visitSetAccessor(node);
     }
 
@@ -118,5 +124,16 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
 
         const options = allOptions[0];
         return options[option];
+    }
+
+    private positionBeforeColon(node: ts.FunctionDeclaration | ts.FunctionExpression | ts.AccessorDeclaration |
+                                        ts.MethodDeclaration | ts.SignatureDeclaration | ts.AccessorDeclaration) {
+        const children = node.getChildren();
+        for (let i = 0; i < children.length; ++i) {
+            if (children[i].getText() === ":") {
+                return children[i].pos;
+            }
+        }
+        return 0;
     }
 }

--- a/test/rules/typedef-whitespace/none/test.ts.lint
+++ b/test/rules/typedef-whitespace/none/test.ts.lint
@@ -44,6 +44,8 @@ var withPreceedingSpacesFn = function (a : number, b : number) : number {
     }
 };
 
+var withPreceedingSpacesCallSignaturePaddedParams = function ( ) : {}
+
 class NoPreceedingSpacesClass {
     [index: number]: string
 
@@ -52,6 +54,13 @@ class NoPreceedingSpacesClass {
     public get name(): string {
         return "some name";
     }
+
+    public set name(a: string): void {}
+
+    public shemp(
+        a: number,
+        b: number
+    ): void {}
 }
 
 class WithPreceedingSpacesClass {
@@ -62,4 +71,11 @@ class WithPreceedingSpacesClass {
     public get name() : string {
         return "some name";
     }
+
+    public set name(a : string) : void {}
+
+    public shemp(
+        a : number,
+        b : number
+    ) : void {}
 }

--- a/test/rules/typedef-whitespace/nospace/test.ts.lint
+++ b/test/rules/typedef-whitespace/nospace/test.ts.lint
@@ -52,6 +52,9 @@ var withPreceedingSpacesFn = function (a : number, b : number) : number {
     }
 };
 
+var withPreceedingSpacesCallSignaturePaddedParams = function ( ) : {}
+                                                                ~         [expected nospace in call-signature]
+
 class NoPreceedingSpacesClass {
     [index: number]: string
 
@@ -60,6 +63,13 @@ class NoPreceedingSpacesClass {
     public get name(): string {
         return "some name";
     }
+
+    public set name(a: string): void {}
+
+    public shemp(
+        a: number,
+        b: number
+    ): void {}
 }
 
 class WithPreceedingSpacesClass {
@@ -74,4 +84,13 @@ class WithPreceedingSpacesClass {
                      ~           [expected nospace in call-signature]
         return "some name";
     }
+
+    public set name(a: string) : void {}
+                              ~            [expected nospace in call-signature]
+
+    public shemp(
+        a: number,
+        b: number
+    ) : void {}
+     ~             [expected nospace in call-signature]
 }

--- a/test/rules/typedef-whitespace/space/test.ts.lint
+++ b/test/rules/typedef-whitespace/space/test.ts.lint
@@ -52,6 +52,8 @@ var withPreceedingSpacesFn = function (a : number, b : number) : number {
     }
 };
 
+var withPreceedingSpacesCallSignaturePaddedParams = function ( ) : {}
+
 class NoPreceedingSpacesClass {
     [index: number]: string
           ~                 [expected space in index-signature]
@@ -64,6 +66,15 @@ class NoPreceedingSpacesClass {
                      ~          [expected space in call-signature]
         return "some name";
     }
+
+    public set name(a : string): void {}
+                               ~            [expected space in call-signature]
+
+    public shemp(
+        a : number,
+        b : number
+    ): void {}
+     ~             [expected space in call-signature]
 }
 
 class WithPreceedingSpacesClass {
@@ -74,4 +85,11 @@ class WithPreceedingSpacesClass {
     public get name() : string {
         return "some name";
     }
+
+    public set name(a : string) : void {}
+
+    public shemp(
+        a : number,
+        b : number
+    ) : void {}
 }


### PR DESCRIPTION
This PR addresses https://github.com/palantir/tslint/issues/955.

There are some bugs related to looking for spaces before and after the colon on a function's return type caused by assuming that the colon comes exactly one character after the end of the parameter list. Instead of assuming, search the AST for the actual colon token.

The only thing I don't like about this solution is that there might not be a colon after the parameter list in which case I return `0` as a sentinel. I could make sure there is a return type before calling my new helper function, but that logic is already happening inside the `checkSpace()` function which is overgeneralized to handle all "check space" logic even for non-function-like cases.

I also noticed that some function types like setter methods and regular instance methods didn't have any tests so I filled in those gaps.