### PR TITLE
Support disallowing namespaces (noNamespace).

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ A sample configuration file with all options is available [here](https://github.
 * `no-inferrable-types` disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.
 * `no-internal-module` disallows internal `module` (use `namespace` instead).
 * `no-invalid-this` disallows using the `this` keyword outside of classes.
+* `no-namespace` disallows both internal `module`s and `namespace`, but allows ES6-style external modules.
+    * `allow-declarations` Allow `declare module ... {}` to describe external APIs.
 * `no-null-keyword` disallows use of the `null` keyword literal.
 * `no-reference` disallows `/// <reference path=>` imports (use ES6-style imports instead).
 * `no-require-imports` disallows invocation of `require()` (use ES6-style imports instead).

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -123,3 +123,14 @@ export function isNodeFlagSet(node: ts.Node, flagToCheck: ts.NodeFlags): boolean
     return (node.flags & flagToCheck) !== 0;
     /* tslint:enable:no-bitwise */
 }
+
+
+/**
+ * Returns true if decl is a nested module declaration, i.e. represents a segment of a dotted module path.
+ */
+export function isNestedModuleDeclaration(decl: ts.ModuleDeclaration) {
+    // in a declaration expression like 'module a.b.c' - 'a' is the top level module declaration node and 'b' and 'c'
+    // are nested therefore we can depend that a node's position will only match with its name's position for nested
+    // nodes
+    return decl.name.pos === decl.pos;
+}

--- a/src/rules/noInternalModuleRule.ts
+++ b/src/rules/noInternalModuleRule.ts
@@ -38,17 +38,10 @@ class NoInternalModuleWalker extends Lint.RuleWalker {
         // an internal module declaration is not a namespace or a nested declaration
         // for external modules, node.name.kind will be a LiteralExpression instead of Identifier
         return !Lint.isNodeFlagSet(node, ts.NodeFlags.Namespace)
-            && !isNestedDeclaration(node)
+            && !Lint.isNestedModuleDeclaration(node)
             && node.name.kind === ts.SyntaxKind.Identifier
             && !isGlobalAugmentation(node);
     }
-}
-
-function isNestedDeclaration(node: ts.ModuleDeclaration) {
-    // in a declaration expression like 'module a.b.c' - 'a' is the top level module declaration node and 'b' and 'c'
-    // are nested therefore we can depend that a node's position will only match with its name's position for nested
-    // nodes
-    return node.name.pos === node.pos;
 }
 
 function isGlobalAugmentation(node: ts.ModuleDeclaration) {

--- a/src/rules/noNamespaceRule.ts
+++ b/src/rules/noNamespaceRule.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../lint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "'namespace' and 'module' are disallowed";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoNamespaceWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NoNamespaceWalker extends Lint.RuleWalker {
+    public visitModuleDeclaration(decl: ts.ModuleDeclaration) {
+        super.visitModuleDeclaration(decl);
+        // declare module 'foo' {} is an external module, not a namespace.
+        if (decl.name.kind === ts.SyntaxKind.StringLiteral) { return; }
+        if (Lint.isNodeFlagSet(decl, ts.NodeFlags.Ambient) && this.hasOption("allow-declarations")) { return; }
+        if (Lint.isNestedModuleDeclaration(decl)) { return; }
+        this.addFailure(this.createFailure(decl.getStart(), decl.getWidth(), Rule.FAILURE_STRING));
+    }
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -93,6 +93,7 @@
         "rules/noInferrableTypesRule.ts",
         "rules/noInternalModuleRule.ts",
         "rules/noInvalidThisRule.ts",
+        "rules/noNamespaceRule.ts",
         "rules/noNullKeywordRule.ts",
         "rules/noReferenceRule.ts",
         "rules/noRequireImportsRule.ts",

--- a/test/rules/no-namespace/allow-declarations/test.ts.lint
+++ b/test/rules/no-namespace/allow-declarations/test.ts.lint
@@ -1,0 +1,3 @@
+declare namespace Foo {
+
+}

--- a/test/rules/no-namespace/allow-declarations/tslint.json
+++ b/test/rules/no-namespace/allow-declarations/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-namespace": [true, "allow-declarations"]
+  }
+}

--- a/test/rules/no-namespace/default/test.ts.lint
+++ b/test/rules/no-namespace/default/test.ts.lint
@@ -1,0 +1,21 @@
+namespace Foo {
+~~~~~~~~~~~~~~~
+}
+~ ['namespace' and 'module' are disallowed]
+namespace Foo.Bar {
+~~~~~~~~~~~~~~~~~~~
+}
+~ ['namespace' and 'module' are disallowed]
+
+module Foo {
+~~~~~~~~~~~~
+}
+~ ['namespace' and 'module' are disallowed]
+
+declare namespace Foo {
+~~~~~~~~~~~~~~~~~~~~~~~
+}
+~ ['namespace' and 'module' are disallowed]
+
+declare module 'foo' {
+}

--- a/test/rules/no-namespace/default/tslint.json
+++ b/test/rules/no-namespace/default/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-namespace": [true]
+  }
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -90,6 +90,7 @@
         "../src/rules/noInferrableTypesRule.ts",
         "../src/rules/noInternalModuleRule.ts",
         "../src/rules/noInvalidThisRule.ts",
+        "../src/rules/noNamespaceRule.ts",
         "../src/rules/noNullKeywordRule.ts",
         "../src/rules/noReferenceRule.ts",
         "../src/rules/noRequireImportsRule.ts",


### PR DESCRIPTION
This allows code bases to outlaw pre-ES6 modules and namespaces. It's often
still useful to declare namespaces when interacting with non-TypeScript code, so
this has an option to allow "declare namespace" style usage.