### PR TITLE
adding linebreak-style rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 # being reported to be 1 character longer
 
 *.lint text eol=lf
+/test/rules/linebreak-style/**/CRLF/*.lint text eol=crlf

--- a/src/rules/linebreakStyleRule.ts
+++ b/src/rules/linebreakStyleRule.ts
@@ -1,6 +1,9 @@
 import * as ts from "typescript";
 import * as Lint from "../lint";
 
+const OPTION_LINEBREAK_STYLE_CRLF = "CRLF";
+const OPTION_LINEBREAK_STYLE_LF = "LF";
+
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRINGS = {
         CRLF: "Expected linebreak to be 'CRLF'",
@@ -20,11 +23,11 @@ export class Rule extends Lint.Rules.AbstractRule {
         let failureString: string;
 
         switch (this.getOptions().ruleArguments[0]) {
-            case "CRLF":
+            case OPTION_LINEBREAK_STYLE_CRLF:
                 expectedEOL = "\r\n";
                 failureString = Rule.FAILURE_STRINGS.CRLF;
                 break;
-            case "LF":
+            case OPTION_LINEBREAK_STYLE_LF:
                 expectedEOL = "\n";
                 failureString = Rule.FAILURE_STRINGS.LF;
                 break;

--- a/src/rules/linebreakStyleRule.ts
+++ b/src/rules/linebreakStyleRule.ts
@@ -3,7 +3,6 @@ import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRINGS = {
-        CR: "Expected linebreak to be 'CR'",
         CRLF: "Expected linebreak to be 'CRLF'",
         LF: "Expected linebreak to be 'LF'",
     };
@@ -21,10 +20,6 @@ export class Rule extends Lint.Rules.AbstractRule {
         let failureString: string;
 
         switch (this.getOptions().ruleArguments[0]) {
-            case "CR":
-                // expectedEOL = "\r";
-                failureString = Rule.FAILURE_STRINGS.CR;
-                break;
             case "CRLF":
                 expectedEOL = "\r\n";
                 failureString = Rule.FAILURE_STRINGS.CRLF;

--- a/src/rules/linebreakStyleRule.ts
+++ b/src/rules/linebreakStyleRule.ts
@@ -1,0 +1,61 @@
+import * as ts from "typescript";
+import * as Lint from "../lint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRINGS = {
+        CR: "Expected linebreak to be 'CR'",
+        CRLF: "Expected linebreak to be 'CRLF'",
+        LF: "Expected linebreak to be 'LF'",
+    };
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        const failures = <Lint.RuleFailure[]>[];
+        const scanner = ts.createScanner(
+            sourceFile.languageVersion,
+            false,
+            sourceFile.languageVariant,
+            sourceFile.getFullText()
+        );
+
+        let expectedEOL: string;
+        let failureString: string;
+
+        switch (this.getOptions().ruleArguments[0]) {
+            case "CR":
+                // expectedEOL = "\r";
+                failureString = Rule.FAILURE_STRINGS.CR;
+                break;
+            case "CRLF":
+                expectedEOL = "\r\n";
+                failureString = Rule.FAILURE_STRINGS.CRLF;
+                break;
+            case "LF":
+                expectedEOL = "\n";
+                failureString = Rule.FAILURE_STRINGS.LF;
+                break;
+        }
+
+        if (expectedEOL != null) {
+            for (let token = scanner.scan(); token !== ts.SyntaxKind.EndOfFileToken; token = scanner.scan()) {
+                if (token === ts.SyntaxKind.NewLineTrivia) {
+                    const text = scanner.getTokenText();
+                    if (text !== expectedEOL) {
+                        failures.push(this.createFailure(sourceFile, scanner, failureString));
+                    }
+                }
+            }
+        }
+
+        return failures;
+    }
+
+    public createFailure(sourceFile: ts.SourceFile, scanner: ts.Scanner, failure: string): Lint.RuleFailure {
+        // get the start of the current line
+        const start = sourceFile.getPositionOfLineAndCharacter(sourceFile.getLineAndCharacterOfPosition(scanner.getStartPos()).line, 0);
+        // since line endings are not visible, we simply end at the beginning of
+        // the line ending, which happens to be the start of the token.
+        const end = scanner.getStartPos();
+
+        return new Lint.RuleFailure(sourceFile, start, end, failure, this.getOptions().ruleName);
+    }
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -73,6 +73,7 @@
         "rules/jsdocFormatRule.ts",
         "rules/labelPositionRule.ts",
         "rules/labelUndefinedRule.ts",
+        "rules/linebreakStyleRule.ts",
         "rules/maxLineLengthRule.ts",
         "rules/memberAccessRule.ts",
         "rules/memberOrderingRule.ts",

--- a/test/rules/linebreak-style/emptyFile/tslint.json
+++ b/test/rules/linebreak-style/emptyFile/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "linebreak-style": [true, "LF"]
+  }
+}

--- a/test/rules/linebreak-style/failure/CRLF/test.ts.lint
+++ b/test/rules/linebreak-style/failure/CRLF/test.ts.lint
@@ -1,0 +1,8 @@
+// this line uses CRLF
+~~~~~~~~~~~~~~~~~~~~~~ [Expected linebreak to be 'LF']
+// this line uses CRLF
+~~~~~~~~~~~~~~~~~~~~~~ [Expected linebreak to be 'LF']
+// this line uses CRLF
+~~~~~~~~~~~~~~~~~~~~~~ [Expected linebreak to be 'LF']
+// this line uses CRLF
+~~~~~~~~~~~~~~~~~~~~~~ [Expected linebreak to be 'LF']

--- a/test/rules/linebreak-style/failure/CRLF/tslint.json
+++ b/test/rules/linebreak-style/failure/CRLF/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "linebreak-style": [true, "LF"]
+  }
+}

--- a/test/rules/linebreak-style/failure/LF/test.ts.lint
+++ b/test/rules/linebreak-style/failure/LF/test.ts.lint
@@ -1,0 +1,8 @@
+// this line uses LF
+~~~~~~~~~~~~~~~~~~~~ [Expected linebreak to be 'CRLF']
+// this line uses LF
+~~~~~~~~~~~~~~~~~~~~ [Expected linebreak to be 'CRLF']
+// this line uses LF
+~~~~~~~~~~~~~~~~~~~~ [Expected linebreak to be 'CRLF']
+// this line uses LF
+~~~~~~~~~~~~~~~~~~~~ [Expected linebreak to be 'CRLF']

--- a/test/rules/linebreak-style/failure/LF/tslint.json
+++ b/test/rules/linebreak-style/failure/LF/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "linebreak-style": [true, "CRLF"]
+  }
+}

--- a/test/rules/linebreak-style/success/CRLF/test.ts.lint
+++ b/test/rules/linebreak-style/success/CRLF/test.ts.lint
@@ -1,0 +1,4 @@
+// this line uses CRLF
+// this line uses CRLF
+// this line uses CRLF
+// this line uses CRLF

--- a/test/rules/linebreak-style/success/CRLF/tslint.json
+++ b/test/rules/linebreak-style/success/CRLF/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "linebreak-style": [true, "CRLF"]
+  }
+}

--- a/test/rules/linebreak-style/success/LF/test.ts.lint
+++ b/test/rules/linebreak-style/success/LF/test.ts.lint
@@ -1,0 +1,4 @@
+// this line uses LF
+// this line uses LF
+// this line uses LF
+// this line uses LF

--- a/test/rules/linebreak-style/success/LF/tslint.json
+++ b/test/rules/linebreak-style/success/LF/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "linebreak-style": [true, "LF"]
+  }
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -70,6 +70,7 @@
         "../src/rules/jsdocFormatRule.ts",
         "../src/rules/labelPositionRule.ts",
         "../src/rules/labelUndefinedRule.ts",
+        "../src/rules/linebreakStyleRule.ts",
         "../src/rules/maxLineLengthRule.ts",
         "../src/rules/memberAccessRule.ts",
         "../src/rules/memberOrderingRule.ts",


### PR DESCRIPTION
initial attempt at the linebreak style rule. I used a manually created scanner because i need to tokenize the `NewLineTrivia` tokens, which aren't exposed in the standard rule framework. basically just walking the tokens until i see the new line token and checking its text content if it matches the configured linebreak type.

`CR` is not supported due to `CR` not really working properly at all. I left the `CR` code stubbed in and disabled for (potential) future use.

Tests are a bit funky because I can't create a mixed line endings file very easily (does git even allow such a thing via `.gitattributes`?). Right now I'm just testing that line endings are detected properly and success and failure scenarios work. But I cannot test a real world scenario where a paste with conflicting line endings occurs. That said it should not be any different than what the tests currently cover.

I would like to eventually add an `AUTO` option that would detect the dominant line endings in a file and then mark any differing line endings as failures, but I feel that it may be important to get the base functionality in first before I (or someone else) begin that type of work.

As always, open to any suggestions and improvements on this approach.

fixes #123