### PR TITLE
Use `resolve` instead of Node.JS require for resolving configuration files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
                 cmd: "npm",
                 args: ["install"],
                 options: {
-                  cwd: "./test/config"
+                    cwd: "./test/config"
                 }
             },
             testBin: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,10 +70,10 @@ module.exports = function (grunt) {
             }
         },
 
-        'npm-command': {
+        "npm-command": {
             test: {
                 options: {
-                    cwd: './test/config'
+                    cwd: "./test/config"
                 }
             }
         }
@@ -96,7 +96,7 @@ module.exports = function (grunt) {
     ]);
     grunt.registerTask("test", [
         "clean:test",
-        "run:installTestDeps",
+        "npm-command:test",
         "ts:test",
         "tslint:test",
         "mochaTest",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,13 @@ module.exports = function (grunt) {
         },
 
         run: {
+            installTestDeps: {
+                cmd: "npm",
+                args: ["install"],
+                options: {
+                  cwd: "./test/config"
+                }
+            },
             testBin: {
                 cmd: "./test/check-bin.sh",
                 options: {quiet: Infinity}
@@ -87,6 +94,7 @@ module.exports = function (grunt) {
     ]);
     grunt.registerTask("test", [
         "clean:test",
+        "run:installTestDeps",
         "ts:test",
         "tslint:test",
         "mochaTest",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,13 +27,6 @@ module.exports = function (grunt) {
         },
 
         run: {
-            installTestDeps: {
-                cmd: "npm",
-                args: ["install"],
-                options: {
-                    cwd: "./test/config"
-                }
-            },
             testBin: {
                 cmd: "./test/check-bin.sh",
                 options: {quiet: Infinity}
@@ -75,6 +68,14 @@ module.exports = function (grunt) {
             test: {
                 tsconfig: "test/tsconfig.json"
             }
+        },
+
+        'npm-command': {
+            test: {
+                options: {
+                    cwd: './test/config'
+                }
+            }
         }
     });
 
@@ -85,6 +86,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-run");
     grunt.loadNpmTasks("grunt-tslint");
     grunt.loadNpmTasks("grunt-ts");
+    grunt.loadNpmTasks("grunt-npm-command");
 
     // register custom tasks
     grunt.registerTask("core", [

--- a/custom-typings/path-is-absolute.d.ts
+++ b/custom-typings/path-is-absolute.d.ts
@@ -1,6 +1,0 @@
-
-declare module "path-is-absolute" {
-    namespace pathIsAbsolute {}
-    function pathIsAbsolute(path: string): boolean;
-    export = pathIsAbsolute;
-}

--- a/custom-typings/resolve.d.ts
+++ b/custom-typings/resolve.d.ts
@@ -1,0 +1,29 @@
+declare module "resolve" {
+  interface ResolveOptions {
+    basedir?: string;
+    extensions?: string[];
+    paths?: string[];
+    moduleDirectory?: string | string[];
+  }
+  interface AsyncResolveOptions extends ResolveOptions {
+    package?: any;
+    readFile?: Function;
+    isFile?: (file: string, cb: Function) => void;
+    packageFilter?: Function;
+    pathFilter?: Function;
+  }
+  interface SyncResolveOptions extends ResolveOptions {
+    readFile?: Function;
+    isFile?: (file: string) => boolean;
+    packageFilter?: Function;
+  }
+  interface ResolveFunction {
+    (id: string, cb: (err: any, res: string, pkg: any) => void): void;
+    (id: string, opts: AsyncResolveOptions, cb: (err: any, res: string, pkg: any) => void): void;
+    sync(id: string, opts?: SyncResolveOptions): string;
+    isCore(pkg: any): any;
+  }
+
+  const resolve: ResolveFunction;
+  export = resolve;
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt-ts": "^5.1.0",
     "grunt-tslint": "latest",
     "mocha": "^2.2.5",
+    "npm": "^3.8.7",
     "tslint": "latest",
     "typescript": "latest"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "findup-sync": "~0.3.0",
     "glob": "^6.0.1",
     "optimist": "~0.6.0",
-    "path-is-absolute": "^1.0.0",
     "resolve": "^1.1.7",
     "underscore.string": "~3.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt-contrib-clean": "^0.6.0",
     "grunt-jscs": "^1.8.0",
     "grunt-mocha-test": "^0.12.7",
+    "grunt-npm-command": "^0.1.1",
     "grunt-run": "^0.3.0",
     "grunt-ts": "^5.1.0",
     "grunt-tslint": "latest",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "glob": "^6.0.1",
     "optimist": "~0.6.0",
     "path-is-absolute": "^1.0.0",
+    "resolve": "^1.1.7",
     "underscore.string": "~3.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "grunt-ts": "^5.1.0",
     "grunt-tslint": "latest",
     "mocha": "^2.2.5",
-    "npm": "^3.8.7",
     "tslint": "latest",
     "typescript": "latest"
   },

--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "grunt-tslint": "latest",
     "mocha": "^2.2.5",
     "tslint": "latest",
-    "tslint-test-config": "./test/external/tslint-test-config",
-    "tslint-test-custom-rules": "./test/external/tslint-test-custom-rules",
     "typescript": "latest"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "grunt-tslint": "latest",
     "mocha": "^2.2.5",
     "tslint": "latest",
+    "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
     "typescript": "latest"
   },
   "peerDependencies": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -18,7 +18,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as findup from "findup-sync";
-import * as pathIsAbsolute from "path-is-absolute";
 import * as resolve from "resolve";
 
 import {arrayify, objectify, stripComments} from "./utils";
@@ -167,22 +166,14 @@ export function loadConfigurationFromPath(configFilePath: string): IConfiguratio
  * @var relativeFilePath Relative path or package name (tslint-config-X) or package short name (X)
  */
 function resolveConfigurationPath(relativeFilePath: string, relativeTo?: string) {
-    let resolvedPath: string;
-    if (pathIsAbsolute(relativeFilePath)) {
-        resolvedPath = relativeFilePath;
-    } else if (relativeFilePath.indexOf(".") === 0) {
-        resolvedPath = getRelativePath(relativeFilePath, relativeTo);
-    } else {
-        try {
-            resolvedPath = resolve.sync(relativeFilePath, { basedir: relativeTo });
-        } catch (err) {
-            throw new Error(`Invalid "extends" configuration value - could not require "${relativeFilePath}". ` +
-                "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +
-                "for the approximate method TSLint uses to find the referenced configuration file.");
-        }
+    const basedir = relativeTo || process.cwd();
+    try {
+        return resolve.sync(relativeFilePath, { basedir });
+    } catch (err) {
+        throw new Error(`Invalid "extends" configuration value - could not require "${relativeFilePath}". ` +
+            "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +
+            "for the approximate method TSLint uses to find the referenced configuration file.");
     }
-
-    return resolvedPath;
 }
 
 export function extendConfigurationFile(config: IConfigurationFile, baseConfig: IConfigurationFile): IConfigurationFile {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -170,9 +170,13 @@ function resolveConfigurationPath(relativeFilePath: string, relativeTo?: string)
     try {
         return resolve.sync(relativeFilePath, { basedir });
     } catch (err) {
-        throw new Error(`Invalid "extends" configuration value - could not require "${relativeFilePath}". ` +
-            "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +
-            "for the approximate method TSLint uses to find the referenced configuration file.");
+        try {
+            return require.resolve(relativeFilePath);
+        } catch (err) {
+            throw new Error(`Invalid "extends" configuration value - could not require "${relativeFilePath}". ` +
+                "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +
+                "for the approximate method TSLint uses to find the referenced configuration file.");
+        }
     }
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,6 +19,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as findup from "findup-sync";
 import * as pathIsAbsolute from "path-is-absolute";
+import * as resolve from "resolve";
 
 import {arrayify, objectify, stripComments} from "./utils";
 
@@ -173,7 +174,7 @@ function resolveConfigurationPath(relativeFilePath: string, relativeTo?: string)
         resolvedPath = getRelativePath(relativeFilePath, relativeTo);
     } else {
         try {
-            resolvedPath = require.resolve(relativeFilePath);
+            resolvedPath = resolve.sync(relativeFilePath, { basedir: relativeTo });
         } catch (err) {
             throw new Error(`Invalid "extends" configuration value - could not require "${relativeFilePath}". ` +
                 "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -21,7 +21,6 @@
         "./test/**/*.ts"
     ],
     "files": [
-        "../custom-typings/path-is-absolute.d.ts",
         "../custom-typings/resolve.d.ts",
         "../typings/colors/colors.d.ts",
         "../typings/diff/diff.d.ts",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -22,6 +22,7 @@
     ],
     "files": [
         "../custom-typings/path-is-absolute.d.ts",
+        "../custom-typings/resolve.d.ts",
         "../typings/colors/colors.d.ts",
         "../typings/diff/diff.d.ts",
         "../typings/findup-sync/findup-sync.d.ts",

--- a/test/check-bin.sh
+++ b/test/check-bin.sh
@@ -20,7 +20,7 @@ expectOut () {
   msg=$3
 
   nodeV=`node -v`
-  
+
   # if Node 0.10.*, node will sometimes exit with status 8 when an error is thrown
   if [[ $expect != $actual || $nodeV == v0.10.* && $expect == 1 && $actual == 8 ]] ; then
     echo "$msg: expected $expect got $actual"
@@ -69,6 +69,10 @@ expectOut $? 0 "tslint with with -r pointing to custom rules did not find lint f
 # make sure path to config without a preceding "./" works on the CLI
 ./bin/tslint -c test/config/tslint-almost-empty.json src/tslint.ts
 expectOut $? 0 "-c relative path without ./ did not work"
+
+# make sure calling tslint with a config file which extends a package relative to the config file works
+./bin/tslint -c test/config/tslint-extends-package-no-mod.json src/tslint.ts
+expectOut $? 0 "tslint (with config file extending relative package) did not work"
 
 # make sure tslint --init generates a file
 cd ./bin

--- a/test/check-bin.sh
+++ b/test/check-bin.sh
@@ -74,6 +74,14 @@ expectOut $? 0 "-c relative path without ./ did not work"
 ./bin/tslint -c test/config/tslint-extends-package-no-mod.json src/tslint.ts
 expectOut $? 0 "tslint (with config file extending relative package) did not work"
 
+# check that a tslint file (outside of the resolution path of the tslint package) can resolve a package that is
+# installed as a dependency of tslint. See palantir/tslint#1172 for details.
+tmpDir=$(mktemp -d)
+echo "{ \"extends\": \"tslint-test-config-non-relative\" }" > $tmpDir/tslint.json
+./bin/tslint -c $tmpDir/tslint.json src/tslint.ts
+expectOut $? 0 "tslint (with config file extending package in tslint scope) did not work"
+rm -r $tmpDir
+
 # make sure tslint --init generates a file
 cd ./bin
 if [ -f tslint.json ]; then

--- a/test/config/package.json
+++ b/test/config/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tslint-test-configs",
+  "version": "0.0.1",
+  "dependencies": {
+    "tslint-test-config": "../external/tslint-test-config",
+    "tslint-test-custom-rules": "../external/tslint-test-custom-rules"
+  }
+}

--- a/test/configurationTests.ts
+++ b/test/configurationTests.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as os from "os";
+import * as path from "path";
 import * as fs from "fs";
 import {IConfigurationFile, extendConfigurationFile, loadConfigurationFromPath} from "../src/configuration";
 
@@ -82,6 +84,35 @@ describe("Configuration", () => {
                 "rule-two": false,
             });
         });
+
+        describe("with config not relative to tslint", () => {
+            let tmpfile: string;
+            beforeEach(() => {
+                for (let i = 0; i < 5; i++) {
+                    const attempt = path.join(os.tmpdir(), `tslint.test${Math.round(Date.now() * Math.random())}.json`);
+                    if (!fs.existsSync(tmpfile)) {
+                        tmpfile = attempt;
+                        break;
+                    }
+                }
+                if (tmpfile === undefined) {
+                    throw new Error("Couldn't create temp file");
+                }
+            });
+            afterEach(() => {
+                if (tmpfile !== undefined) {
+                    fs.unlinkSync(tmpfile);
+                }
+            });
+            it("extends with package installed relative to tslint", () => {
+                fs.writeFileSync(tmpfile, JSON.stringify({ extends: "tslint-test-config-non-relative" }));
+                let config = loadConfigurationFromPath(tmpfile);
+                assert.deepEqual(config.rules, {
+                    "class-name": true,
+                });
+            });
+        });
+
 
         it("extends with package two levels (and relative path in rulesDirectory)", () => {
             let config = loadConfigurationFromPath("./test/config/tslint-extends-package-two-levels.json");

--- a/test/external/tslint-test-config-non-relative/package.json
+++ b/test/external/tslint-test-config-non-relative/package.json
@@ -2,7 +2,7 @@
   "name": "tslint-test-config-non-relative",
   "description": "A test package with a tslint config which is installed in the tslint.",
   "version": "0.0.1",
-  "main": "index.js",
   "private": true,
+  "main": "tslint.json",
   "scripts": {}
 }

--- a/test/external/tslint-test-config-non-relative/package.json
+++ b/test/external/tslint-test-config-non-relative/package.json
@@ -3,5 +3,6 @@
   "description": "A test package with a tslint config which is installed in the tslint.",
   "version": "0.0.1",
   "main": "index.js",
+  "private": true,
   "scripts": {}
 }

--- a/test/external/tslint-test-config-non-relative/package.json
+++ b/test/external/tslint-test-config-non-relative/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tslint-test-config-non-relative",
+  "description": "A test package with a tslint config which is installed in the tslint.",
+  "version": "0.0.1",
+  "main": "index.js",
+  "scripts": {}
+}

--- a/test/external/tslint-test-config-non-relative/tslint.json
+++ b/test/external/tslint-test-config-non-relative/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "tslint-test-custom-rules",
+    "rules": {
+        "rule-two": true,
+        "rule-four": true
+    }
+}

--- a/test/external/tslint-test-config-non-relative/tslint.json
+++ b/test/external/tslint-test-config-non-relative/tslint.json
@@ -1,7 +1,5 @@
 {
-    "extends": "tslint-test-custom-rules",
-    "rules": {
-        "rule-two": true,
-        "rule-four": true
-    }
+  "rules": {
+    "class-name": true
+  }
 }

--- a/test/external/tslint-test-config/package.json
+++ b/test/external/tslint-test-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tslint-test-config",
   "version": "0.0.1",
-  "main": "index.js",
   "private": true,
+  "main": "tslint.json",
   "scripts": {}
 }

--- a/test/external/tslint-test-config/package.json
+++ b/test/external/tslint-test-config/package.json
@@ -2,5 +2,6 @@
   "name": "tslint-test-config",
   "version": "0.0.1",
   "main": "index.js",
+  "private": true,
   "scripts": {}
 }

--- a/test/external/tslint-test-custom-rules/package.json
+++ b/test/external/tslint-test-custom-rules/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tslint-test-custom-rules",
   "version": "0.0.1",
+  "private": true,
   "main": "tslint.json",
   "scripts": {}
 }

--- a/test/external/tslint-test-custom-rules/rules/ruleOneRule.js
+++ b/test/external/tslint-test-custom-rules/rules/ruleOneRule.js
@@ -1,0 +1,27 @@
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var Lint = require("tslint/lib/lint");
+var Rule = (function (_super) {
+    __extends(Rule, _super);
+    function Rule() {
+        _super.apply(this, arguments);
+    }
+    Rule.prototype.apply = function (sourceFile) {
+        return this.applyWithWalker(new NoFailWalker(sourceFile, this.getOptions()));
+    };
+    return Rule;
+})(Lint.Rules.AbstractRule);
+exports.Rule = Rule;
+var NoFailWalker = (function (_super) {
+    __extends(NoFailWalker, _super);
+    function NoFailWalker() {
+        _super.apply(this, arguments);
+    }
+    NoFailWalker.prototype.visitSourceFile = function (node) {
+        // yay, no failures!
+    };
+    return NoFailWalker;
+})(Lint.RuleWalker);

--- a/test/external/tslint-test-custom-rules/rules/ruleThreeRule.js
+++ b/test/external/tslint-test-custom-rules/rules/ruleThreeRule.js
@@ -1,0 +1,27 @@
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var Lint = require("tslint/lib/lint");
+var Rule = (function (_super) {
+    __extends(Rule, _super);
+    function Rule() {
+        _super.apply(this, arguments);
+    }
+    Rule.prototype.apply = function (sourceFile) {
+        return this.applyWithWalker(new NoFailWalker(sourceFile, this.getOptions()));
+    };
+    return Rule;
+})(Lint.Rules.AbstractRule);
+exports.Rule = Rule;
+var NoFailWalker = (function (_super) {
+    __extends(NoFailWalker, _super);
+    function NoFailWalker() {
+        _super.apply(this, arguments);
+    }
+    NoFailWalker.prototype.visitSourceFile = function (node) {
+        // yay, no failures!
+    };
+    return NoFailWalker;
+})(Lint.RuleWalker);

--- a/test/external/tslint-test-custom-rules/rules/ruleTwoRule.js
+++ b/test/external/tslint-test-custom-rules/rules/ruleTwoRule.js
@@ -1,0 +1,27 @@
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var Lint = require("tslint/lib/lint");
+var Rule = (function (_super) {
+    __extends(Rule, _super);
+    function Rule() {
+        _super.apply(this, arguments);
+    }
+    Rule.prototype.apply = function (sourceFile) {
+        return this.applyWithWalker(new NoFailWalker(sourceFile, this.getOptions()));
+    };
+    return Rule;
+})(Lint.Rules.AbstractRule);
+exports.Rule = Rule;
+var NoFailWalker = (function (_super) {
+    __extends(NoFailWalker, _super);
+    function NoFailWalker() {
+        _super.apply(this, arguments);
+    }
+    NoFailWalker.prototype.visitSourceFile = function (node) {
+        // yay, no failures!
+    };
+    return NoFailWalker;
+})(Lint.RuleWalker);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -21,6 +21,7 @@
     ],
     "files": [
         "../custom-typings/path-is-absolute.d.ts",
+        "../custom-typings/resolve.d.ts",
         "../typings/colors/colors.d.ts",
         "../typings/diff/diff.d.ts",
         "../typings/findup-sync/findup-sync.d.ts",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -20,7 +20,6 @@
         "./rule-tester/*.ts"
     ],
     "files": [
-        "../custom-typings/path-is-absolute.d.ts",
         "../custom-typings/resolve.d.ts",
         "../typings/colors/colors.d.ts",
         "../typings/diff/diff.d.ts",


### PR DESCRIPTION
Fixes #1171 by using [resolve](https://www.npmjs.com/package/resolve) to resolve package-based extension configuration files from the directory of the current configuration file.

I've modified the tests for extends so that they have their own node_modules (created by the `run:installTestDeps` task) in `./test/config`, so that `tslint-test-config` and `tslint-test-custom-rules` can't be accessed by tslint directly with `require()`.