### PR TITLE
Update peer dependency for TypeScript nightly version of 2.0.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "next"
   },
   "peerDependencies": {
-    "typescript": ">=1.7.3 || >=1.8.0-dev || >=1.9.0-dev"
+    "typescript": ">=1.7.3 || >=1.8.0-dev || >=1.9.0-dev || >=2.0.0-dev"
   },
   "license": "Apache-2.0",
   "typescript": {


### PR DESCRIPTION
TypeScript Compiler updates it version for release-2.0.0 [here](https://github.com/Microsoft/TypeScript/blob/master/package.json#L5) Update the peer dependency, so older node can install peer dependency correctly as this is currently broken TypeScript build