### PR TITLE
member-access: fix to correctly report the name for static methods/properties

### DIFF
--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -84,25 +84,28 @@ export class MemberAccessWalker extends Lint.RuleWalker {
 
         if (!hasAnyVisibilityModifiers) {
             let memberType: string;
-            let memberName: string;
             let publicOnly = false;
 
             if (node.kind === ts.SyntaxKind.MethodDeclaration) {
                 memberType = "class method";
-                memberName = node.getChildAt(0).getText();
             } else if (node.kind === ts.SyntaxKind.PropertyDeclaration) {
                 memberType = "class property";
-                memberName = node.getChildAt(0).getText();
             } else if (node.kind === ts.SyntaxKind.Constructor) {
                 memberType = "class constructor";
                 publicOnly = true;
             } else if (node.kind === ts.SyntaxKind.GetAccessor) {
                 memberType = "get property accessor";
-                memberName = node.getChildAt(1).getText();
             } else if (node.kind === ts.SyntaxKind.SetAccessor) {
                 memberType = "set property accessor";
-                memberName = node.getChildAt(1).getText();
             }
+
+            // look for the identifier and get it's text
+            let memberName: string;
+            node.getChildren().forEach((n: ts.Node) => {
+                if (n.kind === ts.SyntaxKind.Identifier) {
+                    memberName = n.getText();
+                }
+            });
 
             const failureString = Rule.FAILURE_STRING_FACTORY(memberType, memberName, publicOnly);
             this.addFailure(this.createFailure(node.getStart(), node.getWidth(), failureString));

--- a/test/rules/member-access/default/test.ts.lint
+++ b/test/rules/member-access/default/test.ts.lint
@@ -1,27 +1,45 @@
 declare class AmbientNoAccess {
     a(): number;
     ~~~~~~~~~~~~ [The class method 'a' must be marked either 'private', 'public', or 'protected']
+
+    static b(): number;
+    ~~~~~~~~~~~~~~~~~~~ [The class method 'b' must be marked either 'private', 'public', or 'protected']
 }
 
 declare class AmbientAccess {
     public a(): number;
+    public static b(): number;
 }
 
 class Members {
     i: number;
     ~~~~~~~~~~ [The class property 'i' must be marked either 'private', 'public', or 'protected']
+    static j: number;
+    ~~~~~~~~~~~~~~~~~ [The class property 'j' must be marked either 'private', 'public', or 'protected']
 
     public nPublic: number;
     protected nProtected: number;
     private nPrivate: number;
+
+    public static nsPublic: number;
+    protected static nsProtected: number;
+    private static nsPrivate: number;
 
     noAccess(x: number): number;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' must be marked either 'private', 'public', or 'protected']
     noAccess(o: any): any {}
     ~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' must be marked either 'private', 'public', or 'protected']
 
+    static noAccess(x: number): number;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' must be marked either 'private', 'public', or 'protected']
+    static noAccess(o: any): any {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [The class method 'noAccess' must be marked either 'private', 'public', or 'protected']
+
     public access(x: number): number;
     public access(o: any): any {}
+
+    public static access(x: number): number;
+    public static access(o: any): any {}
 }
 
 const obj = {
@@ -32,6 +50,8 @@ function main() {
     class A {
         i: number;
         ~~~~~~~~~~ [The class property 'i' must be marked either 'private', 'public', or 'protected']
+        static j: number;
+        ~~~~~~~~~~~~~~~~~ [The class property 'j' must be marked either 'private', 'public', or 'protected']
         public n: number;
     }
 }


### PR DESCRIPTION
I recently made PR #1303 (which was _just_ merged in!), but I realized a few moments ago that it did not properly get the member name in instances where the `static` keyword was used.  The tests never made use of this keyword, so I added some usages and updated the rule to properly get the member name regardless if the `static` keyword is used or not.

I like this way better anyway since it no longer assumes the hard-coded index of the identifier