### PR TITLE
Adding missing sample options

### DIFF
--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -20,7 +20,10 @@
       true,
       "spaces"
     ],
-    "interface-name": true,
+    "interface-name": [
+      true,
+      "always-prefix"
+    ],
     "jsdoc-format": true,
     "label-position": true,
     "label-undefined": true,
@@ -96,7 +99,8 @@
     ],
     "triple-equals": [
       true,
-      "allow-null-check"
+      "allow-null-check",
+      "allow-undefined-check"
     ],
     "typedef": [
       true,

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -6,7 +6,13 @@
       "arguments",
       "statements"
     ],
-    "ban": false,
+    "ban": [
+        true,
+        [ "_", "forEach" ],
+        [ "_", "each" ],
+        [ "$", "each" ],
+        [ "angular", "forEach" ]
+    ],
     "class-name": true,
     "comment-format": [
       true,


### PR DESCRIPTION
A few options were missing form the sample `tslint.json` file.  I've added them now.


----

:question: **Question**, should the `ban` option also have an example of how to ban a method call?  Perhaps this would be a good sample? Maybe just a subset of this?

```json
"ban": [
	true,
	[ "_", "forEach" ],
	[ "_", "each" ],
	[ "$", "each" ],
	[ "angular", "forEach" ]
]
```

*(We ban these library loops in our apps since in most cases when devs want to use this, they are just looping over a flat JS array and a standard `for` loop would perform faster)*