### PR TITLE
New Rule: no-useless-files

### DIFF
--- a/docs/rules/no-useless-files/index.html
+++ b/docs/rules/no-useless-files/index.html
@@ -1,0 +1,12 @@
+---
+ruleName: no-useless-files
+description: Disallows empty files, files that only contain whitespace, and files that only contain comments.
+optionsDescription: Not configurable.
+options: null
+optionExamples:
+  - 'true'
+type: typescript
+optionsJSON: 'null'
+layout: rule
+title: 'Rule: no-useless-files'
+---

--- a/src/rules/noUselessFilesRule.ts
+++ b/src/rules/noUselessFilesRule.ts
@@ -1,0 +1,36 @@
+import * as ts from "typescript";
+
+import * as Lint from "../lint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-useless-files",
+        description: "Disallows files that only contain whitespace, or files that only contain comments.",
+        descriptionDetails: `This rule is a reminder to not keep empty or commented out files around`,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "functionality",
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING_EMPTY = `Empty files are not allowed`;
+    public static FAILURE_STRING_COMMENTS = `Files that only contain comments are not allowed`;
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        const ruleFailures: Lint.RuleFailure[] = [];
+
+        const fileContent = sourceFile.getFullText();
+        const endPos = sourceFile.end - 1;
+        const fileContentTrimmed = fileContent.trim();
+        const fileContentNoComments = sourceFile.getText().trim();
+
+        if (fileContentTrimmed.length === 0) {
+            ruleFailures.push(new Lint.RuleFailure(sourceFile, 0, endPos, Rule.FAILURE_STRING_EMPTY, this.getOptions().ruleName));
+        } else if (fileContentNoComments.length === 0) {
+            ruleFailures.push(new Lint.RuleFailure(sourceFile, 0, endPos, Rule.FAILURE_STRING_COMMENTS, this.getOptions().ruleName));
+        }
+        return ruleFailures;
+    }
+}

--- a/src/rules/noUselessFilesRule.ts
+++ b/src/rules/noUselessFilesRule.ts
@@ -6,7 +6,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-useless-files",
-        description: "Disallows files that only contain whitespace, or files that only contain comments.",
+        description: "Disallows empty files, files that only contain whitespace, and files that only contain comments.",
         descriptionDetails: `This rule is a reminder to not keep empty or commented out files around`,
         optionsDescription: "Not configurable.",
         options: null,

--- a/test/rules/no-useless-files/fail-only-comments-multi-line.ts.lint
+++ b/test/rules/no-useless-files/fail-only-comments-multi-line.ts.lint
@@ -1,0 +1,12 @@
+/*function invalidParametersAlignment1(a: number, b: number) {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    var i = 0;
+~~~~~~~~~~~~~~
+}
+~
+function myOldFunction(a: number, b: number, c: number) {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    var i = 0;
+~~~~~~~~~~~~~~
+}*/
+~~~  [Files that only contain comments are not allowed]

--- a/test/rules/no-useless-files/fail-only-comments-single-line.ts.lint
+++ b/test/rules/no-useless-files/fail-only-comments-single-line.ts.lint
@@ -1,0 +1,14 @@
+//function invalidParametersAlignment1(a: number, b: number) {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//    var i = 0;
+~~~~~~~~~~~~~~~~
+//}
+~~~
+//
+~~
+//function myOldFunction(a: number, b: number, c: number) {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//   var i = 0;
+~~~~~~~~~~~~~~~
+//}
+~~~  [Files that only contain comments are not allowed]

--- a/test/rules/no-useless-files/fail-only-whitespace.ts.lint
+++ b/test/rules/no-useless-files/fail-only-whitespace.ts.lint
@@ -1,0 +1,6 @@
+ 
+~
+ 
+~
+ 
+~  [Empty files are not allowed]

--- a/test/rules/no-useless-files/pass.ts.lint
+++ b/test/rules/no-useless-files/pass.ts.lint
@@ -1,0 +1,9 @@
+//function invalidParametersAlignment1(a: number, b: number) {
+//    var i = 0;
+//}
+
+var foo = "bar";
+
+//function myOldFunction(a: number, b: number, c: number) {
+//   var i = 0;
+//}

--- a/test/rules/no-useless-files/tslint.json
+++ b/test/rules/no-useless-files/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-useless-files": true
+  }
+}


### PR DESCRIPTION
#### PR checklist
- [ ] Addresses an existing issue
- [x] New feature
- [x] Includes tests
- [ ] Documentation update
#### What changes did you make?

A new rule named `no-useless-files` has been added.  It reports violations for file that have no content (or only whitespace), and files that only contain comments.
#### Reasoning/History

My organization used this rule internally for a bit to help locate and remove these useless files.  Sometimes an entire file was commented out instead of being removed from source control with the thinking "I'll get back to this later", but of course that never happened and now we just had these useless files cluttering the project.
#### Is there anything you'd like reviewers to focus on?

I feel like my tests are formatted correctly, but they just aren't passing for some reason.  Sometimes it seems to be treating the lines that only contain `~~~~` characters as code, and it underlines those underlines.

Here's what it's showing me:
![2016-10-26 09_11_30-c__windows_system32_cmd exe](https://cloud.githubusercontent.com/assets/463685/19727256/a640055c-9b5c-11e6-8b89-5841825ba3a6.png)

I'm happy to do the work to make these tests pass, I just need a little help understanding why these are failing right now.
