### PR TITLE
Compile with TypeScript 1.8.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Creating a new release
 ----------------------
 <sup>[back to ToC &uarr;](#table-of-contents)</sup>
 
-1. Bump the version number in `package.json` and `src/tslintMutli.ts`
+1. Bump the version number in `package.json` and `src/tslintMulti.ts`
 2. Add release notes in `CHANGELOG.md`
 3. Run `grunt` to build the latest sources
 4. Commit with message `Prepare release <version>`

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Creating a new release
 ----------------------
 <sup>[back to ToC &uarr;](#table-of-contents)</sup>
 
-1. Bump the version number in `package.json` and `src/tslint.ts`
+1. Bump the version number in `package.json`, `src/tslint.ts`, and `src/tslintMutli.ts`
 2. Add release notes in `CHANGELOG.md`
 3. Run `grunt` to build the latest sources
 4. Commit with message `Prepare release <version>`

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Creating a new release
 ----------------------
 <sup>[back to ToC &uarr;](#table-of-contents)</sup>
 
-1. Bump the version number in `package.json`, `src/tslint.ts`, and `src/tslintMutli.ts`
+1. Bump the version number in `package.json` and `src/tslintMutli.ts`
 2. Add release notes in `CHANGELOG.md`
 3. Run `grunt` to build the latest sources
 4. Commit with message `Prepare release <version>`

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "mocha": "^2.2.5",
     "tslint": "latest",
     "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
-    "typescript": "latest"
+    "typescript": "1.8.10"
   },
   "peerDependencies": {
-    "typescript": ">=2.0.0"
+    "typescript": ">=1.7.3"
   },
   "license": "Apache-2.0",
   "typescript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint",
-  "version": "3.15.1",
+  "version": "4.0.0-dev",
   "description": "An extensible static analysis linter for the TypeScript language",
   "bin": {
     "tslint": "./bin/tslint"
@@ -46,7 +46,7 @@
     "typescript": "latest"
   },
   "peerDependencies": {
-    "typescript": ">=1.7.3"
+    "typescript": ">=2.0.0"
   },
   "license": "Apache-2.0",
   "typescript": {

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -29,6 +29,7 @@ export function getSourceFile(fileName: string, source: string): ts.SourceFile {
         getCanonicalFileName: (filename: string) => filename,
         getCurrentDirectory: () => "",
         getDefaultLibFileName: () => "lib.d.ts",
+        getDirectories: (path: string) => [],
         getNewLine: () => "\n",
         getSourceFile: (filenameToGet: string) => {
             if (filenameToGet === normalizedName) {

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -29,7 +29,8 @@ export function getSourceFile(fileName: string, source: string): ts.SourceFile {
         getCanonicalFileName: (filename: string) => filename,
         getCurrentDirectory: () => "",
         getDefaultLibFileName: () => "lib.d.ts",
-        getDirectories: (path: string) => [],
+        // TODO: include this field when compiling with TS 2.0
+        // getDirectories: (path: string) => [],
         getNewLine: () => "\n",
         getSourceFile: (filenameToGet: string) => {
             if (filenameToGet === normalizedName) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -65,6 +65,7 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
                 getCanonicalFileName: (filename: string) => filename,
                 getCurrentDirectory: () => "",
                 getDefaultLibFileName: () => ts.getDefaultLibFileName(compilerOptions),
+                getDirectories: (path: string) => [],
                 getNewLine: () => "\n",
                 getSourceFile(filenameToGet: string) {
                     if (filenameToGet === this.getDefaultLibFileName()) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -65,7 +65,8 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
                 getCanonicalFileName: (filename: string) => filename,
                 getCurrentDirectory: () => "",
                 getDefaultLibFileName: () => ts.getDefaultLibFileName(compilerOptions),
-                getDirectories: (path: string) => [],
+                // TODO: include this field when compiling with TS 2.0
+                // getDirectories: (path: string) => [],
                 getNewLine: () => "\n",
                 getSourceFile(filenameToGet: string) {
                     if (filenameToGet === this.getDefaultLibFileName()) {

--- a/src/tslintMulti.ts
+++ b/src/tslintMulti.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { existsSync } from "fs";
 import * as ts from "typescript";
 
 import {
@@ -39,7 +40,7 @@ import { arrayify } from "./utils";
  * Linter that can lint multiple files in consecutive runs.
  */
 class MultiLinter {
-    public static VERSION = "3.15.1";
+    public static VERSION = "4.0.0-dev";
 
     public static findConfiguration = findConfiguration;
     public static findConfigurationPath = findConfigurationPath;
@@ -61,12 +62,13 @@ class MultiLinter {
             }
         }
 
-        const {config} = ts.readConfigFile(configFile, ts.sys.readFile);
-        const parsed = ts.parseJsonConfigFileContent(config, {
-            fileExists: (path: string) => true,
+        const { config } = ts.readConfigFile(configFile, ts.sys.readFile);
+        const parseConfigHost = {
+            fileExists: existsSync,
             readDirectory: ts.sys.readDirectory,
-            useCaseSensitiveFileNames: false,
-        }, projectDirectory);
+            useCaseSensitiveFileNames: true,
+        };
+        const parsed = ts.parseJsonConfigFileContent(config, parseConfigHost, projectDirectory);
         const host = ts.createCompilerHost(parsed.options, true);
         const program = ts.createProgram(parsed.fileNames, parsed.options, host);
 

--- a/src/tslintMulti.ts
+++ b/src/tslintMulti.ts
@@ -39,7 +39,6 @@ import { arrayify } from "./utils";
  * Linter that can lint multiple files in consecutive runs.
  */
 class MultiLinter {
-
     public static VERSION = "3.15.1";
 
     public static findConfiguration = findConfiguration;
@@ -63,7 +62,11 @@ class MultiLinter {
         }
 
         const {config} = ts.readConfigFile(configFile, ts.sys.readFile);
-        const parsed = ts.parseJsonConfigFileContent(config, {readDirectory: ts.sys.readDirectory}, projectDirectory);
+        const parsed = ts.parseJsonConfigFileContent(config, {
+            fileExists: (path: string) => true,
+            readDirectory: ts.sys.readDirectory,
+            useCaseSensitiveFileNames: false,
+        }, projectDirectory);
         const host = ts.createCompilerHost(parsed.options, true);
         const program = ts.createProgram(parsed.fileNames, parsed.options, host);
 


### PR DESCRIPTION
Breaking changes in compiler APIs broke the master branch. This is a simple workaround to get compilation working, but it forces us to depend on TS 2.0 (it doesn't compile with TS 1.8).

What do you think about bumping the peer dependency @JKillian?