### PR TITLE
Allow source imports to be evaluated similar to named imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ node_modules/
 tscommand*.txt
 # created by grunt-ts for faster compiling
 typings/.basedir.ts
+
+# vim swap files
+*.swo
+*.swp

--- a/test/rules/ordered-imports/case-insensitive/test.ts.lint
+++ b/test/rules/ordered-imports/case-insensitive/test.ts.lint
@@ -9,7 +9,7 @@ import {b, A, C} from 'foo'; // failure
         ~~~~                            [ordered-imports]
 
 
-// Source imports should be alphabetized.
+// Import sources should be alphabetized.
 import * as bar from 'bar';
 import * as foo from 'foo';
 
@@ -29,4 +29,4 @@ import someDefault from "module";
 import "something";
 
 [ordered-imports]: Named imports must be alphabetized.
-[ordered-sources]: Source imports within a group must be alphabetized.
+[ordered-sources]: Import sources within a group must be alphabetized.

--- a/test/rules/ordered-imports/case-insensitive/test.ts.lint
+++ b/test/rules/ordered-imports/case-insensitive/test.ts.lint
@@ -9,7 +9,7 @@ import {b, A, C} from 'foo'; // failure
         ~~~~                            [ordered-imports]
 
 
-// Import sources should be alphabetized.
+// Source imports should be alphabetized.
 import * as bar from 'bar';
 import * as foo from 'foo';
 
@@ -18,6 +18,10 @@ import * as foo from 'foo';
 import * as bar from 'bar'; // failure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~            [ordered-sources]
 
+// Case is irrelevant for source import ordering.
+import {A, B} from 'Bar';
+import {A, B} from 'baz';
+import {A, B} from 'Foo'; // should not fail
 
 // Other styles of import statements.
 import someDefault, {nameA, nameBReallyLong as anotherName} from "./wherever";
@@ -25,4 +29,4 @@ import someDefault from "module";
 import "something";
 
 [ordered-imports]: Named imports must be alphabetized.
-[ordered-sources]: Import sources within a group must be alphabetized.
+[ordered-sources]: Source imports within a group must be alphabetized.

--- a/test/rules/ordered-imports/lowercase-first/test.ts.lint
+++ b/test/rules/ordered-imports/lowercase-first/test.ts.lint
@@ -8,8 +8,7 @@ import {b, A, C} from 'foo';
 import {A, b, C} from 'foo'; // failure
         ~~~~                            [ordered-imports]
 
-
-// Import sources should be alphabetized.
+// Source imports should be alphabetized.
 import * as bar from 'bar';
 import * as foo from 'foo';
 
@@ -18,6 +17,11 @@ import * as foo from 'foo';
 import * as bar from 'bar'; // failure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~            [ordered-sources]
 
+// Lowercase comes before uppercase
+import {A, B} from 'Bar';
+import {A, B} from 'baz';
+~~~~~~~~~~~~~~~~~~~~~~~~~ [ordered-sources]
+import {A, B} from 'Foo';
 
 // Other styles of import statements.
 import someDefault, {nameA, nameBReallyLong as anotherName} from "./wherever";
@@ -25,4 +29,4 @@ import someDefault from "module";
 import "something";
 
 [ordered-imports]: Named imports must be alphabetized.
-[ordered-sources]: Import sources within a group must be alphabetized.
+[ordered-sources]: Source imports within a group must be alphabetized.

--- a/test/rules/ordered-imports/lowercase-first/test.ts.lint
+++ b/test/rules/ordered-imports/lowercase-first/test.ts.lint
@@ -8,7 +8,7 @@ import {b, A, C} from 'foo';
 import {A, b, C} from 'foo'; // failure
         ~~~~                            [ordered-imports]
 
-// Source imports should be alphabetized.
+// Import sources should be alphabetized.
 import * as bar from 'bar';
 import * as foo from 'foo';
 
@@ -29,4 +29,4 @@ import someDefault from "module";
 import "something";
 
 [ordered-imports]: Named imports must be alphabetized.
-[ordered-sources]: Source imports within a group must be alphabetized.
+[ordered-sources]: Import sources within a group must be alphabetized.

--- a/test/rules/ordered-imports/lowercase-first/tslint.json
+++ b/test/rules/ordered-imports/lowercase-first/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "ordered-imports": [true, {"named-imports-order": "lowercase-first", "source-imports-order": "lowercase-first"}]
+    "ordered-imports": [true, {"import-sources-order": "lowercase-first", "named-imports-order": "lowercase-first"}]
   }
 }

--- a/test/rules/ordered-imports/lowercase-first/tslint.json
+++ b/test/rules/ordered-imports/lowercase-first/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "ordered-imports": [true, {"named-imports-order": "lowercase-first"}]
+    "ordered-imports": [true, {"named-imports-order": "lowercase-first", "source-imports-order": "lowercase-first"}]
   }
 }


### PR DESCRIPTION
This fixes #1431 