### PR TITLE
Create local Error interface so that node doesn't need to be externally referenced

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -32,6 +32,14 @@ export interface IConfigurationFile {
     rules?: any;
 }
 
+/**
+ * Define `Error` here to avoid using `Error` from @types/node.
+ * Using the `node` version causes a compilation error when this code is used as an npm library if @types/node is not already imported.
+ */
+export interface Error {
+    message: string;
+}
+
 export interface IConfigurationLoadResult {
     error?: Error;
     path: string;

--- a/src/test/lintError.ts
+++ b/src/test/lintError.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { Error } from "../configuration";
+import { Error } from "../configuration";
 
 export interface PositionInFile {
    line: number;
@@ -42,5 +42,5 @@ export function errorComparator(err1: LintError, err2: LintError) {
 }
 
 export function lintSyntaxError(message: string) {
-    return new Error(`Lint File Syntax Error: ${message}`);
+    return new Error(`Lint File Syntax Error: ${message}`) as Error;
 }

--- a/src/test/lintError.ts
+++ b/src/test/lintError.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export { Error } from "../configuration";
+
 export interface PositionInFile {
    line: number;
    col: number;


### PR DESCRIPTION
The problem: when using TSLint as an NPM library, you see error:

```
node_modules/tslint/lib/configuration.d.ts(1,1): error TS2688: Cannot find type definition file for 'node'.
```

Why: @types/node augments the `Error` interface that was initially defined by TypeScript's `lib.d.ts`. Since the use of this interface is exported by TSLint, the app using TSLint must also include @types/node. Sadly, the property added by Node is currently already defined by `lib.d.ts`

The fix: Don't export the @types/node `Error` interface and define/use our own similar interface.