### PR TITLE
Clarify the "unsorted key" failure message

### DIFF
--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -19,7 +19,8 @@ import * as ts from "typescript";
 import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "unsorted key '";
+    public static FAILURE_STRING_PREFIX = "The key '";
+    public static FAILURE_STRING_POSTFIX = "' is not sorted alphabetically";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new ObjectLiteralSortKeysWalker(sourceFile, this.getOptions()));
@@ -52,7 +53,7 @@ class ObjectLiteralSortKeysWalker extends Lint.RuleWalker {
             if (keyNode.kind === ts.SyntaxKind.Identifier) {
                 const key = (<ts.Identifier> keyNode).text;
                 if (key < lastSortedKey) {
-                    const failureString = Rule.FAILURE_STRING + key + "'";
+                    const failureString = Rule.FAILURE_STRING_PREFIX + key + Rule.FAILURE_STRING_POSTFIX;
                     this.addFailure(this.createFailure(keyNode.getStart(), keyNode.getWidth(), failureString));
                     this.sortedStateStack[this.sortedStateStack.length - 1] = false;
                 } else {

--- a/test/rules/object-literal-sort-keys/test.ts.lint
+++ b/test/rules/object-literal-sort-keys/test.ts.lint
@@ -6,7 +6,7 @@ var passA = {
 var failA = {
     b: 1,
     a: 2
-    ~    [unsorted key 'a']
+    ~    [The key 'a' is not sorted alphabetically]
 };
 
 var passB = {
@@ -19,7 +19,7 @@ var passB = {
 var failB = {
     c: 3,
     a: 1,
-    ~     [unsorted key 'a']
+    ~     [The key 'a' is not sorted alphabetically]
     b: 2,
     d: 4
 };
@@ -37,7 +37,7 @@ var failC = {
     b: {
         bb: 2,
         aa: 1
-        ~~    [unsorted key 'aa']
+        ~~    [The key 'aa' is not sorted alphabetically]
     }
 };
 
@@ -57,7 +57,7 @@ var failD = {
         bb: 2
     },
     b: 3
-    ~    [unsorted key 'b']
+    ~    [The key 'b' is not sorted alphabetically]
 };
 
 var passE = {};
@@ -70,7 +70,7 @@ var passF = {
 var failF = {
     sdfa: {},
     asdf: [1, 2, 3]
-    ~~~~            [unsorted key 'asdf']
+    ~~~~            [The key 'asdf' is not sorted alphabetically]
 };
 
 var passG = {
@@ -81,5 +81,5 @@ var passG = {
 var failG = {
     sdafn: function () {},
     asdfn: function () {}
-    ~~~~~                 [unsorted key 'asdfn']
+    ~~~~~                 [The key 'asdfn' is not sorted alphabetically]
 };


### PR DESCRIPTION
Adding TSLint to our projects has been a huge benefit, but nearly every developer who has encountered the `unsorted key 'a'` message has come to me and asked "I understood how to fix the other errors I saw, but I have no idea what this one means."  

I think just saying "unsorted key" is not enough information to give someone who has never encountered this error before.  So i'm proposing just a small text change to help clarify this.

**Before** :-1: 
>unsorted key 'a'

**After** :+1: 
>The key 'a' is not sorted alphabetically