### PR TITLE
Revert "Update findup-sync"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "diff": "^2.2.1",
-    "findup-sync": "~0.4.0",
+    "findup-sync": "~0.3.0",
     "glob": "^6.0.1",
     "optimist": "~0.6.0",
     "path-is-absolute": "^1.0.0",


### PR DESCRIPTION
This reverts commit 8ecaf3ee636da9c6f70896e33e807594849ac71c.

Fixes #1106.

See also https://github.com/js-cli/node-findup-sync/issues/31

This shouldn't break #1080, as we still upgrade to a slightly newer version of findup-sync which uses the newer version of glob.