### PR TITLE
correct example tslint.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ The configuration file specifies which rules are enabled and their options. A sa
    * - a relative path to a JSON file
    */
   "extends": "tslint:latest",
-  "rules": [
+  "rules": {
     /*
      * Any rules specified here will override those from the base config we are extending
      */
     "no-constructor-vars": true
-  ],
+  },
   "rulesDirectory": [
     /*
      * A list of relative or absolute paths to directories that contain custom rules.


### PR DESCRIPTION
The existing sample in the README is invalid json.
The example used array braces for rules definition, but this should be an object.