### PR TITLE
Add test for semicolons for readonly interface members

### DIFF
--- a/test/rules/semicolon/always/test.ts.lint
+++ b/test/rules/semicolon/always/test.ts.lint
@@ -70,6 +70,8 @@ interface ITest {
     bar: number
                ~nil [missing semicolon]
     baz: boolean;
+
+    readonly raz: number;
 }
 
 import {Router} from 'aurelia-router';


### PR DESCRIPTION
Shows that #1275 isn't a bug