### PR TITLE
README.md - explained that Formatter class must be named Formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ export class Formatter extends Lint.Formatters.AbstractFormatter {
 }
 ```
 
-Such custom formatters can also be written in JavaScript. Formatter files are always named with the suffix `Formatter` and referenced from TSLint without their suffix.
+Such custom formatters can also be written in JavaScript. Formatter files are always named with the suffix `Formatter` and the exported class within the file must be named `Formatter`. A formatter is referenced from TSLint without its suffix.
 
 Development
 -----------


### PR DESCRIPTION
README.md - explained that Formatter class must be named Formatter

I discovered this myself after working about 30 minutes to figure out why it was not found.