### PR TITLE
arrow-parens rule shouldn't warn against generics

### DIFF
--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -49,8 +49,14 @@ class ArrowParensWalker extends Lint.RuleWalker {
             const lastToken = node.getChildAt(2);
             const width = text.length;
             const position = parameter.getStart();
+            let isGenerics = false;
 
-            if (firstToken.kind !== ts.SyntaxKind.OpenParenToken || lastToken.kind !== ts.SyntaxKind.CloseParenToken) {
+            // If firstToken is LessThanToken, it would be Generics.
+            if (firstToken.kind === ts.SyntaxKind.LessThanToken) {
+                isGenerics = true;
+            }
+
+            if ((firstToken.kind !== ts.SyntaxKind.OpenParenToken || lastToken.kind !== ts.SyntaxKind.CloseParenToken) && !isGenerics) {
                 this.addFailure(this.createFailure(position, width, Rule.FAILURE_STRING));
             }
         }

--- a/test/rules/arrow-parens/test.ts.lint
+++ b/test/rules/arrow-parens/test.ts.lint
@@ -7,6 +7,18 @@ var f = a: number => {}; // TSLint don't warn. But syntax is wrong.
 class Foo {
     a: (a) =>{}
 }
+var bar = <T>(method: () => T) => {
+    method();
+};
+var barbar = <T>(method: (a: any) => T) => {
+    method("");
+};
+var barbarbar = <T>(method: (a) => T) => {
+    method("");
+};
+var piyo = <T, U>(method: () => T) => {
+    method();
+};
 
 // invalid case
 var e = (a => {})(1);


### PR DESCRIPTION
fix #1442 