### PR TITLE
Require semicolon for type alias

### DIFF
--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -286,6 +286,10 @@ export class SyntaxWalker {
         this.walkChildren(node);
     }
 
+    protected visitTypeAliasDeclaration(node: ts.TypeAliasDeclaration) {
+        this.walkChildren(node);
+    }
+
     protected visitTypeAssertionExpression(node: ts.TypeAssertion) {
         this.walkChildren(node);
     }
@@ -582,6 +586,10 @@ export class SyntaxWalker {
 
             case ts.SyntaxKind.TryStatement:
                 this.visitTryStatement(<ts.TryStatement> node);
+                break;
+
+            case ts.SyntaxKind.TypeAliasDeclaration:
+                this.visitTypeAliasDeclaration(<ts.TypeAliasDeclaration> node);
                 break;
 
             case ts.SyntaxKind.TypeAssertionExpression:

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -140,6 +140,11 @@ class SemicolonWalker extends Lint.RuleWalker {
         super.visitExportAssignment(node);
     }
 
+    public visitTypeAliasDeclaration(node: ts.TypeAliasDeclaration) {
+        this.checkSemicolonAt(node);
+        super.visitTypeAliasDeclaration(node);
+    }
+
     private checkSemicolonAt(node: ts.Node) {
         const sourceFile = this.getSourceFile();
         const children = node.getChildren(sourceFile);

--- a/test/rules/semicolon/always/test.ts.lint
+++ b/test/rules/semicolon/always/test.ts.lint
@@ -84,3 +84,6 @@ export = Date;
 export = Date
              ~nil [Missing semicolon]
 
+type t = number;
+type t = number
+               ~nil [Missing semicolon]

--- a/test/rules/semicolon/enabled/test.ts.lint
+++ b/test/rules/semicolon/enabled/test.ts.lint
@@ -83,3 +83,7 @@ export default LoginPage
 export = Date;
 export = Date
              ~nil [Missing semicolon]
+
+type t = number;
+type t = number
+               ~nil [Missing semicolon]

--- a/test/rules/semicolon/ignore-interfaces/test.ts.lint
+++ b/test/rules/semicolon/ignore-interfaces/test.ts.lint
@@ -83,3 +83,7 @@ export default LoginPage
 export = Date;
 export = Date
              ~nil [Missing semicolon]
+
+type t = number;
+type t = number
+               ~nil [Missing semicolon]

--- a/test/rules/semicolon/never/test.ts.lint
+++ b/test/rules/semicolon/never/test.ts.lint
@@ -116,3 +116,7 @@ export default LoginPage
 export = Date;
              ~ [Unnecessary semicolon]
 export = Date
+
+type t = number;
+               ~ [Unnecessary semicolon]
+type t = number


### PR DESCRIPTION
This would require all `type t = foo;` to end with a semicolon.