### PR TITLE
Mentioned git --config settings in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,9 +373,10 @@ Development
 #### Quick Start
 
 ```bash
-git clone git@github.com:palantir/tslint.git
+git clone git@github.com:palantir/tslint.git --config core.autocrlf=input --config core.eol=lf
 npm install
-grunt
+npm run compile
+npm run test
 ```
 
 #### `next` branch


### PR DESCRIPTION
Also replaced `grunt` with some new `npm run` commands.

Cloning without endline config settings on Windows results in failed lint checks during tests because of different endline behavior. These are the same settings as https://github.com/microsoft/tslint-microsoft-contrib/#development.