### PR TITLE
fix `adjacent-overload-signatures` to treat static as non-overload

### DIFF
--- a/test/rules/adjacent-overload-signatures/test.ts.lint
+++ b/test/rules/adjacent-overload-signatures/test.ts.lint
@@ -111,3 +111,9 @@ declare namespace N {
     export function a(x: number): void;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [All 'a' signatures should be adjacent]
 }
+
+class Foo {
+  public static bar() {}
+  constructor() {}
+  public bar() {}
+}


### PR DESCRIPTION
fixes #1768 