### PR TITLE
Fix typo in whitespace rule enum

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -48,7 +48,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             items: {
                 type: "string",
                 enum: ["check-branch", "check-decl", "check-operator", "check-module",
-                       "check-seperator", "check-type", "check-typecast"],
+                       "check-separator", "check-type", "check-typecast"],
             },
             minLength: 0,
             maxLength: 7,


### PR DESCRIPTION
This change fixes a typo in `check-separator` option of whitespace rule.