### PR TITLE
Workaround for #1400. Excludes imported properties from error

### DIFF
--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -46,6 +46,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 type VisitedVariables = {[varName: string]: boolean};
 
 class NoUseBeforeDeclareWalker extends Lint.ScopeAwareRuleWalker<VisitedVariables> {
+    private importedPropertiesPositions: number[] = [];
+
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions, private languageService: ts.LanguageService) {
         super(sourceFile, options);
     }
@@ -89,6 +91,9 @@ class NoUseBeforeDeclareWalker extends Lint.ScopeAwareRuleWalker<VisitedVariable
 
     public visitNamedImports(node: ts.NamedImports) {
         for (let namedImport of node.elements) {
+            if (namedImport.propertyName != null) {
+                this.saveImportedPropertiesPositions(namedImport.propertyName.getStart());
+            }
             this.validateUsageForVariable(namedImport.name.text, namedImport.name.getStart());
         }
         super.visitNamedImports(node);
@@ -120,12 +125,20 @@ class NoUseBeforeDeclareWalker extends Lint.ScopeAwareRuleWalker<VisitedVariable
             for (let highlight of highlights) {
                 for (let highlightSpan of highlight.highlightSpans) {
                     const referencePosition = highlightSpan.textSpan.start;
-                    if (referencePosition < position) {
+                    if (referencePosition < position && !this.isImportedPropertyName(referencePosition)) {
                         const failureString = Rule.FAILURE_STRING_PREFIX + name + Rule.FAILURE_STRING_POSTFIX;
                         this.addFailure(this.createFailure(referencePosition, name.length, failureString));
                     }
                 }
             }
         }
+    }
+
+    private saveImportedPropertiesPositions(position: number): void {
+        this.importedPropertiesPositions.push(position);
+    }
+
+    private isImportedPropertyName(position: number): boolean {
+        return this.importedPropertiesPositions.indexOf(position) !== -1;
     }
 }

--- a/test/rules/no-use-before-declare/test.ts.lint
+++ b/test/rules/no-use-before-declare/test.ts.lint
@@ -72,3 +72,12 @@ function a() {
     var b = ({c: dog}) => { dog++; };
     b({ c: 5 });
 }
+
+import { ITest as ITest0 } from './ImportRegularAlias';
+import {/*ensure comments works*/ ITest as ITest1 } from './ImportAliasWithComment';
+import {
+    ITest as ITest2
+} from './ImportWithLineBreaks';
+import {First, ITest as ITest3 } from './ImportAliasSecond';
+
+import ITest from './InterfaceFile';


### PR DESCRIPTION
As I stated in [comment](https://github.com/palantir/tslint/issues/1400#issuecomment-249458412) for issue #1400 - difference with TS 2.x because `languageService.getDocumentHighlights` highlights not only nodes for `ITest` but also for `unknown`. I don't know if it is regression in TS or how it is supposed to filtered in new way.

This fix tracks positions for imported properties and prevents errors if it is "highlighted" as use before declarations.

I'd be glad to improve fix if you have any suggestions.
