### PR TITLE
Extend no-invalid-this rule to disallow `this` in functions in methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ A sample configuration file with all options is available [here](https://github.
 * `no-eval` disallows `eval` function invocations.
 * `no-inferrable-types` disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.
 * `no-internal-module` disallows internal `module` (use `namespace` instead).
-* `no-invalid-this` disallows using the `this` keyword outside of classes.
+* `no-invalid-this` disallows using the `this` keyword in scopes where they are often misinterpreted
+    * `outside-of-class` disallows using the `this` keyword outside of classes.
+    * `in-function-in-method` disallows using the `this` keyword in functions within class methods.
 * `no-namespace` disallows both internal `module`s and `namespace`, but allows ES6-style external modules.
     * `allow-declarations` allows `declare namespace ... {}` to describe external APIs.
 * `no-null-keyword` disallows use of the `null` keyword literal.

--- a/README.md
+++ b/README.md
@@ -240,9 +240,8 @@ A sample configuration file with all options is available [here](https://github.
 * `no-eval` disallows `eval` function invocations.
 * `no-inferrable-types` disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.
 * `no-internal-module` disallows internal `module` (use `namespace` instead).
-* `no-invalid-this` disallows using the `this` keyword in scopes where they are often misinterpreted
-    * `outside-of-class` disallows using the `this` keyword outside of classes.
-    * `in-function-in-method` disallows using the `this` keyword in functions within class methods.
+* `no-invalid-this` disallows using the `this` keyword outside of classes.
+    * `no-this-in-function-in-method` disallows using the `this` keyword in functions within class methods.
 * `no-namespace` disallows both internal `module`s and `namespace`, but allows ES6-style external modules.
     * `allow-declarations` allows `declare namespace ... {}` to describe external APIs.
 * `no-null-keyword` disallows use of the `null` keyword literal.

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -69,8 +69,7 @@
     "no-internal-module": true,
     "no-invalid-this": [
       true,
-      "outside-of-class",
-      "in-function-in-method"
+      "no-this-in-function-in-method"
       ],
     "no-null-keyword": true,
     "no-reference": true,

--- a/docs/sample.tslint.json
+++ b/docs/sample.tslint.json
@@ -67,7 +67,11 @@
     "no-eval": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
-    "no-invalid-this": true,
+    "no-invalid-this": [
+      true,
+      "outside-of-class",
+      "in-function-in-method"
+      ],
     "no-null-keyword": true,
     "no-reference": true,
     "no-require-imports": true,

--- a/src/rules/noInvalidThisRule.ts
+++ b/src/rules/noInvalidThisRule.ts
@@ -23,12 +23,12 @@ interface Scope {
     inFunction: boolean;
 }
 
-const OPTION_OUTSIDE = "outside-of-class";
-const OPTION_INSIDE = "in-function-in-method";
+const OPTION_IN_FUNCTION_IN_METHOD = "no-this-in-function-in-method";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_OUTSIDE = "the \"this\" keyword is disallowed outside of a class body" ;
-    public static FAILURE_STRING_INSIDE = "the \"this\" keyword is disallowed in function bodys inside class methods";
+    public static FAILURE_STRING_INSIDE = "the \"this\" keyword is disallowed in function bodies inside class methods, " +
+        "use arrow functions instead";
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new NoInvalidThisWalker(sourceFile, this.getOptions()));
     }
@@ -52,11 +52,11 @@ class NoInvalidThisWalker extends Lint.ScopeAwareRuleWalker<Scope> {
             inFunction = scope.inFunction ? index + 1 : inFunction;
         });
 
-        if (this.hasOption(OPTION_OUTSIDE) && !inClass) {
+        if (inClass === 0) {
             this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_OUTSIDE));
         }
 
-        if (this.hasOption(OPTION_INSIDE) && inClass && inFunction > inClass) {
+        if (this.hasOption(OPTION_IN_FUNCTION_IN_METHOD) && inClass > 0 && inFunction > inClass) {
             this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_INSIDE));
         }
     }

--- a/src/rules/noInvalidThisRule.ts
+++ b/src/rules/noInvalidThisRule.ts
@@ -18,26 +18,46 @@
 import * as ts from "typescript";
 import * as Lint from "../lint";
 
-export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "the \"this\" keyword is disallowed outside of a class body" ;
+interface Scope {
+    inClass: boolean;
+    inFunction: boolean;
+}
 
+const OPTION_OUTSIDE = "outside-of-class";
+const OPTION_INSIDE = "in-function-in-method";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING_OUTSIDE = "the \"this\" keyword is disallowed outside of a class body" ;
+    public static FAILURE_STRING_INSIDE = "the \"this\" keyword is disallowed in function bodys inside class methods";
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new NoInvalidThisWalker(sourceFile, this.getOptions()));
     }
 }
 
-class NoInvalidThisWalker extends Lint.ScopeAwareRuleWalker<{inClass: boolean}> {
-    public createScope(node: ts.Node): { inClass: boolean } {
+class NoInvalidThisWalker extends Lint.ScopeAwareRuleWalker<Scope> {
+    public createScope(node: ts.Node): Scope {
         const isClassScope = node.kind === ts.SyntaxKind.ClassDeclaration || node.kind === ts.SyntaxKind.ClassExpression;
-
+        let inFunction = node.kind === ts.SyntaxKind.FunctionDeclaration || node.kind === ts.SyntaxKind.FunctionExpression;
         return {
             inClass: isClassScope,
+            inFunction: inFunction,
         };
     }
 
     protected validateThisKeyword(node: ts.Node) {
-        if (!this.getAllScopes().some((scope) => scope.inClass)) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        let inClass = 0;
+        let inFunction = 0;
+        this.getAllScopes().forEach((scope, index) => {
+            inClass = scope.inClass ? index + 1 : inClass;
+            inFunction = scope.inFunction ? index + 1 : inFunction;
+        });
+
+        if (this.hasOption(OPTION_OUTSIDE) && !inClass) {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_OUTSIDE));
+        }
+
+        if (this.hasOption(OPTION_INSIDE) && inClass && inFunction > inClass) {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_INSIDE));
         }
     }
 

--- a/test/rules/no-invalid-this/enabled/test.ts.lint
+++ b/test/rules/no-invalid-this/enabled/test.ts.lint
@@ -9,8 +9,45 @@ function foo(x: number) {
 class AClass {
     private x: number;
 
+    constructor() {
+        this.x = 2;
+    }
+
     public aMethod() {
         this.x = 5;
+    }
+
+    public bMethod() {
+        [3,4].forEach(function(nr){
+            console.log(this.x === nr);
+                        ~~~~[the "this" keyword is disallowed in function bodys inside class methods]
+        });
+    }
+
+    public bMethod() {
+        [3,4].forEach((nr) => {
+            console.log(this.x === nr);
+        });
+    }
+
+    public cMethod = () => {
+        [3,4].forEach(function(nr){
+            console.log(this.x === nr);
+                        ~~~~[the "this" keyword is disallowed in function bodys inside class methods]
+        });
+    }
+
+    public dMethod() {
+        [3,4].forEach(badFunction);
+        function badFunction(nr) {
+            console.log(this.x === nr);
+                        ~~~~[the "this" keyword is disallowed in function bodys inside class methods]
+        }
+    }
+
+    public eMethod() {
+        [3,4].forEach(badFunction);
+        let badFunction = nr => console.log(this.x === nr);
     }
 }
 

--- a/test/rules/no-invalid-this/enabled/test.ts.lint
+++ b/test/rules/no-invalid-this/enabled/test.ts.lint
@@ -1,9 +1,9 @@
 function foo(x: number) {
     console.log(this.x);
-                ~~~~[the "this" keyword is disallowed outside of a class body]
+                ~~~~                      [the "this" keyword is disallowed outside of a class body]
 
     this.evilMethod();
-    ~~~~[the "this" keyword is disallowed outside of a class body]
+    ~~~~                                  [the "this" keyword is disallowed outside of a class body]
 }
 
 class AClass {
@@ -20,7 +20,7 @@ class AClass {
     public bMethod() {
         [3,4].forEach(function(nr){
             console.log(this.x === nr);
-                        ~~~~[the "this" keyword is disallowed in function bodys inside class methods]
+                        ~~~~              [the "this" keyword is disallowed in function bodies inside class methods, use arrow functions instead]
         });
     }
 
@@ -33,7 +33,7 @@ class AClass {
     public cMethod = () => {
         [3,4].forEach(function(nr){
             console.log(this.x === nr);
-                        ~~~~[the "this" keyword is disallowed in function bodys inside class methods]
+                        ~~~~               [the "this" keyword is disallowed in function bodies inside class methods, use arrow functions instead]
         });
     }
 
@@ -41,7 +41,7 @@ class AClass {
         [3,4].forEach(badFunction);
         function badFunction(nr) {
             console.log(this.x === nr);
-                        ~~~~[the "this" keyword is disallowed in function bodys inside class methods]
+                        ~~~~               [the "this" keyword is disallowed in function bodies inside class methods, use arrow functions instead]
         }
     }
 

--- a/test/rules/no-invalid-this/enabled/tslint.json
+++ b/test/rules/no-invalid-this/enabled/tslint.json
@@ -1,5 +1,9 @@
 {
   "rules": {
-    "no-invalid-this": [true]
+    "no-invalid-this": [
+      true,
+      "outside-of-class",
+      "in-function-in-method"
+    ]
   }
 }

--- a/test/rules/no-invalid-this/enabled/tslint.json
+++ b/test/rules/no-invalid-this/enabled/tslint.json
@@ -2,8 +2,7 @@
   "rules": {
     "no-invalid-this": [
       true,
-      "outside-of-class",
-      "in-function-in-method"
+      "no-this-in-function-in-method"
     ]
   }
 }


### PR DESCRIPTION
This PR extends the [no-invalid-this] with the option "in-function-in-method".
If it is enabled it complains about the usage of the `this` keyword inside of function expression within a method.
`this` in such function expressions is usually meant to refer the this outside of the functions scope.
 This rule will not complain about this in arrow functions.

In our project, it happened often when migrating JS to TS. With an angular service written as
```javascript
angular.module('a',[]).factory('Service', function(Helper, Enhancer){
return {
    getAllMapped: function(){
         return Helper.getAll()
             .map(function(item){
                  return Enhancer.enhance(item);
             })
    }
}
}); 
```
We often end up with
```javascript
class ServiceClass {
    constructor(private Helper, private Enhancer){
    }

    public getAllMapped() {
         return this.Helper.getAll()
             .map(function(item){
                  return this.Enhancer.enhance(item);
             })
    }
}
angular.module('a',[]).service('Service', ServiceClass);
```
which will not work as ```this.Enhancer``` is not defined.