### PR TITLE
Removes `no-duplicate-variable` from the default & recommended configs

### DIFF
--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -53,7 +53,6 @@ export const rules = {
     ],
     "no-construct": true,
     "no-debugger": true,
-    "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
     "no-internal-module": true,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -66,7 +66,6 @@ export const DEFAULT_CONFIG = {
         "class-name": true,
         "comment-format": [true, "check-space"],
         "indent": [true, "spaces"],
-        "no-duplicate-variable": true,
         "no-eval": true,
         "no-internal-module": true,
         "no-trailing-whitespace": true,


### PR DESCRIPTION
Per the [docs](https://palantir.github.io/tslint/rules/no-duplicate-variable/) for `no-duplicate-variable` itself:

> This rule is only useful when using the var keyword - the compiler will detect redeclarations of let and const variables.

Given that `no-var-keyword` is already included in both configs, `no-deuplicate-variable` becomes redundant since `var` will never be allowed in those configs.