### PR TITLE
README.md - no-unreachable is a tsc compiler flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ A sample configuration file with all options is available [here](https://github.
 * `no-string-literal` disallows object access via string literals.
 * `no-switch-case-fall-through` disallows falling through case statements.
 * `no-trailing-whitespace` disallows trailing whitespace at the end of a line.
-* `no-unreachable` disallows unreachable code after `break`, `catch`, `throw`, and `return` statements.
+* `no-unreachable` disallows unreachable code after `break`, `catch`, `throw`, and `return` statements. This rule is supported and enforced by default within the TypeScript compiler since version 1.8.
 * `no-unused-expression` disallows unused expression statements, that is, expression statements that are not assignments or function invocations (and thus no-ops).
 * `no-unused-variable` disallows unused imports, variables, functions and private class members. Rule options:
     * `"check-parameters"` disallows unused function and constructor parameters.


### PR DESCRIPTION
Updated README.md to explain that no-unreachable rule is a compiler flag on the tsc compiler that is enabled by default.