### PR TITLE
Add no-type-assertion-expression rule.

### DIFF
--- a/src/rules/noAngleBracketTypeAssertionRule.ts
+++ b/src/rules/noAngleBracketTypeAssertionRule.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../lint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(<Lint.RuleWalker>(new NoAngleBracketTypeAssertionWalker(sourceFile, this.getOptions())));
+    }
+}
+
+class NoAngleBracketTypeAssertionWalker extends Lint.RuleWalker {
+    public visitTypeAssertionExpression(node: ts.TypeAssertion) {
+        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        super.visitTypeAssertionExpression(node);
+    }
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -72,6 +72,7 @@
         "rules/maxLineLengthRule.ts",
         "rules/memberAccessRule.ts",
         "rules/memberOrderingRule.ts",
+        "rules/noAngleBracketTypeAssertionRule.ts",
         "rules/noAnyRule.ts",
         "rules/noArgRule.ts",
         "rules/noBitwiseRule.ts",

--- a/test/rules/no-angle-bracket-type-assertion/test.ts.lint
+++ b/test/rules/no-angle-bracket-type-assertion/test.ts.lint
@@ -1,0 +1,14 @@
+var a = <any>5;
+        ~~~~~~  [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+
+var b = <number><any>5;
+        ~~~~~~~~~~~~~~  [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+                ~~~~~~  [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+
+var c = <number>(5 as any);
+        ~~~~~~~~~~~~~~~~~~  [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+
+var d = <any>5 as number;
+        ~~~~~~            [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+
+var e = 5 as any as number;

--- a/test/rules/no-angle-bracket-type-assertion/tslint.json
+++ b/test/rules/no-angle-bracket-type-assertion/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-angle-bracket-type-assertion": true
+  }
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -70,6 +70,7 @@
         "../src/rules/maxLineLengthRule.ts",
         "../src/rules/memberAccessRule.ts",
         "../src/rules/memberOrderingRule.ts",
+        "../src/rules/noAngleBracketTypeAssertionRule.ts",
         "../src/rules/noAnyRule.ts",
         "../src/rules/noArgRule.ts",
         "../src/rules/noBitwiseRule.ts",


### PR DESCRIPTION
Checks for uses of the `<>` type assertion syntax and suggests changing it to the `as` syntax.

Fixes #639 

---

The name of the rule comes from TS - the `<>` syntax is called a TypeAssertionExpression and the `as` syntax is called an AsExpression. But I can imagine it'll be confusing to tslint users because functionally they're both type assertion expressions. I'm open to suggestions for the name. (`no-angle-bracket-type-assertions` ? I'm hesitant about calling it `old` or `legacy`.)

I also didn't make this a tri-state (disabled, enforce `as`, enforce `<>`) because I'm not sure anyone will care for the last one.

For the test case - I wrote it initially without the errors, then ran `grunt` and accepted its output that contained the errors. Is there anything else I need to do?