### PR TITLE
print nothing when no failures

### DIFF
--- a/src/formatters/proseFormatter.ts
+++ b/src/formatters/proseFormatter.ts
@@ -20,7 +20,7 @@ import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
     public format(failures: RuleFailure[]): string {
-        if (!failures.length) {
+        if (failures.length === 0) {
             return "";
         }
 

--- a/src/formatters/proseFormatter.ts
+++ b/src/formatters/proseFormatter.ts
@@ -20,6 +20,10 @@ import {RuleFailure} from "../language/rule/rule";
 
 export class Formatter extends AbstractFormatter {
     public format(failures: RuleFailure[]): string {
+        if (!failures.length) {
+            return "";
+        }
+
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();
             const failureString = failure.getFailure();

--- a/test/formatters/proseFormatterTests.ts
+++ b/test/formatters/proseFormatterTests.ts
@@ -49,7 +49,7 @@ describe("Prose Formatter", () => {
 
     it("handles no failures", () => {
         const result = formatter.format([]);
-        assert.equal(result, "\n");
+        assert.equal(result, "");
     });
 
     function getPositionString(line: number, character: number) {


### PR DESCRIPTION
https://github.com/palantir/tslint/pull/1472/commits/8fd8723586480f2396574072e5b467f8c096240e introduced a change
where the proseFormatter writes a single newline to stdout when there are no failures