### PR TITLE
Revert changes made to findup-sync during refactoring

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as findup from "findup-sync";
+import findup = require("findup-sync");
 import * as fs from "fs";
 import * as path from "path";
 import * as resolve from "resolve";

--- a/typings/findup-sync/findup-sync.d.ts
+++ b/typings/findup-sync/findup-sync.d.ts
@@ -13,7 +13,6 @@ declare module 'findup-sync' {
 	}
 
 	function mod(pattern: string[] | string, opts?: IOptions): string;
-    namespace mod {} // Literally works around a bug in TS
 
 	export = mod;
 }


### PR DESCRIPTION
Now that TS propertly supports module targets.

@alexeagle needs this for angular licensing reasons.