### PR TITLE
Update no-var-keyword to dissalow var in export statements (fixes #1256)

### DIFF
--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -42,9 +42,9 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoVarKeywordWalker extends Lint.RuleWalker {
     public visitVariableStatement(node: ts.VariableStatement) {
-        if (!Lint.hasModifier(node.modifiers, ts.SyntaxKind.ExportKeyword, ts.SyntaxKind.DeclareKeyword)
+        if (!Lint.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
                 && !Lint.isBlockScopedVariable(node)) {
-            this.addFailure(this.createFailure(node.getStart(), "var".length, Rule.FAILURE_STRING));
+            this.addFailure(this.createFailure(node.declarationList.getStart(), "var".length, Rule.FAILURE_STRING));
         }
 
         super.visitVariableStatement(node);

--- a/test/rules/no-var-keyword/test.ts.lint
+++ b/test/rules/no-var-keyword/test.ts.lint
@@ -20,6 +20,21 @@ for (var n1 in foo);
 for (var n2 of foo);
      ~~~             [Forbidden 'var' keyword, use 'let' or 'const' instead]
 
+export var exportVar0 = 0;
+       ~~~                 [Forbidden 'var' keyword, use 'let' or 'const' instead]
+export   var  exportVar1 = 1;
+         ~~~                  [Forbidden 'var' keyword, use 'let' or 'const' instead]
+export   var  exportVar2 = 2,
+         ~~~                  [Forbidden 'var' keyword, use 'let' or 'const' instead]
+         exportVar21 = 21;
+export /* var tst */ var   exportVar3 = 3;
+                     ~~~                   [Forbidden 'var' keyword, use 'let' or 'const' instead]
+
+module quz {
+    export var i;
+           ~~~    [Forbidden 'var' keyword, use 'let' or 'const' instead]
+}
+
 declare var tmp2: any;
 
 let bar;
@@ -27,10 +42,6 @@ const qux;
 
 let k,
     l;
-
-module quz {
-    export var i;
-}
 
 let [x, y] = [1, 2];
 
@@ -40,3 +51,6 @@ for (let name in foo);
 for (let name of foo);
 for (const name in foo);
 for (const name of foo);
+
+export let exportLet = 1;
+export const exportConst = 1;


### PR DESCRIPTION
Fixes #1256

Test cases with extra whitespaces and comment added to ensure that new way to determine start of `var` keyword works correctly.

Also this is breaking changes and required update to mark one of previously existing test as failure ([line 35](https://github.com/palantir/tslint/commit/b4c2264e8e5dccb100b725a1cb96b3a3206de984#diff-94e704c2977ef54f582abd0ea7f9599dR35)).
One possible solution is to add argument `"allow-in-exports"` which will provide backward compatibility.