### PR TITLE
Rule object-literal-sort-keys to check multiline objects only (#1642)

### DIFF
--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -42,6 +42,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class ObjectLiteralSortKeysWalker extends Lint.RuleWalker {
     // stacks are used to maintain state while recursing through nested object literals
     private lastSortedKeyStack: string[] = [];
+    private multilineFlagStack: boolean[] = [];
     private sortedStateStack: boolean[] = [];
 
     public visitObjectLiteralExpression(node: ts.ObjectLiteralExpression) {
@@ -49,18 +50,21 @@ class ObjectLiteralSortKeysWalker extends Lint.RuleWalker {
         this.lastSortedKeyStack.push("");
         // sorted state is always initially true
         this.sortedStateStack.push(true);
+        this.multilineFlagStack.push(this.isMultilineListNode(node));
         super.visitObjectLiteralExpression(node);
+        this.multilineFlagStack.pop();
         this.lastSortedKeyStack.pop();
         this.sortedStateStack.pop();
     }
 
     public visitPropertyAssignment(node: ts.PropertyAssignment) {
         const sortedState = this.sortedStateStack[this.sortedStateStack.length - 1];
+        const isMultiline = this.multilineFlagStack[this.multilineFlagStack.length - 1];
 
         // skip remainder of object literal scan if a previous key was found
         // in an unsorted position. This ensures only one error is thrown at
-        // a time and keeps error output clean.
-        if (sortedState) {
+        // a time and keeps error output clean. Skip also single line objects.
+        if (sortedState && isMultiline) {
             const lastSortedKey = this.lastSortedKeyStack[this.lastSortedKeyStack.length - 1];
             const keyNode = node.name;
             if (isIdentifierOrStringLiteral(keyNode)) {
@@ -75,6 +79,12 @@ class ObjectLiteralSortKeysWalker extends Lint.RuleWalker {
             }
         }
         super.visitPropertyAssignment(node);
+    }
+
+    private isMultilineListNode(node: ts.ObjectLiteralExpression) {
+        const startLineOfNode = this.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line;
+        const endLineOfNode = this.getSourceFile().getLineAndCharacterOfPosition(node.getEnd()).line;
+        return endLineOfNode !== startLineOfNode;
     }
 }
 

--- a/test/rules/object-literal-sort-keys/test.ts.lint
+++ b/test/rules/object-literal-sort-keys/test.ts.lint
@@ -144,3 +144,20 @@ var failK = {
     ~     [The key 'a' is not sorted alphabetically]
     c: 3
 }
+
+var passL = {z: 1, y: '1', x: [1, 2]};
+
+var failL = {x: 1, y: {
+    b: 1,
+    a: 2
+    ~    [The key 'a' is not sorted alphabetically]
+}, z: [1, 2]};
+
+var passM = {
+    x: 1,
+    y: {
+        a: 1,
+        b: 2
+    },
+    z: {z: 1, y: '1', x: [1, 2]}
+};


### PR DESCRIPTION
`object-literal-sort-keys` will skip single line objects

closes #1642
