### PR TITLE
Tweak trailing-comma rule classification of singleline vs. multiline

### DIFF
--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -53,13 +53,16 @@ class TrailingCommaWalker extends Lint.RuleWalker {
     private lintNode(node: ts.Node) {
         const child = node.getChildAt(1);
         if (child != null && child.kind === ts.SyntaxKind.SyntaxList) {
-            const isMultiline = node.getText().match(/\n|\r/);
-            const option = this.getOption(isMultiline ? "multiline" : "singleline");
             const grandChildren = child.getChildren();
 
             if (grandChildren.length > 0) {
                 const lastGrandChild = grandChildren[grandChildren.length - 1];
                 const hasTrailingComma = lastGrandChild.kind === ts.SyntaxKind.CommaToken;
+
+                const endLineOfNode = this.getSourceFile().getLineAndCharacterOfPosition(node.getEnd()).line;
+                const endLineOfLastElement = this.getSourceFile().getLineAndCharacterOfPosition(lastGrandChild.getEnd()).line;
+                const isMultiline = endLineOfNode !== endLineOfLastElement;
+                const option = this.getOption(isMultiline ? "multiline" : "singleline");
 
                 if (hasTrailingComma && option === "never") {
                     this.addFailure(this.createFailure(lastGrandChild.getStart(), 1, Rule.FAILURE_STRING_NEVER));

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -12,7 +12,6 @@ var x = [{
     c: (a + b)
              ~ [missing trailing comma]
 }];
-~   [missing trailing comma]
 
 var s = {
     sA: 6,

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -5,7 +5,6 @@ var v = [{
     c: (a + b),
               ~ [trailing comma]
 },];
- ~   [trailing comma]
 
 var x = [{
     a: 1,

--- a/test/rules/trailing-comma/singleline-always/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-always/test.ts.lint
@@ -11,6 +11,7 @@ var x = [{
     d: 34,
     c: (a + b)
 }];
+~   [missing trailing comma]
 
 var s = {
     sA: 6,

--- a/test/rules/trailing-comma/singleline-never/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-never/test.ts.lint
@@ -4,6 +4,7 @@ var v = [{
     d: 34,
     c: (a + b),
 },];
+ ~   [trailing comma]
 
 var x = [{
     a: 1,


### PR DESCRIPTION
Fixes #1122 

When linting constructs like such:

```ts
[{
  a: 5,
  b: 6,
}]
```

The array is now handled by the _singleline_ option instead of the multiline option. The object inside the array is still handled with the multiline option.

Constructs are treated as singleline if the last list item ends on the same line as the closing token of the construct. Otherwise, they are considered multiline.

Handled by the singleline option:
```ts
import { a, b, c,
         g, h, i, j } from "wherever";
```

Handled by the multiline option:
```ts
import {
  a,
  b,
  c,
  j,
} from "wherever";
```
