### PR TITLE
Fix misleading example for 'file-header'

### DIFF
--- a/docs/rules/file-header/index.html
+++ b/docs/rules/file-header/index.html
@@ -5,7 +5,7 @@ optionsDescription: Regular expression to match the header.
 options:
   type: string
 optionExamples:
-  - '"true", "Copyright \d{4}"'
+  - '[true, "Copyright \\d{4}"]'
 type: style
 optionsJSON: |-
   {

--- a/docs/rules/file-header/index.html
+++ b/docs/rules/file-header/index.html
@@ -5,7 +5,7 @@ optionsDescription: Regular expression to match the header.
 options:
   type: string
 optionExamples:
-  - 'true, "Copyright \d{4}"'
+  - '"true", "Copyright \d{4}"'
 type: style
 optionsJSON: |-
   {

--- a/docs/rules/file-header/index.html
+++ b/docs/rules/file-header/index.html
@@ -5,7 +5,7 @@ optionsDescription: Regular expression to match the header.
 options:
   type: string
 optionExamples:
-  - '[true, "Copyright \\d{4}"]'
+  - 'true, "Copyright \d{4}"'
 type: style
 optionsJSON: |-
   {

--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -11,7 +11,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         options: {
             type: "string",
         },
-        optionExamples: ['"true", "Copyright \\d{4}"'],
+        optionExamples: ['[true, "Copyright \\\\d{4}"]'],
         type: "style",
     };
     /* tslint:enable:object-literal-sort-keys */


### PR DESCRIPTION
Old example was wrong (braces missing, regex wrong) and therefore misleading

Old example for file-header: `"file-header": "true", "Copyright \d{4}"`
New example for file-header: `"file-header": [true, "Copyright \\d{4}]"`