### PR TITLE
Use jsRules for JSX files

### DIFF
--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -75,8 +75,10 @@ export function loadRules(ruleConfiguration: {[name: string]: any},
         throw new Error(ERROR_MESSAGE);
     } else if (notAllowedInJsRules.length > 0) {
         const JS_ERROR_MESSAGE = `
-           Could not apply to JavaScript files for the following rules specified in the configuration:
-           ${notAllowedInJsRules.join("\n")}
+            Following rules specified in configuration couldn't be applied to .js or .jsx files:
+                ${notAllowedInJsRules.join("\n")}
+
+            Make sure to exclude them from "jsRules" section of your tslint.json.
         `;
 
         throw new Error(JS_ERROR_MESSAGE);

--- a/src/tslintMulti.ts
+++ b/src/tslintMulti.ts
@@ -30,12 +30,12 @@ import {
 import { EnableDisableRulesWalker } from "./enableDisableRules";
 import { findFormatter } from "./formatterLoader";
 import { IFormatter } from "./language/formatter/formatter";
-import {Fix, IRule, RuleFailure} from "./language/rule/rule";
+import { Fix, IRule, RuleFailure } from "./language/rule/rule";
 import { TypedRule } from "./language/rule/typedRule";
 import * as utils from "./language/utils";
 import { IMultiLinterOptions, LintResult } from "./lint";
 import { loadRules } from "./ruleLoader";
-import { arrayify } from "./utils";
+import { arrayify, dedent } from "./utils";
 
 /**
  * Linter that can lint multiple files in consecutive runs.
@@ -113,7 +113,7 @@ class MultiLinter {
             hasLinterRun = true;
         }
 
-        // make a 1st pass or make a 2nd pass if there were any fixes because the positions may be off        
+        // make a 1st pass or make a 2nd pass if there were any fixes because the positions may be off
         if (!hasLinterRun || this.fixes.length > 0) {
             this.failures = [];
             for (let rule of enabledRules) {
@@ -175,7 +175,7 @@ class MultiLinter {
 
         const rulesDirectories = arrayify(this.options.rulesDirectory)
             .concat(arrayify(configuration.rulesDirectory));
-        const isJs = fileName.substr(-3) === ".js";
+        const isJs = /\.jsx?$/i.test(fileName);
         const configurationRules = isJs ? configuration.jsRules : configuration.rules;
         let configuredRules = loadRules(configurationRules, enableDisableRuleMap, rulesDirectories, isJs);
 
@@ -195,7 +195,10 @@ class MultiLinter {
         }
 
         if (sourceFile === undefined) {
-            throw new Error(`Invalid source file: ${fileName}. Ensure that the files supplied to lint have a .ts, .tsx, or .js extension.`);
+            const INVALID_SOURCE_ERROR = dedent`
+                Invalid source file: ${fileName}. Ensure that the files supplied to lint have a .ts, .tsx, .js or .jsx extension.
+            `;
+            throw new Error(INVALID_SOURCE_ERROR);
         }
         return sourceFile;
     }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] ~New feature,~ bugfix, ~or enhancement~
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

This PR ensures that `jsRules` will be used for both `.js` and `.jsx` files. See https://github.com/palantir/tslint/pull/1634#pullrequestreview-8292214

#### Is there anything you'd like reviewers to focus on?

Current `dedent` implementation isn't suitable for strings like `JS_ERROR_MESSAGE` since it calculates minimal indent for all lines and `.join("\n")` makes it 0.

