### PR TITLE
Only return actual files from CLI glob. This fixes #1381

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -297,6 +297,6 @@ if (argv.project != null) {
 }
 
 files = files
-  .map((file: string) => glob.sync(file, { ignore: argv.e }))
+  .map((file: string) => glob.sync(file, { ignore: argv.e, nodir: true }))
   .reduce((a: string[], b: string[]) => a.concat(b));
 processFiles(files, program);


### PR DESCRIPTION
This is probably the smallest change ever but currently as mentioned in issue #1381, if you attempt to run `tslint` with a glob that is not restricted by a file extension (e.g. `src/**/*`) you get the following error:

> Error: EISDIR: illegal operation on a directory, read

This can be confusing to the user as it is not expected behaviour that a command line tool that parses files would consider folders. It had me stumped for a bit.

I have made a small change to ignore folders in globs. After making the change, when I run `tslint` again with no file extension specified I get:

> Error: Invalid source file: src/components/DrawerSelector/DrawerSelector.js. Ensure that the files supplied to lint have a .ts or .tsx extension.

This makes it much clearer that I need to specify `.ts` in my glob.

Do you think it makes sense to apply this change?

Thanks!
