### PR TITLE
Split CLI into tslint-cli and a Runner class

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,0 +1,255 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "fs";
+import * as glob from "glob";
+import * as path from "path";
+import * as ts from "typescript";
+
+import {
+    CONFIG_FILENAME,
+    DEFAULT_CONFIG,
+    findConfiguration,
+} from "./configuration";
+import { FatalError } from "./error";
+import * as Linter from "./linter";
+import { consoleTestResultHandler, runTest } from "./test";
+import { updateNotifierCheck } from "./updateNotifier";
+
+export interface IRunnerOptions {
+    /**
+     * Path to a configuration file.
+     */
+    config?: string;
+
+    /**
+     * Exclude globs from path expansion.
+     */
+    exclude?: string | string[];
+
+    /**
+     * File paths to lint.
+     */
+    files?: string[];
+
+    /**
+     * Whether to return status code 0 even if there are lint errors.
+     */
+    force?: boolean;
+
+    /**
+     * Whether to fixes linting errors for select rules. This may overwrite linted files.
+     */
+    fix?: boolean;
+
+    /**
+     * Output format.
+     */
+    format?: string;
+
+    /**
+     * Formatters directory path.
+     */
+    formattersDirectory?: string;
+
+    /**
+     * Whether to generate a tslint.json config file in the current working directory.
+     */
+    init?: boolean;
+
+    /**
+     * Output file path.
+     */
+    out?: string;
+
+    /**
+     * tsconfig.json file.
+     */
+    project?: string;
+
+    /**
+     * Rules directory paths.
+     */
+    rulesDirectory?: string | string[];
+
+    /**
+     * That TSLint produces the correct output for the specified directory.
+     */
+    test?: string;
+
+    /**
+     * Whether to enable type checking when linting a project.
+     */
+    typeCheck?: boolean;
+
+    /**
+     * Current TSLint version.
+     */
+    version?: boolean;
+}
+
+export class Runner {
+    private static trimSingleQuotes(str: string) {
+        return str.replace(/^'|'$/g, "");
+    }
+
+    constructor(private options: IRunnerOptions, private outputStream: NodeJS.WritableStream) { }
+
+    public run(onComplete: (status: number) => void) {
+        if (this.options.version != null) {
+            this.outputStream.write(Linter.VERSION + "\n");
+            onComplete(0);
+            return;
+        }
+
+        if (this.options.init != null) {
+            if (fs.existsSync(CONFIG_FILENAME)) {
+                console.error(`Cannot generate ${CONFIG_FILENAME}: file already exists`);
+                onComplete(1);
+                return;
+            }
+
+            const tslintJSON = JSON.stringify(DEFAULT_CONFIG, undefined, "    ");
+            fs.writeFileSync(CONFIG_FILENAME, tslintJSON);
+            onComplete(0);
+            return;
+        }
+
+        if (this.options.test != null) {
+            const results = runTest(this.options.test, this.options.rulesDirectory);
+            const didAllTestsPass = consoleTestResultHandler(results);
+            onComplete(didAllTestsPass ? 0 : 1);
+            return;
+        }
+
+        // when provided, it should point to an existing location
+        if (this.options.config && !fs.existsSync(this.options.config)) {
+            console.error("Invalid option for configuration: " + this.options.config);
+            onComplete(1);
+            return;
+        }
+
+        // if both files and tsconfig are present, use files
+        let files = this.options.files;
+        let program: ts.Program;
+
+        if (this.options.project != null) {
+            if (!fs.existsSync(this.options.project)) {
+                console.error("Invalid option for project: " + this.options.project);
+                onComplete(1);
+            }
+            program = Linter.createProgram(this.options.project, path.dirname(this.options.project));
+            if (files.length === 0) {
+                files = Linter.getFileNames(program);
+            }
+            if (this.options.typeCheck) {
+                // if type checking, run the type checker
+                const diagnostics = ts.getPreEmitDiagnostics(program);
+                if (diagnostics.length > 0) {
+                    const messages = diagnostics.map((diag) => {
+                        // emit any error messages
+                        let message = ts.DiagnosticCategory[diag.category];
+                        if (diag.file) {
+                            const {line, character} = diag.file.getLineAndCharacterOfPosition(diag.start);
+                            message += ` at ${diag.file.fileName}:${line + 1}:${character + 1}:`;
+                        }
+                        message += " " + ts.flattenDiagnosticMessageText(diag.messageText, "\n");
+                        return message;
+                    });
+                    throw new Error(messages.join("\n"));
+                }
+            } else {
+                // if not type checking, we don't need to pass in a program object
+                program = undefined;
+            }
+        }
+
+        let ignorePatterns: string[] = [];
+        if (this.options.exclude) {
+            const excludeArguments: string[] = Array.isArray(this.options.exclude) ? this.options.exclude : [this.options.exclude];
+
+            ignorePatterns = excludeArguments.map(Runner.trimSingleQuotes);
+        }
+
+        files = files
+            // remove single quotes which break matching on Windows when glob is passed in single quotes
+            .map(Runner.trimSingleQuotes)
+            .map((file: string) => glob.sync(file, { ignore: ignorePatterns, nodir: true }))
+            .reduce((a: string[], b: string[]) => a.concat(b));
+
+        try {
+            this.processFiles(onComplete, files, program);
+        } catch (error) {
+            if (error.name === FatalError.NAME) {
+                console.error(error.message);
+                onComplete(1);
+            }
+            // rethrow unhandled error
+            throw error;
+        }
+    }
+
+    private processFiles(onComplete: (status: number) => void, files: string[], program?: ts.Program) {
+        const possibleConfigAbsolutePath = this.options.config != null ? path.resolve(this.options.config) : null;
+        const linter = new Linter({
+            fix: this.options.fix,
+            formatter: this.options.format,
+            formattersDirectory: this.options.formattersDirectory || "",
+            rulesDirectory: this.options.rulesDirectory || "",
+        }, program);
+
+        for (const file of files) {
+            if (!fs.existsSync(file)) {
+                console.error(`Unable to open file: ${file}`);
+                onComplete(1);
+            }
+
+            const buffer = new Buffer(256);
+            buffer.fill(0);
+            const fd = fs.openSync(file, "r");
+            try {
+                fs.readSync(fd, buffer, 0, 256, null);
+                if (buffer.readInt8(0) === 0x47 && buffer.readInt8(188) === 0x47) {
+                    // MPEG transport streams use the '.ts' file extension. They use 0x47 as the frame
+                    // separator, repeating every 188 bytes. It is unlikely to find that pattern in
+                    // TypeScript source, so tslint ignores files with the specific pattern.
+                    console.warn(`${file}: ignoring MPEG transport stream`);
+                    return;
+                }
+            } finally {
+                fs.closeSync(fd);
+            }
+
+            const contents = fs.readFileSync(file, "utf8");
+            const configLoad = findConfiguration(possibleConfigAbsolutePath, file);
+            linter.lint(file, contents, configLoad.results);
+        }
+
+        const lintResult = linter.getResult();
+
+        this.outputStream.write(lintResult.output, () => {
+            if (lintResult.failureCount > 0) {
+                onComplete(this.options.force ? 0 : 2);
+            }
+        });
+
+        if (lintResult.format === "prose") {
+            // Check to see if there are any updates available
+            updateNotifierCheck();
+        }
+    }
+}

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -16,22 +16,11 @@
  */
 
 import * as fs from "fs";
-import * as glob from "glob";
 import * as optimist from "optimist";
-import * as path from "path";
-import * as ts from "typescript";
 
-import {
-    CONFIG_FILENAME,
-    DEFAULT_CONFIG,
-    findConfiguration,
-} from "./configuration";
-import { FatalError } from "./error";
-import * as Linter from "./linter";
-import { consoleTestResultHandler, runTest } from "./test";
-import { updateNotifierCheck } from "./updateNotifier";
+import { IRunnerOptions, Runner } from "./runner";
 
-let processed = optimist
+const processed = optimist
     .usage("Usage: $0 [options] file ...")
     .check((argv: any) => {
         // at least one of file, help, version, project or unqualified argument must be present
@@ -102,7 +91,7 @@ let processed = optimist
     });
 const argv = processed.argv;
 
-let outputStream: any;
+let outputStream: NodeJS.WritableStream;
 if (argv.o != null) {
     outputStream = fs.createWriteStream(argv.o, {
         flags: "w+",
@@ -110,28 +99,6 @@ if (argv.o != null) {
     });
 } else {
     outputStream = process.stdout;
-}
-
-if (argv.v != null) {
-    outputStream.write(Linter.VERSION + "\n");
-    process.exit(0);
-}
-
-if (argv.i != null) {
-    if (fs.existsSync(CONFIG_FILENAME)) {
-        console.error(`Cannot generate ${CONFIG_FILENAME}: file already exists`);
-        process.exit(1);
-    }
-
-    const tslintJSON = JSON.stringify(DEFAULT_CONFIG, undefined, "    ");
-    fs.writeFileSync(CONFIG_FILENAME, tslintJSON);
-    process.exit(0);
-}
-
-if (argv.test != null) {
-    const results = runTest(argv.test, argv.r);
-    const didAllTestsPass = consoleTestResultHandler(results);
-    process.exit(didAllTestsPass ? 0 : 1);
 }
 
 if ("help" in argv) {
@@ -220,120 +187,22 @@ tslint accepts the following commandline options:
     process.exit(0);
 }
 
-// when provided, it should point to an existing location
-if (argv.c && !fs.existsSync(argv.c)) {
-    console.error("Invalid option for configuration: " + argv.c);
-    process.exit(1);
-}
-const possibleConfigAbsolutePath = argv.c != null ? path.resolve(argv.c) : null;
-
-const processFiles = (files: string[], program?: ts.Program) => {
-
-    const linter = new Linter({
-        fix: argv.fix,
-        formatter: argv.t,
-        formattersDirectory: argv.s || "",
-        rulesDirectory: argv.r || "",
-    }, program);
-
-    for (const file of files) {
-        if (!fs.existsSync(file)) {
-            console.error(`Unable to open file: ${file}`);
-            process.exit(1);
-        }
-
-        const buffer = new Buffer(256);
-        buffer.fill(0);
-        const fd = fs.openSync(file, "r");
-        try {
-            fs.readSync(fd, buffer, 0, 256, null);
-            if (buffer.readInt8(0) === 0x47 && buffer.readInt8(188) === 0x47) {
-                // MPEG transport streams use the '.ts' file extension. They use 0x47 as the frame
-                // separator, repeating every 188 bytes. It is unlikely to find that pattern in
-                // TypeScript source, so tslint ignores files with the specific pattern.
-                console.warn(`${file}: ignoring MPEG transport stream`);
-                return;
-            }
-        } finally {
-            fs.closeSync(fd);
-        }
-
-        const contents = fs.readFileSync(file, "utf8");
-        const configLoad = findConfiguration(possibleConfigAbsolutePath, file);
-        linter.lint(file, contents, configLoad.results);
-    }
-
-    const lintResult = linter.getResult();
-
-    outputStream.write(lintResult.output, () => {
-        if (lintResult.failureCount > 0) {
-            process.exit(argv.force ? 0 : 2);
-        }
-    });
-
-    if (lintResult.format === "prose") {
-        // Check to see if there are any updates available
-        updateNotifierCheck();
-    }
+const options: IRunnerOptions = {
+    config: argv.c,
+    exclude: argv.exclude,
+    files: argv._,
+    fix: argv.fix,
+    force: argv.force,
+    format: argv.t,
+    formattersDirectory: argv.s,
+    init: argv.init,
+    out: argv.out,
+    project: argv.project,
+    rulesDirectory: argv.r,
+    test: argv.test,
+    typeCheck: argv["type-check"],
+    version: argv.v,
 };
 
-// if both files and tsconfig are present, use files
-let files = argv._;
-let program: ts.Program;
-
-if (argv.project != null) {
-    if (!fs.existsSync(argv.project)) {
-        console.error("Invalid option for project: " + argv.project);
-        process.exit(1);
-    }
-    program = Linter.createProgram(argv.project, path.dirname(argv.project));
-    if (files.length === 0) {
-        files = Linter.getFileNames(program);
-    }
-    if (argv["type-check"]) {
-        // if type checking, run the type checker
-        const diagnostics = ts.getPreEmitDiagnostics(program);
-        if (diagnostics.length > 0) {
-            const messages = diagnostics.map((diag) => {
-                // emit any error messages
-                let message = ts.DiagnosticCategory[diag.category];
-                if (diag.file) {
-                    const {line, character} = diag.file.getLineAndCharacterOfPosition(diag.start);
-                    message += ` at ${diag.file.fileName}:${line + 1}:${character + 1}:`;
-                }
-                message += " " + ts.flattenDiagnosticMessageText(diag.messageText, "\n");
-                return message;
-            });
-            throw new Error(messages.join("\n"));
-        }
-    } else {
-        // if not type checking, we don't need to pass in a program object
-        program = undefined;
-    }
-}
-
-const trimSingleQuotes = (str: string) => str.replace(/^'|'$/g, "");
-
-let ignorePatterns: string[] = [];
-if (argv.e) {
-    const excludeArguments: string[] = Array.isArray(argv.e) ? argv.e : [argv.e];
-
-    ignorePatterns = excludeArguments.map(trimSingleQuotes);
-}
-
-files = files
-    // remove single quotes which break matching on Windows when glob is passed in single quotes
-    .map(trimSingleQuotes)
-    .map((file: string) => glob.sync(file, { ignore: ignorePatterns, nodir: true }))
-    .reduce((a: string[], b: string[]) => a.concat(b));
-
-try {
-    processFiles(files, program);
-} catch (error) {
-    if (error.name === FatalError.NAME) {
-        console.error(error.message);
-        process.exit(1);
-    }
-    // rethrow unhandled error
-    throw error;
-}
+new Runner(options, outputStream)
+    .run((status: number) => process.exit(status));


### PR DESCRIPTION
Fixes #1675.

tslint-cli.ts takes in arguments using optimist and converts them to a friendlier object to pass to a CliRunner. The rest of the logic that used to be in tslint-cli.ts is now in the CliRunner.

Notes:
* I really wanted to make `CliRunner::run` return a `Promise<number>`, but didn't want to add new dependencies or change the output target.
* I tried to stick to the existing code style for the cut-and-pasted code. If you'd like it changed I'm up for that too.
* I'm not confident in `CliRunner` as a name. Alternate suggestions, anyone?