### PR TITLE
Single line ignore switches

### DIFF
--- a/src/enableDisableRules.ts
+++ b/src/enableDisableRules.ts
@@ -50,11 +50,14 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
         if (commentText.match(/^(\/\*|\/\/)\s*tslint:/)) {
             const commentTextParts = commentText.split(":");
             // regex is: start of string followed by either "enable" or "disable"
+            // followed optionally by -line or -next-line
             // followed by either whitespace or end of string
-            const enableOrDisableMatch = commentTextParts[1].match(/^(enable|disable)(\s|$)/);
+            const enableOrDisableMatch = commentTextParts[1].match(/^(enable|disable)(-(line|next-line))?(\s|$)/);
 
             if (enableOrDisableMatch != null) {
                 const isEnabled = enableOrDisableMatch[1] === "enable";
+                const isCurrentLine = enableOrDisableMatch[3] === "line";
+                const isNextLine = enableOrDisableMatch[3] === "next-line";
                 let rulesList = ["all"];
                 if (commentTextParts.length > 2) {
                     rulesList = commentTextParts[2].split(/\s+/);

--- a/test/files/enabledisable.test.ts
+++ b/test/files/enabledisable.test.ts
@@ -27,5 +27,19 @@ re = /`/;
 var AAAaA = 'test'
 // tslint:enable
 
+var AAAaA = 'test' // tslint:disable-line
+var AAAaA = 'test' /* tslint:disable-line */
+
+// tslint:disable-next-line:quotemark variable-name
+var AAAaA = 'test'
+/* tslint:disable-next-line:quotemark variable-name */
+var AAAaA = 'test'
+
+// tslint:disable
+var AAAaA = 'test' // tslint:enable-line:quotemark
+// tslint:enable-next-line:variable-name
+var AAAaA = 'test'
+// tslint:enable
+
 /* tslint:disable:quotemark */
 var s = 'xxx';

--- a/test/ruleDisableEnableTests.ts
+++ b/test/ruleDisableEnableTests.ts
@@ -50,6 +50,9 @@ describe("Enable and Disable Rules", () => {
         const expectedFailure5 = quotemarkFailure([10, 13], [10, 19]);
         const expectedFailure6 = quotemarkFailure([16, 13], [16, 19]);
 
+        const expectedFailure7 = quotemarkFailure([39, 13], [39, 19]);
+        const expectedFailure8 = variableNameFailure([41, 5], [41, 10]);
+
         const ll = new Linter(relativePath, source, options);
         const result = ll.lint();
         const parsedResult = JSON.parse(result.output);
@@ -66,6 +69,8 @@ describe("Enable and Disable Rules", () => {
         TestUtils.assertContainsFailure(actualFailures, expectedFailure4);
         TestUtils.assertContainsFailure(actualFailures, expectedFailure5);
         TestUtils.assertContainsFailure(actualFailures, expectedFailure6);
-        assert.lengthOf(actualFailures, 6);
+        TestUtils.assertContainsFailure(actualFailures, expectedFailure7);
+        TestUtils.assertContainsFailure(actualFailures, expectedFailure8);
+        assert.lengthOf(actualFailures, 8);
     });
 });


### PR DESCRIPTION
This PR supports using ESLint style single line ignore switches by using `tslint:disable-line` and `tslint:disable-next-line`.

This PR resolves #144 