### PR TITLE
Add array-simple option to array-type rule

### DIFF
--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -43,8 +43,11 @@ class ArrayTypeWalker extends Lint.RuleWalker {
         if (this.hasOption(OPTION_GENERIC) || this.hasOption(OPTION_ARRAY_SIMPLE) && !this.isSimpleType(typeName)) {
             const failureString = this.hasOption(OPTION_GENERIC) ? Rule.FAILURE_STRING_GENERIC : Rule.FAILURE_STRING_GENERIC_SIMPLE;
             const parens = typeName.kind === ts.SyntaxKind.ParenthesizedType ? 1 : 0;
+            // Add a space if the type is preceded by 'as' and the node has no leading whitespace
+            const space = !parens && node.parent.kind === ts.SyntaxKind.AsExpression &&
+                node.getStart() === node.getFullStart() ? " " : "";
             const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                this.createReplacement(typeName.getStart(), parens, "Array<"),
+                this.createReplacement(typeName.getStart(), parens, space + "Array<"),
                 // Delete the square brackets and replace with an angle bracket
                 this.createReplacement(typeName.getEnd() - parens, node.getEnd() - typeName.getEnd() + parens, ">"),
             ]);

--- a/test/rules/array-type/array-simple/test.ts.fix
+++ b/test/rules/array-type/array-simple/test.ts.fix
@@ -1,0 +1,38 @@
+let x: number[] = [1] as number[];
+let y: string[] = <string[]>["2"];
+let z: any[] = [3, "4"];
+
+let xx: number[][] = [[1, 2], [3]];
+let yy: number[][] = [[4, 5], [6]];
+
+type Arr<T> = T[];
+
+// Ignore user defined aliases
+let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];
+
+interface ArrayClass<T> {
+    foo: T[];
+    bar: T[];
+    baz: Arr<T>;
+}
+
+function fooFunction(foo: ArrayClass<string>[]) {
+    return foo.map(e => e.foo);
+}
+
+function barFunction(bar: ArrayClass<String>[]) {
+    return bar.map(e => e.bar);
+}
+
+function bazFunction(baz: Arr<ArrayClass<String>>) {
+    return baz.map(e => e.baz);
+}
+
+let fooVar: Array<(c: number) => number>;
+let barVar: Array<(c: number) => number>;
+
+type fooUnion = Array<string|number|boolean>;
+type barUnion = Array<string|number|boolean>;
+
+type fooIntersection = Array<string & number>;
+type barIntersection = Array<string & number>;

--- a/test/rules/array-type/array-simple/test.ts.fix
+++ b/test/rules/array-type/array-simple/test.ts.fix
@@ -5,6 +5,8 @@ let z: any[] = [3, "4"];
 let xx: number[][] = [[1, 2], [3]];
 let yy: number[][] = [[4, 5], [6]];
 
+let ya = [[1, "2"]] as Array<[number, string]>;
+
 type Arr<T> = T[];
 
 // Ignore user defined aliases
@@ -38,10 +40,14 @@ type fooIntersection = Array<string & number>;
 type barIntersection = Array<string & number>;
 
 namespace fooName {
-    type BarType =  { bar: string };
+    type BarType = { bar: string };
     type BazType<T> = Arr<T>;
 }
 
 let v: fooName.BarType[] = [{ bar: "bar" }];
 
 let w: Array<fooName.BazType<string>> = [["baz"]];
+
+interface FooInterface {
+    '.bar': {baz: string[];};
+}

--- a/test/rules/array-type/array-simple/test.ts.fix
+++ b/test/rules/array-type/array-simple/test.ts.fix
@@ -8,7 +8,7 @@ let yy: number[][] = [[4, 5], [6]];
 type Arr<T> = T[];
 
 // Ignore user defined aliases
-let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];
+let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];
 
 interface ArrayClass<T> {
     foo: T[];
@@ -16,11 +16,11 @@ interface ArrayClass<T> {
     baz: Arr<T>;
 }
 
-function fooFunction(foo: ArrayClass<string>[]) {
+function fooFunction(foo: Array<ArrayClass<string>>) {
     return foo.map(e => e.foo);
 }
 
-function barFunction(bar: ArrayClass<String>[]) {
+function barFunction(bar: Array<ArrayClass<String>>) {
     return bar.map(e => e.bar);
 }
 
@@ -36,3 +36,12 @@ type barUnion = Array<string|number|boolean>;
 
 type fooIntersection = Array<string & number>;
 type barIntersection = Array<string & number>;
+
+namespace fooName {
+    type BarType =  { bar: string };
+    type BazType<T> = Arr<T>;
+}
+
+let v: fooName.BarType[] = [{ bar: "bar" }];
+
+let w: Array<fooName.BazType<string>> = [["baz"]];

--- a/test/rules/array-type/array-simple/test.ts.lint
+++ b/test/rules/array-type/array-simple/test.ts.lint
@@ -10,6 +10,9 @@ let xx: Array<Array<number>> = [[1, 2], [3]];
               ~~~~~~~~~~~~~                   [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
 let yy: number[][] = [[4, 5], [6]];
 
+let ya = [[1, "2"]] as[number, string][];
+                      ~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
+
 type Arr<T> = Array<T>;
               ~~~~~~~~  [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
 
@@ -50,7 +53,7 @@ type barIntersection = (string & number)[];
                        ~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
 
 namespace fooName {
-    type BarType =  { bar: string };
+    type BarType = { bar: string };
     type BazType<T> = Arr<T>;
 }
 
@@ -59,3 +62,7 @@ let v: Array<fooName.BarType> = [{ bar: "bar" }];
 
 let w: fooName.BazType<string>[] = [["baz"]];
        ~~~~~~~~~~~~~~~~~~~~~~~~~              [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
+
+interface FooInterface {
+    '.bar': {baz: string[];};
+}

--- a/test/rules/array-type/array-simple/test.ts.lint
+++ b/test/rules/array-type/array-simple/test.ts.lint
@@ -1,0 +1,50 @@
+let x: Array<number> = [1] as number[];
+       ~~~~~~~~~~~~~                    [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+let y: string[] = <Array<string>>["2"];
+                   ~~~~~~~~~~~~~        [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+let z: Array = [3, "4"];
+       ~~~~~             [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+
+let xx: Array<Array<number>> = [[1, 2], [3]];
+        ~~~~~~~~~~~~~~~~~~~~                  [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+              ~~~~~~~~~~~~~                   [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+let yy: number[][] = [[4, 5], [6]];
+
+type Arr<T> = Array<T>;
+              ~~~~~~~~  [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+
+// Ignore user defined aliases
+let yyyy: Arr<Array<Arr<string>>[]> = [[[["2"]]]];
+              ~~~~~~~~~~~~~~~~~~                   [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+
+interface ArrayClass<T> {
+    foo: Array<T>;
+         ~~~~~~~~  [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+    bar: T[];
+    baz: Arr<T>;
+}
+
+function fooFunction(foo: Array<ArrayClass<string>>) {
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~    [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+    return foo.map(e => e.foo);
+}
+
+function barFunction(bar: ArrayClass<String>[]) {
+    return bar.map(e => e.bar);
+}
+
+function bazFunction(baz: Arr<ArrayClass<String>>) {
+    return baz.map(e => e.baz);
+}
+
+let fooVar: Array<(c: number) => number>;
+let barVar: ((c: number) => number)[];
+            ~~~~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for simple types. Use 'Array<T>' instead.]
+
+type fooUnion = Array<string|number|boolean>;
+type barUnion = (string|number|boolean)[];
+                ~~~~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for simple types. Use 'Array<T>' instead.]
+
+type fooIntersection = Array<string & number>;
+type barIntersection = (string & number)[];
+                       ~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for simple types. Use 'Array<T>' instead.]

--- a/test/rules/array-type/array-simple/test.ts.lint
+++ b/test/rules/array-type/array-simple/test.ts.lint
@@ -15,7 +15,7 @@ type Arr<T> = Array<T>;
 
 // Ignore user defined aliases
 let yyyy: Arr<Array<Arr<string>>[]> = [[[["2"]]]];
-              ~~~~~~~~~~~~~~~~~~                   [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+              ~~~~~~~~~~~~~~~~~~~~                 [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
 
 interface ArrayClass<T> {
     foo: Array<T>;
@@ -25,11 +25,11 @@ interface ArrayClass<T> {
 }
 
 function fooFunction(foo: Array<ArrayClass<string>>) {
-                          ~~~~~~~~~~~~~~~~~~~~~~~~~    [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
     return foo.map(e => e.foo);
 }
 
 function barFunction(bar: ArrayClass<String>[]) {
+                          ~~~~~~~~~~~~~~~~~~~~    [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
     return bar.map(e => e.bar);
 }
 
@@ -39,12 +39,23 @@ function bazFunction(baz: Arr<ArrayClass<String>>) {
 
 let fooVar: Array<(c: number) => number>;
 let barVar: ((c: number) => number)[];
-            ~~~~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for simple types. Use 'Array<T>' instead.]
+            ~~~~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
 
 type fooUnion = Array<string|number|boolean>;
 type barUnion = (string|number|boolean)[];
-                ~~~~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for simple types. Use 'Array<T>' instead.]
+                ~~~~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
 
 type fooIntersection = Array<string & number>;
 type barIntersection = (string & number)[];
-                       ~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for simple types. Use 'Array<T>' instead.]
+                       ~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
+
+namespace fooName {
+    type BarType =  { bar: string };
+    type BazType<T> = Arr<T>;
+}
+
+let v: Array<fooName.BarType> = [{ bar: "bar" }];
+       ~~~~~~~~~~~~~~~~~~~~~~                     [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+
+let w: fooName.BazType<string>[] = [["baz"]];
+       ~~~~~~~~~~~~~~~~~~~~~~~~~              [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]

--- a/test/rules/array-type/array-simple/tslint.json
+++ b/test/rules/array-type/array-simple/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "array-type": [true, "array-simple"]
+  }
+}

--- a/test/rules/array-type/array/test.ts.fix
+++ b/test/rules/array-type/array/test.ts.fix
@@ -5,6 +5,8 @@ let z: any[] = [3, "4"];
 let xx: number[][] = [[1, 2], [3]];
 let yy: number[][] = [[4, 5], [6]];
 
+let ya = [[1, "2"]] as[number, string][];
+
 type Arr<T> = T[];
 
 // Ignore user defined aliases
@@ -36,3 +38,7 @@ type barUnion = (string|number|boolean)[];
 
 type fooIntersection = (string & number)[];
 type barIntersection = (string & number)[];
+
+interface FooInterface {
+    '.bar': {baz: string[];};
+}

--- a/test/rules/array-type/array/test.ts.lint
+++ b/test/rules/array-type/array/test.ts.lint
@@ -10,6 +10,8 @@ let xx: Array<Array<number>> = [[1, 2], [3]];
               ~~~~~~~~~~~~~                   [Array type using 'Array<T>' is forbidden. Use 'T[]' instead.]
 let yy: number[][] = [[4, 5], [6]];
 
+let ya = [[1, "2"]] as[number, string][];
+
 type Arr<T> = Array<T>;
               ~~~~~~~~  [Array type using 'Array<T>' is forbidden. Use 'T[]' instead.]
 
@@ -48,3 +50,7 @@ type barUnion = (string|number|boolean)[];
 type fooIntersection = Array<string & number>;
                        ~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'Array<T>' is forbidden. Use 'T[]' instead.]
 type barIntersection = (string & number)[];
+
+interface FooInterface {
+    '.bar': {baz: string[];};
+}

--- a/test/rules/array-type/generic/test.ts.fix
+++ b/test/rules/array-type/generic/test.ts.fix
@@ -5,6 +5,8 @@ let z: Array = [3, "4"];
 let xx: Array<Array<number>> = [[1, 2], [3]];
 let yy: Array<Array<number>> = [[4, 5], [6]];
 
+let ya = [[1, "2"]] as Array<[number, string]>;
+
 type Arr<T> = Array<T>;
 
 // Ignore user defined aliases
@@ -36,3 +38,7 @@ type barUnion = Array<string|number|boolean>;
 
 type fooIntersection = Array<string & number>;
 type barIntersection = Array<string & number>;
+
+interface FooInterface {
+    '.bar': {baz: Array<string>;};
+}

--- a/test/rules/array-type/generic/test.ts.lint
+++ b/test/rules/array-type/generic/test.ts.lint
@@ -9,6 +9,9 @@ let yy: number[][] = [[4, 5], [6]];
         ~~~~~~~~~~                  [Array type using 'T[]' is forbidden. Use 'Array<T>' instead.]
         ~~~~~~~~                    [Array type using 'T[]' is forbidden. Use 'Array<T>' instead.]
 
+let ya = [[1, "2"]] as[number, string][];
+                      ~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden. Use 'Array<T>' instead.]
+
 type Arr<T> = Array<T>;
 
 // Ignore user defined aliases
@@ -46,3 +49,8 @@ type barUnion = (string|number|boolean)[];
 type fooIntersection = Array<string & number>;
 type barIntersection = (string & number)[];
                        ~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden. Use 'Array<T>' instead.]
+
+interface FooInterface {
+    '.bar': {baz: string[];};
+                  ~~~~~~~~    [Array type using 'T[]' is forbidden. Use 'Array<T>' instead.]
+}


### PR DESCRIPTION
Only use '[]' notation for 'simple' types.

Fixes #1526 