### PR TITLE
JetBrains //noinspection whitelisted in comment-format space rule

### DIFF
--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -129,12 +129,18 @@ function startsWithSpace(commentText: string) {
         return true; // comment is "//"? Technically not a violation.
     }
 
+    const commentBody = commentText.substring(2);
+
     // whitelist //#region and //#endregion
-    if ((/^#(end)?region/).test(commentText.substring(2))) {
+    if ((/^#(end)?region/).test(commentBody)) {
+        return true;
+    }
+    // whitelist JetBrains IDEs' "//noinspection ..."
+    if ((/^noinspection\s/).test(commentBody)) {
         return true;
     }
 
-    const firstCharacter = commentText.charAt(2); // first character after the space
+    const firstCharacter = commentBody.charAt(0);
     // three slashes (///) also works, to allow for ///<reference>
     return firstCharacter === " " || firstCharacter === "/";
 }

--- a/test/rules/comment-format/lower/test.ts.lint
+++ b/test/rules/comment-format/lower/test.ts.lint
@@ -19,7 +19,7 @@ class Clazz { // this comment is correct
 `${location.protocol}//${location.hostname}`
 
 //noinspection JSUnusedGlobalSymbols
-const unusedVar;
+const unusedVar = 'unneeded value';
 
 [lower]: comment must start with lowercase letter
 [space]: comment must start with a space

--- a/test/rules/comment-format/lower/test.ts.lint
+++ b/test/rules/comment-format/lower/test.ts.lint
@@ -18,5 +18,8 @@ class Clazz { // this comment is correct
 
 `${location.protocol}//${location.hostname}`
 
+//noinspection JSUnusedGlobalSymbols
+const unusedVar;
+
 [lower]: comment must start with lowercase letter
 [space]: comment must start with a space


### PR DESCRIPTION
JetBrains IDE’s (IntelliJ IDEA, WebStorm, PhpStorm, etc.) disabling
inspections by adding `//noinspection [rulenames]` before the
expression. This violates the rule of single-line comments must start
with a space.