### PR TITLE
Move rimraf to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "glob": "^7.1.1",
     "optimist": "~0.6.0",
     "resolve": "^1.1.7",
-    "rimraf": "^2.5.4",
     "underscore.string": "^3.3.4"
   },
   "devDependencies": {
@@ -62,6 +61,7 @@
     "js-yaml": "^3.6.1",
     "mocha": "^3.1.0",
     "npm-run-all": "^3.1.0",
+    "rimraf": "^2.5.4",
     "tslint": "latest",
     "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
     "typescript": "2.0.3"


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
- [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

Unfortunately I've added `rimraf` as production dependency in previous PR, but it is used only during build process and not required for package consumers.

This PR moves `rimraf` to `devDependencies` section.