### PR TITLE
Add text replacement fixes for rules

### DIFF
--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -89,6 +89,18 @@ export interface IRule {
     applyWithWalker(walker: RuleWalker): RuleFailure[];
 }
 
+export interface IReplacement {
+    start: number;
+    length: number;
+    text: string;
+}
+
+export interface IFix {
+    ruleName: string;
+    description: string;
+    replacements: IReplacement[];
+}
+
 export class RuleFailurePosition {
     constructor(private position: number, private lineAndCharacter: ts.LineAndCharacter) {
     }
@@ -128,7 +140,8 @@ export class RuleFailure {
                 start: number,
                 end: number,
                 private failure: string,
-                private ruleName: string) {
+                private ruleName: string,
+                private fixes: IFix[] = []) {
 
         this.fileName = sourceFile.fileName;
         this.startPosition = this.createFailurePosition(start);
@@ -155,10 +168,15 @@ export class RuleFailure {
         return this.failure;
     }
 
+    public getFixes() {
+        return this.fixes;
+    }
+
     public toJson(): any {
         return {
             endPosition: this.endPosition.toJson(),
             failure: this.failure,
+            fixes: this.fixes,
             name: this.fileName,
             ruleName: this.ruleName,
             startPosition: this.startPosition.toJson(),

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -173,7 +173,7 @@ export class RuleFailure {
                 end: number,
                 private failure: string,
                 private ruleName: string,
-                private fixes: Fix[] = []) {
+                private fix?: Fix) {
 
         this.fileName = sourceFile.fileName;
         this.startPosition = this.createFailurePosition(start);
@@ -200,15 +200,19 @@ export class RuleFailure {
         return this.failure;
     }
 
-    public getFixes() {
-        return this.fixes;
+    public hasFix() {
+        return this.fix !== undefined;
+    }
+
+    public getFix() {
+        return this.fix;
     }
 
     public toJson(): any {
         return {
             endPosition: this.endPosition.toJson(),
             failure: this.failure,
-            fixes: this.fixes,
+            fix: this.fix,
             name: this.fileName,
             ruleName: this.ruleName,
             startPosition: this.startPosition.toJson(),

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -90,23 +90,23 @@ export interface IRule {
 }
 
 export class Replacement {
-    constructor(private start: number, private length: number, private text: string) {
+    constructor(private innerStart: number, private innerLength: number, private innerText: string) {
     }
 
-    public getStart() {
-        return this.start;
+    get start() {
+        return this.innerStart;
     }
 
-    public getLength() {
-        return this.length;
+    get length() {
+        return this.innerLength;
     }
 
-    public getEnd() {
-        return this.start + this.length;
+    get end() {
+        return this.innerStart + this.innerLength;
     }
 
-    public getText() {
-        return this.text;
+    get text() {
+        return this.innerText;
     }
 
     public apply(content: string) {
@@ -115,25 +115,21 @@ export class Replacement {
 }
 
 export class Fix {
-    constructor(private ruleName: string, private description: string, private replacements: Replacement[]) {
+    constructor(private innerRuleName: string, private innerReplacements: Replacement[]) {
     }
 
-    public getRuleName() {
-        return this.ruleName;
+    get ruleName() {
+        return this.innerRuleName;
     }
 
-    public getDescription() {
-        return this.description;
-    }
-
-    public getReplacements() {
-        return this.replacements;
+    get replacements() {
+        return this.innerReplacements;
     }
 
     public apply(content: string) {
         // sort replacements in reverse so that diffs are properly applied
-        this.replacements.sort((a, b) => b.getEnd() - a.getEnd());
-        return this.replacements.reduce((text, r) => r.apply(text), content);
+        this.innerReplacements.sort((a, b) => b.end - a.end);
+        return this.innerReplacements.reduce((text, r) => r.apply(text), content);
     }
 }
 

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -90,6 +90,12 @@ export interface IRule {
 }
 
 export class Replacement {
+    public static applyAll(content: string, replacements: Replacement[]) {
+        // sort in reverse so that diffs are properly applied
+        replacements.sort((a, b) => b.end - a.end);
+        return replacements.reduce((text, r) => r.apply(text), content);
+    }
+
     constructor(private innerStart: number, private innerLength: number, private innerText: string) {
     }
 
@@ -121,9 +127,7 @@ export class Fix {
         for (const fix of fixes) {
             replacements = replacements.concat(fix.replacements);
         }
-        // sort in reverse so that diffs are properly applied
-        replacements.sort((a, b) => b.end - a.end);
-        return replacements.reduce((text, r) => r.apply(text), content);
+        return Replacement.applyAll(content, replacements);
     }
 
     constructor(private innerRuleName: string, private innerReplacements: Replacement[]) {
@@ -138,9 +142,7 @@ export class Fix {
     }
 
     public apply(content: string) {
-        // sort replacements in reverse so that diffs are properly applied
-        this.innerReplacements.sort((a, b) => b.end - a.end);
-        return this.innerReplacements.reduce((text, r) => r.apply(text), content);
+        return Replacement.applyAll(content, this.innerReplacements);
     }
 }
 

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -115,6 +115,17 @@ export class Replacement {
 }
 
 export class Fix {
+    public static applyAll(content: string, fixes: Fix[]) {
+        // accumulate replacements
+        let replacements: Replacement[] = [];
+        for (const fix of fixes) {
+            replacements = replacements.concat(fix.replacements);
+        }
+        // sort in reverse so that diffs are properly applied
+        replacements.sort((a, b) => b.end - a.end);
+        return replacements.reduce((text, r) => r.apply(text), content);
+    }
+
     constructor(private innerRuleName: string, private innerReplacements: Replacement[]) {
     }
 

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -18,7 +18,7 @@
 import * as ts from "typescript";
 
 import {IOptions} from "../../lint";
-import {IDisabledInterval, RuleFailure} from "../rule/rule";
+import {IDisabledInterval, IFix, IReplacement, RuleFailure} from "../rule/rule";
 import {doesIntersect} from "../utils";
 import {SyntaxWalker} from "./syntaxWalker";
 
@@ -69,10 +69,10 @@ export class RuleWalker extends SyntaxWalker {
         this.position += node.getFullWidth();
     }
 
-    public createFailure(start: number, width: number, failure: string): RuleFailure {
+    public createFailure(start: number, width: number, failure: string, fixes: IFix[] = []): RuleFailure {
         const from = (start > this.limit) ? this.limit : start;
         const to = ((start + width) > this.limit) ? this.limit : (start + width);
-        return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName);
+        return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName, fixes);
     }
 
     public addFailure(failure: RuleFailure) {
@@ -80,6 +80,22 @@ export class RuleWalker extends SyntaxWalker {
         if (!this.existsFailure(failure) && !doesIntersect(failure, this.disabledIntervals)) {
             this.failures.push(failure);
         }
+    }
+
+    public createFix(description: string, replacements: IReplacement[]): IFix {
+        return {
+            ruleName: this.ruleName,
+            description,
+            replacements,
+        };
+    }
+
+    public createReplacement(start: number, length: number, text: string): IReplacement {
+        return {
+            length,
+            start,
+            text,
+        };
     }
 
     private existsFailure(failure: RuleFailure) {

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -18,7 +18,7 @@
 import * as ts from "typescript";
 
 import {IOptions} from "../../lint";
-import {IDisabledInterval, IFix, IReplacement, RuleFailure} from "../rule/rule";
+import {Fix, IDisabledInterval, Replacement, RuleFailure} from "../rule/rule";
 import {doesIntersect} from "../utils";
 import {SyntaxWalker} from "./syntaxWalker";
 
@@ -69,7 +69,7 @@ export class RuleWalker extends SyntaxWalker {
         this.position += node.getFullWidth();
     }
 
-    public createFailure(start: number, width: number, failure: string, fixes: IFix[] = []): RuleFailure {
+    public createFailure(start: number, width: number, failure: string, fixes: Fix[] = []): RuleFailure {
         const from = (start > this.limit) ? this.limit : start;
         const to = ((start + width) > this.limit) ? this.limit : (start + width);
         return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName, fixes);
@@ -82,20 +82,12 @@ export class RuleWalker extends SyntaxWalker {
         }
     }
 
-    public createFix(description: string, replacements: IReplacement[]): IFix {
-        return {
-            ruleName: this.ruleName,
-            description,
-            replacements,
-        };
+    public createFix(description: string, replacements: Replacement[]): Fix {
+        return new Fix(this.ruleName, description, replacements);
     }
 
-    public createReplacement(start: number, length: number, text: string): IReplacement {
-        return {
-            length,
-            start,
-            text,
-        };
+    public createReplacement(start: number, length: number, text: string): Replacement {
+        return new Replacement(start, length, text);
     }
 
     private existsFailure(failure: RuleFailure) {

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -82,8 +82,8 @@ export class RuleWalker extends SyntaxWalker {
         }
     }
 
-    public createFix(description: string, replacements: Replacement[]): Fix {
-        return new Fix(this.ruleName, description, replacements);
+    public createFix(replacements: Replacement[]): Fix {
+        return new Fix(this.ruleName, replacements);
     }
 
     public createReplacement(start: number, length: number, text: string): Replacement {

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -82,12 +82,16 @@ export class RuleWalker extends SyntaxWalker {
         }
     }
 
-    public createFix(replacements: Replacement[]): Fix {
-        return new Fix(this.ruleName, replacements);
-    }
-
     public createReplacement(start: number, length: number, text: string): Replacement {
         return new Replacement(start, length, text);
+    }
+
+    public appendText(start: number, text: string): Replacement {
+        return this.createReplacement(start, 0, text);
+    }
+
+    public deleteText(start: number, length: number): Replacement {
+        return this.createReplacement(start, length, "");
     }
 
     private existsFailure(failure: RuleFailure) {

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -69,10 +69,10 @@ export class RuleWalker extends SyntaxWalker {
         this.position += node.getFullWidth();
     }
 
-    public createFailure(start: number, width: number, failure: string, fixes: Fix[] = []): RuleFailure {
+    public createFailure(start: number, width: number, failure: string, fix?: Fix): RuleFailure {
         const from = (start > this.limit) ? this.limit : start;
         const to = ((start + width) > this.limit) ? this.limit : (start + width);
-        return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName, fixes);
+        return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName, fix);
     }
 
     public addFailure(failure: RuleFailure) {

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -58,8 +58,6 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public static FAILURE_STRING_MISSING = "Missing semicolon";
     public static FAILURE_STRING_UNNECESSARY = "Unnecessary semicolon";
-    public static FIX_STRING_MISSING = "Add semicolon";
-    public static FIX_STRING_UNNECESSARY = "Remove semicolon";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new SemicolonWalker(sourceFile, this.getOptions()));
@@ -152,12 +150,10 @@ class SemicolonWalker extends Lint.RuleWalker {
 
         if (always && !hasSemicolon) {
             const failureStart = Math.min(position, this.getLimit());
-            const fixes = [
-                this.createFix(Rule.FIX_STRING_UNNECESSARY, [
-                    this.createReplacement(failureStart, 0, ";"),
-                ]),
-            ];
-            this.addFailure(this.createFailure(failureStart, 0, Rule.FAILURE_STRING_MISSING, fixes));
+            const fixes = this.createFix([
+                this.createReplacement(failureStart, 0, ";"),
+            ]);
+            this.addFailure(this.createFailure(failureStart, 0, Rule.FAILURE_STRING_MISSING, [fixes]));
         } else if (this.hasOption(OPTION_NEVER) && hasSemicolon) {
             const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, sourceFile.text);
             scanner.setTextPos(position);
@@ -170,12 +166,10 @@ class SemicolonWalker extends Lint.RuleWalker {
             if (tokenKind !== ts.SyntaxKind.OpenParenToken && tokenKind !== ts.SyntaxKind.OpenBracketToken
                     && tokenKind !== ts.SyntaxKind.PlusToken && tokenKind !== ts.SyntaxKind.MinusToken) {
                 const failureStart = Math.min(position - 1, this.getLimit());
-                const fixes = [
-                    this.createFix(Rule.FIX_STRING_UNNECESSARY, [
-                        this.createReplacement(failureStart, 1, ""),
-                    ]),
-                ];
-                this.addFailure(this.createFailure(failureStart, 1, Rule.FAILURE_STRING_UNNECESSARY, fixes));
+                const fixes = this.createFix([
+                    this.createReplacement(failureStart, 1, ""),
+                ]);
+                this.addFailure(this.createFailure(failureStart, 1, Rule.FAILURE_STRING_UNNECESSARY, [fixes]));
             }
         }
     }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -150,8 +150,8 @@ class SemicolonWalker extends Lint.RuleWalker {
 
         if (always && !hasSemicolon) {
             const failureStart = Math.min(position, this.getLimit());
-            const fix = this.createFix([
-                this.createReplacement(failureStart, 0, ";"),
+            const fix = new Lint.Fix(Rule.metadata.ruleName, [
+                this.appendText(failureStart, ";"),
             ]);
             this.addFailure(this.createFailure(failureStart, 0, Rule.FAILURE_STRING_MISSING, fix));
         } else if (this.hasOption(OPTION_NEVER) && hasSemicolon) {
@@ -166,8 +166,8 @@ class SemicolonWalker extends Lint.RuleWalker {
             if (tokenKind !== ts.SyntaxKind.OpenParenToken && tokenKind !== ts.SyntaxKind.OpenBracketToken
                     && tokenKind !== ts.SyntaxKind.PlusToken && tokenKind !== ts.SyntaxKind.MinusToken) {
                 const failureStart = Math.min(position - 1, this.getLimit());
-                const fix = this.createFix([
-                    this.createReplacement(failureStart, 1, ""),
+                const fix = new Lint.Fix(Rule.metadata.ruleName, [
+                    this.deleteText(failureStart, 1),
                 ]);
                 this.addFailure(this.createFailure(failureStart, 1, Rule.FAILURE_STRING_UNNECESSARY, fix));
             }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -150,10 +150,10 @@ class SemicolonWalker extends Lint.RuleWalker {
 
         if (always && !hasSemicolon) {
             const failureStart = Math.min(position, this.getLimit());
-            const fixes = this.createFix([
+            const fix = this.createFix([
                 this.createReplacement(failureStart, 0, ";"),
             ]);
-            this.addFailure(this.createFailure(failureStart, 0, Rule.FAILURE_STRING_MISSING, [fixes]));
+            this.addFailure(this.createFailure(failureStart, 0, Rule.FAILURE_STRING_MISSING, fix));
         } else if (this.hasOption(OPTION_NEVER) && hasSemicolon) {
             const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, sourceFile.text);
             scanner.setTextPos(position);
@@ -166,10 +166,10 @@ class SemicolonWalker extends Lint.RuleWalker {
             if (tokenKind !== ts.SyntaxKind.OpenParenToken && tokenKind !== ts.SyntaxKind.OpenBracketToken
                     && tokenKind !== ts.SyntaxKind.PlusToken && tokenKind !== ts.SyntaxKind.MinusToken) {
                 const failureStart = Math.min(position - 1, this.getLimit());
-                const fixes = this.createFix([
+                const fix = this.createFix([
                     this.createReplacement(failureStart, 1, ""),
                 ]);
-                this.addFailure(this.createFailure(failureStart, 1, Rule.FAILURE_STRING_UNNECESSARY, [fixes]));
+                this.addFailure(this.createFailure(failureStart, 1, Rule.FAILURE_STRING_UNNECESSARY, fix));
             }
         }
     }

--- a/src/test.ts
+++ b/src/test.ts
@@ -117,12 +117,7 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
             const stat = fs.statSync(fixedFile);
             if (stat.isFile()) {
                 fixedFileText = fs.readFileSync(fixedFile, "utf8");
-                const fixes: Fix[] = [];
-                for (const failure of failures) {
-                    if (failure.hasFix()) {
-                        fixes.push(failure.getFix());
-                    }
-                }
+                const fixes = failures.filter(f => f.hasFix()).map(f => f.getFix());
                 newFileText = Fix.applyAll(fileTextWithoutMarkup, fixes);
             }
         } catch (e) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -122,11 +122,11 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
                 for (const failure of failures) {
                     const fixes = failure.getFixes();
                     if (fixes.length > 0) {
-                        replacements = replacements.concat(fixes[0].getReplacements());
+                        replacements = replacements.concat(fixes[0].replacements);
                     }
                 }
                 // sort in reverse so that diffs are properly applied
-                replacements.sort((a, b) => b.getEnd() - a.getEnd());
+                replacements.sort((a, b) => b.end - a.end);
                 newFileText = replacements.reduce((text, r) => r.apply(text), fileTextWithoutMarkup);
             }
         } catch (e) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -120,9 +120,9 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
                 // accumulate replacements
                 let replacements: Replacement[] = [];
                 for (const failure of failures) {
-                    const fixes = failure.getFixes();
-                    if (fixes.length > 0) {
-                        replacements = replacements.concat(fixes[0].replacements);
+                    if (failure.hasFix()) {
+                        const fix = failure.getFix();
+                        replacements = replacements.concat(fix.replacements);
                     }
                 }
                 // sort in reverse so that diffs are properly applied

--- a/test/check-bin.sh
+++ b/test/check-bin.sh
@@ -108,6 +108,13 @@ expectOut $? 0 "tslint --test did not exit correctly for a passing test with cus
 ./bin/tslint -r test/files/custom-rules-2 --test test/files/custom-rule-cli-rule-test
 expectOut $? 0 "tslint --test did not exit correctly for a passing test with custom rules from the CLI"
 
+# ensure --test command works correctly with fixes
+./bin/tslint --test test/files/fixes-test
+expectOut $? 0 "tslint --test did not exit correctly for a passing test with fixes"
+
+./bin/tslint --test test/files/incorrect-fixes-test
+expectOut $? 1 "tslint --test did not exit correctly for a failing test with fixes"
+
 # make sure tslint exits correctly when tsconfig is specified but no files are given
 ./bin/tslint -c test/files/tsconfig-test/tslint.json --project test/files/tsconfig-test/tsconfig.json
 expectOut $? 0 "tslint with tsconfig did not exit correctly"

--- a/test/files/fixes-test/test.ts.fix
+++ b/test/files/fixes-test/test.ts.fix
@@ -1,0 +1,9 @@
+var testVariable = "eval";
+
+function a() {
+    function b() {
+        function c() {
+            console.log("hi");
+        }
+    }
+}

--- a/test/files/fixes-test/test.ts.lint
+++ b/test/files/fixes-test/test.ts.lint
@@ -1,0 +1,11 @@
+var testVariable = "eval"
+                         ~nil [Missing semicolon]
+
+function a() {
+    function b() {
+        function c() {
+            console.log("hi")
+                             ~nil [Missing semicolon]
+        }
+    }
+}

--- a/test/files/fixes-test/tslint.json
+++ b/test/files/fixes-test/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "semicolon": [true, "always"]
+  }
+}

--- a/test/files/incorrect-fixes-test/test.ts.fix
+++ b/test/files/incorrect-fixes-test/test.ts.fix
@@ -1,0 +1,9 @@
+var testVariable = "eval";
+
+function a() {
+    function b() {
+        function c() {
+            console.log("hi")
+        }
+    }
+}

--- a/test/files/incorrect-fixes-test/test.ts.lint
+++ b/test/files/incorrect-fixes-test/test.ts.lint
@@ -1,0 +1,11 @@
+var testVariable = "eval"
+                         ~nil [Missing semicolon]
+
+function a() {
+    function b() {
+        function c() {
+            console.log("hi")
+                             ~nil [Missing semicolon]
+        }
+    }
+}

--- a/test/files/incorrect-fixes-test/tslint.json
+++ b/test/files/incorrect-fixes-test/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "semicolon": [true, "always"]
+  }
+}

--- a/test/formatters/jsonFormatterTests.ts
+++ b/test/formatters/jsonFormatterTests.ts
@@ -39,9 +39,10 @@ describe("JSON Formatter", () => {
         ];
 
         /* tslint:disable:object-literal-sort-keys */
-        const expectedResult = [{
+        const expectedResult: any = [{
             name: TEST_FILE,
             failure: "first failure",
+            fixes: [],
             startPosition: {
                 position: 0,
                 line: 0,
@@ -57,6 +58,7 @@ describe("JSON Formatter", () => {
         {
             name: TEST_FILE,
             failure: "last failure",
+            fixes: [],
             startPosition: {
                 position: maxPosition - 1,
                 line: 5,
@@ -72,6 +74,7 @@ describe("JSON Formatter", () => {
         {
             name: TEST_FILE,
             failure: "full failure",
+            fixes: [],
             startPosition: {
                 position: 0,
                 line: 0,

--- a/test/formatters/jsonFormatterTests.ts
+++ b/test/formatters/jsonFormatterTests.ts
@@ -16,7 +16,7 @@
 
 import * as ts from "typescript";
 
-import {IFormatter, RuleFailure, TestUtils} from "../lint";
+import {Fix, IFormatter, Replacement, RuleFailure, TestUtils} from "../lint";
 
 describe("JSON Formatter", () => {
     const TEST_FILE = "formatters/jsonFormatter.test.ts";
@@ -35,14 +35,16 @@ describe("JSON Formatter", () => {
         const failures = [
             new RuleFailure(sourceFile, 0, 1, "first failure", "first-name"),
             new RuleFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name"),
-            new RuleFailure(sourceFile, 0, maxPosition, "full failure", "full-name"),
+            new RuleFailure(sourceFile, 0, maxPosition, "full failure", "full-name",
+                new Fix("full-name", [
+                    new Replacement(0, 0, ""),
+                ])),
         ];
 
         /* tslint:disable:object-literal-sort-keys */
         const expectedResult: any = [{
             name: TEST_FILE,
             failure: "first failure",
-            fixes: [],
             startPosition: {
                 position: 0,
                 line: 0,
@@ -58,7 +60,6 @@ describe("JSON Formatter", () => {
         {
             name: TEST_FILE,
             failure: "last failure",
-            fixes: [],
             startPosition: {
                 position: maxPosition - 1,
                 line: 5,
@@ -74,7 +75,16 @@ describe("JSON Formatter", () => {
         {
             name: TEST_FILE,
             failure: "full failure",
-            fixes: [],
+            fix: {
+                innerReplacements: [
+                    {
+                        innerLength: 0,
+                        innerStart: 0,
+                        innerText: "",
+                    },
+                ],
+                innerRuleName: "full-name",
+            },
             startPosition: {
                 position: 0,
                 line: 0,

--- a/test/rules/semicolon/always/test.ts.fix
+++ b/test/rules/semicolon/always/test.ts.fix
@@ -1,0 +1,63 @@
+var x = 3;
+a += b;
+
+c = () => {
+};
+
+d = function() { };
+
+console.log("i am adam, am i?");
+
+function xyz() {
+    return;
+}
+
+switch(xyz) {
+    case 1:
+        break;
+    case 2:
+        continue;
+}
+
+throw new Error("some error");
+
+do {
+    var a = 4;
+} while(x == 3);
+
+debugger;
+
+import v = require("i");
+module M {
+    export var x;
+}
+
+function useStrictMissingSemicolon() {
+    "use strict";
+    return null;
+}
+
+class MyClass {
+    public name : string;
+    private index : number;
+    private email : string;
+
+    public initializedProperty = 6;
+    public initializedMethodProperty = () => { return "hi"; }
+}
+
+interface ITest {
+    foo?: string;
+    bar: number;
+    baz: boolean;
+}
+
+import {Router} from 'aurelia-router';
+
+import {Controller} from 'my-lib';
+
+export default LoginPage;
+export default LoginPage;
+export = Date;
+export = Date;
+

--- a/test/rules/semicolon/enabled/test.ts.fix
+++ b/test/rules/semicolon/enabled/test.ts.fix
@@ -1,0 +1,62 @@
+var x = 3;
+a += b;
+
+c = () => {
+};
+
+d = function() { };
+
+console.log("i am adam, am i?");
+
+function xyz() {
+    return;
+}
+
+switch(xyz) {
+    case 1:
+        break;
+    case 2:
+        continue;
+}
+
+throw new Error("some error");
+
+do {
+    var a = 4;
+} while(x == 3);
+
+debugger;
+
+import v = require("i");
+module M {
+    export var x;
+}
+
+function useStrictMissingSemicolon() {
+    "use strict";
+    return null;
+}
+
+class MyClass {
+    public name : string;
+    private index : number;
+    private email : string;
+
+    public initializedProperty = 6;
+    public initializedMethodProperty = () => { return "hi"; }
+}
+
+interface ITest {
+    foo?: string;
+    bar: number;
+    baz: boolean;
+}
+
+import {Router} from 'aurelia-router';
+
+import {Controller} from 'my-lib';
+
+export default LoginPage;
+export default LoginPage;
+export = Date;
+export = Date;

--- a/test/rules/semicolon/ignore-interfaces/test.ts.fix
+++ b/test/rules/semicolon/ignore-interfaces/test.ts.fix
@@ -1,0 +1,64 @@
+var x = 3;
+a += b;
+
+c = () => {
+};
+
+d = function() { };
+
+console.log("i am adam, am i?");
+
+function xyz() {
+    return;
+}
+
+switch(xyz) {
+    case 1:
+        break;
+    case 2:
+        continue;
+}
+
+throw new Error("some error");
+
+do {
+    var a = 4;
+} while(x == 3);
+
+debugger;
+
+import v = require("i");
+module M {
+    export var x;
+}
+
+function useStrictMissingSemicolon() {
+    "use strict";
+    return null;
+}
+
+class MyClass {
+    public name : string;
+    private index : number;
+    private email : string;
+
+    public initializedProperty = 6;
+    public initializedMethodProperty = () => { return "hi"; }
+}
+
+interface ITest {
+    foo?: string
+
+    bar: number
+
+    baz: boolean;
+}
+
+import {Router} from 'aurelia-router';
+
+import {Controller} from 'my-lib';
+
+export default LoginPage;
+export default LoginPage;
+export = Date;
+export = Date;

--- a/test/rules/semicolon/never/test.ts.fix
+++ b/test/rules/semicolon/never/test.ts.fix
@@ -1,0 +1,95 @@
+var x = 3
+a += b
+
+c = () => {
+}
+
+d = function() { }
+
+console.log("i am adam, am i?")
+
+function xyz() {
+    return
+}
+
+switch(xyz) {
+    case 1:
+        break
+    case 2:
+        continue
+}
+
+throw new Error("some error")
+
+do {
+    var a = 4
+} while(x == 3)
+
+debugger
+
+import v = require("i")
+module M {
+    export var x
+}
+
+function useStrictUnnecessarySemicolon() {
+    "use strict"
+    return null
+}
+
+class MyClass {
+    public name : string
+    private index : number
+    private email : string
+    public initializedProperty = 6
+    public initializedMethodProperty = () => { return "hi" }
+
+}
+
+interface ITest {
+    foo?: string
+    bar: number
+    baz: boolean
+}
+
+import {Router} from 'aurelia-router'
+
+import {Controller} from 'my-lib'
+
+// Edge cases when not omitting semicolon needs to be supported
+
+var a = 1;
+("1" + "2").length
+
+var a = 1;
+[].length
+
+var a = 1;
++"a"
+
+var a = 1;
+-1
+
+var a = 1
+;("1" + "2").length
+
+var a = 1
+;[].length
+
+var a = 1
+;+"a"
+
+var a = 1
+;-1
+
+// For loops uses semicolons as well so make sure we aren't breaking those
+
+for (var i = 0; i < 10; ++i) {
+  // do something
+}
+
+export default LoginPage
+export default LoginPage
+
+export = Date
+export = Date


### PR DESCRIPTION
* Created IFix and IReplacement structures for representing fixes
  * programWalker includes createFix and createReplacement
* Added optional parameter to createFailure for suggesting fixes
* Modified semicolon rule to suggest fixes (add / remove semicolon)
* Modified testing to check against a file with fixes applied
  * If there is a ".ts.fix" file, then the test will take the first suggested fix and apply to the test file (without markup) and compare

Addresses #561