### PR TITLE
Make sure vscode uses locally provided Typescript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
 		"build",
                 "lib",
 		"node_modules"
-	]
+	],
+
+	// Always use project's provided typescript compiler version
+	"typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
By default, VSCode uses its bundled TypeScript version which may change depending on VSCode version.
Also, it shows warnings when the globally installed TS version differs from the bundled one.

The solution is to instruct VSCode to always use the local TS version that is installed from packages.json in node_modules.