### PR TITLE
Header & Footer removed from formatter output.

### DIFF
--- a/src/formatters/checkstyleFormatter.ts
+++ b/src/formatters/checkstyleFormatter.ts
@@ -2,8 +2,16 @@ import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
+    public getHeader(): string {
+        return `<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">`;
+    }
+
+    public getFooter(): string {
+        return `</checkstyle>`;
+    }
+
     public format(failures: RuleFailure[]): string {
-        let output = '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">';
+        let output = ``;
 
         if (failures.length) {
             output += `<file name="${this.escapeXml(failures[0].getFileName())}">`;
@@ -18,7 +26,6 @@ export class Formatter extends AbstractFormatter {
             output += "</file>";
         }
 
-        output += "</checkstyle>";
         return output;
     }
 

--- a/src/formatters/jsonFormatter.ts
+++ b/src/formatters/jsonFormatter.ts
@@ -19,6 +19,14 @@ import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
+    public getHeader(): string {
+        return ``;
+    }
+
+    public getFooter(): string {
+        return ``;
+    }
+
     public format(failures: RuleFailure[]): string {
         const failuresJSON = failures.map((failure) => failure.toJson());
         return JSON.stringify(failuresJSON);

--- a/src/formatters/msbuildFormatter.ts
+++ b/src/formatters/msbuildFormatter.ts
@@ -18,6 +18,14 @@ import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
+    public getHeader(): string {
+        return ``;
+    }
+
+    public getFooter(): string {
+        return ``;
+    }
+
     public format(failures: RuleFailure[]): string {
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();

--- a/src/formatters/pmdFormatter.ts
+++ b/src/formatters/pmdFormatter.ts
@@ -19,8 +19,16 @@ import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
+    public getHeader(): string {
+        return `<pmd version="tslint">`;
+    }
+
+    public getFooter(): string {
+        return `</pmd>`;
+    }
+
     public format(failures: RuleFailure[]): string {
-        let output = "<pmd version=\"tslint\">";
+        let output = ``;
 
         for (let failure of failures) {
             const failureString = failure.getFailure()
@@ -39,7 +47,6 @@ export class Formatter extends AbstractFormatter {
             output += " rule=\"" + failureString + "\"> </violation></file>";
         }
 
-        output += "</pmd>";
         return output;
     }
 }

--- a/src/formatters/proseFormatter.ts
+++ b/src/formatters/proseFormatter.ts
@@ -19,6 +19,14 @@ import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
+    public getHeader(): string {
+        return ``;
+    }
+
+    public getFooter(): string {
+        return ``;
+    }
+
     public format(failures: RuleFailure[]): string {
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();

--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -21,6 +21,14 @@ import {RuleFailure} from "../language/rule/rule";
 import * as colors from "colors";
 
 export class Formatter extends AbstractFormatter {
+    public getHeader(): string {
+        return ``;
+    }
+
+    public getFooter(): string {
+        return ``;
+    }
+
     public format(failures: RuleFailure[]): string {
         if (typeof failures[0] === "undefined") {
             return "\n";

--- a/src/formatters/verboseFormatter.ts
+++ b/src/formatters/verboseFormatter.ts
@@ -19,6 +19,14 @@ import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
+    public getHeader(): string {
+        return ``;
+    }
+
+    public getFooter(): string {
+        return ``;
+    }
+
     public format(failures: RuleFailure[]): string {
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();

--- a/src/formatters/vsoFormatter.ts
+++ b/src/formatters/vsoFormatter.ts
@@ -18,6 +18,14 @@ import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
+    public getHeader(): string {
+        return ``;
+    }
+
+    public getFooter(): string {
+        return ``;
+    }
+
     public format(failures: RuleFailure[]): string {
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();

--- a/src/language/formatter/abstractFormatter.ts
+++ b/src/language/formatter/abstractFormatter.ts
@@ -19,5 +19,7 @@ import {RuleFailure} from "../rule/rule";
 import {IFormatter} from "./formatter";
 
 export abstract class AbstractFormatter implements IFormatter {
+    public abstract getHeader(): string;
+    public abstract getFooter(): string;
     public abstract format(failures: RuleFailure[]): string;
 }

--- a/src/language/formatter/formatter.ts
+++ b/src/language/formatter/formatter.ts
@@ -18,5 +18,7 @@
 import {RuleFailure} from "../rule/rule";
 
 export interface IFormatter {
+    getHeader(): string;
+    getFooter(): string;
     format(failures: RuleFailure[]): string;
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -43,6 +43,8 @@ export interface LintResult {
     failureCount: number;
     failures: RuleFailure[];
     format: string | Function;
+    header: string;
+    footer: string;
     output: string;
 }
 

--- a/src/tslint.ts
+++ b/src/tslint.ts
@@ -135,7 +135,9 @@ class Linter {
         return {
             failureCount: failures.length,
             failures: failures,
+            footer: formatter.getFooter(),
             format: this.options.formatter,
+            header: formatter.getHeader(),
             output: output,
         };
     }

--- a/test/formatters/checkstyleFormatterTests.ts
+++ b/test/formatters/checkstyleFormatterTests.ts
@@ -22,20 +22,28 @@ describe("Checkstyle Formatter", () => {
             new RuleFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name"),
         ];
         const expectedResult =
-            '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">' +
             `<file name="${TEST_FILE}">` +
             '<error line="1" column="1" severity="warning" message="first failure" source="failure.tslint.first-name" />' +
             '<error line="1" column="3" severity="warning" message="&amp;&lt;&gt;&#39;&quot; should be escaped" ' +
             'source="failure.tslint.escape" />' +
             '<error line="6" column="3" severity="warning" message="last failure" source="failure.tslint.last-name" />' +
-            "</file>" +
-            "</checkstyle>";
+            "</file>";
 
         assert.equal(formatter.format(failures), expectedResult);
     });
 
     it("handles no failures", () => {
         const result = formatter.format([]);
-        assert.deepEqual(result, '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"></checkstyle>');
+        assert.deepEqual(result, ``);
+    });
+
+    it("handles the header", () => {
+        const result = formatter.getHeader();
+        assert.deepEqual(result, `<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">`);
+    });
+
+    it("handles the footer", () => {
+        const result = formatter.getFooter();
+        assert.deepEqual(result, `</checkstyle>`);
     });
 });

--- a/test/formatters/pmdFormatterTests.ts
+++ b/test/formatters/pmdFormatterTests.ts
@@ -39,30 +39,38 @@ describe("PMD Formatter", () => {
             new RuleFailure(sourceFile, 0, maxPosition, "full failure", "full-name"),
         ];
         const expectedResult =
-            "<pmd version=\"tslint\">" +
-                "<file name=\"formatters/pmdFormatter.test.ts\">" +
-                    "<violation begincolumn=\"1\" beginline=\"1\" priority=\"1\" rule=\"first failure\"> " +
-                    "</violation>" +
-                "</file>" +
-                "<file name=\"formatters/pmdFormatter.test.ts\">" +
-                    "<violation begincolumn=\"3\" beginline=\"1\" priority=\"1\" rule=\"&amp;&lt;&gt;&#39;&quot; should be escaped\"> " +
-                    "</violation>" +
-                "</file>" +
-                "<file name=\"formatters/pmdFormatter.test.ts\">" +
-                    "<violation begincolumn=\"3\" beginline=\"6\" priority=\"1\" rule=\"last failure\"> " +
-                    "</violation>" +
-                "</file>" +
-                "<file name=\"formatters/pmdFormatter.test.ts\">" +
-                    "<violation begincolumn=\"1\" beginline=\"1\" priority=\"1\" rule=\"full failure\"> " +
-                    "</violation>" +
-                "</file>" +
-            "</pmd>";
+            "<file name=\"formatters/pmdFormatter.test.ts\">" +
+                "<violation begincolumn=\"1\" beginline=\"1\" priority=\"1\" rule=\"first failure\"> " +
+                "</violation>" +
+            "</file>" +
+            "<file name=\"formatters/pmdFormatter.test.ts\">" +
+                "<violation begincolumn=\"3\" beginline=\"1\" priority=\"1\" rule=\"&amp;&lt;&gt;&#39;&quot; should be escaped\"> " +
+                "</violation>" +
+            "</file>" +
+            "<file name=\"formatters/pmdFormatter.test.ts\">" +
+                "<violation begincolumn=\"3\" beginline=\"6\" priority=\"1\" rule=\"last failure\"> " +
+                "</violation>" +
+            "</file>" +
+            "<file name=\"formatters/pmdFormatter.test.ts\">" +
+                "<violation begincolumn=\"1\" beginline=\"1\" priority=\"1\" rule=\"full failure\"> " +
+                "</violation>" +
+            "</file>";
 
         assert.equal(formatter.format(failures), expectedResult);
     });
 
     it("handles no failures", () => {
         const result = formatter.format([]);
-        assert.deepEqual(result, "<pmd version=\"tslint\"></pmd>");
+        assert.deepEqual(result, ``);
+    });
+
+    it("handles the header", () => {
+        const result = formatter.getHeader();
+        assert.deepEqual(result, `<pmd version="tslint">`);
+    });
+
+    it("handles the footer", () => {
+        const result = formatter.getFooter();
+        assert.deepEqual(result, `</pmd>`);
     });
 });


### PR DESCRIPTION
Current PMD output:

`<pmd version="tslint"><file ...></file></pmd><pmd version="tslint"><file ...></file></pmd><pmd version="tslint"><file ...></file></pmd>...<pmd version="tslint"><file ...></file></pmd>`

This is not a valid PMD content.

This Pull Request solves this issue, proposed output:

`<pmd version="tslint"><file ...></file><file ...></file><file ...></file>...<file ...></file></pmd>`
