### PR TITLE
Relax TypedRule detection (fix #1637, fix #1522)

### DIFF
--- a/src/language/rule/typedRule.ts
+++ b/src/language/rule/typedRule.ts
@@ -18,9 +18,14 @@
 import * as ts from "typescript";
 
 import {AbstractRule} from "./abstractRule";
-import {RuleFailure} from "./rule";
+import {IRule, RuleFailure} from "./rule";
 
 export abstract class TypedRule extends AbstractRule {
+
+    public static isTypedRule(rule: IRule): rule is TypedRule {
+        return "applyWithProgram" in rule;
+    }
+
     public apply(_sourceFile: ts.SourceFile): RuleFailure[] {
         // if no program is given to the linter, throw an error
         throw new Error(`${this.getOptions().ruleName} requires type checking`);

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -154,7 +154,7 @@ class Linter {
 
     private applyRule(rule: IRule, sourceFile: ts.SourceFile) {
         let ruleFailures: RuleFailure[] = [];
-        if (this.program && rule instanceof TypedRule) {
+        if (this.program && TypedRule.isTypedRule(rule)) {
             ruleFailures = rule.applyWithProgram(sourceFile, this.program);
         } else {
             ruleFailures = rule.apply(sourceFile);


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1637, #1522
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

Relax TypedRule detection:

- `TypedRule` exists to notify the consumer that they must implement the `applyWithProgram` method. 
- Checking `instanceof` is fragile, as is checking `constructor.name`.
- Checking [`isTypedRule`](https://github.com/palantir/tslint/issues/1637#issuecomment-254051190) makes the API bulkier, though it is more explicit, which is good. My rationale is if the consumer defined `applyWithProgram`, then the intention is to make the rule a typed rule, so an additional flag is probably not necessary.
