### PR TITLE
Make semi-colon rule laxer with bound-method properties

### DIFF
--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -83,8 +83,8 @@ class SemicolonWalker extends Lint.RuleWalker {
 
     public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
         const initializer = node.initializer;
-        if (this.hasOption(OPTION_ALWAYS) || this.hasOption(OPTION_NEVER) ||
-            !(initializer && initializer.kind === ts.SyntaxKind.ArrowFunction)) {
+        /* ALWAYS === "enabled" for this rule. */
+        if (this.hasOption(OPTION_NEVER) || !(initializer && initializer.kind === ts.SyntaxKind.ArrowFunction)) {
             this.checkSemicolonAt(node);
         }
         super.visitPropertyDeclaration(node);

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -82,7 +82,11 @@ class SemicolonWalker extends Lint.RuleWalker {
     }
 
     public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
-        this.checkSemicolonAt(node);
+        const initializer = node.initializer;
+        if (this.hasOption(OPTION_ALWAYS) || this.hasOption(OPTION_NEVER) ||
+            !(initializer && initializer.kind === ts.SyntaxKind.ArrowFunction)) {
+            this.checkSemicolonAt(node);
+        }
         super.visitPropertyDeclaration(node);
     }
 

--- a/test/rules/semicolon/always/test.ts.lint
+++ b/test/rules/semicolon/always/test.ts.lint
@@ -62,7 +62,6 @@ class MyClass {
     public initializedProperty = 6
                                   ~nil [missing semicolon]
     public initializedMethodProperty = () => { return "hi"; }
-                                                             ~nil [missing semicolon]
 }
 
 interface ITest {

--- a/test/rules/semicolon/always/test.ts.lint
+++ b/test/rules/semicolon/always/test.ts.lint
@@ -58,6 +58,11 @@ class MyClass {
     private index : number
                           ~nil [missing semicolon]
     private email : string;
+
+    public initializedProperty = 6
+                                  ~nil [missing semicolon]
+    public initializedMethodProperty = () => { return "hi"; }
+                                                             ~nil [missing semicolon]
 }
 
 interface ITest {

--- a/test/rules/semicolon/enabled/test.ts.lint
+++ b/test/rules/semicolon/enabled/test.ts.lint
@@ -58,6 +58,9 @@ class MyClass {
     private index : number
                           ~nil [missing semicolon]
     private email : string;
+    public initializedProperty = 6
+                                  ~nil [missing semicolon]
+    public initializedMethodProperty = () => { return "hi"; }
 }
 
 interface ITest {

--- a/test/rules/semicolon/never/test.ts.lint
+++ b/test/rules/semicolon/never/test.ts.lint
@@ -58,6 +58,10 @@ class MyClass {
     private index : number;
                           ~ [unnecessary semicolon]
     private email : string
+    public initializedProperty = 6
+    public initializedMethodProperty = () => { return "hi" };
+                                                            ~ [unnecessary semicolon]
+
 }
 
 interface ITest {


### PR DESCRIPTION
Methods declared like:

```ts
class Foo {
      bar = () => { }
}
```

shouldn't be marked as requiring a trailing semi-colon for the closing `}`

Addresses: #1076 