### PR TITLE
Add "any" order transform for "ordered-imports" rule

### DIFF
--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -42,6 +42,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`"case-insensitive'\`: Correct order is \`"Bar"\`, \`"baz"\`, \`"Foo"\`. (This is the default.)
             * \`"lowercase-first"\`: Correct order is \`"baz"\`, \`"Bar"\`, \`"Foo"\`.
             * \`"lowercase-last"\`: Correct order is \`"Bar"\`, \`"Foo"\`, \`"baz"\`.
+            * \`"any"\`: Allow any order.
 
             You may set the \`"named-imports-order"\` option to control the ordering of named
             imports (the \`{A, B, C}\` in \`import {A, B, C} from "foo"\`).
@@ -51,6 +52,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`"case-insensitive'\`: Correct order is \`{A, b, C}\`. (This is the default.)
             * \`"lowercase-first"\`: Correct order is \`{b, A, C}\`.
             * \`"lowercase-last"\`: Correct order is \`{A, C, b}\`.
+            * \`"any"\`: Allow any order.
 
         `,
         options: {
@@ -58,11 +60,11 @@ export class Rule extends Lint.Rules.AbstractRule {
             properties: {
                 "import-sources-order": {
                     type: "string",
-                    enum: ["case-insensitive", "lowercase-first", "lowercase-last"],
+                    enum: ["case-insensitive", "lowercase-first", "lowercase-last", "any"],
                 },
                 "named-imports-order": {
                     type: "string",
-                    enum: ["case-insensitive", "lowercase-first", "lowercase-last"],
+                    enum: ["case-insensitive", "lowercase-first", "lowercase-last", "any"],
                 },
             },
             additionalProperties: false,
@@ -110,6 +112,7 @@ function findUnsortedPair(xs: ts.Node[], transform: (x: string) => string): [ts.
 // Transformations to apply to produce the desired ordering of imports.
 // The imports must be lexicographically sorted after applying the transform.
 const TRANSFORMS: {[ordering: string]: (x: string) => string} = {
+    any: () => "",
     "case-insensitive": (x: string) => x.toLowerCase(),
     "lowercase-first": flipCase,
     "lowercase-last": (x: string) => x,

--- a/test/rules/ordered-imports/import-sources-any/test.ts.lint
+++ b/test/rules/ordered-imports/import-sources-any/test.ts.lint
@@ -1,0 +1,31 @@
+// Named imports should be alphabetized.
+import {A, B} from 'foo';
+import {B, A} from 'foo'; // failure
+        ~~~~                         [ordered-imports]
+
+// Case is irrelevant for named import ordering.
+import {A, b, C} from 'foo';
+import {b, A, C} from 'foo'; // failure
+        ~~~~                            [ordered-imports]
+
+
+// Import sources don't need to be alphabetized.
+import * as bar from 'bar';
+import * as foo from 'foo';
+
+import * as abc from 'abc';
+import * as foo from 'foo';
+import * as bar from 'bar'; // should not fail
+
+// Case is irrelevant for source import ordering.
+import {A, B} from 'Bar';
+import {A, B} from 'baz';
+import {A, B} from 'Foo'; // should not fail
+
+// Other styles of import statements.
+import someDefault, {nameA, nameBReallyLong as anotherName} from "./wherever";
+import someDefault from "module";
+import "something";
+
+[ordered-imports]: Named imports must be alphabetized.
+[ordered-sources]: Import sources within a group must be alphabetized.

--- a/test/rules/ordered-imports/import-sources-any/tslint.json
+++ b/test/rules/ordered-imports/import-sources-any/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "ordered-imports": [true, {"import-sources-order": "any"}]
+  }
+}

--- a/test/rules/ordered-imports/named-imports-any/test.ts.lint
+++ b/test/rules/ordered-imports/named-imports-any/test.ts.lint
@@ -1,0 +1,30 @@
+// Named imports do not need to be alphabetized.
+import {A, B} from 'foo';
+import {B, A} from 'foo'; // should not fail
+
+// Case is irrelevant for named import ordering.
+import {A, b, C} from 'foo';
+import {b, A, C} from 'foo'; // should not fail
+
+
+// Import sources should be alphabetized.
+import * as bar from 'bar';
+import * as foo from 'foo';
+
+import * as abc from 'abc';
+import * as foo from 'foo';
+import * as bar from 'bar'; // failure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~            [ordered-sources]
+
+// Case is irrelevant for source import ordering.
+import {A, B} from 'Bar';
+import {A, B} from 'baz';
+import {A, B} from 'Foo'; // should not fail
+
+// Other styles of import statements.
+import someDefault, {nameA, nameBReallyLong as anotherName} from "./wherever";
+import someDefault from "module";
+import "something";
+
+[ordered-imports]: Named imports must be alphabetized.
+[ordered-sources]: Import sources within a group must be alphabetized.

--- a/test/rules/ordered-imports/named-imports-any/tslint.json
+++ b/test/rules/ordered-imports/named-imports-any/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "ordered-imports": [true, {"named-imports-order": "any"}]
+  }
+}


### PR DESCRIPTION
`TRANSFORMS#any` transforms every input name to the empty string, so that they always equal to each other, thus all names are always sorted.

Fixes #1600 