### PR TITLE
Stylish Formatter: output all file names

### DIFF
--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -26,20 +26,18 @@ export class Formatter extends AbstractFormatter {
             return "\n";
         }
 
-        const outputLines: Array<string> = [];
-
-        const positionMaxSize = this.getPositionMaxSize(failures);
-        const ruleMaxSize     = this.getRuleMaxSize(failures);
+        const outputLines: string[] = [];
+        const positionMaxSize       = this.getPositionMaxSize(failures);
+        const ruleMaxSize           = this.getRuleMaxSize(failures);
 
         let currentFile: string;
 
         for (const failure of failures) {
-            // File name for each new file
             const fileName = failure.getFileName();
+
+            // Output the name of each file once
             if (currentFile !== fileName) {
-                if (currentFile) {
-                    outputLines.push("");
-                }
+                outputLines.push("");
                 outputLines.push(fileName);
                 currentFile = fileName;
             }
@@ -62,6 +60,11 @@ export class Formatter extends AbstractFormatter {
             const output = `${positionTuple}  ${ruleName}  ${failureString}`;
 
             outputLines.push(output);
+        }
+
+        // Removes initial blank line
+        if (outputLines[0] === "") {
+            outputLines.shift();
         }
 
         return outputLines.join("\n") + "\n\n";

--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -26,15 +26,24 @@ export class Formatter extends AbstractFormatter {
             return "\n";
         }
 
-        const fileName        = failures[0].getFileName();
+        const outputLines: Array<string> = [];
+
         const positionMaxSize = this.getPositionMaxSize(failures);
         const ruleMaxSize     = this.getRuleMaxSize(failures);
 
-        const outputLines = [
-            fileName,
-        ];
+        let currentFile: string;
 
         for (const failure of failures) {
+            // File name for each new file
+            const fileName = failure.getFileName();
+            if (currentFile !== fileName) {
+                if (currentFile) {
+                    outputLines.push("");
+                }
+                outputLines.push(fileName);
+                currentFile = fileName;
+            }
+
             const failureString = failure.getFailure();
 
             // Rule


### PR DESCRIPTION
Currently the stylish formatter prints *only* the first fileName, and then a list of lint errors from all files without specifying to which file they belong.
After this fix, each time a new file is reached, a new-line will be added, and then the name of the file, so each group of lint failures will be group with their fileName.