### PR TITLE
Adding class expression checks to max-classes-per-file rule

### DIFF
--- a/src/rules/maxClassesPerFileRule.ts
+++ b/src/rules/maxClassesPerFileRule.ts
@@ -54,11 +54,20 @@ class MaxClassesPerFileWalker extends Lint.RuleWalker {
     }
 
     public visitClassDeclaration(node: ts.ClassDeclaration) {
+        this.increaseClassCount(node);
+        super.visitClassDeclaration(node);
+    }
+
+    public visitClassExpression(node: ts.ClassExpression) {
+        this.increaseClassCount(node);
+        super.visitClassExpression(node);
+    }
+
+    private increaseClassCount(node: ts.ClassExpression | ts.ClassDeclaration) {
         this.classCount++;
         if (this.classCount > this.maxClassCount) {
             const msg = Rule.FAILURE_STRING_FACTORY(this.maxClassCount);
             this.addFailure(this.createFailure(node.getStart(), node.getWidth(), msg));
         }
-        super.visitClassDeclaration(node);
     }
 }

--- a/test/rules/max-classes-per-file/one/test.ts.lint
+++ b/test/rules/max-classes-per-file/one/test.ts.lint
@@ -10,3 +10,10 @@ class two {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 }
 ~ [A maximum of 1 class per file is allowed]
+
+let three = class {
+            ~~~~~~~
+    public foo = "bar";
+~~~~~~~~~~~~~~~~~~~~~~~
+}
+~ [A maximum of 1 class per file is allowed]

--- a/test/rules/max-classes-per-file/two/test.ts.lint
+++ b/test/rules/max-classes-per-file/two/test.ts.lint
@@ -6,8 +6,8 @@ class two {
     public foo = "bar";
 }
 
-class three {
-~~~~~~~~~~~~
+let three = class {
+            ~~~~~~~
     public foo = "bar";
 ~~~~~~~~~~~~~~~~~~~~~~~
 }


### PR DESCRIPTION
Just an update to #1656 that adds support & tests for checking class expressions to the new `max-classes-per-file` rule

( I wasn't quick enough in my last PR!)