### PR TITLE
fix isBlockScopeBoundary, add test case for no-shadowed-variable.

### DIFF
--- a/src/language/walker/blockScopeAwareRuleWalker.ts
+++ b/src/language/walker/blockScopeAwareRuleWalker.ts
@@ -80,6 +80,11 @@ export abstract class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalk
             || (node.parent != null
                 && (node.parent.kind === ts.SyntaxKind.TryStatement
                     || node.parent.kind === ts.SyntaxKind.IfStatement)
+                )
+            || (node.kind === ts.SyntaxKind.Block
+                && (
+                    node.parent.kind === ts.SyntaxKind.Block
+                    || node.parent.kind === ts.SyntaxKind.SourceFile)
                 );
     }
 }

--- a/test/rules/no-shadowed-variable/test.ts.lint
+++ b/test/rules/no-shadowed-variable/test.ts.lint
@@ -152,3 +152,12 @@ function testParameterDestructuring(
             ~~~                 [shadowed variable: 'pos']
     }
 }
+
+
+{
+    const simpleBlockVar = 3
+}
+
+function testSimpleBlockVar() {
+    const simpleBlockVar = 4
+}


### PR DESCRIPTION
fix #1021

If node is a alone block, e.g.
```
{
   const a = 3
}
```
`isBlockScopeBoundary()` should return true