### PR TITLE
Add support for glob patterns in single quotes for files and exclude arguments

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -26,7 +26,7 @@ import {
     DEFAULT_CONFIG,
     findConfiguration,
 } from "./configuration";
-import {consoleTestResultHandler, runTest} from "./test";
+import { consoleTestResultHandler, runTest } from "./test";
 import * as Linter from "./tslintMulti";
 
 let processed = optimist
@@ -49,6 +49,7 @@ let processed = optimist
         e: {
             alias: "exclude",
             describe: "exclude globs from path expansion",
+            type: "string",
         },
         force: {
             describe: "return status code 0 even if there are lint errors",
@@ -296,7 +297,19 @@ if (argv.project != null) {
     }
 }
 
+const trimSingleQuotes = (str: string) => str.replace(/^'|'$/g, "");
+
+let ignorePatterns: string[] = [];
+if (argv.e) {
+    const excludeArguments: string[] = Array.isArray(argv.e) ? argv.e : [argv.e];
+
+    ignorePatterns = excludeArguments.map(trimSingleQuotes);
+}
+
 files = files
-  .map((file: string) => glob.sync(file, { ignore: argv.e, nodir: true }))
-  .reduce((a: string[], b: string[]) => a.concat(b));
+    // remove single quotes which break mathing on Windows when glob is passed in single quotes
+    .map(trimSingleQuotes)
+    .map((file: string) => glob.sync(file, { ignore: ignorePatterns, nodir: true }))
+    .reduce((a: string[], b: string[]) => a.concat(b));
+
 processFiles(files, program);

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -307,7 +307,7 @@ if (argv.e) {
 }
 
 files = files
-    // remove single quotes which break mathing on Windows when glob is passed in single quotes
+    // remove single quotes which break matching on Windows when glob is passed in single quotes
     .map(trimSingleQuotes)
     .map((file: string) => glob.sync(file, { ignore: ignorePatterns, nodir: true }))
     .reduce((a: string[], b: string[]) => a.concat(b));

--- a/src/tslintMulti.ts
+++ b/src/tslintMulti.ts
@@ -20,11 +20,11 @@ import * as ts from "typescript";
 
 import {
     DEFAULT_CONFIG,
+    IConfigurationFile,
     findConfiguration,
     findConfigurationPath,
     getRelativePath,
     getRulesDirectories,
-    IConfigurationFile,
     loadConfigurationFromPath,
 } from "./configuration";
 import { EnableDisableRulesWalker } from "./enableDisableRules";
@@ -169,6 +169,6 @@ class MultiLinter {
 }
 
 // tslint:disable-next-line:no-namespace
-namespace MultiLinter {}
+namespace MultiLinter { }
 
 export = MultiLinter;

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -217,6 +217,35 @@ describe("Executable", function() {
 
         });
     });
+
+    describe("globs and quotes", () => {
+        // when glob pattern is passed without quotes in npm script `process.env` will contain:
+        // on Windows - pattern string without any quotes
+        // on Linux - list of files that mathes glob (may differ from `glob` module results)
+
+        it("exits with code 2 if correctly finds file containing lint errors when glob is in double quotes", (done) => {
+            // when glob pattern is passed in double quotes in npm script `process.env` will contain:
+            // on Windows - pattern string without any quotes
+            // on Linux - pattern string without any quotes (glob is not expanded)
+            execCli(["-c", "./test/config/tslint-custom-rules.json", "-r", "./test/files/custom-rules", "src/**/tslint.ts"], (err) => {
+                assert.isNotNull(err, "process should exit with error");
+                assert.strictEqual(err.code, 2, "error code should be 2");
+                done();
+            });
+        });
+
+        it("exits with code 2 if correctly finds file containing lint errors when glob is in single quotes", (done) => {
+            // when glob pattern is passed in single quotes in npm script `process.env` will contain:
+            // on Windows - pattern string wrapped in single quotes
+            // on Linux - pattern string without any quotes (glob is not expanded)
+            execCli(["-c", "./test/config/tslint-custom-rules.json", "-r", "./test/files/custom-rules", "'src/**/tslint.ts'"], (err) => {
+                assert.isNotNull(err, "process should exit with error");
+                assert.strictEqual(err.code, 2, "error code should be 2");
+                done();
+            });
+        });
+
+    });
 });
 
 type ExecFileCallback = (error: any, stdout: string, stderr: string) => void;

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -221,7 +221,7 @@ describe("Executable", function() {
     describe("globs and quotes", () => {
         // when glob pattern is passed without quotes in npm script `process.env` will contain:
         // on Windows - pattern string without any quotes
-        // on Linux - list of files that mathes glob (may differ from `glob` module results)
+        // on Linux - list of files that matches glob (may differ from `glob` module results)
 
         it("exits with code 2 if correctly finds file containing lint errors when glob is in double quotes", (done) => {
             // when glob pattern is passed in double quotes in npm script `process.env` will contain:


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1639 _(related)_
- [X] ~~New feature, bugfix, or~~ enhancement
  - [X] Includes tests
- [ ] Documentation update

#### What changes did you make?

There were three ways to pass globs in npm scripts were mentioned in #1639:

1. Without quotes `src/**/*.ts`
  - works on Windows (`src/**/*.ts` is passed to process and matching is done with `glob` module)
  - doesn't match all files on Linux (see #1678)

2. With single quotes `'src/**/*.ts'`
  - works on Linux (`src/**/*.ts` is passed to process and matched with `glob` module)
  - doesn't match anything on Windows since process receives quotes string as argument `'src/**/*.ts'` and `glob` returns no matches with quotes

3. With double quotes `"src/**/*.ts"`
  - works both on Windows and Linux (`src/**/*.ts` is passed to process and matching is done with `glob` module)
  - requires escaping in `package.json file`  (e.g. `"lint": "tslint \"src/**/*.ts\""`) which hurts readability and might lead to errors if code editor doesn't notify about errors immediately

First case is OS specific and can't be addressed in TSLint package, but second might be properly handled.

This PR simply clears single quotes that may appear on Windows platform if glob is wrapped in single quotes in npm script.
Main intent is to increase interoperability between platforms and make npm scripts easy to write/read.
