### PR TITLE
Clearer message for `no-var-keyword` rule

### DIFF
--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -19,7 +19,7 @@ import * as ts from "typescript";
 import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "forbidden var keyword";
+    public static FAILURE_STRING = "forbidden 'var' keyword, use 'let' or 'const' instead";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const noVarKeywordWalker = new NoVarKeywordWalker(sourceFile, this.getOptions());

--- a/test/rules/no-var-keyword/test.ts.lint
+++ b/test/rules/no-var-keyword/test.ts.lint
@@ -1,24 +1,24 @@
 var foo;
-~~~      [forbidden var keyword]
+~~~      [forbidden 'var' keyword, use 'let' or 'const' instead]
 
 function tmp(t: any) {
     var x = 3;
-    ~~~        [forbidden var keyword]
+    ~~~        [forbidden 'var' keyword, use 'let' or 'const' instead]
 }
 
 var i,
-~~~    [forbidden var keyword]
+~~~    [forbidden 'var' keyword, use 'let' or 'const' instead]
     j;
 
 var [a, b] = [1, 2];
-~~~                  [forbidden var keyword]
+~~~                  [forbidden 'var' keyword, use 'let' or 'const' instead]
 
 for (var n; false;);
-     ~~~             [forbidden var keyword]
+     ~~~             [forbidden 'var' keyword, use 'let' or 'const' instead]
 for (var n1 in foo);
-     ~~~             [forbidden var keyword]
+     ~~~             [forbidden 'var' keyword, use 'let' or 'const' instead]
 for (var n2 of foo);
-     ~~~             [forbidden var keyword]
+     ~~~             [forbidden 'var' keyword, use 'let' or 'const' instead]
 
 declare var tmp2: any;
 


### PR DESCRIPTION
Instead of just telling someone what they can't do, give suggestions about how to fix it and what they should do as an alternative.

Currently the rule `no-var-keyword` complains with 
>forbidden var keyword

But that really doesn't help, especially if someone is new to TypeScript and is not even aware that `let` and `const` are possibilities.

Now it will complain with this message

>forbidden 'var' keyword, use 'let' or 'const' instead