### PR TITLE
Narrowed no-internal-module failure to the keyword

### DIFF
--- a/src/rules/noInternalModuleRule.ts
+++ b/src/rules/noInternalModuleRule.ts
@@ -43,7 +43,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoInternalModuleWalker extends Lint.RuleWalker {
     public visitModuleDeclaration(node: ts.ModuleDeclaration) {
         if (this.isInternalModuleDeclaration(node)) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            const start = this.getStartBeforeModule(node);
+            this.addFailure(this.createFailure(node.getStart() + start, "module".length, Rule.FAILURE_STRING));
         }
         super.visitModuleDeclaration(node);
     }
@@ -56,10 +57,14 @@ class NoInternalModuleWalker extends Lint.RuleWalker {
             && node.name.kind === ts.SyntaxKind.Identifier
             && !isGlobalAugmentation(node);
     }
+
+    private getStartBeforeModule(node: ts.ModuleDeclaration) {
+        return node.getText().indexOf("module");
+    }
 }
 
 function isGlobalAugmentation(node: ts.ModuleDeclaration) {
-    // augmenting global uses a sepcial syntax that is allowed
+    // augmenting global uses a special syntax that is allowed
     // see https://github.com/Microsoft/TypeScript/pull/6213
     return node.name.kind === ts.SyntaxKind.Identifier && node.name.text === "global";
 }

--- a/test/rules/no-internal-module/test.ts.lint
+++ b/test/rules/no-internal-module/test.ts.lint
@@ -5,14 +5,12 @@ namespace foo {
 declare global { }
 
 module bar {
-~~~~~~~~~~~~
+~~~~~~   [0]
 }
-~ [0]
 
 declare module buzz {
-~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~   [0]
 }
-~ [0]
 
 declare module "hoge" {
 }
@@ -30,29 +28,20 @@ namespace foo {
 
 namespace foo.bar {
     module baz {
-    ~~~~~~~~~~~~
+    ~~~~~~   [0]
         namespace buzz {
-~~~~~~~~~~~~~~~~~~~~~~~~
         }
-~~~~~~~~~
     }
-~~~~~ [0]
 }
 
 module foo.bar {
-~~~~~~~~~~~~~~~~
+~~~~~~   [0]
     namespace baz {
-~~~~~~~~~~~~~~~~~~~
         module buzz {
-~~~~~~~~~~~~~~~~~~~~~
-        ~~~~~~~~~~~~~
+        ~~~~~~   [0]
         }
-~~~~~~~~~
-~~~~~~~~~ [0]
     }
-~~~~~
 }
-~ [0]
 
 namespace name.namespace {
 }
@@ -61,21 +50,17 @@ namespace namespace.name {
 
 // intentionally malformed for test cases, do not format
 declare module declare
-~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~   [0]
 .dec{}
-~~~~~~ [0]
 declare  module dec . declare  {
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         ~~~~~~   [0]
 }
-~ [0]
 
 module  mod.module{}
-~~~~~~~~~~~~~~~~~~~~ [0]
+~~~~~~   [0]
 module module.mod
-~~~~~~~~~~~~~~~~~
+~~~~~~   [0]
 {
-~
 }
-~ [0]
 
 [0]: The internal 'module' syntax is deprecated, use the 'namespace' keyword instead.


### PR DESCRIPTION
Fixes #939.

A couple of notes:
* @adidahiya suggested also including the module name in the failure. This doesn't since IMO the failure is just on the `module` keyword, not the name... but I'm not opposed to also including the name if asked.
* This blindly uses `node.getText().indexOf("module")` to determine where to start the error, since the logic for parsing `declare ` and `declare    ` could get a little complex.