### PR TITLE
Make member-variable-declaration check that for property assignment of an arrow function, either the property has a type def, or all parameters of the arrow function have type defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Core rules are included in the `tslint` package.
     * `"arrow-parameter"` checks type specifier of function parameters for arrow functions.
     * `"property-declaration"` checks return types of interface properties.
     * `"variable-declaration"` checks variable declarations.
-    * `"member-variable-declaration"` checks member variable declarations.
+    * `"member-variable-declaration"` checks member variable declarations. For arrow functions being assigned as properties, either the property itself or the arrow functions parameters must have a typedef.
 * `typedef-whitespace` enforces spacing whitespace for type definitions. Each rule option requires a value of `"nospace"`,
   `"onespace"` or `"space"` to require no space, exactly one or at least one space before or after the type specifier's
   colon. You can specify two objects containing the five options. The first one describes the left, the second one the

--- a/test/rules/typedef/all/test.ts.lint
+++ b/test/rules/typedef/all/test.ts.lint
@@ -48,8 +48,21 @@ class TsLint {
     };
 
     arrowHelloWorld = () => {
-                   ~          [expected member-variable-declaration: 'arrowHelloWorld' to have a typedef]
                        ~      [expected arrow-call-signature to have a typedef]
+        return this.helloWorld();
+    };
+
+    arrowHelloWorldWithArgsNoTypedef = (arg1) => {
+                                            ~      [expected member-variable-declaration: 'arg1' to have a typedef]
+                                            ~      [expected arrow-call-signature to have a typedef]
+        return this.helloWorld();
+    };
+
+    arrowHelloWorldWithArgsTypedefProperty: (arg1: string) => string = (arg1) => {
+        return this.helloWorld();
+    };
+
+    arrowHelloWorldWithArgsTypedefInline = (arg1: string): string => {
         return this.helloWorld();
     };
 }

--- a/test/rules/typedef/member-variable-declaration/test.ts.lint
+++ b/test/rules/typedef/member-variable-declaration/test.ts.lint
@@ -1,0 +1,16 @@
+class TypesMemberArrowFn {
+  fn: (param: string) => void = (param) => {}
+}
+
+class TypesInFunctionMemberArrowFn {
+  fn = (param: string) => {}
+}
+
+class TypesInFunctionWithReturnMemberArrowFn {
+  fn = (param: string): void => {}
+}
+
+class NoTypesMemberArrowFn {
+  fn = (param) => {}
+             ~       [expected member-variable-declaration: 'param' to have a typedef]
+}

--- a/test/rules/typedef/member-variable-declaration/tslint.json
+++ b/test/rules/typedef/member-variable-declaration/tslint.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+      "typedef": [true,
+         "member-variable-declaration"
+      ]
+   }
+}


### PR DESCRIPTION
The rationale behind this is that with the existing `"member-variable-declaration"` option, the type definition for a arrow function member variable needs to be on the variable itself:

```
myMember: (param: string) => void = (param) => {
```

which leads to duplication (`param` is written twice) - even more so if you are using the `"arrow-parameter"` rule, in which case you would need:

```
myMember: (param: string) => void = (param: string): void => {
```

A more natural syntax, which has the same type safety, is:

```
myMember = (param: string): void => {
```

To enable this syntax, we need to split out the typedef checking of arrow function member variables vs. all other member variables, hence the `"arrow-member-variable-declaration"` rule.

However, if you are not using `"arrow-parameter"`, then tslint won't enforce a type definition on the arrow function either, so with just `"arrow-member-variable-declaration"`, this would be allowed:

```
myMember = (param) => {
```

So in this case, we probably want to enforce that arrow functions *should* have parameter definitions, but only if they are a member variable, which is what `"arrow-member-variable-declaration-in-function"` achieves, so with that the following is valid:

```
myMember = (param: string): void => {
```

There might be a better way to achieve this (or a less verbose way of naming the options!), I kind of hacked it together so I'm happy to discuss further!