### PR TITLE
Revert local modification of findup typings

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as findup from "findup-sync";
+const findup = require("findup-sync");
 import * as fs from "fs";
 import * as path from "path";
 import * as resolve from "resolve";

--- a/typings/findup-sync/findup-sync.d.ts
+++ b/typings/findup-sync/findup-sync.d.ts
@@ -13,7 +13,6 @@ declare module 'findup-sync' {
 	}
 
 	function mod(pattern: string[] | string, opts?: IOptions): string;
-    namespace mod {} // Literally works around a bug in TS
 
 	export = mod;
 }


### PR DESCRIPTION
findup typings in the `typings/` directory don't match the SHA from `tsd.json` which makes the build hard to repro externally.
This PR in place of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/10061