### PR TITLE
Add `node_module:` prefix for loading rules from a node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt-tslint": "latest",
     "mocha": "^2.2.5",
     "tslint": "latest",
+    "tslint-eslint-rules": "1.1.1",
     "typescript": "latest"
   },
   "peerDependencies": {

--- a/test/configurationTests.ts
+++ b/test/configurationTests.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {IConfigFile, extendConfigFile} from "../src/configuration";
+import {IConfigFile, extendConfigFile, getRulesDirectories} from "../src/configuration";
+import {loadRules} from "./lint";
 
 describe("Configuration", () => {
     it("extendConfigFile", () => {
@@ -50,5 +51,11 @@ describe("Configuration", () => {
             },
             rulesDirectory: ["foo", "bar", "baz"],
         });
+    });
+
+    it("resolves rules directories with a node_module: prefix correctly", () => {
+        const resolvedDirectories = getRulesDirectories("node_module:tslint-eslint-rules/dist/rules");
+        const rules = loadRules({"valid-typeof": true}, {}, resolvedDirectories);
+        assert.strictEqual(rules.length, 1);
     });
 });


### PR DESCRIPTION
Allows one to provide directories to custom rules living in a node module using the "node_module:" prefix:

```
{
  rulesDirectory: "node_module:tslint-eslint-rules/dist/rules"
  rules: { ... }
}
```

This is better than relative paths to node modules, which can behave funky depending on where the node module gets installed. Internally, this uses `require.resolve` to find the location of the node module, which means that it's using node's package finding algorithm, which is good.