### PR TITLE
Added additional type constraint for findFormatter function parameter

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -42,19 +42,19 @@ export var Utils = utils;
 export interface LintResult {
     failureCount: number;
     failures: RuleFailure[];
-    format: string;
+    format: string | Function;
     output: string;
 }
 
 export interface ILinterOptionsRaw {
     configuration?: any;
-    formatter?: string;
+    formatter?: string | Function;
     formattersDirectory?: string;
     rulesDirectory?: string | string[];
 }
 
 export interface ILinterOptions extends ILinterOptionsRaw {
     configuration: any;
-    formatter: string;
+    formatter: string | Function;
     rulesDirectory: string | string[];
 }


### PR DESCRIPTION
I've added added additional type constraint for `formatter` in ILinterOptionsRaw interface and `findFormatter` function parameter name as it accepts the type Function, but was constrained to `string` only.