### PR TITLE
Improve stylish formatter colors

### DIFF
--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -60,7 +60,7 @@ export class Formatter extends AbstractFormatter {
             }
 
             let failureString = failure.getFailure();
-            failureString     = colors.red(failureString);
+            failureString     = colors.yellow(failureString);
 
             // Rule
             let ruleName = failure.getRuleName();
@@ -72,7 +72,7 @@ export class Formatter extends AbstractFormatter {
 
             let positionTuple = `${lineAndCharacter.line + 1}:${lineAndCharacter.character + 1}`;
             positionTuple     = this.pad(positionTuple, positionMaxSize);
-            positionTuple     = colors.yellow(positionTuple);
+            positionTuple     = colors.red(positionTuple);
 
             // Ouput
             const output = `${positionTuple}  ${ruleName}  ${failureString}`;

--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -59,19 +59,20 @@ export class Formatter extends AbstractFormatter {
                 currentFile = fileName;
             }
 
-            const failureString = failure.getFailure();
+            let failureString = failure.getFailure();
+            failureString     = colors.red(failureString);
 
             // Rule
             let ruleName = failure.getRuleName();
             ruleName     = this.pad(ruleName, ruleMaxSize);
-            ruleName     = colors.yellow(ruleName);
+            ruleName     = colors.grey(ruleName);
 
             // Lines
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
 
             let positionTuple = `${lineAndCharacter.line + 1}:${lineAndCharacter.character + 1}`;
             positionTuple     = this.pad(positionTuple, positionMaxSize);
-            positionTuple     = colors.red(positionTuple);
+            positionTuple     = colors.yellow(positionTuple);
 
             // Ouput
             const output = `${positionTuple}  ${ruleName}  ${failureString}`;

--- a/test/formatters/stylishFormatterTests.ts
+++ b/test/formatters/stylishFormatterTests.ts
@@ -47,10 +47,10 @@ describe("Stylish Formatter", () => {
 
         const expectedResult = colors.enabled ?
             "formatters/stylishFormatter.test.ts" + "\n" +
-            "\u001b[33m1:1\u001b[39m  \u001b[90mfirst-name\u001b[39m  \u001b[31mfirst failure\u001b[39m" + "\n" +
-            "\u001b[33m1:3\u001b[39m  \u001b[90mescape    \u001b[39m  \u001b[31m&<>'\" should be escaped\u001b[39m" + "\n" +
-            `\u001b[33m${maxPositionTuple}\u001b[39m  \u001b[90mlast-name \u001b[39m  \u001b[31mlast failure\u001b[39m` + "\n" +
-            "\u001b[33m1:1\u001b[39m  \u001b[90mfull-name \u001b[39m  \u001b[31mfull failure\u001b[39m" + "\n" +
+            "\u001b[31m1:1\u001b[39m  \u001b[90mfirst-name\u001b[39m  \u001b[33mfirst failure\u001b[39m" + "\n" +
+            "\u001b[31m1:3\u001b[39m  \u001b[90mescape    \u001b[39m  \u001b[33m&<>'\" should be escaped\u001b[39m" + "\n" +
+            `\u001b[31m${maxPositionTuple}\u001b[39m  \u001b[90mlast-name \u001b[39m  \u001b[33mlast failure\u001b[39m` + "\n" +
+            "\u001b[31m1:1\u001b[39m  \u001b[90mfull-name \u001b[39m  \u001b[33mfull failure\u001b[39m" + "\n" +
             "\n" :
             "formatters/stylishFormatter.test.ts" + "\n" +
             "1:1  first-name  first failure" + "\n" +

--- a/test/formatters/stylishFormatterTests.ts
+++ b/test/formatters/stylishFormatterTests.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as colors from "colors";
+
 import * as ts from "typescript";
 
 import {IFormatter, RuleFailure, TestUtils} from "../lint";
@@ -43,12 +45,12 @@ describe("Stylish Formatter", () => {
 
         const maxPositionTuple = `${maxPositionObj.line + 1}:${maxPositionObj.character + 1}`;
 
-        const expectedResult = (require("colors").supportsColor) ?
+        const expectedResult = colors.enabled ?
             "formatters/stylishFormatter.test.ts" + "\n" +
-            "\u001b[31m1:1\u001b[39m  \u001b[33mfirst-name\u001b[39m  first failure" + "\n" +
-            "\u001b[31m1:3\u001b[39m  \u001b[33mescape    \u001b[39m  &<>'\" should be escaped" + "\n" +
-            `\u001b[31m${maxPositionTuple}\u001b[39m  \u001b[33mlast-name \u001b[39m  last failure` + "\n" +
-            "\u001b[31m1:1\u001b[39m  \u001b[33mfull-name \u001b[39m  full failure" + "\n" +
+            "\u001b[33m1:1\u001b[39m  \u001b[90mfirst-name\u001b[39m  \u001b[31mfirst failure\u001b[39m" + "\n" +
+            "\u001b[33m1:3\u001b[39m  \u001b[90mescape    \u001b[39m  \u001b[31m&<>'\" should be escaped\u001b[39m" + "\n" +
+            `\u001b[33m${maxPositionTuple}\u001b[39m  \u001b[90mlast-name \u001b[39m  \u001b[31mlast failure\u001b[39m` + "\n" +
+            "\u001b[33m1:1\u001b[39m  \u001b[90mfull-name \u001b[39m  \u001b[31mfull failure\u001b[39m" + "\n" +
             "\n" :
             "formatters/stylishFormatter.test.ts" + "\n" +
             "1:1  first-name  first failure" + "\n" +


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue
- [x] ~~New feature, bugfix, or~~ **enhancement**
- [x] Includes tests
- [ ] Documentation update

#### What changes did you make?

I've updated the `stylish` formatter to have nicer looking colored output.

**Before**
![old](https://cloud.githubusercontent.com/assets/463685/19944926/3423f326-a114-11e6-8839-3910a1c68cc4.png)

**After**
![new](https://cloud.githubusercontent.com/assets/463685/19945403/5accbd62-a116-11e6-9151-55b383f00d1f.png)

🔹 Using a different color for the message and the file name helps to more easily distinguish them from each other
🔹 Using a grey color for the rule name de-emphasizes it since the file, position, and message are the most important pieces of information
