### PR TITLE
[2.0] Make only-arrow-functions allow functions with a `this` parameter

### DIFF
--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -55,16 +55,31 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-        if (!node.asteriskToken && !this.hasOption(OPTION_ALLOW_DECLARATIONS)) {
-            this.addFailure(this.createFailure(node.getStart(), "function".length, Rule.FAILURE_STRING));
+        if (!this.hasOption(OPTION_ALLOW_DECLARATIONS)) {
+            this.failUnlessExempt(node);
         }
         super.visitFunctionDeclaration(node);
     }
 
     public visitFunctionExpression(node: ts.FunctionExpression) {
-        if (!node.asteriskToken) {
-            this.addFailure(this.createFailure(node.getStart(), "function".length, Rule.FAILURE_STRING));
-        }
+        this.failUnlessExempt(node);
         super.visitFunctionExpression(node);
     }
+
+    private failUnlessExempt(node: ts.FunctionLikeDeclaration) {
+        if (!functionIsExempt(node)) {
+            this.addFailure(this.createFailure(node.getStart(), "function".length, Rule.FAILURE_STRING));
+        }
+    }
+}
+
+/** Generator functions and functions explicitly declaring `this` are allowed. */
+function functionIsExempt(node: ts.FunctionLikeDeclaration) {
+    return node.asteriskToken || hasThisParameter(node);
+}
+
+function hasThisParameter(node: ts.FunctionLikeDeclaration) {
+    const first = node.parameters[0];
+    return first && first.name.kind === ts.SyntaxKind.Identifier &&
+        (first.name as ts.Identifier).originalKeywordKind === ts.SyntaxKind.ThisKeyword;
 }

--- a/test/rules/only-arrow-functions/allow-declarations/test.ts.lint
+++ b/test/rules/only-arrow-functions/allow-declarations/test.ts.lint
@@ -20,4 +20,7 @@ function () {
 function* generator() {}
 let generator = function*() {}
 
+function hasThisParameter(this) {}
+let hasThisParameter = function(this) {}
+
 [0]: non-arrow functions are forbidden

--- a/test/rules/only-arrow-functions/default/test.ts.lint
+++ b/test/rules/only-arrow-functions/default/test.ts.lint
@@ -23,4 +23,7 @@ function () {
 function* generator() {}
 let generator = function*() {}
 
+function hasThisParameter(this) {}
+let hasThisParameter = function(this) {}
+
 [0]: non-arrow functions are forbidden


### PR DESCRIPTION
Fixes #1513

This requires TypeScript 2.0 to parse the `this` parameters.
Changes to `package.json`, `src/test.ts`, and `src/language/utils.ts` are quick fixes to get it working with 2.0.
Merging this should wait until tslint has been properly upgraded to 2.0.
