### PR TITLE
Improve an error message on invalid source file

### DIFF
--- a/src/tslint.ts
+++ b/src/tslint.ts
@@ -91,6 +91,10 @@ class Linter {
             sourceFile = getSourceFile(this.fileName, this.source);
         }
 
+        if (sourceFile === undefined) {
+            throw new Error(`Invalid source file: ${this.fileName}. Ensure that the files supplied to lint have a .ts or .tsx extension.`);
+        }
+
         // walk the code first to find all the intervals where rules are disabled
         const rulesWalker = new EnableDisableRulesWalker(sourceFile, {
             disabledIntervals: [],


### PR DESCRIPTION
When input file is not a TypeScript code, `getSourceFile()` returns`undefined` but tslint doesn't handle it properly.  As the result, tslint raises an error which is not easy to understand when invalid soruce file is passed.

```
$ tslint mocha.opts
```

It raised below error:

```
/path/to/node_modules/tslint/lib/language/walker/ruleWalker.js:18
        this.limit = this.sourceFile.getFullWidth();
```

I improved this error message by checking returned value from `getSourceFile` is valid or not. Improved error message is below:

```
Error: Invalid source code: test/mocha.opts
```

I didn't write a test for this yet because I couldn't find where I should add tests for `src/tslint.ts`.