### PR TITLE
Trailing comma rule now encompasses function decls, exprs and types

### DIFF
--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -86,6 +86,10 @@ export class SyntaxWalker {
         this.walkChildren(node);
     }
 
+    protected visitConstructSignature(node: ts.ConstructSignatureDeclaration) {
+        this.walkChildren(node);
+    }
+
     protected visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
         this.walkChildren(node);
     }
@@ -394,6 +398,10 @@ export class SyntaxWalker {
 
             case ts.SyntaxKind.ConditionalExpression:
                 this.visitConditionalExpression(<ts.ConditionalExpression> node);
+                break;
+
+            case ts.SyntaxKind.ConstructSignature:
+                this.visitConstructSignature(<ts.ConstructSignatureDeclaration> node);
                 break;
 
             case ts.SyntaxKind.Constructor:

--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -294,6 +294,10 @@ export class SyntaxWalker {
         this.walkChildren(node);
     }
 
+    protected visitTupleType(node: ts.TupleTypeNode) {
+        this.walkChildren(node);
+    }
+
     protected visitTypeAliasDeclaration(node: ts.TypeAliasDeclaration) {
         this.walkChildren(node);
     }
@@ -602,6 +606,10 @@ export class SyntaxWalker {
 
             case ts.SyntaxKind.TryStatement:
                 this.visitTryStatement(<ts.TryStatement> node);
+                break;
+
+            case ts.SyntaxKind.TupleType:
+                this.visitTupleType(<ts.TupleTypeNode> node);
                 break;
 
             case ts.SyntaxKind.TypeAliasDeclaration:

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -65,65 +65,129 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class TrailingCommaWalker extends Lint.RuleWalker {
+    private static SYNTAX_LIST_WRAPPER_TOKENS: [ts.SyntaxKind, ts.SyntaxKind][] = [
+        [ts.SyntaxKind.OpenBracketToken, ts.SyntaxKind.CloseBracketToken],
+        [ts.SyntaxKind.OpenParenToken, ts.SyntaxKind.CloseParenToken],
+        [ts.SyntaxKind.LessThanToken, ts.SyntaxKind.GreaterThanToken],
+    ];
+
     public visitArrayLiteralExpression(node: ts.ArrayLiteralExpression) {
-        this.lintNode(node, 1);
+        this.lintChildNodeWithIndex(node, 1);
         super.visitArrayLiteralExpression(node);
     }
 
     public visitArrowFunction(node: ts.FunctionLikeDeclaration) {
-        this.lintNode(node, 1);
+        this.lintChildNodeWithIndex(node, 1);
         super.visitArrowFunction(node);
     }
 
     public visitBindingPattern(node: ts.BindingPattern) {
         if (node.kind === ts.SyntaxKind.ArrayBindingPattern || node.kind === ts.SyntaxKind.ObjectBindingPattern) {
-            this.lintNode(node, 1);
+            this.lintChildNodeWithIndex(node, 1);
         }
         super.visitBindingPattern(node);
     }
 
+    public visitCallExpression(node: ts.CallExpression) {
+        this.lintNode(node);
+        super.visitCallExpression(node);
+    }
+
+    public visitClassDeclaration(node: ts.ClassDeclaration) {
+        this.lintNode(node);
+        super.visitClassDeclaration(node);
+    }
+
+    public visitConstructSignature(node: ts.ConstructSignatureDeclaration) {
+        this.lintNode(node);
+        super.visitConstructSignature(node);
+    }
+
+    public visitConstructorDeclaration(node: ts.ConstructorDeclaration) {
+        this.lintNode(node);
+        super.visitConstructorDeclaration(node);
+    }
+
+    public visitConstructorType(node: ts.FunctionOrConstructorTypeNode) {
+        this.lintNode(node);
+        super.visitConstructorType(node);
+    }
+
     public visitFunctionType(node: ts.FunctionOrConstructorTypeNode) {
-        this.lintNode(node, 1);
+        this.lintChildNodeWithIndex(node, 1);
         super.visitFunctionType(node);
     }
 
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-        this.visitFunctionLikeNode(node);
+        this.lintNode(node);
         super.visitFunctionDeclaration(node);
     }
 
     public visitFunctionExpression(node: ts.FunctionExpression) {
-        this.visitFunctionLikeNode(node);
+        this.lintNode(node);
         super.visitFunctionExpression(node);
     }
 
+    public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
+        this.lintNode(node);
+        super.visitInterfaceDeclaration(node);
+    }
+
+    public visitMethodDeclaration(node: ts.MethodDeclaration) {
+        this.lintNode(node);
+        super.visitMethodDeclaration(node);
+    }
+
+    public visitMethodSignature(node: ts.SignatureDeclaration) {
+        this.lintNode(node);
+        super.visitMethodSignature(node);
+    }
+
     public visitNamedImports(node: ts.NamedImports) {
-        this.lintNode(node, 1);
+        this.lintChildNodeWithIndex(node, 1);
         super.visitNamedImports(node);
     }
 
     public visitObjectLiteralExpression(node: ts.ObjectLiteralExpression) {
-        this.lintNode(node, 1);
+        this.lintChildNodeWithIndex(node, 1);
         super.visitObjectLiteralExpression(node);
     }
 
+    public visitSetAccessor(node: ts.AccessorDeclaration) {
+        this.lintNode(node);
+        super.visitSetAccessor(node);
+    }
+
     public visitTupleType(node: ts.TupleTypeNode) {
-        this.lintNode(node, 1);
+        this.lintChildNodeWithIndex(node, 1);
         super.visitTupleType(node);
     }
 
-    private visitFunctionLikeNode(node: ts.Node) {
+    public visitTypeLiteral(node: ts.TypeLiteralNode) {
+        this.lintNode(node);
+        super.visitTypeLiteral(node);
+    }
+
+    public visitTypeReference(node: ts.TypeReferenceNode) {
+        this.lintNode(node);
+        super.visitTypeReference(node);
+    }
+
+    private lintNode(node: ts.Node) {
         const children = node.getChildren();
+
         for (let i = 0; i < children.length - 2; i++) {
-            if (children[i].kind === ts.SyntaxKind.OpenParenToken &&
-                children[i + 1].kind === ts.SyntaxKind.SyntaxList &&
-                children[i + 2].kind === ts.SyntaxKind.CloseParenToken) {
-                this.lintNode(node, i + 1);
-            }
+            TrailingCommaWalker.SYNTAX_LIST_WRAPPER_TOKENS.forEach(([openToken, closeToken]) => {
+                if (children[i].kind === openToken &&
+                    children[i + 1].kind === ts.SyntaxKind.SyntaxList &&
+                    children[i + 2].kind === closeToken) {
+                    this.lintChildNodeWithIndex(node, i + 1);
+                }
+            });
         }
     }
 
-    private lintNode(node: ts.Node, childNodeIndex: number) {
+    private lintChildNodeWithIndex(node: ts.Node, childNodeIndex: number) {
         const child = node.getChildAt(childNodeIndex);
         if (child != null && child.kind === ts.SyntaxKind.SyntaxList) {
             const grandChildren = child.getChildren();

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -23,7 +23,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "trailing-comma",
-        description: "Requires or disallows trailing commas in array and object literals, destructuring assignments and named imports.",
+        description: Lint.Utils.dedent`
+            Requires or disallows trailing commas in array and object literals, destructuring assignments, function and tuple typings,
+            named imports and function parameters.`,
         optionsDescription: Lint.Utils.dedent`
             One argument which is an object with the keys \`multiline\` and \`singleline\`.
             Both should be set to either \`"always"\` or \`"never"\`.
@@ -33,7 +35,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
             A array is considered "multiline" if its closing bracket is on a line
             after the last array element. The same general logic is followed for
-            object literals and named import statements.`,
+            object literals, function and tuple typings, named import statements
+            and function parameters.`,
         options: {
             type: "object",
             properties: {
@@ -63,29 +66,65 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class TrailingCommaWalker extends Lint.RuleWalker {
     public visitArrayLiteralExpression(node: ts.ArrayLiteralExpression) {
-        this.lintNode(node);
+        this.lintNode(node, 1);
         super.visitArrayLiteralExpression(node);
+    }
+
+    public visitArrowFunction(node: ts.FunctionLikeDeclaration) {
+        this.lintNode(node, 1);
+        super.visitArrowFunction(node);
     }
 
     public visitBindingPattern(node: ts.BindingPattern) {
         if (node.kind === ts.SyntaxKind.ArrayBindingPattern || node.kind === ts.SyntaxKind.ObjectBindingPattern) {
-            this.lintNode(node);
+            this.lintNode(node, 1);
         }
         super.visitBindingPattern(node);
     }
 
+    public visitFunctionType(node: ts.FunctionOrConstructorTypeNode) {
+        this.lintNode(node, 1);
+        super.visitFunctionType(node);
+    }
+
+    public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
+        this.visitFunctionLikeNode(node);
+        super.visitFunctionDeclaration(node);
+    }
+
+    public visitFunctionExpression(node: ts.FunctionExpression) {
+        this.visitFunctionLikeNode(node);
+        super.visitFunctionExpression(node);
+    }
+
     public visitNamedImports(node: ts.NamedImports) {
-        this.lintNode(node);
+        this.lintNode(node, 1);
         super.visitNamedImports(node);
     }
 
     public visitObjectLiteralExpression(node: ts.ObjectLiteralExpression) {
-        this.lintNode(node);
+        this.lintNode(node, 1);
         super.visitObjectLiteralExpression(node);
     }
 
-    private lintNode(node: ts.Node) {
-        const child = node.getChildAt(1);
+    public visitTupleType(node: ts.TupleTypeNode) {
+        this.lintNode(node, 1);
+        super.visitTupleType(node);
+    }
+
+    private visitFunctionLikeNode(node: ts.Node) {
+        const children = node.getChildren();
+        for (let i = 0; i < children.length - 2; i++) {
+            if (children[i].kind === ts.SyntaxKind.OpenParenToken &&
+                children[i + 1].kind === ts.SyntaxKind.SyntaxList &&
+                children[i + 2].kind === ts.SyntaxKind.CloseParenToken) {
+                this.lintNode(node, i + 1);
+            }
+        }
+    }
+
+    private lintNode(node: ts.Node, childNodeIndex: number) {
+        const child = node.getChildAt(childNodeIndex);
         if (child != null && child.kind === ts.SyntaxKind.SyntaxList) {
             const grandChildren = child.getChildren();
 
@@ -93,9 +132,13 @@ class TrailingCommaWalker extends Lint.RuleWalker {
                 const lastGrandChild = grandChildren[grandChildren.length - 1];
                 const hasTrailingComma = lastGrandChild.kind === ts.SyntaxKind.CommaToken;
 
-                const endLineOfNode = this.getSourceFile().getLineAndCharacterOfPosition(node.getEnd()).line;
                 const endLineOfLastElement = this.getSourceFile().getLineAndCharacterOfPosition(lastGrandChild.getEnd()).line;
-                const isMultiline = endLineOfNode !== endLineOfLastElement;
+                let closingElementNode = node.getChildAt(childNodeIndex + 1);
+                if (closingElementNode == null) {
+                    closingElementNode = node;
+                }
+                const endLineOfClosingElement = this.getSourceFile().getLineAndCharacterOfPosition(closingElementNode.getEnd()).line;
+                const isMultiline = endLineOfClosingElement !== endLineOfLastElement;
                 const option = this.getOption(isMultiline ? "multiline" : "singleline");
 
                 if (hasTrailingComma && option === "never") {

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -293,6 +293,48 @@ var x = foo(
     43,
 );
 
+var x = new Test("foo");
+
+var x = new Test("foo",);
+
+var x = new Test(
+    "foo"
+        ~ [Missing trailing comma]
+);
+
+var x = new Test(
+    "foo",
+);
+
+var x: { foo: string; bar: string };
+
+var x: { foo: string; bar: string; };
+
+var x: {
+    foo: string;
+    bar: string
+};
+
+var x: {
+    foo: string;
+    bar: string;
+};
+
+var x: { foo: string, bar: string };
+
+var x: { foo: string, bar: string, };
+
+var x: {
+    foo: string,
+    bar: string
+              ~ [Missing trailing comma]
+};
+
+var x: {
+    foo: string,
+    bar: string,
+};
+
 class Test<A, B, C> {
 
     constructor(bar: string) { }
@@ -509,4 +551,34 @@ interface ITest4<
     B,
     C,
 > { }
+
+enum Foo { BAR, BAZ }
+
+enum Foo { BAR, BAZ, }
+
+enum Foo {
+    Bar,
+    Baz
+      ~ [Missing trailing comma]
+}
+
+enum Foo {
+    Bar,
+    Baz,
+}
+
+const enum Foo { BAR = 1, BAZ = 2 }
+
+const enum Foo { BAR = 1, BAZ = 2, }
+
+const enum Foo {
+    Bar = 1,
+    Baz = 2
+          ~ [Missing trailing comma]
+}
+
+const enum Foo {
+    Bar = 1,
+    Baz = 2,
+}
 

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -113,6 +113,21 @@ var [ccA, ccB,] = cc;
 
 var [ddOne, ddTwo] = dd;
 
+var a: [string, number] = null;
+
+var a: [string, number,] = null;
+
+var a: [
+    string,
+    number
+         ~ [Missing trailing comma]
+] = null;
+
+var a: [
+    string,
+    number,
+] = null;
+
 import {
     ClassS,
 } from "module";
@@ -136,3 +151,115 @@ import {
 import {ClassA, ClassB,} from "module";
 
 import {ClassC, ClassD} from "module";
+
+function foo(bar: string, baz: string);
+
+function foo(bar: string, baz: string,);
+
+function foo(
+    bar: string,
+    baz: string
+              ~ [Missing trailing comma]
+);
+
+function foo(
+    bar: string,
+    baz: string,
+);
+
+var foo = function(bar: string, baz: string) { return 42; };
+
+var foo = function(bar: string, baz: string,) { return 42; };
+
+var foo = function(
+    bar: string,
+    baz: string
+              ~ [Missing trailing comma]
+) {
+    return 42;
+};
+
+var foo = function(
+    bar: string,
+    baz: string,
+) {
+    return 42;
+};
+
+function foo(bar: string, baz: string) { return 42; }
+
+function foo(bar: string, baz: string,) { return 42; }
+
+function foo(
+    bar: string,
+    baz: string
+              ~ [Missing trailing comma]
+) {
+    return 42;
+}
+
+function foo(
+    bar: string,
+    baz: string,
+) {
+    return 42;
+}
+
+function foo(bar: string, baz: string,
+    ack: string
+              ~ [Missing trailing comma]
+) {
+    return 42;
+}
+
+function foo(bar: string, baz: string,
+    ack: string,
+) {
+    return 42;
+}
+
+var foo = (bar: string, baz: string) => 42;
+
+var foo = (bar: string, baz: string,) => 42;
+
+var foo = (
+    bar: string,
+    baz: string
+              ~ [Missing trailing comma]
+) => 42;
+
+var foo = (
+    bar: string,
+    baz: string,
+) => 42;
+
+var foo: (bar: string, baz: string) => number = null;
+
+var foo: (bar: string, baz: string,) => number = null;
+
+var foo: (
+    bar: string,
+    baz: string
+              ~ [Missing trailing comma]
+) => number = null;
+
+var foo: (
+    bar: string,
+    baz: string,
+) => number = null;
+
+var foo: (bar: string, baz: string) => number;
+
+var foo: (bar: string, baz: string,) => number;
+
+var foo: (
+    bar: string,
+    baz: string
+              ~ [Missing trailing comma]
+) => number;
+
+var foo: (
+    bar: string,
+    baz: string,
+) => number
+

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -261,5 +261,252 @@ var foo: (
 var foo: (
     bar: string,
     baz: string,
-) => number
+) => number;
+
+var foo: new (bar: string, baz: string) => Test;
+
+var foo: new (bar: string, baz: string,) => Test;
+
+var foo: new (
+    bar: string,
+    baz: string
+              ~ [Missing trailing comma]
+) => Test;
+
+var foo: new (
+    bar: string,
+    baz: string,
+) => Test;
+
+var x = foo(42, 43);
+
+var x = foo(42, 43,);
+
+var x = foo(
+    42,
+    43
+     ~ [Missing trailing comma]
+);
+
+var x = foo(
+    42,
+    43,
+);
+
+class Test<A, B, C> {
+
+    constructor(bar: string) { }
+
+    constructor(bar: string, baz: string,) { }
+
+    constructor(
+        bar: string,
+        baz: string,
+        ack: string
+                  ~ [Missing trailing comma]
+    ) { }
+
+    constructor(
+        bar: string,
+        baz: string,
+        ack: string,
+        foo: string,
+    ) { }
+
+    public foo(bar: string, baz: string) {
+        return 42;
+    }
+
+    private foo2(bar: string, baz: string,) {
+        return 42;
+    }
+
+    public static foo3(
+        bar: string,
+        baz: string
+                  ~ [Missing trailing comma]
+    ) {
+        return 42;
+    }
+
+    private static foo4(
+        bar: string,
+        baz: string,
+    ) {
+        return 42;
+    }
+
+    foo5<
+        T extends Test<[A, A], [A, A,], A>,
+        U extends Test<B, B, B,>,
+        V extends Test<
+            [
+                C,
+                C
+                ~ [Missing trailing comma]
+            ],
+            [
+                C,
+                C,
+            ]
+            C
+            ~ [Missing trailing comma]
+        >
+        ~ [Missing trailing comma]
+    >(
+        bar: A,
+        baz: T,
+    ) {
+        return 42;
+    }
+
+    foo6<
+        T extends { foo: A; bar: B; },
+        U extends { foo: A; bar: B; },
+        V extends {
+            foo: A;
+            bar: B;
+        },
+        W extends {
+            foo: [
+                string,
+                string,
+            ];
+        },
+    >() { return 42; }
+
+    set bar(foo: string) { }
+
+    set bar2(foo: string,) { }
+
+    set bar3(
+        foo: string
+                  ~ [Missing trailing comma]
+    ) { }
+
+    set bar4(
+        foo: string,
+    ) { }
+}
+
+class Test2<A, B, C,> { }
+
+class Test3<
+    A,
+    B,
+    C
+    ~ [Missing trailing comma]
+> { }
+
+class Test4<
+    A,
+    B,
+    C,
+> { }
+
+interface ITest<A ,B, C> {
+
+    new <U, V>(bar: U): ITest<U, U, V>;
+
+    new <U, V,>(bar: U, baz: V,): ITest<U, U, V,>;
+
+    new <
+        U,
+        V
+        ~ [Missing trailing comma]
+    >(
+        bar: U,
+        baz: U,
+        ack: V 
+             ~ [Missing trailing comma]
+    ): ITest<
+        U,
+        U,
+        V
+        ~ [Missing trailing comma]
+    >;
+
+    new <
+        U,
+        V,
+    >(
+        bar: U,
+        baz: U,
+        ack: V,
+        foo: V,
+    ): ITest<
+        U,
+        U,
+        V,
+    >;
+
+    foo(bar: string, baz: string);
+
+    foo2(bar: string, baz: string,);
+
+    foo3(
+        bar: string,
+        baz: string
+                  ~ [Missing trailing comma]
+    );
+
+    foo4(
+        bar: string,
+        baz: string,
+    );
+
+    foo5<
+        T extends Test<[A, A], [A, A,], A>,
+        U extends Test<B, B, B,>,
+        V extends Test<
+            [
+                C,
+                C
+                ~ [Missing trailing comma]
+            ],
+            [
+                C,
+                C,
+            ]
+            C
+            ~ [Missing trailing comma]
+        >
+        ~ [Missing trailing comma]
+    >(
+        bar: A,
+        baz: T,
+    );
+
+    foo6<
+        T extends { foo: A; bar: B; },
+        U extends { foo: A; bar: B; },
+        V extends {
+            foo: A;
+            bar: B;
+        },
+        W extends {
+            foo: [
+                string,
+                string
+                     ~ [Missing trailing comma]
+            ];
+        }
+        ~ [Missing trailing comma]
+    >();
+}
+
+interface ITest2<A, B, C> { }
+
+interface ITest3<
+    A,
+    B,
+    C
+    ~ [Missing trailing comma]
+> { }
+
+interface ITest4<
+    A,
+    B,
+    C,
+> { }
 

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -261,5 +261,203 @@ var foo: (
     bar: string,
     baz: string,
                ~ [Unnecessary trailing comma]
-) => number
+) => number;
+
+var foo: new (bar: string, baz: string) => Test;
+
+var foo: new (bar: string, baz: string,) => Test;
+
+var foo: new (
+    bar: string,
+    baz: string
+) => Test;
+
+var foo: new (
+    bar: string,
+    baz: string,
+               ~ [Unnecessary trailing comma]
+) => Test;
+
+var x = foo(42, 43);
+
+var x = foo(42, 43,);
+
+var x = foo(
+    42,
+    43
+);
+
+var x = foo(
+    42,
+    43,
+      ~ [Unnecessary trailing comma]
+);
+
+class Test<A, B, C> {
+
+    constructor(bar: string) { }
+
+    constructor(bar: string, baz: string,) { }
+
+    constructor(
+        bar: string,
+        baz: string,
+        ack: string
+    ) { }
+
+    constructor(
+        bar: string,
+        baz: string,
+        ack: string,
+        foo: string,
+                   ~ [Unnecessary trailing comma]
+    ) { }
+
+    public foo(bar: string, baz: string) {
+        return 42;
+    }
+
+    private foo2(bar: string, baz: string,) {
+        return 42;
+    }
+
+    public static foo3(
+        bar: string,
+        baz: string
+    ) {
+        return 42;
+    }
+
+    private static foo4(
+        bar: string,
+        baz: string,
+                   ~ [Unnecessary trailing comma]
+    ) {
+        return 42;
+    }
+
+    foo5<
+        T extends Test<[A, A], [A, A,], A>,
+        U extends Test<B, B, B,>,
+        V extends Test<
+            [
+                C,
+                C
+            ],
+            [
+                C,
+                C,
+                 ~ [Unnecessary trailing comma]
+            ]
+            C
+        >
+    >(
+        bar: A,
+        baz: T,
+              ~ [Unnecessary trailing comma]
+    ) {
+        return 42;
+    }
+
+    foo6<
+        T extends { foo: A; bar: B; },
+        U extends { foo: A; bar: B; },
+        V extends {
+            foo: A;
+            bar: B;
+        },
+        W extends {
+            foo: [
+                string,
+                string,
+                      ~ [Unnecessary trailing comma]
+            ];
+        },
+         ~ [Unnecessary trailing comma]
+    >() { return 42; }
+}
+
+class Test2<A, B, C,> { }
+
+class Test3<
+    A,
+    B,
+    C
+> { }
+
+class Test4<
+    A,
+    B,
+    C,
+     ~ [Unnecessary trailing comma]
+> { }
+
+interface ITest<A ,B, C> {
+    foo(bar: string, baz: string);
+
+    foo2(bar: string, baz: string,);
+
+    foo3(
+        bar: string,
+        baz: string
+    );
+
+    foo4(
+        bar: string,
+        baz: string,
+                   ~ [Unnecessary trailing comma]
+    );
+
+    foo5<
+        T extends Test<[A, A], [A, A,], A>,
+        U extends Test<B, B, B,>,
+        V extends Test<
+            [
+                C,
+                C
+            ],
+            [
+                C,
+                C,
+                 ~ [Unnecessary trailing comma]
+            ]
+            C
+        >
+    >(
+        bar: A,
+        baz: T,
+              ~ [Unnecessary trailing comma]
+    );
+
+    foo6<
+        T extends { foo: A; bar: B; },
+        U extends { foo: A; bar: B; },
+        V extends {
+            foo: A;
+            bar: B;
+        },
+        W extends {
+            foo: [
+                string,
+                string
+            ];
+        }
+    >();
+}
+
+interface ITest2<A, B, C> { }
+
+interface ITest3<
+    A,
+    B,
+    C
+> { }
+
+interface ITest4<
+    A,
+    B,
+    C,
+     ~ [Unnecessary trailing comma]
+> { }
+
 

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -113,6 +113,21 @@ var [ccA, ccB,] = cc;
 
 var [ddOne, ddTwo] = dd;
 
+var a: [string, number] = null;
+
+var a: [string, number,] = null;
+
+var a: [
+    string,
+    number
+] = null;
+
+var a: [
+    string,
+    number,
+          ~ [Unnecessary trailing comma]
+] = null;
+
 import {
     ClassS,
           ~ [Unnecessary trailing comma]
@@ -136,3 +151,115 @@ import {
 import {ClassA, ClassB,} from "module";
 
 import {ClassC, ClassD} from "module";
+
+function foo(bar: string, baz: string);
+
+function foo(bar: string, baz: string,);
+
+function foo(
+    bar: string,
+    baz: string
+);
+
+function foo(
+    bar: string,
+    baz: string,
+               ~ [Unnecessary trailing comma]
+);
+
+var foo = function(bar: string, baz: string) { return 42; };
+
+var foo = function(bar: string, baz: string,) { return 42; };
+
+var foo = function(
+    bar: string,
+    baz: string
+) {
+    return 42;
+};
+
+var foo = function(
+    bar: string,
+    baz: string,
+               ~ [Unnecessary trailing comma]
+) {
+    return 42;
+};
+
+function foo(bar: string, baz: string) { return 42; }
+
+function foo(bar: string, baz: string,) { return 42; }
+
+function foo(
+    bar: string,
+    baz: string
+) {
+    return 42;
+}
+
+function foo(
+    bar: string,
+    baz: string,
+               ~ [Unnecessary trailing comma]
+) {
+    return 42;
+}
+
+function foo(bar: string, baz: string,
+    ack: string
+) {
+    return 42;
+}
+
+function foo(bar: string, baz: string,
+    ack: string,
+               ~ [Unnecessary trailing comma]
+) {
+    return 42;
+}
+
+var foo = (bar: string, baz: string) => 42;
+
+var foo = (bar: string, baz: string,) => 42;
+
+var foo = (
+    bar: string,
+    baz: string
+) => 42;
+
+var foo = (
+    bar: string,
+    baz: string,
+               ~ [Unnecessary trailing comma]
+) => 42;
+
+var foo: (bar: string, baz: string) => number = null;
+
+var foo: (bar: string, baz: string,) => number = null;
+
+var foo: (
+    bar: string,
+    baz: string
+) => number = null;
+
+var foo: (
+    bar: string,
+    baz: string,
+               ~ [Unnecessary trailing comma]
+) => number = null;
+
+var foo: (bar: string, baz: string) => number;
+
+var foo: (bar: string, baz: string,) => number;
+
+var foo: (
+    bar: string,
+    baz: string
+) => number;
+
+var foo: (
+    bar: string,
+    baz: string,
+               ~ [Unnecessary trailing comma]
+) => number
+

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -293,6 +293,48 @@ var x = foo(
       ~ [Unnecessary trailing comma]
 );
 
+var x = new Test("foo");
+
+var x = new Test("foo",);
+
+var x = new Test(
+    "foo"
+);
+
+var x = new Test(
+    "foo",
+         ~ [Unnecessary trailing comma]
+);
+
+var x: { foo: string; bar: string };
+
+var x: { foo: string; bar: string; };
+
+var x: {
+    foo: string;
+    bar: string
+};
+
+var x: {
+    foo: string;
+    bar: string;
+};
+
+var x: { foo: string, bar: string };
+
+var x: { foo: string, bar: string, };
+
+var x: {
+    foo: string,
+    bar: string
+};
+
+var x: {
+    foo: string,
+    bar: string,
+               ~ [Unnecessary trailing comma]
+};
+
 class Test<A, B, C> {
 
     constructor(bar: string) { }
@@ -460,4 +502,33 @@ interface ITest4<
      ~ [Unnecessary trailing comma]
 > { }
 
+enum Foo { BAR, BAZ }
+
+enum Foo { BAR, BAZ, }
+
+enum Foo {
+    Bar,
+    Baz
+}
+
+enum Foo {
+    Bar,
+    Baz,
+       ~ [Unnecessary trailing comma]
+}
+
+const enum Foo { BAR = 1, BAZ = 2 }
+
+const enum Foo { BAR = 1, BAZ = 2, }
+
+const enum Foo {
+    Bar = 1,
+    Baz = 2
+}
+
+const enum Foo {
+    Bar = 1,
+    Baz = 2,
+           ~ [Unnecessary trailing comma]
+}
 

--- a/test/rules/trailing-comma/singleline-always/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-always/test.ts.lint
@@ -111,6 +111,21 @@ var [ccA, ccB,] = cc;
 var [ddOne, ddTwo] = dd;
                 ~        [Missing trailing comma]
 
+var a: [string, number] = null;
+                     ~          [Missing trailing comma]
+
+var a: [string, number,] = null;
+
+var a: [
+    string,
+    number
+] = null;
+
+var a: [
+    string,
+    number,
+] = null;
+
 import {
     ClassS,
 } from "module";
@@ -133,3 +148,114 @@ import {ClassA, ClassB,} from "module";
 
 import {ClassC, ClassD} from "module";
                      ~                 [Missing trailing comma]
+
+function foo(bar: string, baz: string);
+                                    ~   [Missing trailing comma]
+
+function foo(bar: string, baz: string,);
+
+function foo(
+    bar: string,
+    baz: string
+);
+
+function foo(
+    bar: string,
+    baz: string,
+);
+
+var foo = function(bar: string, baz: string) { return 42; };
+                                          ~                  [Missing trailing comma]
+
+var foo = function(bar: string, baz: string,) { return 42; };
+
+var foo = function(
+    bar: string,
+    baz: string
+) {
+    return 42;
+};
+
+var foo = function(
+    bar: string,
+    baz: string,
+) {
+    return 42;
+};
+
+function foo(bar: string, baz: string) { return 42; }
+                                    ~                 [Missing trailing comma]
+
+function foo(bar: string, baz: string,) { return 42; }
+
+function foo(
+    bar: string,
+    baz: string
+) {
+    return 42;
+}
+
+function foo(
+    bar: string,
+    baz: string,
+) {
+    return 42;
+}
+
+function foo(bar: string, baz: string,
+    ack: string
+) {
+    return 42;
+}
+
+function foo(bar: string, baz: string,
+    ack: string,
+) {
+    return 42;
+}
+
+var foo = (bar: string, baz: string) => 42;
+                                  ~         [Missing trailing comma]
+
+var foo = (bar: string, baz: string,) => 42;
+
+var foo = (
+    bar: string,
+    baz: string
+) => 42;
+
+var foo = (
+    bar: string,
+    baz: string,
+) => 42;
+
+var foo: (bar: string, baz: string) => number = null;
+                                 ~                    [Missing trailing comma]
+
+var foo: (bar: string, baz: string,) => number = null;
+
+var foo: (
+    bar: string,
+    baz: string
+) => number = null;
+
+var foo: (
+    bar: string,
+    baz: string,
+) => number = null;
+
+var foo: (bar: string, baz: string) => number;
+                                 ~             [Missing trailing comma]
+
+var foo: (bar: string, baz: string,) => number;
+
+var foo: (
+    bar: string,
+    baz: string
+) => number;
+
+var foo: (
+    bar: string,
+    baz: string,
+) => number
+

--- a/test/rules/trailing-comma/singleline-always/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-always/test.ts.lint
@@ -257,5 +257,247 @@ var foo: (
 var foo: (
     bar: string,
     baz: string,
-) => number
+) => number;
+
+var foo: new (bar: string, baz: string) => Test;
+                                     ~           [Missing trailing comma]
+
+var foo: new (bar: string, baz: string,) => Test;
+
+var foo: new (
+    bar: string,
+    baz: string
+) => Test;
+
+var foo: new (
+    bar: string,
+    baz: string,
+) => Test;
+
+var x = foo(42, 43);
+                 ~   [Missing trailing comma]
+
+var x = foo(42, 43,);
+
+var x = foo(
+    42,
+    43
+);
+
+var x = foo(
+    42,
+    43,
+);
+
+class Test<A, B, C> {
+                 ~    [Missing trailing comma]
+
+    constructor(bar: string) { }
+                          ~      [Missing trailing comma]
+
+    constructor(bar: string, baz: string,) { }
+
+    constructor(
+        bar: string,
+        baz: string,
+        ack: string
+    ) { }
+
+    constructor(
+        bar: string,
+        baz: string,
+        ack: string,
+        foo: string,
+    ) { }
+
+    public foo(bar: string, baz: string) {
+                                      ~    [Missing trailing comma]
+        return 42;
+    }
+
+    private foo2(bar: string, baz: string,) {
+        return 42;
+    }
+
+    public static foo3(
+        bar: string,
+        baz: string
+    ) {
+        return 42;
+    }
+
+    private static foo4(
+        bar: string,
+        baz: string,
+    ) {
+        return 42;
+    }
+
+    foo5<
+        T extends Test<[A, A], [A, A,], A>,
+                           ~                [Missing trailing comma]
+                                        ~   [Missing trailing comma]
+        U extends Test<B, B, B,>,
+        V extends Test<
+            [
+                C,
+                C
+            ],
+            [
+                C,
+                C,
+            ]
+            C
+        >
+    >(
+        bar: A,
+        baz: T,
+    ) {
+        return 42;
+    }
+
+    foo6<
+        T extends { foo: A; bar: B; },
+        U extends { foo: A; bar: B; },
+        V extends {
+            foo: A;
+            bar: B;
+        },
+        W extends {
+            foo: [
+                string,
+                string,
+            ];
+        },
+    >() { return 42; }
+
+    set bar(foo: string) { }
+                      ~      [Missing trailing comma]
+
+    set bar2(foo: string,) { }
+
+    set bar3(
+        foo: string
+    ) { }
+
+    set bar4(
+        foo: string,
+    ) { }
+}
+
+class Test2<A, B, C,> { }
+
+class Test3<
+    A,
+    B,
+    C
+> { }
+
+class Test4<
+    A,
+    B,
+    C,
+> { }
+
+interface ITest<A ,B, C> {
+                      ~    [Missing trailing comma]
+
+    new <U, V>(bar: U): ITest<U, U, V>;
+            ~                           [Missing trailing comma]
+                    ~                   [Missing trailing comma]
+                                    ~   [Missing trailing comma]
+
+    new <
+        U,
+        V
+    >(
+        bar: U,
+        baz: U,
+        ack: V 
+    ): ITest<
+        U,
+        U,
+        V
+    >;
+
+    new <
+        U,
+        V,
+    >(
+        bar: U,
+        baz: U,
+        ack: V,
+        foo: V,
+    ): ITest<
+        U,
+        U,
+        V,
+    >;
+
+    foo(bar: string, baz: string);
+                               ~   [Missing trailing comma]
+
+    foo2(bar: string, baz: string,);
+
+    foo3(
+        bar: string,
+        baz: string
+    );
+
+    foo4(
+        bar: string,
+        baz: string,
+    );
+
+    foo5<
+        T extends Test<[A, A], [A, A,], A>,
+                           ~                [Missing trailing comma]
+                                        ~   [Missing trailing comma]
+        U extends Test<B, B, B,>,
+        V extends Test<
+            [
+                C,
+                C
+            ],
+            [
+                C,
+                C,
+            ]
+            C
+        >
+    >(
+        bar: A,
+        baz: T,
+    );
+
+    foo6<
+        T extends { foo: A; bar: B; },
+        U extends { foo: A; bar: B; },
+        V extends {
+            foo: A;
+            bar: B;
+        },
+        W extends {
+            foo: [
+                string,
+                string
+            ];
+        }
+    >();
+}
+
+interface ITest2<A, B, C> { }
+                       ~      [Missing trailing comma]
+
+interface ITest3<
+    A,
+    B,
+    C
+> { }
+
+interface ITest4<
+    A,
+    B,
+    C,
+> { }
 

--- a/test/rules/trailing-comma/singleline-always/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-always/test.ts.lint
@@ -289,6 +289,48 @@ var x = foo(
     43,
 );
 
+var x = new Test("foo");
+                     ~   [Missing trailing comma]
+
+var x = new Test("foo",);
+
+var x = new Test(
+    "foo"
+);
+
+var x = new Test(
+    "foo",
+);
+
+var x: { foo: string; bar: string };
+
+var x: { foo: string; bar: string; };
+
+var x: {
+    foo: string;
+    bar: string
+};
+
+var x: {
+    foo: string;
+    bar: string;
+};
+
+var x: { foo: string, bar: string };
+                                ~    [Missing trailing comma]
+
+var x: { foo: string, bar: string, };
+
+var x: {
+    foo: string,
+    bar: string
+};
+
+var x: {
+    foo: string,
+    bar: string,
+};
+
 class Test<A, B, C> {
                  ~    [Missing trailing comma]
 
@@ -500,4 +542,34 @@ interface ITest4<
     B,
     C,
 > { }
+
+enum Foo { BAR, BAZ }
+                  ~   [Missing trailing comma]
+
+enum Foo { BAR, BAZ, }
+
+enum Foo {
+    Bar,
+    Baz
+}
+
+enum Foo {
+    Bar,
+    Baz,
+}
+
+const enum Foo { BAR = 1, BAZ = 2 }
+                                ~   [Missing trailing comma]
+
+const enum Foo { BAR = 1, BAZ = 2, }
+
+const enum Foo {
+    Bar = 1,
+    Baz = 2
+}
+
+const enum Foo {
+    Bar = 1,
+    Baz = 2,
+}
 

--- a/test/rules/trailing-comma/singleline-never/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-never/test.ts.lint
@@ -258,5 +258,203 @@ var foo: (
 var foo: (
     bar: string,
     baz: string,
-) => number
+) => number;
+
+var foo: new (bar: string, baz: string) => Test;
+
+var foo: new (bar: string, baz: string,) => Test;
+                                      ~           [Unnecessary trailing comma]
+
+var foo: new (
+    bar: string,
+    baz: string
+) => Test;
+
+var foo: new (
+    bar: string,
+    baz: string,
+) => Test;
+
+var x = foo(42, 43);
+
+var x = foo(42, 43,);
+                  ~   [Unnecessary trailing comma]
+
+
+var x = foo(
+    42,
+    43
+);
+
+var x = foo(
+    42,
+    43,
+);
+
+class Test<A, B, C> {
+
+    constructor(bar: string) { }
+
+    constructor(bar: string, baz: string,) { }
+                                        ~      [Unnecessary trailing comma]
+
+    constructor(
+        bar: string,
+        baz: string,
+        ack: string
+    ) { }
+
+    constructor(
+        bar: string,
+        baz: string,
+        ack: string,
+        foo: string,
+    ) { }
+
+    public foo(bar: string, baz: string) {
+        return 42;
+    }
+
+    private foo2(bar: string, baz: string,) {
+                                         ~    [Unnecessary trailing comma]
+        return 42;
+    }
+
+    public static foo3(
+        bar: string,
+        baz: string
+    ) {
+        return 42;
+    }
+
+    private static foo4(
+        bar: string,
+        baz: string,
+    ) {
+        return 42;
+    }
+
+    foo5<
+        T extends Test<[A, A], [A, A,], A>,
+                                    ~       [Unnecessary trailing comma]
+        U extends Test<B, B, B,>,
+                              ~   [Unnecessary trailing comma]
+        V extends Test<
+            [
+                C,
+                C
+            ],
+            [
+                C,
+                C,
+            ]
+            C
+        >
+    >(
+        bar: A,
+        baz: T,
+    ) {
+        return 42;
+    }
+
+    foo6<
+        T extends { foo: A, bar: B },
+        U extends { foo: A, bar: B },
+        V extends {
+            foo: A;
+            bar: B;
+        },
+        W extends {
+            foo: [
+                string,
+                string,
+            ];
+        },
+    >() { return 42; }
+}
+
+class Test2<A, B, C,> { }
+                   ~      [Unnecessary trailing comma]
+
+
+class Test3<
+    A,
+    B,
+    C
+> { }
+
+class Test4<
+    A,
+    B,
+    C,
+> { }
+
+interface ITest<A ,B, C> {
+    foo(bar: string, baz: string);
+
+    foo2(bar: string, baz: string,);
+                                 ~   [Unnecessary trailing comma]
+
+    foo3(
+        bar: string,
+        baz: string
+    );
+
+    foo4(
+        bar: string,
+        baz: string,
+    );
+
+    foo5<
+        T extends Test<[A, A], [A, A,], A>,
+                                    ~       [Unnecessary trailing comma]
+        U extends Test<B, B, B,>,
+                              ~   [Unnecessary trailing comma]
+        V extends Test<
+            [
+                C,
+                C
+            ],
+            [
+                C,
+                C,
+            ]
+            C
+        >
+    >(
+        bar: A,
+        baz: T,
+    );
+
+    foo6<
+        T extends { foo: A, bar: B },
+        U extends { foo: A, bar: B },
+        V extends {
+            foo: A;
+            bar: B;
+        },
+        W extends {
+            foo: [
+                string,
+                string
+            ];
+        }
+    >();
+}
+
+interface ITest2<A, B, C> { }
+
+interface ITest3<
+    A,
+    B,
+    C
+> { }
+
+interface ITest4<
+    A,
+    B,
+    C,
+> { }
+
+
 

--- a/test/rules/trailing-comma/singleline-never/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-never/test.ts.lint
@@ -280,7 +280,6 @@ var x = foo(42, 43);
 var x = foo(42, 43,);
                   ~   [Unnecessary trailing comma]
 
-
 var x = foo(
     42,
     43
@@ -290,6 +289,48 @@ var x = foo(
     42,
     43,
 );
+
+var x = new Test("foo");
+
+var x = new Test("foo",);
+                      ~   [Unnecessary trailing comma]
+
+var x = new Test(
+    "foo"
+);
+
+var x = new Test(
+    "foo",
+);
+
+var x: { foo: string; bar: string };
+
+var x: { foo: string; bar: string; };
+
+var x: {
+    foo: string;
+    bar: string
+};
+
+var x: {
+    foo: string;
+    bar: string;
+};
+
+var x: { foo: string, bar: string };
+
+var x: { foo: string, bar: string, };
+                                 ~    [Unnecessary trailing comma]
+
+var x: {
+    foo: string,
+    bar: string
+};
+
+var x: {
+    foo: string,
+    bar: string,
+};
 
 class Test<A, B, C> {
 
@@ -456,5 +497,33 @@ interface ITest4<
     C,
 > { }
 
+enum Foo { BAR, BAZ }
 
+enum Foo { BAR, BAZ, }
+                   ~   [Unnecessary trailing comma]
+
+enum Foo {
+    Bar,
+    Baz
+}
+
+enum Foo {
+    Bar,
+    Baz,
+}
+
+const enum Foo { BAR = 1, BAZ = 2 }
+
+const enum Foo { BAR = 1, BAZ = 2, }
+                                 ~   [Unnecessary trailing comma]
+
+const enum Foo {
+    Bar = 1,
+    Baz = 2
+}
+
+const enum Foo {
+    Bar = 1,
+    Baz = 2,
+}
 

--- a/test/rules/trailing-comma/singleline-never/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-never/test.ts.lint
@@ -111,6 +111,22 @@ var [ccA, ccB,] = cc;
 
 var [ddOne, ddTwo] = dd;
 
+var a: [string, number] = null;
+
+var a: [string, number,] = null;
+                      ~          [Unnecessary trailing comma]
+
+var a: [
+    string,
+    number
+] = null;
+
+var a: [
+    string,
+    number,
+] = null;
+
+
 import {
     ClassS,
 } from "module";
@@ -133,3 +149,114 @@ import {ClassA, ClassB,} from "module";
                       ~                 [Unnecessary trailing comma]
 
 import {ClassC, ClassD} from "module";
+
+function foo(bar: string, baz: string);
+
+function foo(bar: string, baz: string,);
+                                     ~  [Unnecessary trailing comma]
+
+function foo(
+    bar: string,
+    baz: string
+);
+
+function foo(
+    bar: string,
+    baz: string,
+);
+
+var foo = function(bar: string, baz: string) { return 42; };
+
+var foo = function(bar: string, baz: string,) { return 42; };
+                                           ~                  [Unnecessary trailing comma]
+
+var foo = function(
+    bar: string,
+    baz: string
+) {
+    return 42;
+};
+
+var foo = function(
+    bar: string,
+    baz: string,
+) {
+    return 42;
+};
+
+function foo(bar: string, baz: string) { return 42; }
+
+function foo(bar: string, baz: string,) { return 42; }
+                                     ~                 [Unnecessary trailing comma]
+
+function foo(
+    bar: string,
+    baz: string
+) {
+    return 42;
+}
+
+function foo(
+    bar: string,
+    baz: string,
+) {
+    return 42;
+}
+
+function foo(bar: string, baz: string,
+    ack: string
+) {
+    return 42;
+}
+
+function foo(bar: string, baz: string,
+    ack: string,
+) {
+    return 42;
+}
+
+var foo = (bar: string, baz: string) => 42;
+
+var foo = (bar: string, baz: string,) => 42;
+                                   ~         [Unnecessary trailing comma]
+
+var foo = (
+    bar: string,
+    baz: string
+) => 42;
+
+var foo = (
+    bar: string,
+    baz: string,
+) => 42;
+
+var foo: (bar: string, baz: string) => number = null;
+
+var foo: (bar: string, baz: string,) => number = null;
+                                  ~                    [Unnecessary trailing comma]
+
+var foo: (
+    bar: string,
+    baz: string
+) => number = null;
+
+var foo: (
+    bar: string,
+    baz: string,
+) => number = null;
+
+var foo: (bar: string, baz: string) => number;
+
+var foo: (bar: string, baz: string,) => number;
+                                  ~             [Unnecessary trailing comma]
+
+var foo: (
+    bar: string,
+    baz: string
+) => number;
+
+var foo: (
+    bar: string,
+    baz: string,
+) => number
+


### PR DESCRIPTION
Fixes #1409 