### PR TITLE
Treat one-line arrow funcs like a normal statement regarding semicolons

### DIFF
--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -121,7 +121,9 @@ class SemicolonWalker extends Lint.RuleWalker {
 
     public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
         const initializer = node.initializer;
-        if (initializer && initializer.kind === ts.SyntaxKind.ArrowFunction) {
+
+        // check if this is a multi-line arrow function (`[^]` in the regex matches all characters including CR & LF)
+        if (initializer && initializer.kind === ts.SyntaxKind.ArrowFunction && /\{[^]*\n/.test(node.getText())) {
             if (!this.hasOption(OPTION_IGNORE_BOUND_CLASS_METHODS)) {
                 this.checkSemicolonAt(node, "never");
             }

--- a/test/rules/semicolon/always/test.js.lint
+++ b/test/rules/semicolon/always/test.js.lint
@@ -54,7 +54,19 @@ class MyClass {
 
     initializedProperty = 6
                            ~nil [Missing semicolon]
-    initializedMethodProperty = () => { return "hi"; }
+    public initializedMethodProperty = () => {
+        return "hi";
+    };
+     ~ [Unnecessary semicolon]
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again"; 
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; }
+                                                                                        ~nil [Missing semicolon]
 }
 
 import {Router} from 'aurelia-router';

--- a/test/rules/semicolon/always/test.ts.fix
+++ b/test/rules/semicolon/always/test.ts.fix
@@ -51,8 +51,17 @@ class MyClass {
     private email : string;
 
     public initializedProperty = 6;
-    public initializedMethodProperty = () => { return "hi"; }
-    public initializedMethodPropertyWithoutSemicolon = () => { return "hi again"; }
+    public initializedMethodProperty = () => {
+        return "hi";
+    }
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again";
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; };
 }
 
 interface ITest {

--- a/test/rules/semicolon/always/test.ts.lint
+++ b/test/rules/semicolon/always/test.ts.lint
@@ -71,9 +71,19 @@ class MyClass {
 
     public initializedProperty = 6
                                   ~nil [Missing semicolon]
-    public initializedMethodProperty = () => { return "hi"; };
-                                                             ~ [Unnecessary semicolon]
-    public initializedMethodPropertyWithoutSemicolon = () => { return "hi again"; }
+    public initializedMethodProperty = () => {
+        return "hi";
+    };
+     ~ [Unnecessary semicolon]
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again";
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; }
+                                                                                        ~nil [Missing semicolon]
 }
 
 interface ITest {

--- a/test/rules/semicolon/enabled/test.ts.fix
+++ b/test/rules/semicolon/enabled/test.ts.fix
@@ -4,6 +4,10 @@ a += b;
 c = () => {
 };
 
+f(() => {
+    return 1;
+});
+
 d = function() { };
 
 console.log("i am adam, am i?");
@@ -51,8 +55,17 @@ class MyClass {
     private email : string;
 
     public initializedProperty = 6;
-    public initializedMethodProperty = () => { return "hi"; }
-    public initializedMethodPropertyWithoutSemicolon = () => { return "hi again"; }
+    public initializedMethodProperty: mytype = () => {
+        return "hi";
+    }
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again"; 
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; };
 }
 
 interface ITest {

--- a/test/rules/semicolon/enabled/test.ts.lint
+++ b/test/rules/semicolon/enabled/test.ts.lint
@@ -7,6 +7,10 @@ c = () => {
 }
  ~nil [Missing semicolon]
 
+f(() => {
+    return 1;
+});
+
 d = function() { }
                   ~nil [Missing semicolon]
 
@@ -71,9 +75,19 @@ class MyClass {
 
     public initializedProperty = 6
                                   ~nil [Missing semicolon]
-    public initializedMethodProperty = () => { return "hi"; };
-                                                             ~ [Unnecessary semicolon]
-    public initializedMethodPropertyWithoutSemicolon = () => { return "hi again"; }
+    public initializedMethodProperty: mytype = () => {
+        return "hi";
+    };
+     ~ [Unnecessary semicolon]
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again"; 
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; }
+                                                                                        ~nil [Missing semicolon]
 }
 
 interface ITest {

--- a/test/rules/semicolon/ignore-bound-class-methods/test.ts.fix
+++ b/test/rules/semicolon/ignore-bound-class-methods/test.ts.fix
@@ -51,8 +51,17 @@ class MyClass {
     private email : string;
 
     public initializedProperty = 6;
-    public initializedMethodProperty = () => { return "hi"; };
-    public initializedMethodPropertyWithoutSemicolon = () => { return "hi again"; }
+    public initializedMethodProperty = () => {
+        return "hi";
+    };
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again"; 
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; };
 }
 
 interface ITest {

--- a/test/rules/semicolon/ignore-bound-class-methods/test.ts.lint
+++ b/test/rules/semicolon/ignore-bound-class-methods/test.ts.lint
@@ -71,8 +71,18 @@ class MyClass {
 
     public initializedProperty = 6
                                   ~nil [Missing semicolon]
-    public initializedMethodProperty = () => { return "hi"; };
-    public initializedMethodPropertyWithoutSemicolon = () => { return "hi again"; }
+    public initializedMethodProperty = () => {
+        return "hi";
+    };
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again"; 
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; }
+                                                                                        ~nil [Missing semicolon]
 }
 
 interface ITest {

--- a/test/rules/semicolon/ignore-interfaces/test.ts.fix
+++ b/test/rules/semicolon/ignore-interfaces/test.ts.fix
@@ -51,8 +51,17 @@ class MyClass {
     private email : string;
 
     public initializedProperty = 6;
-    public initializedMethodProperty = () => { return "hi"; }
-    public initializedMethodPropertyWithoutSemicolon = () => { return "hi again"; }
+    public initializedMethodProperty = () => {
+        return "hi";
+    }
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again"; 
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; };
 }
 
 interface ITest {

--- a/test/rules/semicolon/ignore-interfaces/test.ts.lint
+++ b/test/rules/semicolon/ignore-interfaces/test.ts.lint
@@ -71,9 +71,19 @@ class MyClass {
 
     public initializedProperty = 6
                                   ~nil [Missing semicolon]
-    public initializedMethodProperty = () => { return "hi"; };
-                                                             ~ [Unnecessary semicolon]
-    public initializedMethodPropertyWithoutSemicolon = () => { return "hi again"; }
+    public initializedMethodProperty = () => {
+        return "hi";
+    };
+     ~ [Unnecessary semicolon]
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again"; 
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; }
+                                                                                        ~nil [Missing semicolon]
 }
 
 interface ITest {

--- a/test/rules/semicolon/never/test.ts.fix
+++ b/test/rules/semicolon/never/test.ts.fix
@@ -50,8 +50,17 @@ class MyClass {
     private index : number
     private email : string
     public initializedProperty = 6
-    public initializedMethodProperty = () => { return "hi" }
+    public initializedMethodProperty = () => {
+        return "hi"
+    }
 
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again" 
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi" }
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again" }
 }
 
 interface ITest {

--- a/test/rules/semicolon/never/test.ts.lint
+++ b/test/rules/semicolon/never/test.ts.lint
@@ -70,9 +70,23 @@ class MyClass {
                           ~ [Unnecessary semicolon]
     private email : string
     public initializedProperty = 6
-    public initializedMethodProperty = () => { return "hi" };
-                                                            ~ [Unnecessary semicolon]
+    public initializedMethodProperty = () => {
+        return "hi";
+                   ~ [Unnecessary semicolon]
+    };
+     ~ [Unnecessary semicolon]
 
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again"; 
+                         ~ [Unnecessary semicolon]
+    }
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+                                                               ~ [Unnecessary semicolon]
+                                                                  ~ [Unnecessary semicolon]
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; }
+                                                                                     ~ [Unnecessary semicolon]
 }
 
 interface ITest {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1674 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### What changes did you make?

Only apply rule of arrows and semicolons on multiline functions

#### Is there anything you'd like reviewers to focus on?

(optional)
