### PR TITLE
Allow to use beta-version of typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "latest"
   },
   "peerDependencies": {
-    "typescript": ">=1.7.3"
+    "typescript": ">=1.7.3 || >=1.9.0-dev"
   },
   "license": "Apache-2.0",
   "typescript": {


### PR DESCRIPTION
This change allow to use tslint in projects, which uses beta-version of typescript