### PR TITLE
Upgrade typescript to v2.0.10 and fix invalid typescript in comma tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rimraf": "^2.5.4",
     "tslint": "latest",
     "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
-    "typescript": "2.0.3"
+    "typescript": "2.0.10"
   },
   "peerDependencies": {
     "typescript": ">=2.0.0"

--- a/test/rules/trailing-comma/multiline-always/test.ts.fix
+++ b/test/rules/trailing-comma/multiline-always/test.ts.fix
@@ -364,7 +364,7 @@ class Test<A, B, C> {
             [
                 C,
                 C,
-            ]
+            ],
             C,
         >,
     >(
@@ -474,7 +474,7 @@ interface ITest<A ,B, C> {
             [
                 C,
                 C,
-            ]
+            ],
             C,
         >,
     >(

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -390,7 +390,7 @@ class Test<A, B, C> {
             [
                 C,
                 C,
-            ]
+            ],
             C
             ~ [Missing trailing comma]
         >
@@ -509,7 +509,7 @@ interface ITest<A ,B, C> {
             [
                 C,
                 C,
-            ]
+            ],
             C
             ~ [Missing trailing comma]
         >

--- a/test/rules/trailing-comma/multiline-never/test.ts.fix
+++ b/test/rules/trailing-comma/multiline-never/test.ts.fix
@@ -364,7 +364,7 @@ class Test<A, B, C> {
             [
                 C,
                 C
-            ]
+            ],
             C
         >
     >(
@@ -430,7 +430,7 @@ interface ITest<A ,B, C> {
             [
                 C,
                 C
-            ]
+            ],
             C
         >
     >(

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -390,7 +390,7 @@ class Test<A, B, C> {
                 C,
                 C,
                  ~ [Unnecessary trailing comma]
-            ]
+            ],
             C
         >
     >(
@@ -462,7 +462,7 @@ interface ITest<A ,B, C> {
                 C,
                 C,
                  ~ [Unnecessary trailing comma]
-            ]
+            ],
             C
         >
     >(


### PR DESCRIPTION
Upgrading TypeScript caused some test errors. I investigated, and it turns out the TypeScript in the test was invalid