### PR TITLE
Fatal errors from API should be unhandled and caught in tslint-cli

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -850,7 +850,7 @@
   },
   {
     "ruleName": "no-unused-variable",
-    "deprecationMessage": "Use the compiler options --noUnusedParameters and --noUnusedLocals instead.",
+    "deprecationMessage": "Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.",
     "description": "Disallows unused imports, variables, functions and private class members.",
     "optionsDescription": "\nThree optional arguments may be optionally provided:\n\n* `\"check-parameters\"` disallows unused function and constructor parameters.\n    * NOTE: this option is experimental and does not work with classes\n    that use abstract method declarations, among other things.\n* `\"react\"` relaxes the rule for a namespace import named `React`\n(from either the module `\"react\"` or `\"react/addons\"`).\nAny JSX expression in the file will be treated as a usage of `React`\n(because it expands to `React.createElement `).\n* `{\"ignore-pattern\": \"pattern\"}` where pattern is a case-sensitive regexp.\nVariable names that match the pattern will be ignored.",
     "options": {

--- a/docs/rules/no-unused-variable/index.html
+++ b/docs/rules/no-unused-variable/index.html
@@ -1,6 +1,6 @@
 ---
 ruleName: no-unused-variable
-deprecationMessage: Use the compiler options --noUnusedParameters and --noUnusedLocals instead.
+deprecationMessage: Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.
 description: 'Disallows unused imports, variables, functions and private class members.'
 optionsDescription: |-
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,6 +19,7 @@ import findup = require("findup-sync");
 import * as fs from "fs";
 import * as path from "path";
 import * as resolve from "resolve";
+import { FatalError } from "./error";
 
 import {arrayify, objectify, stripComments} from "./utils";
 
@@ -32,16 +33,7 @@ export interface IConfigurationFile {
     rules?: any;
 }
 
-/**
- * Define `Error` here to avoid using `Error` from @types/node.
- * Using the `node` version causes a compilation error when this code is used as an npm library if @types/node is not already imported.
- */
-export interface Error {
-    message: string;
-}
-
 export interface IConfigurationLoadResult {
-    error?: Error;
     path: string;
     results?: IConfigurationFile;
 }
@@ -119,11 +111,10 @@ export function findConfiguration(configFile: string, inputFilePath: string): IC
 
     try {
         loadResult.results = loadConfigurationFromPath(path);
+        return loadResult;
     } catch (error) {
-        loadResult.error = error;
+        throw new FatalError(`Failed to load ${path}: ${error.message}`, error);
     }
-
-    return loadResult;
 }
 
 /**

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Generic error typing for EcmaScript errors
+ * Define `Error` here to avoid using `Error` from @types/node.
+ * Using the `node` version causes a compilation error when this code is used as an npm library if @types/node is not already imported.
+ */
+export declare class Error {
+    public name?: string;
+    public message: string;
+    public stack?: string;
+    constructor(message?: string);
+}
+
+/**
+ * Used to exit the program and display a friendly message without the callstack.
+ */
+export class FatalError extends Error {
+    public static NAME = "FatalError";
+    constructor(public message: string, public innerError?: Error) {
+        super(message);
+        this.name = FatalError.NAME;
+        this.stack = new Error().stack;
+    }
+}

--- a/src/test/lintError.ts
+++ b/src/test/lintError.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Error } from "../configuration";
+import { Error } from "../error";
 
 export interface PositionInFile {
    line: number;


### PR DESCRIPTION
fixes #1759

3rd party apps should be able to see the fatal errors thrown by the API. #1686 changed it so that the error was caught and added as a property to IConfigurationLoadResult. It's not reasonable for 3rd party apps to be aware of this property, so we should follow convention and throw an unhandled exception that the app itself can handle.

This change creates a new FatalError class which is caught in `tslint.cli`.