### PR TITLE
Do not apply trailing comma rule to type parameter lists

### DIFF
--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -70,7 +70,6 @@ class TrailingCommaWalker extends Lint.RuleWalker {
         [ts.SyntaxKind.OpenBraceToken, ts.SyntaxKind.CloseBraceToken],
         [ts.SyntaxKind.OpenBracketToken, ts.SyntaxKind.CloseBracketToken],
         [ts.SyntaxKind.OpenParenToken, ts.SyntaxKind.CloseParenToken],
-        [ts.SyntaxKind.LessThanToken, ts.SyntaxKind.GreaterThanToken],
     ];
 
     public visitArrayLiteralExpression(node: ts.ArrayLiteralExpression) {

--- a/test/rules/trailing-comma/multiline-always/test.ts.fix
+++ b/test/rules/trailing-comma/multiline-always/test.ts.fix
@@ -355,7 +355,7 @@ class Test<A, B, C> {
 
     foo5<
         T extends Test<[A, A], [A, A,], A>,
-        U extends Test<B, B, B,>,
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -365,8 +365,8 @@ class Test<A, B, C> {
                 C,
                 C,
             ],
-            C,
-        >,
+            C
+        >
     >(
         bar: A,
         baz: T,
@@ -386,7 +386,7 @@ class Test<A, B, C> {
                 string,
                 string,
             ];
-        },
+        }
     >() { return 42; }
 
     set bar(foo: string) { }
@@ -402,29 +402,29 @@ class Test<A, B, C> {
     ) { }
 }
 
-class Test2<A, B, C,> { }
+class Test2<A, B, C> { }
 
 class Test3<
     A,
     B,
-    C,
+    C
 > { }
 
 class Test4<
     A,
     B,
-    C,
+    C
 > { }
 
 interface ITest<A ,B, C> {
 
     new <U, V>(bar: U): ITest<U, U, V>;
 
-    new <U, V,>(bar: U, baz: V,): ITest<U, U, V,>;
+    new <U, V>(bar: U, baz: V,): ITest<U, U, V>;
 
     new <
         U,
-        V,
+        V
     >(
         bar: U,
         baz: U,
@@ -432,12 +432,12 @@ interface ITest<A ,B, C> {
     ): ITest<
         U,
         U,
-        V,
+        V
     >;
 
     new <
         U,
-        V,
+        V
     >(
         bar: U,
         baz: U,
@@ -446,7 +446,7 @@ interface ITest<A ,B, C> {
     ): ITest<
         U,
         U,
-        V,
+        V
     >;
 
     foo(bar: string, baz: string);
@@ -465,7 +465,7 @@ interface ITest<A ,B, C> {
 
     foo5<
         T extends Test<[A, A], [A, A,], A>,
-        U extends Test<B, B, B,>,
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -475,8 +475,8 @@ interface ITest<A ,B, C> {
                 C,
                 C,
             ],
-            C,
-        >,
+            C
+        >
     >(
         bar: A,
         baz: T,
@@ -494,7 +494,7 @@ interface ITest<A ,B, C> {
                 string,
                 string,
             ];
-        },
+        }
     >();
 }
 
@@ -503,13 +503,13 @@ interface ITest2<A, B, C> { }
 interface ITest3<
     A,
     B,
-    C,
+    C
 > { }
 
 interface ITest4<
     A,
     B,
-    C,
+    C
 > { }
 
 enum Foo { BAR, BAZ }

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -380,7 +380,7 @@ class Test<A, B, C> {
 
     foo5<
         T extends Test<[A, A], [A, A,], A>,
-        U extends Test<B, B, B,>,
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -392,9 +392,7 @@ class Test<A, B, C> {
                 C,
             ],
             C
-            ~ [Missing trailing comma]
         >
-        ~ [Missing trailing comma]
     >(
         bar: A,
         baz: T,
@@ -414,7 +412,7 @@ class Test<A, B, C> {
                 string,
                 string,
             ];
-        },
+        }
     >() { return 42; }
 
     set bar(foo: string) { }
@@ -431,46 +429,42 @@ class Test<A, B, C> {
     ) { }
 }
 
-class Test2<A, B, C,> { }
+class Test2<A, B, C> { }
 
 class Test3<
     A,
     B,
     C
-    ~ [Missing trailing comma]
 > { }
 
 class Test4<
     A,
     B,
-    C,
+    C
 > { }
 
 interface ITest<A ,B, C> {
 
     new <U, V>(bar: U): ITest<U, U, V>;
 
-    new <U, V,>(bar: U, baz: V,): ITest<U, U, V,>;
+    new <U, V>(bar: U, baz: V,): ITest<U, U, V>;
 
     new <
         U,
         V
-        ~ [Missing trailing comma]
     >(
         bar: U,
         baz: U,
-        ack: V
-             ~ [Missing trailing comma]
+        ack: V,
     ): ITest<
         U,
         U,
         V
-        ~ [Missing trailing comma]
     >;
 
     new <
         U,
-        V,
+        V
     >(
         bar: U,
         baz: U,
@@ -479,7 +473,7 @@ interface ITest<A ,B, C> {
     ): ITest<
         U,
         U,
-        V,
+        V
     >;
 
     foo(bar: string, baz: string);
@@ -499,7 +493,7 @@ interface ITest<A ,B, C> {
 
     foo5<
         T extends Test<[A, A], [A, A,], A>,
-        U extends Test<B, B, B,>,
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -511,9 +505,7 @@ interface ITest<A ,B, C> {
                 C,
             ],
             C
-            ~ [Missing trailing comma]
         >
-        ~ [Missing trailing comma]
     >(
         bar: A,
         baz: T,
@@ -533,7 +525,6 @@ interface ITest<A ,B, C> {
                      ~ [Missing trailing comma]
             ];
         }
-        ~ [Missing trailing comma]
     >();
 }
 
@@ -543,13 +534,12 @@ interface ITest3<
     A,
     B,
     C
-    ~ [Missing trailing comma]
 > { }
 
 interface ITest4<
     A,
     B,
-    C,
+    C
 > { }
 
 enum Foo { BAR, BAZ }

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -414,8 +414,7 @@ class Test<A, B, C> {
                 string,
                       ~ [Unnecessary trailing comma]
             ];
-        },
-         ~ [Unnecessary trailing comma]
+        }
     >() { return 42; }
 }
 

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -430,8 +430,7 @@ class Test3<
 class Test4<
     A,
     B,
-    C,
-     ~ [Unnecessary trailing comma]
+    C
 > { }
 
 interface ITest<A ,B, C> {
@@ -498,8 +497,7 @@ interface ITest3<
 interface ITest4<
     A,
     B,
-    C,
-     ~ [Unnecessary trailing comma]
+    C
 > { }
 
 enum Foo { BAR, BAZ }

--- a/test/rules/trailing-comma/singleline-always/test.ts.fix
+++ b/test/rules/trailing-comma/singleline-always/test.ts.fix
@@ -312,7 +312,7 @@ var x: {
     bar: string,
 };
 
-class Test<A, B, C,> {
+class Test<A, B, C> {
 
     constructor(bar: string,) { }
 
@@ -354,8 +354,8 @@ class Test<A, B, C,> {
     }
 
     foo5<
-        T extends Test<[A, A,], [A, A,], A,>,
-        U extends Test<B, B, B,>,
+        T extends Test<[A, A,], [A, A,], A>,
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -402,7 +402,7 @@ class Test<A, B, C,> {
     ) { }
 }
 
-class Test2<A, B, C,> { }
+class Test2<A, B, C> { }
 
 class Test3<
     A,
@@ -416,9 +416,9 @@ class Test4<
     C,
 > { }
 
-interface ITest<A ,B, C,> {
+interface ITest<A ,B, C> {
 
-    new <U, V,>(bar: U,): ITest<U, U, V,>;
+    new <U, V>(bar: U,): ITest<U, U, V>;
 
     new <
         U,
@@ -435,7 +435,7 @@ interface ITest<A ,B, C,> {
 
     new <
         U,
-        V,
+        V
     >(
         bar: U,
         baz: U,
@@ -444,7 +444,7 @@ interface ITest<A ,B, C,> {
     ): ITest<
         U,
         U,
-        V,
+        V
     >;
 
     foo(bar: string, baz: string,);
@@ -462,8 +462,8 @@ interface ITest<A ,B, C,> {
     );
 
     foo5<
-        T extends Test<[A, A,], [A, A,], A,>,
-        U extends Test<B, B, B,>,
+        T extends Test<[A, A,], [A, A,], A>,
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -496,7 +496,7 @@ interface ITest<A ,B, C,> {
     >();
 }
 
-interface ITest2<A, B, C,> { }
+interface ITest2<A, B, C> { }
 
 interface ITest3<
     A,

--- a/test/rules/trailing-comma/singleline-always/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-always/test.ts.lint
@@ -332,7 +332,6 @@ var x: {
 };
 
 class Test<A, B, C> {
-                 ~    [Missing trailing comma]
 
     constructor(bar: string) { }
                           ~      [Missing trailing comma]
@@ -378,8 +377,7 @@ class Test<A, B, C> {
     foo5<
         T extends Test<[A, A], [A, A,], A>,
                            ~                [Missing trailing comma]
-                                        ~   [Missing trailing comma]
-        U extends Test<B, B, B,>,
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -427,7 +425,7 @@ class Test<A, B, C> {
     ) { }
 }
 
-class Test2<A, B, C,> { }
+class Test2<A, B, C> { }
 
 class Test3<
     A,
@@ -442,12 +440,9 @@ class Test4<
 > { }
 
 interface ITest<A ,B, C> {
-                      ~    [Missing trailing comma]
 
     new <U, V>(bar: U): ITest<U, U, V>;
-            ~                           [Missing trailing comma]
                     ~                   [Missing trailing comma]
-                                    ~   [Missing trailing comma]
 
     new <
         U,
@@ -464,7 +459,7 @@ interface ITest<A ,B, C> {
 
     new <
         U,
-        V,
+        V
     >(
         bar: U,
         baz: U,
@@ -473,7 +468,7 @@ interface ITest<A ,B, C> {
     ): ITest<
         U,
         U,
-        V,
+        V
     >;
 
     foo(bar: string, baz: string);
@@ -494,8 +489,7 @@ interface ITest<A ,B, C> {
     foo5<
         T extends Test<[A, A], [A, A,], A>,
                            ~                [Missing trailing comma]
-                                        ~   [Missing trailing comma]
-        U extends Test<B, B, B,>,
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -529,7 +523,6 @@ interface ITest<A ,B, C> {
 }
 
 interface ITest2<A, B, C> { }
-                       ~      [Missing trailing comma]
 
 interface ITest3<
     A,

--- a/test/rules/trailing-comma/singleline-never/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-never/test.ts.lint
@@ -378,8 +378,7 @@ class Test<A, B, C> {
     foo5<
         T extends Test<[A, A], [A, A,], A>,
                                     ~       [Unnecessary trailing comma]
-        U extends Test<B, B, B,>,
-                              ~   [Unnecessary trailing comma]
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,
@@ -414,8 +413,7 @@ class Test<A, B, C> {
     >() { return 42; }
 }
 
-class Test2<A, B, C,> { }
-                   ~      [Unnecessary trailing comma]
+class Test2<A, B, C> { }
 
 
 class Test3<
@@ -449,8 +447,7 @@ interface ITest<A ,B, C> {
     foo5<
         T extends Test<[A, A], [A, A,], A>,
                                     ~       [Unnecessary trailing comma]
-        U extends Test<B, B, B,>,
-                              ~   [Unnecessary trailing comma]
+        U extends Test<B, B, B>,
         V extends Test<
             [
                 C,


### PR DESCRIPTION
Typescript disallows trailing commas in type parameter lists, both on declaration and invocation. Linting should not flag this case as fixing the lint error would introduce a compiler error.

See https://github.com/palantir/tslint/issues/1769