### PR TITLE
Add "no-invalid-this" rule

### DIFF
--- a/src/language/walker/scopeAwareRuleWalker.ts
+++ b/src/language/walker/scopeAwareRuleWalker.ts
@@ -25,10 +25,10 @@ export abstract class ScopeAwareRuleWalker<T> extends RuleWalker {
         super(sourceFile, options);
 
         // initialize stack with global scope
-        this.scopeStack = [this.createScope()];
+        this.scopeStack = [this.createScope(sourceFile)];
     }
 
-    public abstract createScope(): T;
+    public abstract createScope(node: ts.Node): T;
 
     public getCurrentScope(): T {
         return this.scopeStack[this.scopeStack.length - 1];
@@ -57,7 +57,7 @@ export abstract class ScopeAwareRuleWalker<T> extends RuleWalker {
         const isNewScope = this.isScopeBoundary(node);
 
         if (isNewScope) {
-            this.scopeStack.push(this.createScope());
+            this.scopeStack.push(this.createScope(node));
         }
 
         this.onScopeStart();

--- a/src/language/walker/scopeAwareRuleWalker.ts
+++ b/src/language/walker/scopeAwareRuleWalker.ts
@@ -80,6 +80,7 @@ export abstract class ScopeAwareRuleWalker<T> extends RuleWalker {
             || node.kind === ts.SyntaxKind.ArrowFunction
             || node.kind === ts.SyntaxKind.ParenthesizedExpression
             || node.kind === ts.SyntaxKind.ClassDeclaration
+            || node.kind === ts.SyntaxKind.ClassExpression
             || node.kind === ts.SyntaxKind.InterfaceDeclaration
             || node.kind === ts.SyntaxKind.GetAccessor
             || node.kind === ts.SyntaxKind.SetAccessor;

--- a/src/rules/noInvalidThisRule.ts
+++ b/src/rules/noInvalidThisRule.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../lint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "the \"this\" keyword is disallowed outside of a class body" ;
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoInvalidThisWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NoInvalidThisWalker extends Lint.ScopeAwareRuleWalker<{inClass: boolean}> {
+    public createScope(node: ts.Node): { inClass: boolean } {
+        const isClassScope = node.kind === ts.SyntaxKind.ClassDeclaration || node.kind === ts.SyntaxKind.ClassExpression;
+
+        return {
+            inClass: isClassScope,
+        };
+    }
+
+    protected validateThisKeyword(node: ts.Node) {
+        if (!this.getAllScopes().some((scope) => scope.inClass)) {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        }
+    }
+
+    public visitNode(node: ts.Node) {
+        if (node.kind === ts.SyntaxKind.ThisKeyword) {
+            this.validateThisKeyword(node);
+        }
+
+        super.visitNode(node);
+    }
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -91,6 +91,7 @@
         "rules/noEvalRule.ts",
         "rules/noInferrableTypesRule.ts",
         "rules/noInternalModuleRule.ts",
+        "rules/noInvalidThisRule.ts",
         "rules/noNullKeywordRule.ts",
         "rules/noRequireImportsRule.ts",
         "rules/noShadowedVariableRule.ts",

--- a/test/rules/no-invalid-this/enabled/test.ts.lint
+++ b/test/rules/no-invalid-this/enabled/test.ts.lint
@@ -1,0 +1,23 @@
+function foo(x: number) {
+    console.log(this.x);
+                ~~~~[the "this" keyword is disallowed outside of a class body]
+
+    this.evilMethod();
+    ~~~~[the "this" keyword is disallowed outside of a class body]
+}
+
+class AClass {
+    private x: number;
+
+    public aMethod() {
+        this.x = 5;
+    }
+}
+
+const AClassExpression = class {
+    private x: number;
+
+    public aMethod() {
+        this.x = 5;
+    }
+}

--- a/test/rules/no-invalid-this/enabled/tslint.json
+++ b/test/rules/no-invalid-this/enabled/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-invalid-this": [true]
+  }
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -88,6 +88,7 @@
         "../src/rules/noEvalRule.ts",
         "../src/rules/noInferrableTypesRule.ts",
         "../src/rules/noInternalModuleRule.ts",
+        "../src/rules/noInvalidThisRule.ts",
         "../src/rules/noNullKeywordRule.ts",
         "../src/rules/noRequireImportsRule.ts",
         "../src/rules/noShadowedVariableRule.ts",


### PR DESCRIPTION
This PR adds a rule that flags usage of the `this` keyword outside of class-body scopes.

Often I find myself refactoring code that looks like:

```ts
class Foo {
    private aMethod() {
        doWorkOn(this.someState.x);
    }
}
```

to pull `aMethod` out into a function that looks like:

```ts
function(someState) {
    doWorkOn(someState.x);
}
```

When I make this change by hand I find that I screw up a lot and accidentally write:

```ts
function(someState) {
    doWorkOn(this.someState.x); /* note `this` */
}
```

which does not cause a compile error because typescript unhelpfully infers `this` with type `any`.

I've found that `this` outside of a `class` in code that is using ES6-class syntax is almost always a mistake. I wouldn't turn this on by default for all users of tslint, but it'd be very useful in my case (and I imagine for others.)