### PR TITLE
Fix parameter type of hasModifier

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -77,8 +77,8 @@ export function scanAllTokens(scanner: ts.Scanner, callback: (s: ts.Scanner) => 
 /**
  * @returns true if any modifier kinds passed along exist in the given modifiers array
  */
-export function hasModifier(modifiers: ts.ModifiersArray|null|undefined, ...modifierKinds: ts.SyntaxKind[]) {
-    if (modifiers == null || modifierKinds == null) {
+export function hasModifier(modifiers: ts.ModifiersArray|undefined, ...modifierKinds: ts.SyntaxKind[]) {
+    if (modifiers === undefined || modifierKinds.length === 0) {
         return false;
     }
 

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -77,7 +77,7 @@ export function scanAllTokens(scanner: ts.Scanner, callback: (s: ts.Scanner) => 
 /**
  * @returns true if any modifier kinds passed along exist in the given modifiers array
  */
-export function hasModifier(modifiers: ts.ModifiersArray, ...modifierKinds: ts.SyntaxKind[]) {
+export function hasModifier(modifiers: ts.ModifiersArray|null|undefined, ...modifierKinds: ts.SyntaxKind[]) {
     if (modifiers == null || modifierKinds == null) {
         return false;
     }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

Avoid compiler error with strictNullChecks.
hasModifier already checks for null and undefined.
This commit adds types null and undefined to the modifiers parameter.