### PR TITLE
Use parameter properties to simplify constructors across codebase

### DIFF
--- a/src/language/rule/abstractRule.ts
+++ b/src/language/rule/abstractRule.ts
@@ -22,17 +22,15 @@ import {IRule, IRuleMetadata, IDisabledInterval, RuleFailure} from "./rule";
 
 export abstract class AbstractRule implements IRule {
     public static metadata: IRuleMetadata;
-    private value: any;
     private options: IOptions;
 
-    constructor(ruleName: string, value: any, disabledIntervals: IDisabledInterval[]) {
+    constructor(ruleName: string, private value: any, disabledIntervals: IDisabledInterval[]) {
         let ruleArguments: any[] = [];
 
         if (Array.isArray(value) && value.length > 1) {
             ruleArguments = value.slice(1);
         }
 
-        this.value = value;
         this.options = {
             disabledIntervals: disabledIntervals,
             ruleArguments: ruleArguments,

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -84,12 +84,7 @@ export interface IRule {
 }
 
 export class RuleFailurePosition {
-    private position: number;
-    private lineAndCharacter: ts.LineAndCharacter;
-
-    constructor(position: number, lineAndCharacter: ts.LineAndCharacter) {
-        this.position = position;
-        this.lineAndCharacter = lineAndCharacter;
+    constructor(private position: number, private lineAndCharacter: ts.LineAndCharacter) {
     }
 
     public getPosition() {
@@ -119,25 +114,19 @@ export class RuleFailurePosition {
 }
 
 export class RuleFailure {
-    private sourceFile: ts.SourceFile;
     private fileName: string;
     private startPosition: RuleFailurePosition;
     private endPosition: RuleFailurePosition;
-    private failure: string;
-    private ruleName: string;
 
-    constructor(sourceFile: ts.SourceFile,
+    constructor(private sourceFile: ts.SourceFile,
                 start: number,
                 end: number,
-                failure: string,
-                ruleName: string) {
+                private failure: string,
+                private ruleName: string) {
 
-        this.sourceFile = sourceFile;
         this.fileName = sourceFile.fileName;
         this.startPosition = this.createFailurePosition(start);
         this.endPosition = this.createFailurePosition(end);
-        this.failure = failure;
-        this.ruleName = ruleName;
     }
 
     public getFileName() {

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -26,17 +26,15 @@ export class RuleWalker extends SyntaxWalker {
     private position: number;
     private options: any[];
     private failures: RuleFailure[];
-    private sourceFile: ts.SourceFile;
     private disabledIntervals: IDisabledInterval[];
     private ruleName: string;
 
-    constructor(sourceFile: ts.SourceFile, options: IOptions) {
+    constructor(private sourceFile: ts.SourceFile, options: IOptions) {
         super();
 
         this.position = 0;
         this.failures = [];
         this.options = options.ruleArguments;
-        this.sourceFile = sourceFile;
         this.limit = this.sourceFile.getFullWidth();
         this.disabledIntervals = options.disabledIntervals;
         this.ruleName = options.ruleName;

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -57,10 +57,6 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 export class MemberAccessWalker extends Lint.RuleWalker {
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
-        super(sourceFile, options);
-    }
-
     public visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
         if (this.hasOption("check-constructor")) {
             // constructor is only allowed to have public or nothing, but the compiler will catch this

--- a/src/rules/noMergeableNamespaceRule.ts
+++ b/src/rules/noMergeableNamespaceRule.ts
@@ -42,11 +42,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class NoMergeableNamespaceWalker extends Lint.RuleWalker {
-    private languageService: ts.LanguageService;
-
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, languageService: ts.LanguageService) {
+    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, private languageService: ts.LanguageService) {
         super(sourceFile, options);
-        this.languageService = languageService;
     }
 
     public visitModuleDeclaration(node: ts.ModuleDeclaration) {

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -81,7 +81,6 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class NoUnusedVariablesWalker extends Lint.RuleWalker {
-    private languageService: ts.LanguageService;
     private skipBindingElement: boolean;
     private skipParameterDeclaration: boolean;
     private skipVariableDeclaration: boolean;
@@ -91,9 +90,8 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
     private isReactUsed: boolean;
     private reactImport: ts.NamespaceImport;
 
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, languageService: ts.LanguageService) {
+    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, private languageService: ts.LanguageService) {
         super(sourceFile, options);
-        this.languageService = languageService;
         this.skipVariableDeclaration = false;
         this.skipParameterDeclaration = false;
         this.hasSeenJsxElement = false;

--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -45,11 +45,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 type VisitedVariables = {[varName: string]: boolean};
 
 class NoUseBeforeDeclareWalker extends Lint.ScopeAwareRuleWalker<VisitedVariables> {
-    private languageService: ts.LanguageService;
-
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, languageService: ts.LanguageService) {
+    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, private languageService: ts.LanguageService) {
         super(sourceFile, options);
-        this.languageService = languageService;
     }
 
     public createScope(): VisitedVariables {

--- a/src/rules/noVarRequiresRule.ts
+++ b/src/rules/noVarRequiresRule.ts
@@ -42,10 +42,6 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class NoVarRequiresWalker extends Lint.ScopeAwareRuleWalker<{}> {
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
-        super(sourceFile, options);
-    }
-
     public createScope(): {} {
         return {};
     }

--- a/src/tslint.ts
+++ b/src/tslint.ts
@@ -40,13 +40,9 @@ class Linter {
     public static getRulesDirectories = getRulesDirectories;
     public static loadConfigurationFromPath = loadConfigurationFromPath;
 
-    private fileName: string;
-    private source: string;
     private options: ILinterOptions;
 
-    constructor(fileName: string, source: string, options: ILinterOptionsRaw) {
-        this.fileName = fileName;
-        this.source = source;
+    constructor(private fileName: string, private source: string, options: ILinterOptionsRaw) {
         this.options = this.computeFullOptions(options);
     }
 


### PR DESCRIPTION
Small refactoring of constructors across code base to use parameter properties.

There was also a couple of places where constructors on derived classes were just passing arguments through to a base class with no additional logic, so i have removed those where I could see them.

Fixes #619 