### PR TITLE
Fix adjacentOverloadSignatures for constructors

### DIFF
--- a/src/rules/adjacentOverloadSignaturesRule.ts
+++ b/src/rules/adjacentOverloadSignaturesRule.ts
@@ -116,7 +116,10 @@ function isLiteralExpression(node: ts.Node): node is ts.LiteralExpression {
 function getTextOfPropertyName(node: ts.InterfaceDeclaration | ts.TypeElement | ts.ClassElement): string {
     let nameText: string;
     if (node.name == null) {
-        return null;
+        if (node.kind === ts.SyntaxKind.Constructor) {
+            return "constructor";
+        }
+        return undefined;
     }
     switch (node.name.kind) {
         case ts.SyntaxKind.Identifier:

--- a/test/rules/adjacent-overload-signatures/test.ts.lint
+++ b/test/rules/adjacent-overload-signatures/test.ts.lint
@@ -37,7 +37,6 @@ interface i6 {
     toString(): string;
 }
 
-
 // bad
 
 interface b1 {
@@ -114,6 +113,17 @@ declare namespace N {
 
 class Foo {
   public static bar() {}
-  constructor() {}
+  private constructor() {}
   public bar() {}
+  public constructor(foo: any) {}
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [All 'constructor' signatures should be adjacent]
 }
+
+// A semi-colon on it's own is a statement with no name
+class Bar {
+  private constructor() {}
+  ;
+  public bar() {}
+  ;
+}
+


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### What changes did you make?

adjacent-overload-signatures did not work for nodes without names, such as constructors or empty lines. For empty lines, that's not really an issue we care about for this rule, but we probably want to catch constructors that are not adjacent.

#### Is there anything you'd like reviewers to focus on?

(optional)

