### PR TITLE
Add rule name to msbuild formatter output

### DIFF
--- a/src/formatters/msbuildFormatter.ts
+++ b/src/formatters/msbuildFormatter.ts
@@ -37,11 +37,12 @@ export class Formatter extends AbstractFormatter {
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();
             const failureString = failure.getFailure();
+            const rule = failure.getRuleName();
 
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
             const positionTuple = `(${lineAndCharacter.line + 1},${lineAndCharacter.character + 1})`;
 
-            return `${fileName}${positionTuple}: warning: ${failureString}`;
+            return `${fileName}${positionTuple}: warning ${rule}: ${failureString}`;
         });
 
         return outputLines.join("\n") + "\n";

--- a/src/formatters/msbuildFormatter.ts
+++ b/src/formatters/msbuildFormatter.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {camelize} from "underscore.string";
+
 import {AbstractFormatter} from "../language/formatter/abstractFormatter";
 import {IFormatterMetadata} from "../language/formatter/formatter";
 import {RuleFailure} from "../language/rule/rule";
@@ -37,12 +39,12 @@ export class Formatter extends AbstractFormatter {
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();
             const failureString = failure.getFailure();
-            const ruleCamelCase = failure.getRuleName().replace(/(\-\w)/g, (m) => m[1].toUpperCase());
+            const camelizedRule = camelize(failure.getRuleName());
 
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
             const positionTuple = `(${lineAndCharacter.line + 1},${lineAndCharacter.character + 1})`;
 
-            return `${fileName}${positionTuple}: warning ${ruleCamelCase}: ${failureString}`;
+            return `${fileName}${positionTuple}: warning ${camelizedRule}: ${failureString}`;
         });
 
         return outputLines.join("\n") + "\n";

--- a/src/formatters/msbuildFormatter.ts
+++ b/src/formatters/msbuildFormatter.ts
@@ -37,12 +37,12 @@ export class Formatter extends AbstractFormatter {
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();
             const failureString = failure.getFailure();
-            const rule = failure.getRuleName();
+            const ruleCamelCase = failure.getRuleName().replace(/(\-\w)/g, (m) => m[1].toUpperCase());
 
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
             const positionTuple = `(${lineAndCharacter.line + 1},${lineAndCharacter.character + 1})`;
 
-            return `${fileName}${positionTuple}: warning ${rule}: ${failureString}`;
+            return `${fileName}${positionTuple}: warning ${ruleCamelCase}: ${failureString}`;
         });
 
         return outputLines.join("\n") + "\n";

--- a/test/formatters/msbuildFormatterTests.ts
+++ b/test/formatters/msbuildFormatterTests.ts
@@ -39,9 +39,9 @@ describe("MSBuild Formatter", () => {
         ];
 
         const expectedResult =
-            getFailureString(TEST_FILE, 1,  1, "first failure") +
-            getFailureString(TEST_FILE, 2, 12, "mid failure") +
-            getFailureString(TEST_FILE, 9,  2,  "last failure");
+            getFailureString(TEST_FILE, 1,  1, "first failure", "first-name") +
+            getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
+            getFailureString(TEST_FILE, 9,  2,  "last failure", "last-name");
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);
@@ -52,7 +52,7 @@ describe("MSBuild Formatter", () => {
         assert.equal(result, "\n");
     });
 
-    function getFailureString(file: string, line: number, character: number, reason: string) {
-        return `${file}(${line},${character}): warning: ${reason}\n`;
+    function getFailureString(file: string, line: number, character: number, reason: string, rule: string) {
+        return `${file}(${line},${character}): warning ${rule}: ${reason}\n`;
     }
 });

--- a/test/formatters/msbuildFormatterTests.ts
+++ b/test/formatters/msbuildFormatterTests.ts
@@ -39,9 +39,9 @@ describe("MSBuild Formatter", () => {
         ];
 
         const expectedResult =
-            getFailureString(TEST_FILE, 1,  1, "first failure", "first-name") +
-            getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
-            getFailureString(TEST_FILE, 9,  2,  "last failure", "last-name");
+            getFailureString(TEST_FILE, 1,  1, "first failure", "firstName") +
+            getFailureString(TEST_FILE, 2, 12, "mid failure", "midName") +
+            getFailureString(TEST_FILE, 9,  2,  "last failure", "lastName");
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);
@@ -52,7 +52,7 @@ describe("MSBuild Formatter", () => {
         assert.equal(result, "\n");
     });
 
-    function getFailureString(file: string, line: number, character: number, reason: string, rule: string) {
-        return `${file}(${line},${character}): warning ${rule}: ${reason}\n`;
+    function getFailureString(file: string, line: number, character: number, reason: string, ruleCamelCase: string) {
+        return `${file}(${line},${character}): warning ${ruleCamelCase}: ${reason}\n`;
     }
 });


### PR DESCRIPTION
#### PR checklist
- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
- [x] Includes tests
- [ ] Documentation update
#### What changes did you make?

I added camel-cased rule name to the output of msbuild formatter since every line should contain an error code composed of letters and numbers (as shown here: https://blogs.msdn.microsoft.com/msbuild/2006/11/02/msbuild-visual-studio-aware-error-messages-and-message-formats/)
