### PR TITLE
no-for-in-array rule

### DIFF
--- a/src/rules/noForInArrayRule.ts
+++ b/src/rules/noForInArrayRule.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../lint";
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-for-in-array",
+        description: "Disallows for-in loops over array types.",
+        descriptionDetails: Lint.Utils.dedent`
+            A for-in loop (\`for (var k in o)\`) iterates over the properties of an Object.
+
+            While it is legal to use for-in loops with array types, it is not common.
+            for-in will iterate over the indices of the array as strings, omitting any "holes" in
+            the array.
+
+            More common is to use for-of, which iterates over the values of an array.
+            If you want to iterate over the indices, alternatives include:
+
+            array.forEach((value, index) => { ... });
+            for (const [index, value] of array.entries()) { ... }
+            for (let i = 0; i < array.length; i++) { ... }
+            `,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        requiresTypeInfo: true,
+        type: "functionality",
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "for-in loops over arrays are forbidden. Use for-of or array.forEach instead.";
+
+    public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+        const noForInArrayWalker = new NoForInArrayWalker(sourceFile, this.getOptions(), program);
+        return this.applyWithWalker(noForInArrayWalker);
+    }
+}
+
+class NoForInArrayWalker extends Lint.ProgramAwareRuleWalker {
+    public visitForInStatement(node: ts.ForInStatement) {
+        const iteratee = node.expression;
+        const tc = this.getTypeChecker();
+        const type = tc.getTypeAtLocation(iteratee);
+
+        /* tslint:disable:no-bitwise */
+        const isArrayType = (type.flags & ts.TypeFlags.Reference) !== 0;
+        const isStringType = (type.flags & ts.TypeFlags.StringLike) !== 0;
+        /* tslint:enable:no-bitwise */
+
+        if (isArrayType || isStringType) {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        }
+
+        super.visitForInStatement(node);
+    }
+}

--- a/src/rules/noForInArrayRule.ts
+++ b/src/rules/noForInArrayRule.ts
@@ -61,7 +61,7 @@ class NoForInArrayWalker extends Lint.ProgramAwareRuleWalker {
         const type = tc.getTypeAtLocation(iteratee);
 
         /* tslint:disable:no-bitwise */
-        const isArrayType = (type.flags & ts.TypeFlags.Reference) !== 0;
+        const isArrayType = type.symbol && type.symbol.name === "Array";
         const isStringType = (type.flags & ts.TypeFlags.StringLike) !== 0;
         /* tslint:enable:no-bitwise */
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -103,6 +103,7 @@
         "rules/noDuplicateVariableRule.ts",
         "rules/noEmptyRule.ts",
         "rules/noEvalRule.ts",
+        "rules/noForInArrayRule.ts",
         "rules/noInferrableTypesRule.ts",
         "rules/noInternalModuleRule.ts",
         "rules/noInvalidThisRule.ts",

--- a/test/rules/no-for-in-array/test.ts.lint
+++ b/test/rules/no-for-in-array/test.ts.lint
@@ -19,12 +19,16 @@ class C {
 }
 c = new C();
 
+class A<T> { }
+let refType: A<number>;
+
 // valid cases
 for (var k in o);
 for (var k in d);
 for (var k in map);
 for (var k in numArray);
 for (var k in c);
+for (var k in refType);
 
 // invalid cases
 for (var k in array);

--- a/test/rules/no-for-in-array/test.ts.lint
+++ b/test/rules/no-for-in-array/test.ts.lint
@@ -1,0 +1,41 @@
+const array = [1, 2, 3, 4];
+const strArray = ['a', 'b', 'c'];
+const objArray = [{a: 1}, {a: 2, b: 10}, {a: 3}];
+const o = {};
+const numArray = {
+    1: "a",
+    2: "b"
+};
+const d = new Date();
+const str = "abc";
+const objectMap = {} as {[key: string]: number};
+const map = new Map([['a', 1], ['b', 2]]);
+const set = new Set([1, 2, 3]);
+
+class C {
+  a: number;
+  f() {}
+  g() {}
+}
+c = new C();
+
+// valid cases
+for (var k in o);
+for (var k in d);
+for (var k in map);
+for (var k in numArray);
+for (var k in c);
+
+// invalid cases
+for (var k in array);
+~~~~~~~~~~~~~~~~~~~~~  [0]
+for (var k in str);
+~~~~~~~~~~~~~~~~~~~  [0]
+for (var k in objArray);
+~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+
+// Ideally these would also be forbidden:
+for (var k in map);
+for (var k in set);
+
+[0]: for-in loops over arrays are forbidden. Use for-of or array.forEach instead.

--- a/test/rules/no-for-in-array/tslint.json
+++ b/test/rules/no-for-in-array/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-for-in-array": true
+  }
+}

--- a/test/rules/no-for-in-array/tslint.json
+++ b/test/rules/no-for-in-array/tslint.json
@@ -1,5 +1,8 @@
 {
   "rules": {
     "no-for-in-array": true
+  },
+  "linterOptions": {
+    "typeCheck": true
   }
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -99,6 +99,7 @@
         "../src/rules/noDuplicateVariableRule.ts",
         "../src/rules/noEmptyRule.ts",
         "../src/rules/noEvalRule.ts",
+        "../src/rules/noForInArrayRule.ts",
         "../src/rules/noInferrableTypesRule.ts",
         "../src/rules/noInternalModuleRule.ts",
         "../src/rules/noInvalidThisRule.ts",


### PR DESCRIPTION
Fixes #1380 

I would be interested in feedback on whether this is accurate:

```ts
const isArrayType = (type.flags & ts.TypeFlags.Reference) !== 0;
```

The `typescript.d.ts` file is quite terse about what a "Generic type reference" is, but in my testing it seems to correspond precisely to array types.