### PR TITLE
fix: do not flag nested or .d.ts namespaces.

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -117,6 +117,13 @@ export function getBindingElementVariableDeclaration(node: ts.BindingElement): t
 }
 
 /**
+ * Returns true if some ancestor of `node` satisfies `predicate`, including `node` itself.
+ */
+export function someAncestor(node: ts.Node, predicate: (n: ts.Node)=>boolean): boolean {
+    return predicate(node) || (node.parent && someAncestor(node.parent, predicate));
+}
+
+/**
  * Bitwise check for node flags.
  */
 export function isNodeFlagSet(node: ts.Node, flagToCheck: ts.NodeFlags): boolean {

--- a/src/rules/noNamespaceRule.ts
+++ b/src/rules/noNamespaceRule.ts
@@ -54,11 +54,21 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class NoNamespaceWalker extends Lint.RuleWalker {
+    public visitSourceFile(node: ts.SourceFile) {
+        // Ignore all .d.ts files by returning and not walking their ASTs.
+        // .d.ts declarations do not have the Ambient flag set, but are still declarations.
+        if (this.hasOption("allow-declarations") && node.fileName.match(/\.d\.ts$/)) { return; }
+        this.walkChildren(node);
+    }
+
     public visitModuleDeclaration(decl: ts.ModuleDeclaration) {
         super.visitModuleDeclaration(decl);
         // declare module 'foo' {} is an external module, not a namespace.
         if (decl.name.kind === ts.SyntaxKind.StringLiteral) { return; }
-        if (Lint.isNodeFlagSet(decl, ts.NodeFlags.Ambient) && this.hasOption("allow-declarations")) { return; }
+        if (Lint.someAncestor(decl, (n) => Lint.isNodeFlagSet(n, ts.NodeFlags.Ambient)) &&
+            this.hasOption("allow-declarations")) {
+            return;
+        }
         if (Lint.isNestedModuleDeclaration(decl)) { return; }
         this.addFailure(this.createFailure(decl.getStart(), decl.getWidth(), Rule.FAILURE_STRING));
     }

--- a/test/rules/no-namespace/allow-declarations/test.ts.lint
+++ b/test/rules/no-namespace/allow-declarations/test.ts.lint
@@ -1,3 +1,6 @@
 declare namespace Foo {
+    // Allowed because namespaces nested in ambients are implicitly ambient.
+    namespace Foo {
 
+    }
 }


### PR DESCRIPTION
Note: I've been unable to test this properly as on my machine grunt for some reason picks up tsc 2.0.3, which fails to compile tslint.
