### PR TITLE
Add linterOptions to tslint.json

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -23,6 +23,9 @@ import * as resolve from "resolve";
 import {arrayify, objectify, stripComments} from "./utils";
 
 export interface IConfigurationFile {
+    linterOptions?: {
+        typeCheck?: boolean,
+    };
     extends?: string | string[];
     rulesDirectory?: string | string[];
     rules?: any;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -23,10 +23,10 @@ import * as resolve from "resolve";
 import {arrayify, objectify, stripComments} from "./utils";
 
 export interface IConfigurationFile {
+    extends?: string | string[];
     linterOptions?: {
         typeCheck?: boolean,
     };
-    extends?: string | string[];
     rulesDirectory?: string | string[];
     rules?: any;
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -73,9 +73,12 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
             writeFile: () => null,
         };
 
-        const program = ts.createProgram([fileCompileName], compilerOptions, compilerHost);
-        // perform type checking on the program, updating nodes with symbol table references
-        ts.getPreEmitDiagnostics(program);
+        let program: ts.Program;
+        if (tslintConfig.linterOptions && tslintConfig.linterOptions.typeCheck) {
+            program = ts.createProgram([fileCompileName], compilerOptions, compilerHost);
+            // perform type checking on the program, updating nodes with symbol table references
+            ts.getPreEmitDiagnostics(program);
+        }
 
         const lintOptions = {
             configuration: tslintConfig,

--- a/src/test.ts
+++ b/src/test.ts
@@ -53,28 +53,28 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
         const fileTextWithoutMarkup = parse.removeErrorMarkup(fileText);
         const errorsFromMarkup = parse.parseErrorsFromMarkup(fileText);
 
-        const compilerOptions = createCompilerOptions();
-        const compilerHost: ts.CompilerHost = {
-            fileExists: () => true,
-            getCanonicalFileName: (filename: string) => filename,
-            getCurrentDirectory: () => "",
-            getDefaultLibFileName: () => ts.getDefaultLibFileName(compilerOptions),
-            getNewLine: () => "\n",
-            getSourceFile: function (filenameToGet: string) {
-                if (filenameToGet === this.getDefaultLibFileName()) {
-                    const fileText = fs.readFileSync(ts.getDefaultLibFilePath(compilerOptions)).toString();
-                    return ts.createSourceFile(filenameToGet, fileText, compilerOptions.target);
-                } else if (filenameToGet === fileCompileName) {
-                    return ts.createSourceFile(fileBasename, fileTextWithoutMarkup, compilerOptions.target, true);
-                }
-            },
-            readFile: () => null,
-            useCaseSensitiveFileNames: () => true,
-            writeFile: () => null,
-        };
-
         let program: ts.Program;
         if (tslintConfig.linterOptions && tslintConfig.linterOptions.typeCheck) {
+            const compilerOptions = createCompilerOptions();
+            const compilerHost: ts.CompilerHost = {
+                fileExists: () => true,
+                getCanonicalFileName: (filename: string) => filename,
+                getCurrentDirectory: () => "",
+                getDefaultLibFileName: () => ts.getDefaultLibFileName(compilerOptions),
+                getNewLine: () => "\n",
+                getSourceFile: function (filenameToGet: string) {
+                    if (filenameToGet === this.getDefaultLibFileName()) {
+                        const fileText = fs.readFileSync(ts.getDefaultLibFilePath(compilerOptions)).toString();
+                        return ts.createSourceFile(filenameToGet, fileText, compilerOptions.target);
+                    } else if (filenameToGet === fileCompileName) {
+                        return ts.createSourceFile(fileBasename, fileTextWithoutMarkup, compilerOptions.target, true);
+                    }
+                },
+                readFile: () => null,
+                useCaseSensitiveFileNames: () => true,
+                writeFile: () => null,
+            };
+
             program = ts.createProgram([fileCompileName], compilerOptions, compilerHost);
             // perform type checking on the program, updating nodes with symbol table references
             ts.getPreEmitDiagnostics(program);

--- a/test/rules/restrict-plus-operands/tslint.json
+++ b/test/rules/restrict-plus-operands/tslint.json
@@ -1,4 +1,7 @@
 {
+  "linterOptions": {
+    "typeCheck": true
+  },
   "rules": {
     "restrict-plus-operands": true
   }


### PR DESCRIPTION
- only enable type checking during tests when `typeCheck: true` is configured
- fixes #1402 

I haven't documented this as a public API yet; we're only using it internally for tests. If we did want to make it public, we'd have to refactor tslint-cli.ts to read the configuration file before it tries to run the type checker on a program.