### PR TITLE
Make only-arrow-functions allow generator functions

### DIFF
--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -55,14 +55,16 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-        if (!this.hasOption(OPTION_ALLOW_DECLARATIONS)) {
+        if (!node.asteriskToken && !this.hasOption(OPTION_ALLOW_DECLARATIONS)) {
             this.addFailure(this.createFailure(node.getStart(), "function".length, Rule.FAILURE_STRING));
         }
         super.visitFunctionDeclaration(node);
     }
 
     public visitFunctionExpression(node: ts.FunctionExpression) {
-        this.addFailure(this.createFailure(node.getStart(), "function".length, Rule.FAILURE_STRING));
+        if (!node.asteriskToken) {
+            this.addFailure(this.createFailure(node.getStart(), "function".length, Rule.FAILURE_STRING));
+        }
         super.visitFunctionExpression(node);
     }
 }

--- a/test/rules/only-arrow-functions/allow-declarations/test.ts.lint
+++ b/test/rules/only-arrow-functions/allow-declarations/test.ts.lint
@@ -17,4 +17,7 @@ function () {
 
 ((func) => func())(() => {});
 
+function* generator() {}
+let generator = function*() {}
+
 [0]: non-arrow functions are forbidden

--- a/test/rules/only-arrow-functions/default/test.ts.lint
+++ b/test/rules/only-arrow-functions/default/test.ts.lint
@@ -20,4 +20,7 @@ function () {
 
 ((func) => func())(() => {});
 
+function* generator() {}
+let generator = function*() {}
+
 [0]: non-arrow functions are forbidden


### PR DESCRIPTION
Currently the only way to write a generator function is with the `function` keyword, so it makes sense to allow this without requiring a flag.
This also appears to be the behavior of [eslint](http://eslint.org/docs/rules/prefer-arrow-callback).
