### PR TITLE
[docs] 3.15.0 docs update

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -1,5 +1,15 @@
 [
   {
+    "ruleName": "adjacent-overload-signatures",
+    "description": "Enforces function overloads to be consecutive.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "typescript"
+  },
+  {
     "ruleName": "align",
     "description": "Enforces vertical alignment.",
     "rationale": "Helps maintain a readable, consistent style in your codebase.",
@@ -115,6 +125,18 @@
       "true"
     ],
     "type": "maintainability"
+  },
+  {
+    "ruleName": "file-header",
+    "description": "Enforces a certain header comment for all files, matched by a regular expression.",
+    "optionsDescription": "Regular expression to match the header.",
+    "options": {
+      "type": "string"
+    },
+    "optionExamples": [
+      "\"true\", \"Copyright \\d{4}\""
+    ],
+    "type": "style"
   },
   {
     "ruleName": "forin",
@@ -815,6 +837,15 @@
     "type": "style"
   },
   {
+    "ruleName": "object-literal-shorthand",
+    "description": "Enforces use of ES6 object literal shorthand when possible.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "style"
+  },
+  {
     "ruleName": "object-literal-sort-keys",
     "description": "Requires keys in object literals to be sorted alphabetically",
     "rationale": "Useful in preventing merge conflicts",
@@ -874,10 +905,21 @@
     "ruleName": "only-arrow-functions",
     "description": "Disallows traditional (non-arrow) function expressions.",
     "rationale": "Traditional functions don't bind lexical scope, which can lead to unexpected behavior when accessing 'this'.",
-    "optionsDescription": "Not configurable.",
-    "options": null,
+    "optionsDescription": "\nOne argument may be optionally provided:\n\n* `\"allow-declarations\"` allows standalone function declarations.\n        ",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "allow-declarations"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 1
+    },
     "optionExamples": [
-      "true"
+      "true",
+      "[true, \"allow-declarations\"]"
     ],
     "type": "typescript"
   },
@@ -885,10 +927,18 @@
     "ruleName": "ordered-imports",
     "description": "Requires that import statements be alphabetized.",
     "descriptionDetails": "\nEnforce a consistent ordering for ES6 imports:\n- Named imports must be alphabetized (i.e. \"import {A, B, C} from \"foo\";\")\n    - The exact ordering can be controled by the named-imports-order option.\n    - \"longName as name\" imports are ordered by \"longName\".\n- Import sources must be alphabetized within groups, i.e.:\n        import * as foo from \"a\";\n        import * as bar from \"b\";\n- Groups of imports are delineated by blank lines. You can use these to group imports\n    however you like, e.g. by first- vs. third-party or thematically.",
-    "optionsDescription": "\nYou may set the `\"named-imports-order\"` option to control the ordering of named\nimports (the `{A, B, C}` in 'import {A, B, C} from \"foo\"`.)\n\nPossible values for `\"named-imports-order\"` are:\n\n* `\"case-insensitive'`: Correct order is `{A, b, C}`. (This is the default.)\n* `\"lowercase-first\"`: Correct order is `{b, A, C}`.\n* `\"lowercase-last\"`: Correct order is `{A, C, b}`.\n        ",
+    "optionsDescription": "\nYou may set the `\"import-sources-order\"` option to control the ordering of source\nimports (the `\"foo\"` in `import {A, B, C} from \"foo\"`).\n\nPossible values for `\"import-sources-order\"` are:\n* `\"case-insensitive'`: Correct order is `\"Bar\"`, `\"baz\"`, `\"Foo\"`. (This is the default.)\n* `\"lowercase-first\"`: Correct order is `\"baz\"`, `\"Bar\"`, `\"Foo\"`.\n* `\"lowercase-last\"`: Correct order is `\"Bar\"`, `\"Foo\"`, `\"baz\"`.\n\nYou may set the `\"named-imports-order\"` option to control the ordering of named\nimports (the `{A, B, C}` in `import {A, B, C} from \"foo\"`).\n\nPossible values for `\"named-imports-order\"` are:\n\n* `\"case-insensitive'`: Correct order is `{A, b, C}`. (This is the default.)\n* `\"lowercase-first\"`: Correct order is `{b, A, C}`.\n* `\"lowercase-last\"`: Correct order is `{A, C, b}`.\n\n        ",
     "options": {
       "type": "object",
       "properties": {
+        "import-sources-order": {
+          "type": "string",
+          "enum": [
+            "case-insensitive",
+            "lowercase-first",
+            "lowercase-last"
+          ]
+        },
         "named-imports-order": {
           "type": "string",
           "enum": [
@@ -902,7 +952,7 @@
     },
     "optionExamples": [
       "true",
-      "[true, {\"named-imports-order\": \"lowercase-first\"}]"
+      "[true, {\"import-sources-order\": \"lowercase-last\", \"named-imports-order\": \"lowercase-first\"}]"
     ],
     "type": "style"
   },
@@ -1048,13 +1098,14 @@
   {
     "ruleName": "typedef",
     "description": "Requires type definitions to exist.",
-    "optionsDescription": "\nSix arguments may be optionally provided:\n\n* `\"call-signature\"` checks return type of functions.\n* `\"parameter\"` checks type specifier of function parameters for non-arrow functions.\n* `\"arrow-parameter\"` checks type specifier of function parameters for arrow functions.\n* `\"property-declaration\"` checks return types of interface properties.\n* `\"variable-declaration\"` checks variable declarations.\n* `\"member-variable-declaration\"` checks member variable declarations.",
+    "optionsDescription": "\nSeven arguments may be optionally provided:\n\n* `\"call-signature\"` checks return type of functions.\n* `\"arrow-call-signature\"` checks return type of arrow functions.\n* `\"parameter\"` checks type specifier of function parameters for non-arrow functions.\n* `\"arrow-parameter\"` checks type specifier of function parameters for arrow functions.\n* `\"property-declaration\"` checks return types of interface properties.\n* `\"variable-declaration\"` checks variable declarations.\n* `\"member-variable-declaration\"` checks member variable declarations.",
     "options": {
       "type": "array",
       "items": {
         "type": "string",
         "enum": [
           "call-signature",
+          "arrow-call-signature",
           "parameter",
           "arrow-parameter",
           "property-declaration",
@@ -1063,7 +1114,7 @@
         ]
       },
       "minLength": 0,
-      "maxLength": 6
+      "maxLength": 7
     },
     "optionExamples": [
       "[true, \"call-signature\", \"parameter\", \"member-variable-declaration\"]"
@@ -1248,7 +1299,7 @@
           "check-decl",
           "check-operator",
           "check-module",
-          "check-seperator",
+          "check-separator",
           "check-type",
           "check-typecast"
         ]

--- a/docs/rules/adjacent-overload-signatures/index.html
+++ b/docs/rules/adjacent-overload-signatures/index.html
@@ -1,0 +1,12 @@
+---
+ruleName: adjacent-overload-signatures
+description: Enforces function overloads to be consecutive.
+optionsDescription: Not configurable.
+options: null
+optionExamples:
+  - 'true'
+type: typescript
+optionsJSON: 'null'
+layout: rule
+title: 'Rule: adjacent-overload-signatures'
+---

--- a/docs/rules/file-header/index.html
+++ b/docs/rules/file-header/index.html
@@ -1,0 +1,16 @@
+---
+ruleName: file-header
+description: 'Enforces a certain header comment for all files, matched by a regular expression.'
+optionsDescription: Regular expression to match the header.
+options:
+  type: string
+optionExamples:
+  - '"true", "Copyright \d{4}"'
+type: style
+optionsJSON: |-
+  {
+    "type": "string"
+  }
+layout: rule
+title: 'Rule: file-header'
+---

--- a/docs/rules/object-literal-shorthand/index.html
+++ b/docs/rules/object-literal-shorthand/index.html
@@ -1,0 +1,11 @@
+---
+ruleName: object-literal-shorthand
+description: Enforces use of ES6 object literal shorthand when possible.
+options: null
+optionExamples:
+  - 'true'
+type: style
+optionsJSON: 'null'
+layout: rule
+title: 'Rule: object-literal-shorthand'
+---

--- a/docs/rules/only-arrow-functions/index.html
+++ b/docs/rules/only-arrow-functions/index.html
@@ -2,12 +2,36 @@
 ruleName: only-arrow-functions
 description: Disallows traditional (non-arrow) function expressions.
 rationale: 'Traditional functions don''t bind lexical scope, which can lead to unexpected behavior when accessing ''this''.'
-optionsDescription: Not configurable.
-options: null
+optionsDescription: |-
+
+  One argument may be optionally provided:
+
+  * `"allow-declarations"` allows standalone function declarations.
+          
+options:
+  type: array
+  items:
+    type: string
+    enum:
+      - allow-declarations
+  minLength: 0
+  maxLength: 1
 optionExamples:
   - 'true'
+  - '[true, "allow-declarations"]'
 type: typescript
-optionsJSON: 'null'
+optionsJSON: |-
+  {
+    "type": "array",
+    "items": {
+      "type": "string",
+      "enum": [
+        "allow-declarations"
+      ]
+    },
+    "minLength": 0,
+    "maxLength": 1
+  }
 layout: rule
 title: 'Rule: only-arrow-functions'
 ---

--- a/docs/rules/ordered-imports/index.html
+++ b/docs/rules/ordered-imports/index.html
@@ -14,18 +14,33 @@ descriptionDetails: |-
       however you like, e.g. by first- vs. third-party or thematically.
 optionsDescription: |-
 
+  You may set the `"import-sources-order"` option to control the ordering of source
+  imports (the `"foo"` in `import {A, B, C} from "foo"`).
+
+  Possible values for `"import-sources-order"` are:
+  * `"case-insensitive'`: Correct order is `"Bar"`, `"baz"`, `"Foo"`. (This is the default.)
+  * `"lowercase-first"`: Correct order is `"baz"`, `"Bar"`, `"Foo"`.
+  * `"lowercase-last"`: Correct order is `"Bar"`, `"Foo"`, `"baz"`.
+
   You may set the `"named-imports-order"` option to control the ordering of named
-  imports (the `{A, B, C}` in 'import {A, B, C} from "foo"`.)
+  imports (the `{A, B, C}` in `import {A, B, C} from "foo"`).
 
   Possible values for `"named-imports-order"` are:
 
   * `"case-insensitive'`: Correct order is `{A, b, C}`. (This is the default.)
   * `"lowercase-first"`: Correct order is `{b, A, C}`.
   * `"lowercase-last"`: Correct order is `{A, C, b}`.
+
           
 options:
   type: object
   properties:
+    import-sources-order:
+      type: string
+      enum:
+        - case-insensitive
+        - lowercase-first
+        - lowercase-last
     named-imports-order:
       type: string
       enum:
@@ -35,12 +50,20 @@ options:
   additionalProperties: false
 optionExamples:
   - 'true'
-  - '[true, {"named-imports-order": "lowercase-first"}]'
+  - '[true, {"import-sources-order": "lowercase-last", "named-imports-order": "lowercase-first"}]'
 type: style
 optionsJSON: |-
   {
     "type": "object",
     "properties": {
+      "import-sources-order": {
+        "type": "string",
+        "enum": [
+          "case-insensitive",
+          "lowercase-first",
+          "lowercase-last"
+        ]
+      },
       "named-imports-order": {
         "type": "string",
         "enum": [

--- a/docs/rules/typedef/index.html
+++ b/docs/rules/typedef/index.html
@@ -3,9 +3,10 @@ ruleName: typedef
 description: Requires type definitions to exist.
 optionsDescription: |-
 
-  Six arguments may be optionally provided:
+  Seven arguments may be optionally provided:
 
   * `"call-signature"` checks return type of functions.
+  * `"arrow-call-signature"` checks return type of arrow functions.
   * `"parameter"` checks type specifier of function parameters for non-arrow functions.
   * `"arrow-parameter"` checks type specifier of function parameters for arrow functions.
   * `"property-declaration"` checks return types of interface properties.
@@ -17,13 +18,14 @@ options:
     type: string
     enum:
       - call-signature
+      - arrow-call-signature
       - parameter
       - arrow-parameter
       - property-declaration
       - variable-declaration
       - member-variable-declaration
   minLength: 0
-  maxLength: 6
+  maxLength: 7
 optionExamples:
   - '[true, "call-signature", "parameter", "member-variable-declaration"]'
 type: typescript
@@ -34,6 +36,7 @@ optionsJSON: |-
       "type": "string",
       "enum": [
         "call-signature",
+        "arrow-call-signature",
         "parameter",
         "arrow-parameter",
         "property-declaration",
@@ -42,7 +45,7 @@ optionsJSON: |-
       ]
     },
     "minLength": 0,
-    "maxLength": 6
+    "maxLength": 7
   }
 layout: rule
 title: 'Rule: typedef'

--- a/docs/rules/whitespace/index.html
+++ b/docs/rules/whitespace/index.html
@@ -22,7 +22,7 @@ options:
       - check-decl
       - check-operator
       - check-module
-      - check-seperator
+      - check-separator
       - check-type
       - check-typecast
   minLength: 0
@@ -40,7 +40,7 @@ optionsJSON: |-
         "check-decl",
         "check-operator",
         "check-module",
-        "check-seperator",
+        "check-separator",
         "check-type",
         "check-typecast"
       ]


### PR DESCRIPTION
All changes are automatically generated from the rule metadata via the `grunt docs` command.