### PR TITLE
Use update-notifier to notify of new versions #990

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "glob": "^7.1.1",
     "optimist": "~0.6.0",
     "resolve": "^1.1.7",
-    "underscore.string": "^3.3.4"
+    "underscore.string": "^3.3.4",
+    "update-notifier": "^1.0.2"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -28,6 +28,7 @@ import {
 } from "./configuration";
 import { consoleTestResultHandler, runTest } from "./test";
 import * as Linter from "./tslintMulti";
+import { updateNotifierCheck } from "./updateNotifier";
 
 let processed = optimist
     .usage("Usage: $0 [options] file ...")
@@ -267,6 +268,11 @@ const processFiles = (files: string[], program?: ts.Program) => {
             process.exit(argv.force ? 0 : 2);
         }
     });
+
+    if (lintResult.format === "prose") {
+        // Check to see if there are any updates available
+        updateNotifierCheck();
+    }
 };
 
 // if both files and tsconfig are present, use files

--- a/src/updateNotifier.ts
+++ b/src/updateNotifier.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tslint:disable-next-line:no-var-requires
+const updateNotifier = require("update-notifier");
+// tslint:disable-next-line:no-var-requires 
+const pkg = require("../package.json");
+
+export function updateNotifierCheck(): void {
+    // Check every 3 days for a new version
+    const cacheTime: number = 1000 * 60 * 60 * 24 * 3;
+    const changeLogUrl: string = "https://github.com/palantir/tslint/blob/master/CHANGELOG.md";
+    const notifier = updateNotifier({
+        pkg,
+        updateCheckInterval: cacheTime,
+    });
+
+    if (notifier.notify && notifier.update) {
+        let message: string = `TSLint update available v${notifier.update.current} → v${notifier.update.latest} \n See ${changeLogUrl}`;
+        notifier.notify({ message });
+    }
+};


### PR DESCRIPTION
#### PR checklist

- [x] Use update-notifier to notify users of new versions in a non-intrusive way #990
- [x] New feature, bugfix, or enhancement
- [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?
I've added the functionality of the [update-notifier](https://github.com/yeoman/update-notifier) to have it display the update message when there is a new tslint version available. 

The functionality is inside a new file called 'updateNotifier.ts', to keep it separate and because I need to require the plugin as well as the package.json. The new function is implemented via the cli.

#### Is there anything you'd like reviewers to focus on?
Do you think implementing the function call at this level is correct? 

My reasons for placing it here is because it then runs every time. The interval for checking a new version is set to three days (default is once a day).

I've tested it by setting the 'updateCheckInterval' to 0 and by lowering the version inside the package.json to '3.15.0', so it would trigger the check.

This triggers the image below:
<img width="404" alt="update-message" src="https://cloud.githubusercontent.com/assets/201702/20073509/d2f5226a-a52c-11e6-9915-25b5d9891b55.png">


