### PR TITLE
Improving failure messages for the member-access rule to be more specific about what failed

### DIFF
--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -21,7 +21,7 @@ import * as Lint from "../lint";
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_FACTORY = (memberType: string, memberName: string, publicOnly: boolean) => {
         memberName = memberName == null ? "" : ` '${memberName}'`;
-        if(publicOnly){
+        if (publicOnly) {
             return `The ${memberType}${memberName} must be marked as 'public'`;
         }
         return `The ${memberType}${memberName} must be marked either 'private', 'public', or 'protected'`;

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -20,8 +20,8 @@ import * as Lint from "../lint";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_FACTORY = (memberType: string, memberName: string) => {
-        memberName = memberName ? " '" + memberName + "'" : "";
-        return `The ${memberType}${memberName} is missing an access modifier`;
+        memberName = memberName == null ? "" : ` '${memberName}'`;
+        return `The ${memberType}${memberName} must be marked either 'private', 'public', or 'protected'`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/test/rules/member-access/accessor/test.ts.lint
+++ b/test/rules/member-access/accessor/test.ts.lint
@@ -4,9 +4,9 @@ class Members {
         return 1;
 ~~~~~~~~~~~~~~~~~
     }
-~~~~~ [default access modifier on member/method not allowed]
+~~~~~ [The get property accessor 'g' is missing an access modifier]
     set s(o: any) {}
-    ~~~~~~~~~~~~~~~~ [default access modifier on member/method not allowed]
+    ~~~~~~~~~~~~~~~~ [The set property accessor 's' is missing an access modifier]
 
     public get publicG() {
         return 1;

--- a/test/rules/member-access/accessor/test.ts.lint
+++ b/test/rules/member-access/accessor/test.ts.lint
@@ -4,9 +4,9 @@ class Members {
         return 1;
 ~~~~~~~~~~~~~~~~~
     }
-~~~~~ [The get property accessor 'g' is missing an access modifier]
+~~~~~ [The get property accessor 'g' must be marked either 'private', 'public', or 'protected']
     set s(o: any) {}
-    ~~~~~~~~~~~~~~~~ [The set property accessor 's' is missing an access modifier]
+    ~~~~~~~~~~~~~~~~ [The set property accessor 's' must be marked either 'private', 'public', or 'protected']
 
     public get publicG() {
         return 1;

--- a/test/rules/member-access/constructor/test.ts.lint
+++ b/test/rules/member-access/constructor/test.ts.lint
@@ -1,8 +1,8 @@
 class ContructorsNoAccess {
     constructor(i: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~ [The class constructor must be marked either 'private', 'public', or 'protected']
+    ~~~~~~~~~~~~~~~~~~~~~~~ [The class constructor must be marked as 'public']
     constructor(o: any) {}
-    ~~~~~~~~~~~~~~~~~~~~~~ [The class constructor must be marked either 'private', 'public', or 'protected']
+    ~~~~~~~~~~~~~~~~~~~~~~ [The class constructor must be marked as 'public']
 }
 
 class ContructorsAccess {

--- a/test/rules/member-access/constructor/test.ts.lint
+++ b/test/rules/member-access/constructor/test.ts.lint
@@ -1,8 +1,8 @@
 class ContructorsNoAccess {
     constructor(i: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~ [The class constructor is missing an access modifier]
+    ~~~~~~~~~~~~~~~~~~~~~~~ [The class constructor must be marked either 'private', 'public', or 'protected']
     constructor(o: any) {}
-    ~~~~~~~~~~~~~~~~~~~~~~ [The class constructor is missing an access modifier]
+    ~~~~~~~~~~~~~~~~~~~~~~ [The class constructor must be marked either 'private', 'public', or 'protected']
 }
 
 class ContructorsAccess {

--- a/test/rules/member-access/constructor/test.ts.lint
+++ b/test/rules/member-access/constructor/test.ts.lint
@@ -1,8 +1,8 @@
 class ContructorsNoAccess {
     constructor(i: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~ [default access modifier on member/method not allowed]
+    ~~~~~~~~~~~~~~~~~~~~~~~ [The class constructor is missing an access modifier]
     constructor(o: any) {}
-    ~~~~~~~~~~~~~~~~~~~~~~ [default access modifier on member/method not allowed]
+    ~~~~~~~~~~~~~~~~~~~~~~ [The class constructor is missing an access modifier]
 }
 
 class ContructorsAccess {

--- a/test/rules/member-access/default/test.ts.lint
+++ b/test/rules/member-access/default/test.ts.lint
@@ -1,6 +1,6 @@
 declare class AmbientNoAccess {
     a(): number;
-    ~~~~~~~~~~~~ [The class method 'a' is missing an access modifier]
+    ~~~~~~~~~~~~ [The class method 'a' must be marked either 'private', 'public', or 'protected']
 }
 
 declare class AmbientAccess {
@@ -9,16 +9,16 @@ declare class AmbientAccess {
 
 class Members {
     i: number;
-    ~~~~~~~~~~ [The class property 'i' is missing an access modifier]
+    ~~~~~~~~~~ [The class property 'i' must be marked either 'private', 'public', or 'protected']
 
     public nPublic: number;
     protected nProtected: number;
     private nPrivate: number;
 
     noAccess(x: number): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' is missing an access modifier]
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' must be marked either 'private', 'public', or 'protected']
     noAccess(o: any): any {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' is missing an access modifier]
+    ~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' must be marked either 'private', 'public', or 'protected']
 
     public access(x: number): number;
     public access(o: any): any {}
@@ -31,7 +31,7 @@ const obj = {
 function main() {
     class A {
         i: number;
-        ~~~~~~~~~~ [The class property 'i' is missing an access modifier]
+        ~~~~~~~~~~ [The class property 'i' must be marked either 'private', 'public', or 'protected']
         public n: number;
     }
 }

--- a/test/rules/member-access/default/test.ts.lint
+++ b/test/rules/member-access/default/test.ts.lint
@@ -1,6 +1,6 @@
 declare class AmbientNoAccess {
     a(): number;
-    ~~~~~~~~~~~~ [0]
+    ~~~~~~~~~~~~ [The class method 'a' is missing an access modifier]
 }
 
 declare class AmbientAccess {
@@ -9,16 +9,16 @@ declare class AmbientAccess {
 
 class Members {
     i: number;
-    ~~~~~~~~~~ [0]
+    ~~~~~~~~~~ [The class property 'i' is missing an access modifier]
 
     public nPublic: number;
     protected nProtected: number;
     private nPrivate: number;
 
     noAccess(x: number): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' is missing an access modifier]
     noAccess(o: any): any {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+    ~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' is missing an access modifier]
 
     public access(x: number): number;
     public access(o: any): any {}
@@ -31,9 +31,7 @@ const obj = {
 function main() {
     class A {
         i: number;
-        ~~~~~~~~~~ [0]
+        ~~~~~~~~~~ [The class property 'i' is missing an access modifier]
         public n: number;
     }
 }
-
-[0]: default access modifier on member/method not allowed


### PR DESCRIPTION
:-1:  **Before**:
>default access modifier on member/method not allowed

:+1: **After**:
>The class method 'a' is missing an access modifier

or

>The class property 'i' is missing an access modifier


I always though a message about "default access modifier" was never very clear, especially for those new to TypeScript.  It doesn't **have** a default modifier, the issue is that it **does not have** a prefixed keyword that the rule requires.

Hopefully these changes will make this message easier to understand.

---

I considered making the message something like:
>The class method 'a' must be marked as either 'private', 'public', or 'protected'

I do like that it's more specific about what needs to be added, but I was unsure if it was too much.  What do you think, should I change it to be more like that example?