### PR TITLE
Fix no-empty rule on readonly modifier on parameters (#1629)

### DIFF
--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -67,7 +67,8 @@ class BlockWalker extends Lint.RuleWalker {
                 param.modifiers,
                 ts.SyntaxKind.PrivateKeyword,
                 ts.SyntaxKind.ProtectedKeyword,
-                ts.SyntaxKind.PublicKeyword
+                ts.SyntaxKind.PublicKeyword,
+                ts.SyntaxKind.ReadonlyKeyword
             );
 
             if (hasPropertyAccessModifier) {

--- a/test/rules/no-empty/test.ts.lint
+++ b/test/rules/no-empty/test.ts.lint
@@ -40,3 +40,8 @@ class testClass3 {
     }
 ~~~~~ [block is empty]
 }
+
+class testClass4 {
+    constructor(readonly allowed: any) {
+    }
+}


### PR DESCRIPTION
Fixing https://github.com/palantir/tslint/issues/1629