### PR TITLE
variable-names: allow-aliases.

### DIFF
--- a/test/rules/variable-name/default/test.ts.lint
+++ b/test/rules/variable-name/default/test.ts.lint
@@ -48,3 +48,18 @@ let optionallyValid_ = "bar";
     ~~~~~~~~~~~~~~~~          [variable name must be in camelcase or uppercase]
 let _$httpBackend_ = "leading and trailing";
     ~~~~~~~~~~~~~~          [variable name must be in camelcase or uppercase]
+
+// Aliases.
+class X {
+  ValidAlias = ValidAlias;
+}
+
+var ValidAlias = some.ValidAlias;
+var ValidAlias = some.InValidAlias;
+    ~~~~~~~~~~                [variable name must be in camelcase or uppercase]
+
+var someObject = {MoreValidAlias: 1};
+var {MoreValidAlias: localVar} = someObject;
+var {MoreValidAlias: LocalVar} = someObject;
+                     ~~~~~~~~                [variable name must be in camelcase or uppercase]
+var {MoreValidAlias} = someObject;


### PR DESCRIPTION
This option allows aliasing symbols, as long as the left hand side name
is identical to the right hand side name.

The use case is interoperating with legacy code that uses namespaces,
but still being able to abbreviate long namespaces in an ES6 module:

    const SomeClass = some.long.namespace.SomeClass;

Another use case is exposing enums or other PascalCased objects to a
template in an Angular application (or similar environments):

    class MyCtrl {
      SomeEnum = SomeEnum;
    }