### PR TITLE
Add new typedef rule: "arrow-parameter", to check typedefs are supplied for arrow function parameters separately from other functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ A sample configuration file with all options is available [here](https://github.
     * `"allow-null-check"` allows `==` and `!=` when comparing to `null`.
 * `typedef` enforces type definitions to exist. Rule options:
     * `"call-signature"` checks return type of functions.
-    * `"parameter"` checks type specifier of function parameters.
+    * `"parameter"` checks type specifier of function parameters for non-arrow functions.
+    * `"arrow-parameter"` checks type specifier of function parameters for arrow functions.
     * `"property-declaration"` checks return types of interface properties.
     * `"variable-declaration"` checks variable declarations.
     * `"member-variable-declaration"` checks member variable declarations.

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -101,6 +101,7 @@
       true,
       "call-signature",
       "parameter",
+      "arrow-parameter",
       "property-declaration",
       "variable-declaration",
       "member-variable-declaration"

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -75,7 +75,8 @@ class TypedefWalker extends Lint.RuleWalker {
     public visitParameterDeclaration(node: ts.ParameterDeclaration) {
         // a parameter's "type" could be a specific string value, for example `fn(option: "someOption", anotherOption: number)`
         if (node.type == null || node.type.kind !== ts.SyntaxKind.StringLiteral) {
-            this.checkTypeAnnotation("parameter", node.getEnd(), <ts.TypeNode> node.type, node.name);
+            const optionName = node.parent.kind === ts.SyntaxKind.ArrowFunction ? "arrow-parameter" : "parameter";
+            this.checkTypeAnnotation(optionName, node.getEnd(), <ts.TypeNode> node.type, node.name);
         }
         super.visitParameterDeclaration(node);
     }

--- a/test/rules/typedef/all/tslint.json
+++ b/test/rules/typedef/all/tslint.json
@@ -3,6 +3,7 @@
       "typedef": [true,
          "call-signature",
          "parameter",
+         "arrow-parameter",
          "variable-declaration",
          "property-declaration",
          "member-variable-declaration"

--- a/test/rules/typedef/arrow-parameter/test.ts.lint
+++ b/test/rules/typedef/arrow-parameter/test.ts.lint
@@ -1,0 +1,5 @@
+var NoTypesFn = function (a, b) {}
+
+var NoTypesArrowFn = (a, b) => {}
+                       ~ [expected arrow-parameter: 'a' to have a typedef]
+                          ~ [expected arrow-parameter: 'b' to have a typedef]

--- a/test/rules/typedef/arrow-parameter/tslint.json
+++ b/test/rules/typedef/arrow-parameter/tslint.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+      "typedef": [true,
+         "arrow-parameter"
+      ]
+   }
+}

--- a/test/rules/typedef/parameter/test.ts.lint
+++ b/test/rules/typedef/parameter/test.ts.lint
@@ -1,0 +1,6 @@
+var NoTypesFn = function (a, b) {
+                           ~ [expected parameter: 'a' to have a typedef]
+                              ~ [expected parameter: 'b' to have a typedef]
+}
+
+var NoTypesArrowFn = (a, b) => {}

--- a/test/rules/typedef/parameter/tslint.json
+++ b/test/rules/typedef/parameter/tslint.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+      "typedef": [true,
+         "parameter"
+      ]
+   }
+}


### PR DESCRIPTION
See https://github.com/palantir/tslint/issues/333 for discussion.

This was a quick fix this for me to use personally, but I am happy to make any changes required for this PR to be merged if the functionality is desired.