### PR TITLE
Allow enabling/disabling tslint using single line comments.

### DIFF
--- a/src/enableDisableRules.ts
+++ b/src/enableDisableRules.ts
@@ -36,7 +36,8 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
                 return;
             }
 
-            if (scanner.getToken() === ts.SyntaxKind.MultiLineCommentTrivia) {
+            if (scanner.getToken() === ts.SyntaxKind.MultiLineCommentTrivia ||
+                scanner.getToken() === ts.SyntaxKind.SingleLineCommentTrivia) {
                 const commentText = scanner.getTokenText();
                 const startPosition = scanner.getTokenPos();
                 this.handlePossibleTslintSwitch(commentText, startPosition);
@@ -45,8 +46,8 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
     }
 
     private handlePossibleTslintSwitch(commentText: string, startingPosition: number) {
-        // regex is: start of string followed by "/*" followed by any amount of whitespace followed by "tslint:"
-        if (commentText.match(/^\/\*\s*tslint:/)) {
+        // regex is: start of string followed by "/*" or "//" followed by any amount of whitespace followed by "tslint:"
+        if (commentText.match(/^(\/\*|\/\/)\s*tslint:/)) {
             const commentTextParts = commentText.split(":");
             // regex is: start of string followed by either "enable" or "disable"
             // followed by either whitespace or end of string

--- a/test/files/enabledisable.test.ts
+++ b/test/files/enabledisable.test.ts
@@ -23,5 +23,9 @@ var AAAaA = 'test'
 var  re;
 re = /`/;
 
+// tslint:disable
+var AAAaA = 'test'
+// tslint:enable
+
 /* tslint:disable:quotemark */
 var s = 'xxx';


### PR DESCRIPTION
Quite some people prefer using single line comments for implementation comments (as opposed to documentation comments e.g. on function headers). This change allows them.