### PR TITLE
Make typescriptOnly and optionsDescription required on IRuleMetadata

### DIFF
--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -74,7 +74,7 @@ export interface IRuleMetadata {
     requiresTypeInfo?: boolean;
 
     /**
-     * Whether or not the rule use for TypeScript only.
+     * Whether or not the rule use for TypeScript only. If `false`, this rule may be used with .js files.
      */
     typescriptOnly: boolean;
 }

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -48,7 +48,7 @@ export interface IRuleMetadata {
     /**
      * An explanation of the available options for the rule.
      */
-    optionsDescription?: string;
+    optionsDescription: string;
 
     /**
      * Schema of the options the rule accepts.
@@ -76,7 +76,7 @@ export interface IRuleMetadata {
     /**
      * Whether or not the rule use for TypeScript only.
      */
-    typescriptOnly?: boolean;
+    typescriptOnly: boolean;
 }
 
 export type RuleType = "functionality" | "maintainability" | "style" | "typescript";

--- a/src/rules/adjacentOverloadSignaturesRule.ts
+++ b/src/rules/adjacentOverloadSignaturesRule.ts
@@ -28,6 +28,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: ["true"],
+        rationale: "Improves readability and organization by grouping naturally related items together.",
         type: "typescript",
         typescriptOnly: true,
     };

--- a/src/rules/cyclomaticComplexityRule.ts
+++ b/src/rules/cyclomaticComplexityRule.ts
@@ -50,6 +50,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         },
         optionExamples: ["true", "[true, 20]"],
         type: "maintainability",
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/maxClassesPerFileRule.ts
+++ b/src/rules/maxClassesPerFileRule.ts
@@ -27,6 +27,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         },
         optionExamples: ["[true, 1]", "[true, 5]"],
         type: "maintainability",
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -6,6 +6,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "object-literal-shorthand",
         description: "Enforces use of ES6 object literal shorthand when possible.",
+        optionsDescription: "Not configurable.",
         options: null,
         optionExamples: ["true"],
         type: "style",

--- a/src/rules/preferForOfRule.ts
+++ b/src/rules/preferForOfRule.ts
@@ -28,6 +28,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         options: null,
         optionExamples: ["true"],
         type: "typescript",
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 


### PR DESCRIPTION
Make properties required to ensure that people think about them when adding new rules.