### PR TITLE
Recognize directives in class constructors and properties.

### DIFF
--- a/src/rules/noUnusedExpressionRule.ts
+++ b/src/rules/noUnusedExpressionRule.ts
@@ -130,6 +130,9 @@ function isDirective(node: ts.Node, checkPreviousSiblings = true): boolean {
         ts.SyntaxKind.FunctionExpression,
         ts.SyntaxKind.FunctionDeclaration,
         ts.SyntaxKind.MethodDeclaration,
+        ts.SyntaxKind.Constructor,
+        ts.SyntaxKind.GetAccessor,
+        ts.SyntaxKind.SetAccessor,
     ].indexOf(grandParentKind) > -1;
 
     if (!(parentIsSourceFile || parentIsFunctionBody || parentIsNSBody) || !isStringExpression) {

--- a/test/rules/no-unused-expression/test.ts.lint
+++ b/test/rules/no-unused-expression/test.ts.lint
@@ -31,13 +31,28 @@ function fun3(a: number, b: number) {
 
 namespace Fam { 'use strict'; 'use cool'; }
 module Bam { 'use strict'; 'use cool'; }
-namespace Az.Bz.Cz.Dz { 
+namespace Az.Bz.Cz.Dz {
     'ngInject';
 }
 
 class Foo {
+    constructor() {
+        "ngInject";
+        var a = 1;
+        'notdirective';
+        ~~~~~~~~~~~~~~~ [0]
+    }
+
     bar() {
         'use strict';
+    }
+
+    get baz() {
+        'use asm';
+    }
+
+    set baz(newValue) {
+        "use asm";
     }
 }
 


### PR DESCRIPTION
This builds on work in #1094 (related to #1050) by improving no-unused-expression rule to recognize directives in class constructors and property getters and setters.