### PR TITLE
Show rule deprecation warning only once

### DIFF
--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -24,6 +24,7 @@ import {IDisabledInterval, IRule} from "./language/rule/rule";
 
 const moduleDirectory = path.dirname(module.filename);
 const CORE_RULES_DIRECTORY = path.resolve(moduleDirectory, ".", "rules");
+const shownDeprecations: string[] = [];
 
 export interface IEnableDisablePosition {
     isEnabled: boolean;
@@ -49,8 +50,9 @@ export function loadRules(ruleConfiguration: {[name: string]: any},
                 const disabledIntervals = buildDisabledIntervalsFromSwitches(ruleSpecificList, allList);
                 rules.push(new Rule(ruleName, ruleValue, disabledIntervals));
 
-                if (Rule.metadata && Rule.metadata.deprecationMessage) {
+                if (Rule.metadata && Rule.metadata.deprecationMessage && shownDeprecations.indexOf(Rule.metadata.ruleName) === -1) {
                     console.warn(`${Rule.metadata.ruleName} is deprecated. ${Rule.metadata.deprecationMessage}`);
+                    shownDeprecations.push(Rule.metadata.ruleName);
                 }
             }
         }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
- [ ] Includes tests (no tests for deprecation messages)
- [ ] Documentation update (no docs for deprecation messags)

#### What changes did you make?

Currently deprecation messages are shown for each file when deprecated rule is used.
Therefore on projects where `no-unused-variable` rule is enabled developers will see long list with same deprecation message.
For example output from tests:
```
test/rules/no-unused-expression/test.ts.lint: Passed
test/rules/no-unused-new/test.ts.lint: Passed
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
test/rules/no-unused-variable/check-parameters/test.ts.lint: Passed
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
no-unused-variable is deprecated. Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
test/rules/no-unused-variable/default/class.ts.lint: Passed
test/rules/no-unused-variable/default/false-positives.ts.lint: Passed
test/rules/no-unused-variable/default/function.ts.lint: Passed
test/rules/no-unused-variable/default/import.ts.lint: Passed
test/rules/no-unused-variable/default/react-addons1.tsx.lint: Passed
test/rules/no-unused-variable/default/react-addons2.tsx.lint: Passed
test/rules/no-unused-variable/default/react-addons3.tsx.lint: Passed
test/rules/no-unused-variable/default/react1.tsx.lint: Passed
test/rules/no-unused-variable/default/react2.tsx.lint: Passed
test/rules/no-unused-variable/default/react3.tsx.lint: Passed
test/rules/no-unused-variable/default/react4.tsx.lint: Passed
test/rules/no-unused-variable/default/var.ts.lint: Passed
```

This PR ensures that deprecation message is shown only once per TSLint launch (cached rule name if deprecation was shown and prevents further messages).