### PR TITLE
Visit JsxExpression node.

### DIFF
--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -178,6 +178,10 @@ export class SyntaxWalker {
         this.walkChildren(node);
     }
 
+    protected visitJsxExpression(node: ts.JsxExpression) {
+        this.walkChildren(node);
+    }
+
     protected visitJsxSelfClosingElement(node: ts.JsxSelfClosingElement) {
         this.walkChildren(node);
     }
@@ -462,6 +466,10 @@ export class SyntaxWalker {
 
             case ts.SyntaxKind.JsxElement:
                 this.visitJsxElement(<ts.JsxElement> node);
+                break;
+
+            case ts.SyntaxKind.JsxExpression:
+                this.visitJsxExpression(<ts.JsxExpression> node);
                 break;
 
             case ts.SyntaxKind.JsxSelfClosingElement:


### PR DESCRIPTION
Visit JsxExpression node.

I am going to port [jsx-curly-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/jsx-curly-spacing.js) rule and find no such node visitor function.