### PR TITLE
Use denormalized path in test (fixes Windows build)

### DIFF
--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -123,12 +123,12 @@ describe("Executable", function() {
             execCli(["-c", "test/files/multiple-fixes-test/tslint.json", tempFile, "--fix"],
                 (err, stdout) => {
                     const content = fs.readFileSync(tempFile, "utf8");
-                    // compare against file name which will be retyrned by formatter (used in TypeScript)
-                    const denornalizedFileName = denormalizeWinPath(tempFile);
+                    // compare against file name which will be returned by formatter (used in TypeScript)
+                    const denormalizedFileName = denormalizeWinPath(tempFile);
                     fs.unlinkSync(tempFile);
                     assert.strictEqual(content, "import * as y from \"a_long_module\";\nimport * as x from \"b\";\n");
                     assert.isNull(err, "process should exit without an error");
-                    assert.strictEqual(stdout, `Fixed 2 error(s) in ${denornalizedFileName}`);
+                    assert.strictEqual(stdout, `Fixed 2 error(s) in ${denormalizedFileName}`);
                     done();
                 });
         });

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createTempFile } from "../utils";
+import { createTempFile, denormalizeWinPath } from "../utils";
 import * as cp from "child_process";
 import * as fs from "fs";
 import * as os from "os";
@@ -123,10 +123,12 @@ describe("Executable", function() {
             execCli(["-c", "test/files/multiple-fixes-test/tslint.json", tempFile, "--fix"],
                 (err, stdout) => {
                     const content = fs.readFileSync(tempFile, "utf8");
+                    // compare against file name which will be retyrned by formatter (used in TypeScript)
+                    const denornalizedFileName = denormalizeWinPath(tempFile);
                     fs.unlinkSync(tempFile);
                     assert.strictEqual(content, "import * as y from \"a_long_module\";\nimport * as x from \"b\";\n");
                     assert.isNull(err, "process should exit without an error");
-                    assert.strictEqual(stdout, `Fixed 2 error(s) in ${tempFile}`);
+                    assert.strictEqual(stdout, `Fixed 2 error(s) in ${denornalizedFileName}`);
                     done();
                 });
         });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -98,3 +98,8 @@ export function createTempFile(extension: string) {
     }
     return tmpfile;
 }
+
+// converts Windows normalized paths (witn backwars slash `\`) to paths used by TypeScript (with forward slash `/`)
+export function denormalizeWinPath(path: string): string {
+    return path.replace(/\\/g, "/");
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -99,7 +99,7 @@ export function createTempFile(extension: string) {
     return tmpfile;
 }
 
-// converts Windows normalized paths (witn backwars slash `\`) to paths used by TypeScript (with forward slash `/`)
+// converts Windows normalized paths (with backwards slash `\`) to paths used by TypeScript (with forward slash `/`)
 export function denormalizeWinPath(path: string): string {
     return path.replace(/\\/g, "/");
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] ~~New feature,~~ bugfix, ~~or enhancement~~
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

Currently build fails since normalized path returned from Node.js API (with `\` as path separator) is compared to deormalized one (with `/` as path separator, which is also valid on Windows) which was picked from TypeScript.

This PR fixes build on Windows by converting normalized path to denormalized and using it in comparison.


#### Is there anything you'd like reviewers to focus on?

I've reviewed 3 possible solutions:

1. Normalize `fileName`'s when they are stored in `RuleFailure` class (used only in formatters) 

1. Normalize only absolute `fileName`'s when they are stored in `RuleFailure` class (probably rare case, but matches problem in test)

1. Use denormalized path in test

While first two solution fix problem, I think they bring almost no value and will lead to inconsistency in paths output between platforms.