### PR TITLE
Fix bug in member-ordering rule

### DIFF
--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -216,6 +216,11 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
         // don't call super from here -- we want to skip the property declarations in type literals
     }
 
+    public visitObjectLiteralExpression(node: ts.ObjectLiteralExpression) {
+        // again, don't call super here - object literals can have methods,
+        // and we don't wan't to check these
+    }
+
     /* start old code */
     private resetPreviousModifiers() {
         this.previousMember = {

--- a/test/rules/member-ordering/order/custom/test.ts.lint
+++ b/test/rules/member-ordering/order/custom/test.ts.lint
@@ -13,3 +13,17 @@ class Bad {
     static b() {}
     ~~~~~~~~~~~~~ [Declaration of public static method not allowed after declaration of private instance field. Instead, this should come at the beginning of the class/interface.]
 }
+
+class AlsoOkay {
+    constructor() {
+        const bar = {
+            someMethod() {}
+        };
+    }
+    private z = 10;
+}
+
+const foo = {
+    // TS treats this as a method, but we should be careful not to
+    someMethod() {}
+};


### PR DESCRIPTION
Fixes #1243 

Object literals can have "methods" in them, this makes sure we don't check them.

We could do a check in `pushMember` to make sure `memberStack.length > 0`, but this would be treating the symptom instead of the disease... do we want to do this anyways in addition?