### PR TITLE
Fix member ordering bug

### DIFF
--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -70,6 +70,10 @@ export class SyntaxWalker {
         this.walkChildren(node);
     }
 
+    protected visitClassExpression(node: ts.ClassExpression) {
+        this.walkChildren(node);
+    }
+
     protected visitCatchClause(node: ts.CatchClause) {
         this.walkChildren(node);
     }
@@ -350,6 +354,10 @@ export class SyntaxWalker {
 
             case ts.SyntaxKind.ClassDeclaration:
                 this.visitClassDeclaration(<ts.ClassDeclaration> node);
+                break;
+
+            case ts.SyntaxKind.ClassExpression:
+                this.visitClassExpression(<ts.ClassExpression> node);
                 break;
 
             case ts.SyntaxKind.CatchClause:

--- a/test/rules/member-ordering/order/custom/test.ts.lint
+++ b/test/rules/member-ordering/order/custom/test.ts.lint
@@ -20,6 +20,7 @@ class AlsoOkay {
             someMethod() {}
         };
     }
+
     private z = 10;
 }
 
@@ -27,3 +28,9 @@ const foo = {
     // TS treats this as a method, but we should be careful not to
     someMethod() {}
 };
+
+function makeAClass() {
+    const myClass = class {
+        method(){}
+    };
+}


### PR DESCRIPTION
Should fix #1251 and #1250 

Also, only run code dealing with `order` option if it's specified. If there are any further bugs, this should prevent them for people using the old options