### PR TITLE
Extend adjacent-overload-signatures to work in classes, source files, modules, and namespaces

### DIFF
--- a/src/rules/adjacentOverloadSignaturesRule.ts
+++ b/src/rules/adjacentOverloadSignaturesRule.ts
@@ -41,34 +41,63 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class AdjacentOverloadSignaturesWalker extends Lint.RuleWalker {
+    public visitSourceFile(node: ts.SourceFile) {
+        this.visitStatements(node.statements);
+        super.visitSourceFile(node);
+    }
+
+    public visitModuleDeclaration(node: ts.ModuleDeclaration) {
+        const { body } = node;
+        if (body && body.kind === ts.SyntaxKind.ModuleBlock) {
+            this.visitStatements((body as ts.ModuleBlock).statements);
+        }
+        super.visitModuleDeclaration(node);
+    }
 
     public visitInterfaceDeclaration(node: ts.InterfaceDeclaration): void {
-        this.checkNode(node);
+        this.checkOverloadsAdjacent(node.members, member => member.name && getTextOfPropertyName(member.name));
         super.visitInterfaceDeclaration(node);
     }
 
-    public visitTypeLiteral(node: ts.TypeLiteralNode): void {
-        this.checkNode(node);
+    public visitClassDeclaration(node: ts.ClassDeclaration) {
+        this.visitMembers(node.members);
+        super.visitClassDeclaration(node);
+    }
+
+    public visitTypeLiteral(node: ts.TypeLiteralNode) {
+        this.visitMembers(node.members);
         super.visitTypeLiteral(node);
     }
 
-    public checkNode(node: ts.TypeLiteralNode | ts.InterfaceDeclaration) {
-        let last: string = undefined;
-        const seen: { [name: string]: boolean } = {};
-        for (const member of node.members) {
-            if (member.name !== undefined) {
-                const methodName = getTextOfPropertyName(member.name);
-                if (methodName !== undefined) {
-                    if (seen.hasOwnProperty(methodName) && last !== methodName) {
-                        this.addFailure(this.createFailure(member.getStart(), member.getWidth(),
-                            Rule.FAILURE_STRING_FACTORY(methodName)));
-                    }
-                    last = methodName;
-                    seen[methodName] = true;
-                }
+    private visitStatements(statements: ts.Statement[]) {
+        this.checkOverloadsAdjacent(statements, statement => {
+            if (statement.kind === ts.SyntaxKind.FunctionDeclaration) {
+                const name = (statement as ts.FunctionDeclaration).name;
+                return name && name.text;
             } else {
-                last = undefined;
+                return undefined;
             }
+        });
+    }
+
+    private visitMembers(members: (ts.TypeElement | ts.ClassElement)[]) {
+        this.checkOverloadsAdjacent(members, member => member.name && getTextOfPropertyName(member.name));
+    }
+
+    /** 'getOverloadName' may return undefined for nodes that cannot be overloads, e.g. a `const` declaration. */
+    private checkOverloadsAdjacent<T extends ts.Node>(overloads: T[], getOverloadName: (node: T) => string | undefined) {
+        let last: string | undefined = undefined;
+        const seen: { [name: string]: true } = Object.create(null);
+        for (const node of overloads) {
+            const name = getOverloadName(node);
+            if (name !== undefined) {
+                if (name in seen && last !== name) {
+                    this.addFailure(this.createFailure(node.getStart(), node.getWidth(),
+                        Rule.FAILURE_STRING_FACTORY(name)));
+                }
+                seen[name] = true;
+            }
+            last = name;
         }
     }
 }

--- a/test/rules/adjacent-overload-signatures/test.ts.lint
+++ b/test/rules/adjacent-overload-signatures/test.ts.lint
@@ -83,3 +83,31 @@ interface b5 {
         ~~~~~~~~~~~~~~~~~~~  [All 'a' signatures should be adjacent]
     }
 }
+
+// Also works in classes, source files, modules, namespaces
+
+class C {
+    a(): void;
+    b(): void;
+    a(x: number): void;
+    ~~~~~~~~~~~~~~~~~~~  [All 'a' signatures should be adjacent]
+}
+
+declare function a(): void;
+declare function b(): void;
+declare function a(x: number): void;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [All 'a' signatures should be adjacent]
+
+declare module "m" {
+    export function a(): void;
+    export function b(): void;
+    export function a(x: number): void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [All 'a' signatures should be adjacent]
+}
+
+declare namespace N {
+    export function a(): void;
+    export function b(): void;
+    export function a(x: number): void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [All 'a' signatures should be adjacent]
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### What changes did you make?

The adjacent-overload-signatures rule now works in situations other than interfaces and type literals.
I don't think this needs a documentation update, since the existing documentation doesn't say anything about being specific to just those.
