### PR TITLE
Make CLI arg types stronger

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -49,12 +49,12 @@ export interface IRunnerOptions {
     /**
      * Whether to return status code 0 even if there are lint errors.
      */
-    force?: boolean;
+    force: boolean;
 
     /**
      * Whether to fixes linting errors for select rules. This may overwrite linted files.
      */
-    fix?: boolean;
+    fix: boolean;
 
     /**
      * Output format.
@@ -69,7 +69,7 @@ export interface IRunnerOptions {
     /**
      * Whether to generate a tslint.json config file in the current working directory.
      */
-    init?: boolean;
+    init: boolean;
 
     /**
      * Output file path.
@@ -94,12 +94,12 @@ export interface IRunnerOptions {
     /**
      * Whether to enable type checking when linting a project.
      */
-    typeCheck?: boolean;
+    typeCheck: boolean;
 
     /**
      * Current TSLint version.
      */
-    version?: boolean;
+    version: boolean;
 }
 
 export class Runner {
@@ -110,13 +110,13 @@ export class Runner {
     constructor(private options: IRunnerOptions, private outputStream: NodeJS.WritableStream) { }
 
     public run(onComplete: (status: number) => void) {
-        if (this.options.version != null) {
+        if (this.options.version) {
             this.outputStream.write(Linter.VERSION + "\n");
             onComplete(0);
             return;
         }
 
-        if (this.options.init != null) {
+        if (this.options.init) {
             if (fs.existsSync(CONFIG_FILENAME)) {
                 console.error(`Cannot generate ${CONFIG_FILENAME}: file already exists`);
                 onComplete(1);
@@ -129,7 +129,7 @@ export class Runner {
             return;
         }
 
-        if (this.options.test != null) {
+        if (this.options.test) {
             const results = runTest(this.options.test, this.options.rulesDirectory);
             const didAllTestsPass = consoleTestResultHandler(results);
             onComplete(didAllTestsPass ? 0 : 1);

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -36,6 +36,7 @@ const processed = optimist
         "c": {
             alias: "config",
             describe: "configuration file",
+            type: "string",
         },
         "e": {
             alias: "exclude",
@@ -53,40 +54,50 @@ const processed = optimist
         "h": {
             alias: "help",
             describe: "display detailed help",
+            type: "boolean",
         },
         "i": {
             alias: "init",
             describe: "generate a tslint.json config file in the current working directory",
+            type: "boolean",
         },
         "o": {
             alias: "out",
             describe: "output file",
+            type: "string",
         },
         "project": {
             describe: "tsconfig.json file",
+            type: "string",
         },
         "r": {
             alias: "rules-dir",
             describe: "rules directory",
+            type: "string",
         },
         "s": {
             alias: "formatters-dir",
             describe: "formatters directory",
+            type: "string",
         },
         "t": {
             alias: "format",
             default: "prose",
             describe: "output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist)",
+            type: "string",
         },
         "test": {
             describe: "test that tslint produces the correct output for the specified directory",
+            type: "string",
         },
         "type-check": {
             describe: "enable type checking when linting a project",
+            type: "boolean",
         },
         "v": {
             alias: "version",
             describe: "current version",
+            type: "boolean",
         },
     });
 const argv = processed.argv;
@@ -101,7 +112,7 @@ if (argv.o != null) {
     outputStream = process.stdout;
 }
 
-if ("help" in argv) {
+if (argv.help) {
     outputStream.write(processed.help());
     const outputString = `
 tslint accepts the following commandline options:


### PR DESCRIPTION
CLI arguments that were actually boolean flags but weren't marked as such would swallow the next argument, even if it was another flag.

For example `tslint --type-check --project x` would set `type-check`="--project"

Marking these as boolean with *optimist* also ensures that the value is either true or false... and not undefined