### PR TITLE
Added no-magic-numbers rule

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -679,7 +679,7 @@
   },
   {
     "ruleName": "no-magic-numbers",
-    "description": "\nDisallows the use constant number values outside of variable assignments.\nWhen no list of allowed values is specified, 0 and 1 are allowed by default.",
+    "description": "\nDisallows the use constant number values outside of variable assignments.\nWhen no list of allowed values is specified, -1, 0 and 1 are allowed by default.",
     "rationale": "\nMagic numbers should be avoided as they often lack documentation, forcing\nthem to be stored in variables gives them implicit documentation.",
     "optionsDescription": "A list of allowed numbers.",
     "options": {

--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -679,9 +679,9 @@
   },
   {
     "ruleName": "no-magic-numbers",
-    "description": "Disallows the use constant number values outside of variable assignment. -1, 0 and 1 are allowed by default.",
+    "description": "\nDisallows the use constant number values outside of variable assignments.\nWhen no list of allowed values is specified, 0 and 1 are allowed by default.",
     "rationale": "\nMagic numbers should be avoided as they often lack documentation, forcing\nthem to be stored in variables gives them implicit documentation.",
-    "optionsDescription": "A list of allowed number.",
+    "optionsDescription": "A list of allowed numbers.",
     "options": {
       "type": "array",
       "items": {

--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -678,6 +678,25 @@
     "typescriptOnly": false
   },
   {
+    "ruleName": "no-magic-numbers",
+    "description": "Disallows the use constant number values outside of variable assignment. -1, 0 and 1 are allowed by default.",
+    "rationale": "\nMagic numbers should be avoided as they often lack documentation, forcing\nthem to be stored in variables gives them implicit documentation.",
+    "optionsDescription": "A list of allowed number.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minLength": 1
+    },
+    "optionExamples": [
+      "true",
+      "[true, 1, 2, 3]"
+    ],
+    "type": "typescript",
+    "typescriptOnly": false
+  },
+  {
     "ruleName": "no-mergeable-namespace",
     "description": "Disallows mergeable namespaces in the same file.",
     "optionsDescription": "Not configurable.",
@@ -1082,6 +1101,19 @@
     ],
     "type": "typescript",
     "typescriptOnly": false
+  },
+  {
+    "ruleName": "promise-function-async",
+    "description": "Requires any function or method that returns a promise to be marked async.",
+    "rationale": "\nEnsures that each function is only capable of 1) returning a rejected promise, or 2)\nthrowing an Error object. In contrast, non-`async` `Promise`-returning functions\nare technically capable of either. This practice removes a requirement for consuming\ncode to handle both cases.\n        ",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "requiresTypeInfo": true
   },
   {
     "ruleName": "quotemark",

--- a/docs/rules/no-magic-numbers/index.html
+++ b/docs/rules/no-magic-numbers/index.html
@@ -3,7 +3,7 @@ ruleName: no-magic-numbers
 description: |-
 
   Disallows the use constant number values outside of variable assignments.
-  When no list of allowed values is specified, 0 and 1 are allowed by default.
+  When no list of allowed values is specified, -1, 0 and 1 are allowed by default.
 rationale: |-
 
   Magic numbers should be avoided as they often lack documentation, forcing

--- a/docs/rules/no-magic-numbers/index.html
+++ b/docs/rules/no-magic-numbers/index.html
@@ -1,11 +1,14 @@
 ---
 ruleName: no-magic-numbers
-description: 'Disallows the use constant number values outside of variable assignment. -1, 0 and 1 are allowed by default.'
+description: |-
+
+  Disallows the use constant number values outside of variable assignments.
+  When no list of allowed values is specified, 0 and 1 are allowed by default.
 rationale: |-
 
   Magic numbers should be avoided as they often lack documentation, forcing
   them to be stored in variables gives them implicit documentation.
-optionsDescription: A list of allowed number.
+optionsDescription: A list of allowed numbers.
 options:
   type: array
   items:

--- a/docs/rules/no-magic-numbers/index.html
+++ b/docs/rules/no-magic-numbers/index.html
@@ -1,0 +1,29 @@
+---
+ruleName: no-magic-numbers
+description: 'Disallows the use constant number values outside of variable assignment. -1, 0 and 1 are allowed by default.'
+rationale: |-
+
+  Magic numbers should be avoided as they often lack documentation, forcing
+  them to be stored in variables gives them implicit documentation.
+optionsDescription: A list of allowed number.
+options:
+  type: array
+  items:
+    type: number
+  minLength: 1
+optionExamples:
+  - 'true'
+  - '[true, 1, 2, 3]'
+type: typescript
+typescriptOnly: false
+layout: rule
+title: 'Rule: no-magic-numbers'
+optionsJSON: |-
+  {
+    "type": "array",
+    "items": {
+      "type": "number"
+    },
+    "minLength": 1
+  }
+---

--- a/docs/rules/promise-function-async/index.html
+++ b/docs/rules/promise-function-async/index.html
@@ -1,0 +1,21 @@
+---
+ruleName: promise-function-async
+description: Requires any function or method that returns a promise to be marked async.
+rationale: |-
+
+  Ensures that each function is only capable of 1) returning a rejected promise, or 2)
+  throwing an Error object. In contrast, non-`async` `Promise`-returning functions
+  are technically capable of either. This practice removes a requirement for consuming
+  code to handle both cases.
+          
+optionsDescription: Not configurable.
+options: null
+optionExamples:
+  - 'true'
+type: typescript
+typescriptOnly: false
+requiresTypeInfo: true
+layout: rule
+title: 'Rule: promise-function-async'
+optionsJSON: 'null'
+---

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-magic-numbers",
+        description: "Disallows the use constant number values outside of variable assignment. -1, 0 and 1 are allowed by default.",
+        rationale: Lint.Utils.dedent`
+            Magic numbers should be avoided as they often lack documentation, forcing
+            them to be stored in variables gives them implicit documentation.`,
+        optionsDescription: "A list of allowed number.",
+        options: {
+            type: "array",
+            items: {
+                type: "number",
+            },
+            minLength: 1,
+        },
+        optionExamples: ["true", "[true, 1, 2, 3]"],
+        type: "typescript",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "'magic numbers' are no allowed";
+
+    public static ALLOWED_NODES = [
+        ts.SyntaxKind.ExportAssignment,
+        ts.SyntaxKind.FirstAssignment,
+        ts.SyntaxKind.LastAssignment,
+        ts.SyntaxKind.PropertyAssignment,
+        ts.SyntaxKind.ShorthandPropertyAssignment,
+        ts.SyntaxKind.VariableDeclaration,
+        ts.SyntaxKind.VariableDeclarationList,
+    ];
+
+    public static DEFAULT_ALLOWED = [
+        0,
+        1,
+    ];
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoMagicNumbersWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NoMagicNumbersWalker extends Lint.RuleWalker {
+    public visitNode(node: ts.Node) {
+        if (node.kind === ts.SyntaxKind.NumericLiteral &&
+            Rule.ALLOWED_NODES.indexOf(node.parent.kind) === -1) {
+            const options = this.getOptions();
+
+            const allowed: number[] = options.length > 0 ? options : Rule.DEFAULT_ALLOWED;
+            if (allowed.indexOf(Number(node.getText())) === -1) {
+                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            }
+        }
+        super.visitNode(node);
+    }
+}

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -59,11 +59,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         [ts.SyntaxKind.PropertyDeclaration]: true,
     };
 
-    public static DEFAULT_ALLOWED = [
-        -1,
-        0,
-        1,
-    ];
+    public static DEFAULT_ALLOWED = [ -1, 0, 1 ];
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new NoMagicNumbersWalker(sourceFile, this.getOptions()));
@@ -76,10 +72,10 @@ class NoMagicNumbersWalker extends Lint.RuleWalker {
         super(sourceFile, options);
 
         const configOptions = this.getOptions();
-        const allowedArray: number[] = configOptions.length > 0 ? configOptions : Rule.DEFAULT_ALLOWED;
+        const allowedNumbers: number[] = configOptions.length > 0 ? configOptions : Rule.DEFAULT_ALLOWED;
 
         const allowed: { [prop: string]: boolean } = {};
-        allowedArray.forEach((value) => {
+        allowedNumbers.forEach((value) => {
             allowed[value] = true;
         });
         this.allowed = allowed;

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -51,6 +51,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         ts.SyntaxKind.ShorthandPropertyAssignment,
         ts.SyntaxKind.VariableDeclaration,
         ts.SyntaxKind.VariableDeclarationList,
+        ts.SyntaxKind.EnumMember,
+        ts.SyntaxKind.PropertyDeclaration,
     ];
 
     public static DEFAULT_ALLOWED = [

--- a/test/rules/no-magic-numbers/custom/test.js.lint
+++ b/test/rules/no-magic-numbers/custom/test.js.lint
@@ -1,4 +1,7 @@
 console.log(1337);
+console.log(-1337);
 console.log(1337.7);
 console.log(1338);
             ~~~~                      ['magic numbers' are no allowed]
+console.log(-1338)
+            ~~~~~                     ['magic numbers' are no allowed]

--- a/test/rules/no-magic-numbers/custom/test.js.lint
+++ b/test/rules/no-magic-numbers/custom/test.js.lint
@@ -1,3 +1,4 @@
 console.log(1337);
+console.log(1337.7);
 console.log(1338);
             ~~~~                      ['magic numbers' are no allowed]

--- a/test/rules/no-magic-numbers/custom/test.js.lint
+++ b/test/rules/no-magic-numbers/custom/test.js.lint
@@ -1,0 +1,3 @@
+console.log(1337);
+console.log(1338);
+            ~~~~                      ['magic numbers' are no allowed]

--- a/test/rules/no-magic-numbers/custom/test.js.lint
+++ b/test/rules/no-magic-numbers/custom/test.js.lint
@@ -2,6 +2,6 @@ console.log(1337);
 console.log(-1337);
 console.log(1337.7);
 console.log(1338);
-            ~~~~                      ['magic numbers' are no allowed]
+            ~~~~                      ['magic numbers' are not allowed]
 console.log(-1338)
-            ~~~~~                     ['magic numbers' are no allowed]
+            ~~~~~                     ['magic numbers' are not allowed]

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -1,4 +1,7 @@
 console.log(1337);
+console.log(-1337);
 console.log(1337.7);
 console.log(1338);
             ~~~~                      ['magic numbers' are no allowed]
+console.log(-1338)
+            ~~~~~                     ['magic numbers' are no allowed]

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -1,3 +1,4 @@
 console.log(1337);
+console.log(1337.7);
 console.log(1338);
             ~~~~                      ['magic numbers' are no allowed]

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -1,0 +1,3 @@
+console.log(1337);
+console.log(1338);
+            ~~~~                      ['magic numbers' are no allowed]

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -2,6 +2,6 @@ console.log(1337);
 console.log(-1337);
 console.log(1337.7);
 console.log(1338);
-            ~~~~                      ['magic numbers' are no allowed]
+            ~~~~                      ['magic numbers' are not allowed]
 console.log(-1338)
-            ~~~~~                     ['magic numbers' are no allowed]
+            ~~~~~                     ['magic numbers' are not allowed]

--- a/test/rules/no-magic-numbers/custom/tslint.json
+++ b/test/rules/no-magic-numbers/custom/tslint.json
@@ -1,8 +1,8 @@
 {
   "rules": {
-    "no-magic-numbers": [true, 1337, 1337.7]
+    "no-magic-numbers": [true, 1337, 1337.7, -1337]
   },
   "jsRules": {
-    "no-magic-numbers": [true, 1337, 1337.7]
+    "no-magic-numbers": [true, 1337, 1337.7, -1337]
   }
 }

--- a/test/rules/no-magic-numbers/custom/tslint.json
+++ b/test/rules/no-magic-numbers/custom/tslint.json
@@ -1,8 +1,8 @@
 {
   "rules": {
-    "no-magic-numbers": [true, 1337]
+    "no-magic-numbers": [true, 1337, 1337.7]
   },
   "jsRules": {
-    "no-magic-numbers": [true, 1337]
+    "no-magic-numbers": [true, 1337, 1337.7]
   }
 }

--- a/test/rules/no-magic-numbers/custom/tslint.json
+++ b/test/rules/no-magic-numbers/custom/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-magic-numbers": [true, 1337]
+  },
+  "jsRules": {
+    "no-magic-numbers": [true, 1337]
+  }
+}

--- a/test/rules/no-magic-numbers/default/test.js.lint
+++ b/test/rules/no-magic-numbers/default/test.js.lint
@@ -1,0 +1,24 @@
+console.log(-1, 0, 1);
+
+const a = 1337;
+const b = {
+    a: 1338,
+}
+b.b = 1339;
+      ~~~~                            ['magic numbers' are no allowed]
+
+console.log(1340);
+            ~~~~                      ['magic numbers' are no allowed]
+for(let i = 0;i>1341;++i) {
+                ~~~~                  ['magic numbers' are no allowed]
+}
+
+throw 1342;
+      ~~~~                            ['magic numbers' are no allowed]
+
+class A {
+    constructor () {
+        this.a = 1345;
+                 ~~~~                 ['magic numbers' are no allowed]
+    }
+}

--- a/test/rules/no-magic-numbers/default/test.js.lint
+++ b/test/rules/no-magic-numbers/default/test.js.lint
@@ -1,28 +1,28 @@
 console.log(-1, 0, 1);
 console.log(42.42);
-            ~~~~~                     ['magic numbers' are no allowed]
+            ~~~~~                     ['magic numbers' are not allowed]
 
 const a = 1337;
 const b = {
     a: 1338,
 }
 b.b = 1339;
-      ~~~~                            ['magic numbers' are no allowed]
+      ~~~~                            ['magic numbers' are not allowed]
 
 const c = 42.42;
 
 console.log(1340);
-            ~~~~                      ['magic numbers' are no allowed]
+            ~~~~                      ['magic numbers' are not allowed]
 for(let i = 0;i>1341;++i) {
-                ~~~~                  ['magic numbers' are no allowed]
+                ~~~~                  ['magic numbers' are not allowed]
 }
 
 throw 1342;
-      ~~~~                            ['magic numbers' are no allowed]
+      ~~~~                            ['magic numbers' are not allowed]
 
 class A {
     constructor () {
         this.a = 1345;
-                 ~~~~                 ['magic numbers' are no allowed]
+                 ~~~~                 ['magic numbers' are not allowed]
     }
 }

--- a/test/rules/no-magic-numbers/default/test.js.lint
+++ b/test/rules/no-magic-numbers/default/test.js.lint
@@ -1,4 +1,6 @@
 console.log(-1, 0, 1);
+console.log(42.42);
+            ~~~~~                     ['magic numbers' are no allowed]
 
 const a = 1337;
 const b = {
@@ -6,6 +8,8 @@ const b = {
 }
 b.b = 1339;
       ~~~~                            ['magic numbers' are no allowed]
+
+const c = 42.42;
 
 console.log(1340);
             ~~~~                      ['magic numbers' are no allowed]

--- a/test/rules/no-magic-numbers/default/test.ts.lint
+++ b/test/rules/no-magic-numbers/default/test.ts.lint
@@ -1,0 +1,24 @@
+console.log(-1, 0, 1);
+
+const a = 1337;
+const b = {
+    a: 1338,
+    b: 0,
+}
+b.b = 1339;
+      ~~~~                          ['magic numbers' are no allowed]
+
+console.log(1340);
+            ~~~~                    ['magic numbers' are no allowed]
+for(let i = 0;i>1341;++i) {
+                ~~~~                ['magic numbers' are no allowed]
+}
+
+throw 1342;
+      ~~~~                          ['magic numbers' are no allowed]
+
+class A {
+    constructor (private a = 1337) {
+                             ~~~~   ['magic numbers' are no allowed]
+    }
+}

--- a/test/rules/no-magic-numbers/default/test.ts.lint
+++ b/test/rules/no-magic-numbers/default/test.ts.lint
@@ -18,7 +18,13 @@ throw 1342;
       ~~~~                          ['magic numbers' are no allowed]
 
 class A {
+    static test = 1337;
+
     constructor (private a = 1337) {
                              ~~~~   ['magic numbers' are no allowed]
     }
+}
+
+enum Test {
+    key = 1337,
 }

--- a/test/rules/no-magic-numbers/default/test.ts.lint
+++ b/test/rules/no-magic-numbers/default/test.ts.lint
@@ -1,5 +1,6 @@
 console.log(-1, 0, 1);
-
+console.log(42.42);
+            ~~~~~                     ['magic numbers' are no allowed]
 const a = 1337;
 const b = {
     a: 1338,

--- a/test/rules/no-magic-numbers/default/test.ts.lint
+++ b/test/rules/no-magic-numbers/default/test.ts.lint
@@ -1,28 +1,28 @@
 console.log(-1, 0, 1);
 console.log(42.42);
-            ~~~~~                     ['magic numbers' are no allowed]
+            ~~~~~                     ['magic numbers' are not allowed]
 const a = 1337;
 const b = {
     a: 1338,
     b: 0,
 }
 b.b = 1339;
-      ~~~~                          ['magic numbers' are no allowed]
+      ~~~~                          ['magic numbers' are not allowed]
 
 console.log(1340);
-            ~~~~                    ['magic numbers' are no allowed]
+            ~~~~                    ['magic numbers' are not allowed]
 for(let i = 0;i>1341;++i) {
-                ~~~~                ['magic numbers' are no allowed]
+                ~~~~                ['magic numbers' are not allowed]
 }
 
 throw 1342;
-      ~~~~                          ['magic numbers' are no allowed]
+      ~~~~                          ['magic numbers' are not allowed]
 
 class A {
     static test = 1337;
 
     constructor (private a = 1337) {
-                             ~~~~   ['magic numbers' are no allowed]
+                             ~~~~   ['magic numbers' are not allowed]
     }
 }
 

--- a/test/rules/no-magic-numbers/default/tslint.json
+++ b/test/rules/no-magic-numbers/default/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-magic-numbers": true
+  },
+  "jsRules": {
+    "no-magic-numbers": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### What changes did you make?

Added a rule to prevent _magic numbers_.

See the added tests for examples.

Basic usage: `"no-magic-numbers": true` disallows all except 0 and 1/-1.
Custom allow list: `"no-magic-numbers": [true, 1337, 1338]"` Only 1337 and 1338 are allowed.

#### Is there anything you'd like reviewers to focus on?

I am not very familiar with tslint and the TS API and it would love to get feedback on the filter method.