### PR TITLE
arrow-parens: fix async case

### DIFF
--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -56,7 +56,8 @@ class ArrowParensWalker extends Lint.RuleWalker {
                 isGenerics = true;
             }
 
-            if ((firstToken.kind !== ts.SyntaxKind.OpenParenToken || lastToken.kind !== ts.SyntaxKind.CloseParenToken) && !isGenerics) {
+            if ((firstToken.kind !== ts.SyntaxKind.OpenParenToken || lastToken.kind !== ts.SyntaxKind.CloseParenToken)
+                 && !isGenerics && node.flags !== ts.NodeFlags.Async) {
                 this.addFailure(this.createFailure(position, width, Rule.FAILURE_STRING));
             }
         }

--- a/test/rules/arrow-parens/test.ts.lint
+++ b/test/rules/arrow-parens/test.ts.lint
@@ -27,6 +27,3 @@ var e = (a => {})(1);
          ~            [Parentheses are required around the parameters of an arrow function definition]
 var f = a => {};
         ~             [Parentheses are required around the parameters of an arrow function definition]
-
-// I think should warn following case, but I have no idea to validate this. 
-const invalidAsync = async param => {};

--- a/test/rules/arrow-parens/test.ts.lint
+++ b/test/rules/arrow-parens/test.ts.lint
@@ -19,6 +19,8 @@ var barbarbar = <T>(method: (a) => T) => {
 var piyo = <T, U>(method: () => T) => {
     method();
 };
+const validAsync = async (param: any) => {};
+const validAsync = async (param) => {};
 
 // invalid case
 var e = (a => {})(1);

--- a/test/rules/arrow-parens/test.ts.lint
+++ b/test/rules/arrow-parens/test.ts.lint
@@ -25,3 +25,6 @@ var e = (a => {})(1);
          ~            [Parentheses are required around the parameters of an arrow function definition]
 var f = a => {};
         ~             [Parentheses are required around the parameters of an arrow function definition]
+
+// I think should warn following case, but I have no idea to validate this. 
+const invalidAsync = async param => {};


### PR DESCRIPTION
fix #1458 

I resolve following case.

```ts
const validAsync = async (param: any) => {};
const validAsync = async (param) => {};
```

I think should warn following case, but I have no idea to validate this. 
Do you have any Idea?

`const invalidAsync = async param => {};`
