### PR TITLE
npm-debug.log in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@
 /lib/
 node_modules/
 tscommand*.txt
+npm-debug.log
 # created by grunt-ts for faster compiling
 typings/.basedir.ts
-npm-debug.log
 
 # vim swap files
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 tscommand*.txt
 # created by grunt-ts for faster compiling
 typings/.basedir.ts
+npm-debug.log
 
 # vim swap files
 *.swo


### PR DESCRIPTION
npm-debug.log file is generated by any npm tasks that returns with an error-code.
This file should not remain in git.