### PR TITLE
Revert "Require semicolon for type alias"

### DIFF
--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -286,10 +286,6 @@ export class SyntaxWalker {
         this.walkChildren(node);
     }
 
-    protected visitTypeAliasDeclaration(node: ts.TypeAliasDeclaration) {
-        this.walkChildren(node);
-    }
-
     protected visitTypeAssertionExpression(node: ts.TypeAssertion) {
         this.walkChildren(node);
     }
@@ -586,10 +582,6 @@ export class SyntaxWalker {
 
             case ts.SyntaxKind.TryStatement:
                 this.visitTryStatement(<ts.TryStatement> node);
-                break;
-
-            case ts.SyntaxKind.TypeAliasDeclaration:
-                this.visitTypeAliasDeclaration(<ts.TypeAliasDeclaration> node);
                 break;
 
             case ts.SyntaxKind.TypeAssertionExpression:

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -140,11 +140,6 @@ class SemicolonWalker extends Lint.RuleWalker {
         super.visitExportAssignment(node);
     }
 
-    public visitTypeAliasDeclaration(node: ts.TypeAliasDeclaration) {
-        this.checkSemicolonAt(node);
-        super.visitTypeAliasDeclaration(node);
-    }
-
     private checkSemicolonAt(node: ts.Node) {
         const sourceFile = this.getSourceFile();
         const children = node.getChildren(sourceFile);

--- a/test/rules/semicolon/always/test.ts.lint
+++ b/test/rules/semicolon/always/test.ts.lint
@@ -84,6 +84,3 @@ export = Date;
 export = Date
              ~nil [Missing semicolon]
 
-type t = number;
-type t = number
-               ~nil [Missing semicolon]

--- a/test/rules/semicolon/enabled/test.ts.lint
+++ b/test/rules/semicolon/enabled/test.ts.lint
@@ -83,7 +83,3 @@ export default LoginPage
 export = Date;
 export = Date
              ~nil [Missing semicolon]
-
-type t = number;
-type t = number
-               ~nil [Missing semicolon]

--- a/test/rules/semicolon/ignore-interfaces/test.ts.lint
+++ b/test/rules/semicolon/ignore-interfaces/test.ts.lint
@@ -83,7 +83,3 @@ export default LoginPage
 export = Date;
 export = Date
              ~nil [Missing semicolon]
-
-type t = number;
-type t = number
-               ~nil [Missing semicolon]

--- a/test/rules/semicolon/never/test.ts.lint
+++ b/test/rules/semicolon/never/test.ts.lint
@@ -116,7 +116,3 @@ export default LoginPage
 export = Date;
              ~ [Unnecessary semicolon]
 export = Date
-
-type t = number;
-               ~ [Unnecessary semicolon]
-type t = number


### PR DESCRIPTION
Reverts palantir/tslint#1475

Reverting this temporarily, as #1475 was a breaking change and we're experiencing some weirdness with tests.