### PR TITLE
Fix for no-consecutive-blank-lines to also see whitespace

### DIFF
--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -29,28 +29,52 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoConsecutiveBlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
     public visitSourceFile(node: ts.SourceFile) {
         super.visitSourceFile(node);
-
-        // starting with 1 to cover the case where the file starts with two blank lines
-        let newLinesInARowSeenSoFar = 1;
-        Lint.scanAllTokens(ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text), (scanner: ts.Scanner) => {
-            const startPos = scanner.getStartPos();
-            if (this.tokensToSkipStartEndMap[startPos] != null) {
-                // tokens to skip are places where the scanner gets confused about what the token is, without the proper context
-                // (specifically, regex, identifiers, and templates). So skip those tokens.
-                scanner.setTextPos(this.tokensToSkipStartEndMap[startPos]);
-                newLinesInARowSeenSoFar = 0;
-                return;
-            }
-
-            if (scanner.getToken() === ts.SyntaxKind.NewLineTrivia) {
-                newLinesInARowSeenSoFar += 1;
-                if (newLinesInARowSeenSoFar >= 3) {
-                    const failure = this.createFailure(scanner.getStartPos(), 1, Rule.FAILURE_STRING);
-                    this.addFailure(failure);
-                }
-            } else {
-                newLinesInARowSeenSoFar = 0;
+        
+        //Find all the lines that are blank or only contain whitespace
+        let blankLineIndexes:number[] = [];
+        node.getFullText().split(/\n/).forEach(function(txt, i){
+            if(txt.trim()===""){
+                blankLineIndexes.push(i);
             }
         });
+
+        //console.log("==================")
+        //console.log("Blank or whitespace line numbers ", blankLineIndexes.map((n)=>n+1))
+        
+        //Now only keep the found blank lines that are consecutive
+        let consecutiveBlankLineStarts:number[] = [];
+        for(let i=0; i < blankLineIndexes.length; i++) {
+            let diff = blankLineIndexes[i+1] - blankLineIndexes[i];
+            if(Math.abs(diff)==1) {
+                consecutiveBlankLineStarts.push(blankLineIndexes[i]);
+            }
+        }
+        
+        //Now only keep the beginning number in each sequence of consecutive numbers
+        let result:number[] = [];
+        let temp:number[] = [];
+        let difference:number;
+        for (let i = 0; i < consecutiveBlankLineStarts.length; i += 1) {
+            if (difference !== (consecutiveBlankLineStarts[i] - i)) {
+                if (difference !== undefined) {
+                    if(temp.length){
+                        result.push(temp[0])
+                        this.addFailure(this.createFailure(temp[0], 1, Rule.FAILURE_STRING));
+                    }
+                    temp = [];
+                }
+                difference = consecutiveBlankLineStarts[i] - i;
+            }
+            temp.push(consecutiveBlankLineStarts[i]);
+        }
+
+        if (temp.length>0) {
+            result.push(temp[0])
+            this.addFailure(this.createFailure(temp[0], 1, Rule.FAILURE_STRING));
+        }
+        
+        //console.log("==================")
+        //console.log("First lines of CONSECUTIVE blank or whitespace lines", result.map((n)=>n+1))
+        //console.log("==================")
     }
 }

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -29,36 +29,36 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoConsecutiveBlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
     public visitSourceFile(node: ts.SourceFile) {
         super.visitSourceFile(node);
-        
-        //Find all the lines that are blank or only contain whitespace
-        let blankLineIndexes:number[] = [];
+
+        // find all the lines that are blank or only contain whitespace
+        let blankLineIndexes: number[] = [];
         node.getFullText().split(/\n/).forEach(function(txt, i){
-            if(txt.trim()===""){
+            if (txt.trim() === "") {
                 blankLineIndexes.push(i);
             }
         });
 
-        //console.log("==================")
-        //console.log("Blank or whitespace line numbers ", blankLineIndexes.map((n)=>n+1))
-        
-        //Now only keep the found blank lines that are consecutive
-        let consecutiveBlankLineStarts:number[] = [];
-        for(let i=0; i < blankLineIndexes.length; i++) {
-            let diff = blankLineIndexes[i+1] - blankLineIndexes[i];
-            if(Math.abs(diff)==1) {
+        // console.log("==================")
+        // console.log("Blank or whitespace line numbers ", blankLineIndexes.map((n)=>n+1))
+
+        // now only keep the found blank lines that are consecutive
+        let consecutiveBlankLineStarts: number[] = [];
+        for (let i = 0; i < blankLineIndexes.length; i++) {
+            let diff = blankLineIndexes[i + 1] - blankLineIndexes[i];
+            if (Math.abs(diff) === 1) {
                 consecutiveBlankLineStarts.push(blankLineIndexes[i]);
             }
         }
-        
-        //Now only keep the beginning number in each sequence of consecutive numbers
-        let result:number[] = [];
-        let temp:number[] = [];
-        let difference:number;
+
+        // now only keep the beginning number in each sequence of consecutive numbers
+        let result: number[] = [];
+        let temp: number[] = [];
+        let difference: number;
         for (let i = 0; i < consecutiveBlankLineStarts.length; i += 1) {
             if (difference !== (consecutiveBlankLineStarts[i] - i)) {
                 if (difference !== undefined) {
-                    if(temp.length){
-                        result.push(temp[0])
+                    if (temp.length) {
+                        result.push(temp[0]);
                         this.addFailure(this.createFailure(temp[0], 1, Rule.FAILURE_STRING));
                     }
                     temp = [];
@@ -68,13 +68,13 @@ class NoConsecutiveBlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
             temp.push(consecutiveBlankLineStarts[i]);
         }
 
-        if (temp.length>0) {
-            result.push(temp[0])
+        if (temp.length > 0) {
+            result.push(temp[0]);
             this.addFailure(this.createFailure(temp[0], 1, Rule.FAILURE_STRING));
         }
-        
-        //console.log("==================")
-        //console.log("First lines of CONSECUTIVE blank or whitespace lines", result.map((n)=>n+1))
-        //console.log("==================")
+
+        // console.log("==================")
+        // console.log("First lines of CONSECUTIVE blank or whitespace lines", result.map((n)=>n+1))
+        // console.log("==================")
     }
 }

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -38,43 +38,13 @@ class NoConsecutiveBlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
             }
         });
 
-        // console.log("==================")
-        // console.log("Blank or whitespace line numbers ", blankLineIndexes.map((n)=>n+1))
-
-        // now only keep the found blank lines that are consecutive
-        let consecutiveBlankLineStarts: number[] = [];
+        // now only throw failures for the fisrt number from groups of consecutive blank line indexes
         for (let i = 0; i < blankLineIndexes.length; i++) {
-            let diff = blankLineIndexes[i + 1] - blankLineIndexes[i];
-            if (Math.abs(diff) === 1) {
-                consecutiveBlankLineStarts.push(blankLineIndexes[i]);
+            let diff = Math.abs(blankLineIndexes[i + 1] - blankLineIndexes[i]);
+            let prevDiff = Math.abs(blankLineIndexes[i] - blankLineIndexes[i - 1]);
+            if (diff === 1 && prevDiff !== 1) {
+                this.addFailure(this.createFailure(blankLineIndexes[i], 1, Rule.FAILURE_STRING));
             }
         }
-
-        // now only keep the beginning number in each sequence of consecutive numbers
-        let result: number[] = [];
-        let temp: number[] = [];
-        let difference: number;
-        for (let i = 0; i < consecutiveBlankLineStarts.length; i += 1) {
-            if (difference !== (consecutiveBlankLineStarts[i] - i)) {
-                if (difference !== undefined) {
-                    if (temp.length) {
-                        result.push(temp[0]);
-                        this.addFailure(this.createFailure(temp[0], 1, Rule.FAILURE_STRING));
-                    }
-                    temp = [];
-                }
-                difference = consecutiveBlankLineStarts[i] - i;
-            }
-            temp.push(consecutiveBlankLineStarts[i]);
-        }
-
-        if (temp.length > 0) {
-            result.push(temp[0]);
-            this.addFailure(this.createFailure(temp[0], 1, Rule.FAILURE_STRING));
-        }
-
-        // console.log("==================")
-        // console.log("First lines of CONSECUTIVE blank or whitespace lines", result.map((n)=>n+1))
-        // console.log("==================")
     }
 }

--- a/test/rules/no-consecutive-blank-lines/test.ts.lint
+++ b/test/rules/no-consecutive-blank-lines/test.ts.lint
@@ -9,6 +9,7 @@ class Clazz { // comment
         console.log("test");
 ~nil                         [consecutive blank lines are disallowed]
 
+
     }
 ~nil                         [consecutive blank lines are disallowed]
 

--- a/test/rules/no-consecutive-blank-lines/test.ts.lint
+++ b/test/rules/no-consecutive-blank-lines/test.ts.lint
@@ -1,22 +1,33 @@
+// the markup for this test is a little bit weird
+// tslint, for the first error below, says it goes from 
+// [5, 1] to [6, 1], and thus the markup appears to be off (but it's not)
+
+
+~nil
 class Clazz { // comment
-    
+~nil                     [consecutive blank lines are disallowed]
+
     public funcxion() {
 
-        // The next two lines of "code" contain only tabs or spaces, they are also considered "blank" lines
-~nil                         [consecutive blank lines are disallowed]
-        
-		
+        // also comment
+
+
+~nil
         console.log("test");
 ~nil                         [consecutive blank lines are disallowed]
 
-
     }
-~nil                         [consecutive blank lines are disallowed]
 
 
-
+~nil
 }
+~nil  [consecutive blank lines are disallowed]
+
+//Begin whitespace
+// The next two lines of "code" contain only tabs or spaces, they are also considered "blank" lines
 ~nil                         [consecutive blank lines are disallowed]
-  
-  
-  
+        
+        
+		
+		
+//End whitespace

--- a/test/rules/no-consecutive-blank-lines/test.ts.lint
+++ b/test/rules/no-consecutive-blank-lines/test.ts.lint
@@ -1,24 +1,21 @@
-// the markup for this test is a little bit weird
-// tslint, for the first error below, says it goes from 
-// [5, 1] to [6, 1], and thus the markup appears to be off (but it's not)
-
-
-~nil
 class Clazz { // comment
-~nil                     [consecutive blank lines are disallowed]
-
+    
     public funcxion() {
 
-        // also comment
-
-
-~nil
+        // The next two lines of "code" contain only tabs or spaces, they are also considered "blank" lines
+~nil                         [consecutive blank lines are disallowed]
+        
+		
         console.log("test");
 ~nil                         [consecutive blank lines are disallowed]
 
     }
+~nil                         [consecutive blank lines are disallowed]
 
 
-~nil
+
 }
-~nil  [consecutive blank lines are disallowed]
+~nil                         [consecutive blank lines are disallowed]
+  
+  
+  

--- a/test/rules/no-consecutive-blank-lines/test.ts.lint
+++ b/test/rules/no-consecutive-blank-lines/test.ts.lint
@@ -5,7 +5,7 @@
 
 ~nil
 class Clazz { // comment
-~nil                     [consecutive blank lines are disallowed]
+~nil [consecutive blank lines are disallowed]
 
     public funcxion() {
 
@@ -14,20 +14,20 @@ class Clazz { // comment
 
 ~nil
         console.log("test");
-~nil                         [consecutive blank lines are disallowed]
+~nil [consecutive blank lines are disallowed]
 
     }
 
 
 ~nil
 }
-~nil  [consecutive blank lines are disallowed]
+~nil [consecutive blank lines are disallowed]
 
 //Begin whitespace
 // The next two lines of "code" contain only tabs or spaces, they are also considered "blank" lines
-~nil                         [consecutive blank lines are disallowed]
         
         
+~ [consecutive blank lines are disallowed]
 		
 		
 //End whitespace


### PR DESCRIPTION
Related: #1249

Now this rule will consider lines that only contain whitespace as "blank" lines.

NOTE: Currently the tests for this rule fail, but it's because I'm not fully understanding the test file syntax.  All the failures appear to be reported correctly, except for that it reports some extra failures that I can't figure out.  It seems to report an incorrect failure at the beginning for every failure that exists afterwards. Any help here would be appreciated!  Below is a screenshot of the console output.  Note the debug output at the beginning.

![image](https://cloud.githubusercontent.com/assets/463685/15930441/f44d3976-2e20-11e6-8512-0355fcfbca11.png)
