### PR TITLE
Update peer dependency to 2.1.0 as TypeScript nightly will be 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "next"
   },
   "peerDependencies": {
-    "typescript": ">=1.7.3 || >=1.8.0-dev || >=1.9.0-dev || >=2.0.0-dev"
+    "typescript": ">=1.7.3 || >=1.8.0-dev || >=1.9.0-dev || >=2.0.0-dev || >=2.1.0-dev"
   },
   "license": "Apache-2.0",
   "typescript": {


### PR DESCRIPTION
We are updating our nightly version to be 2.1.0 tonight. [(merged PR)](https://github.com/Microsoft/TypeScript/pull/9615) 
