### PR TITLE
Support outlawing `/// <reference>` style imports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ A sample configuration file with all options is available [here](https://github.
 * `no-inferrable-types` disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.
 * `no-internal-module` disallows internal `module` (use `namespace` instead).
 * `no-null-keyword` disallows use of the `null` keyword literal
+* `no-reference` disallows `/// <reference>` imports (use ES6-style imports instead).
 * `no-require-imports` disallows invocation of `require()` (use ES6-style imports instead).
 * `no-shadowed-variable` disallows shadowed variable declarations.
 * `no-string-literal` disallows object access via string literals.

--- a/src/rules/noReferenceRule.ts
+++ b/src/rules/noReferenceRule.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../lint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "<reference> is not allowed, use imports";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoReferenceWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NoReferenceWalker extends Lint.RuleWalker {
+    public visitSourceFile(node: ts.SourceFile) {
+        for (let ref of node.referencedFiles) {
+            this.addFailure(this.createFailure(ref.pos, ref.end - ref.pos, Rule.FAILURE_STRING));
+        }
+    }
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -93,6 +93,7 @@
         "rules/noInternalModuleRule.ts",
         "rules/noInvalidThisRule.ts",
         "rules/noNullKeywordRule.ts",
+        "rules/noReferenceRule.ts",
         "rules/noRequireImportsRule.ts",
         "rules/noShadowedVariableRule.ts",
         "rules/noStringLiteralRule.ts",

--- a/test/rules/no-reference/test.ts.lint
+++ b/test/rules/no-reference/test.ts.lint
@@ -1,0 +1,2 @@
+/// <reference path="something.ts"/>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [<reference> is not allowed, use imports]

--- a/test/rules/no-reference/tslint.json
+++ b/test/rules/no-reference/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-reference": true
+  }
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -90,6 +90,7 @@
         "../src/rules/noInternalModuleRule.ts",
         "../src/rules/noInvalidThisRule.ts",
         "../src/rules/noNullKeywordRule.ts",
+        "../src/rules/noReferenceRule.ts",
         "../src/rules/noRequireImportsRule.ts",
         "../src/rules/noShadowedVariableRule.ts",
         "../src/rules/noStringLiteralRule.ts",


### PR DESCRIPTION
The reasoning is that these are superseded by ES6 style imports, and the syntax
overall isn't too pleasant.