### PR TITLE
Treat member variables initialized to a function as a function for ordering purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ A sample configuration file with all options is available [here](https://github.
 * `member-ordering` enforces member ordering. Rule options:
     * `public-before-private` All public members must be declared before private members.
     * `static-before-instance` All static members must be declared before instance members.
-    * `variables-before-functions` All variables needs to be declared before functions.
+    * `variables-before-functions` All member variables need to be declared before member functions.
+       Member variables initialized to a function literal are treated as member functions.
 * `no-any` diallows usages of `any` as a type decoration.
 * `no-arg` disallows access to `arguments.callee`.
 * `no-bitwise` disallows bitwise operators.

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -78,12 +78,16 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
     }
 
     public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
-        this.checkModifiersAndSetPrevious(node, getModifiers(false, node.modifiers));
+        const { initializer } = node;
+        const isFunction = initializer != null
+            && (initializer.kind === ts.SyntaxKind.ArrowFunction || initializer.kind === ts.SyntaxKind.FunctionExpression);
+        this.checkModifiersAndSetPrevious(node, getModifiers(isFunction, node.modifiers));
         super.visitPropertyDeclaration(node);
     }
 
-    public visitPropertySignature(node: ts.Node) {
-        this.checkModifiersAndSetPrevious(node, getModifiers(false, node.modifiers));
+    public visitPropertySignature(node: ts.PropertyDeclaration) {
+        const isFunction = node.type != null && node.type.kind === ts.SyntaxKind.FunctionType;
+        this.checkModifiersAndSetPrevious(node, getModifiers(isFunction, node.modifiers));
         super.visitPropertySignature(node);
     }
 

--- a/test/rules/member-ordering/method/test.ts.lint
+++ b/test/rules/member-ordering/method/test.ts.lint
@@ -19,4 +19,25 @@ class Foo {
     ~~~~~~~~~~ [0]
 }
 
+interface IArrowMethods {
+    a: number;
+    b(): void;
+    c: () => void;
+}
+
+class ArrowMethods {
+    public a = 5;
+    public b = "foo";
+    public c() {}
+    public d = () => {};
+    public e = function() {};
+}
+
+class OutOfOrder {
+    a = () => {};
+    b = 5;
+    ~~~~~~ [0]
+}
+
 [0]: Declaration of public instance member variable not allowed to appear after declaration of public instance member function
+


### PR DESCRIPTION
Fixes #226 