### PR TITLE
Special case the empty string in object-literal-key-quotes rule

### DIFF
--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -77,7 +77,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 // This is simplistic. See https://mothereff.in/js-properties for the gorey details.
-const IDENTIFIER_NAME_REGEX = /^(?:[\$A-Z_a-z])*$/;
+const IDENTIFIER_NAME_REGEX = /^(?:[\$A-Z_a-z])+$/;
 const NUMBER_REGEX = /^[0-9]+$/;
 type QuotesMode = "always" | "as-needed" | "consistent" | "consistent-as-needed";
 

--- a/test/rules/object-literal-key-quotes/as-needed/test.js.lint
+++ b/test/rules/object-literal-key-quotes/as-needed/test.js.lint
@@ -19,4 +19,5 @@ const o = {
   "0x0": 0,
   "true": 0, // failure
   ~~~~~~  [Unnecessarily quoted property 'true' found.]
+  '': 'always quote the empty string',
 };

--- a/test/rules/object-literal-key-quotes/as-needed/test.ts.lint
+++ b/test/rules/object-literal-key-quotes/as-needed/test.ts.lint
@@ -19,4 +19,5 @@ const o = {
   "0x0": 0,
   "true": 0, // failure
   ~~~~~~  [Unnecessarily quoted property 'true' found.]
+  '': 'always quote the empty string',
 };


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1761
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### What changes did you make?

* The bug in #1761 appears to be rooted in `IDENTIFIER_NAME_REGEX` using a `*` instead of `+` repeat modifier. This has been addressed.
* I added a test case for `''` in the `"as-needed"` files.

#### Is there anything you'd like reviewers to focus on?

I don't know enough about the spirit of "consistent" or "consistent-as-needed" to know if this case should be flagged as a failure or not:

```typescript
const uncertain = {
  foo: 'bar',
  '': 'baz',
};
```

Right now, this test fails in both cases. It seems like this is correct, but I welcome confirmation. Once I have it I'll update the tests.
