### PR TITLE
JSDoc rule should not block arbitrary comments like /********/

### DIFF
--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -76,8 +76,8 @@ class JsdocWalker extends Lint.SkippableTokenAwareRuleWalker {
         const firstLine = lines[0];
         let jsdocPosition = currentPosition;
 
-        // regex is: start of string, followed by any amount of whitespace, followed by /**
-        const isJsdocMatch = firstLine.match(/^\s*\/\*\*[^*]/);
+        // regex is: start of string, followed by any amount of whitespace, followed by /** but not more than 2 **
+        const isJsdocMatch = firstLine.match(/^\s*\/\*\*([^*]|$)/);
         if (isJsdocMatch != null) {
             if (lines.length === 1) {
                 const firstLineMatch = firstLine.match(/^\s*\/\*\* (.* )?\*\/$/);

--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -77,7 +77,7 @@ class JsdocWalker extends Lint.SkippableTokenAwareRuleWalker {
         let jsdocPosition = currentPosition;
 
         // regex is: start of string, followed by any amount of whitespace, followed by /**
-        const isJsdocMatch = firstLine.match(/^\s*\/\*\*/);
+        const isJsdocMatch = firstLine.match(/^\s*\/\*\*\s/);
         if (isJsdocMatch != null) {
             if (lines.length === 1) {
                 const firstLineMatch = firstLine.match(/^\s*\/\*\* (.* )?\*\/$/);

--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -77,7 +77,7 @@ class JsdocWalker extends Lint.SkippableTokenAwareRuleWalker {
         let jsdocPosition = currentPosition;
 
         // regex is: start of string, followed by any amount of whitespace, followed by /**
-        const isJsdocMatch = firstLine.match(/^\s*\/\*\*\s/);
+        const isJsdocMatch = firstLine.match(/^\s*\/\*\*[^*]/);
         if (isJsdocMatch != null) {
             if (lines.length === 1) {
                 const firstLineMatch = firstLine.match(/^\s*\/\*\* (.* )?\*\/$/);

--- a/test/rules/jsdoc-format/jsdoc.ts.lint
+++ b/test/rules/jsdoc-format/jsdoc.ts.lint
@@ -23,6 +23,10 @@ I've even got characters where I shouldn't. How fun!    *
          */
     }
 
+    /**********************************************************/
+    /* this is just an arbitrary separator, not a jsdoc block */
+    /**********************************************************/
+
     /**
      * this is also jsdoc
      *and it has a problem on this line


### PR DESCRIPTION
# Problem
There are 2 prime examples of comments that confuse tslint JSDoc detection regex:
A separator:
```typescript
class MyClass {
    public prop1;
    public prop2;
    /********************************************/
    constructor() { ... }
    public method1() { ... }
    public method2() { ... }
    /********************************************/
    private internal1() { ... }
}
```
and
```typescript
/**************
 * my-file.ts *
 **************/
```

These can be used as visual separator or guides, and are definitely not JSDocs.
Was also reported in issue #1121 several months ago.

# Solution
Instead of matching any `/^\s*\/\*\*/`, I suggest that when there are more than 2 asterisks in a row, it should not be tested as a JSDoc comment.
Thus, the regex is updated to `/^\s*\/\*\*([^*]|$)/` which would accept `/**` followed by anything but another `*`.

## matched as jsdoc
```typescript
/** (space) */ // valid, empty
/**text */ // invalid
/**_ */ // invalid
/** (new-line) // valid
 */
```

## not jsdoc
```typescript
/***/
/*/
/*******/
/******
*******/
```
