### PR TITLE
Support multiple files in checkstyle formatter

### DIFF
--- a/src/formatters/checkstyleFormatter.ts
+++ b/src/formatters/checkstyleFormatter.ts
@@ -26,16 +26,28 @@ export class Formatter extends AbstractFormatter {
         let output = '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">';
 
         if (failures.length) {
-            output += `<file name="${this.escapeXml(failures[0].getFileName())}">`;
-            for (let failure of failures) {
-                output += `<error line="${failure.getStartPosition().getLineAndCharacter().line + 1}" `;
-                output += `column="${failure.getStartPosition().getLineAndCharacter().character + 1}" `;
-                output += `severity="warning" `;
-                output += `message="${this.escapeXml(failure.getFailure())}" `;
+            var failuresSorted = failures.sort(function(a,b){
+                return a.getFileName().localeCompare(b.getFileName());
+            });
+            var previousFilename: string = null;
+            for (var failure of failuresSorted) {
+                if (failure.getFileName() !== previousFilename) {
+                    if (previousFilename) {
+                        output += "</file>";
+                    }
+                    previousFilename = failure.getFileName();
+                    output += "<file name=\"" + this.escapeXml(failure.getFileName()) + "\">";
+                }
+                output += "<error line=\"" + (failure.getStartPosition().getLineAndCharacter().line + 1) + "\" ";
+                output += "column=\"" + (failure.getStartPosition().getLineAndCharacter().character + 1) + "\" ";
+                output += "severity=\"warning\" ";
+                output += "message=\"" + this.escapeXml(failure.getFailure()) + "\" ";
                 // checkstyle parser wants "source" to have structure like <anything>dot<category>dot<type>
-                output += `source="failure.tslint.${this.escapeXml(failure.getRuleName())}" />`;
+                output += "source=\"failure.tslint." + this.escapeXml(failure.getRuleName()) + "\" />";
             }
-            output += "</file>";
+            if (previousFilename) {
+                output += "</file>";
+            }
         }
 
         output += "</checkstyle>";

--- a/src/formatters/checkstyleFormatter.ts
+++ b/src/formatters/checkstyleFormatter.ts
@@ -26,11 +26,11 @@ export class Formatter extends AbstractFormatter {
         let output = '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">';
 
         if (failures.length) {
-            var failuresSorted = failures.sort(function(a,b){
+            let failuresSorted = failures.sort((a, b) => {
                 return a.getFileName().localeCompare(b.getFileName());
             });
-            var previousFilename: string = null;
-            for (var failure of failuresSorted) {
+            let previousFilename: string = null;
+            for (let failure of failuresSorted) {
                 if (failure.getFileName() !== previousFilename) {
                     if (previousFilename) {
                         output += "</file>";

--- a/test/formatters/checkstyleFormatterTests.ts
+++ b/test/formatters/checkstyleFormatterTests.ts
@@ -5,28 +5,28 @@ import {IFormatter, RuleFailure, TestUtils} from "../lint";
 describe("Checkstyle Formatter", () => {
     const TEST_FILE_1 = "formatters/jsonFormatter.test.ts"; // reuse existing sample file
     const TEST_FILE_2 = "formatters/pmdFormatter.test.ts"; // reuse existing sample file
-    let sourceFile_1: ts.SourceFile;
-    let sourceFile_2: ts.SourceFile;
+    let sourceFile1: ts.SourceFile;
+    let sourceFile2: ts.SourceFile;
     let formatter: IFormatter;
 
     before(() => {
         const Formatter = TestUtils.getFormatter("checkstyle");
-        sourceFile_1 = TestUtils.getSourceFile(TEST_FILE_1);
-        sourceFile_2 = TestUtils.getSourceFile(TEST_FILE_2);
+        sourceFile1 = TestUtils.getSourceFile(TEST_FILE_1);
+        sourceFile2 = TestUtils.getSourceFile(TEST_FILE_2);
         formatter = new Formatter();
     });
 
     it("formats failures", () => {
-        const maxPosition_1 = sourceFile_1.getFullWidth();
-        const maxPosition_2 = sourceFile_2.getFullWidth();
+        const maxPosition1 = sourceFile1.getFullWidth();
+        const maxPosition2 = sourceFile2.getFullWidth();
 
         const failures = [
-            new RuleFailure(sourceFile_1, 0, 1, "first failure", "first-name"),
-            new RuleFailure(sourceFile_1, 2, 3, "&<>'\" should be escaped", "escape"),
-            new RuleFailure(sourceFile_1, maxPosition_1 - 1, maxPosition_1, "last failure", "last-name"),
-            new RuleFailure(sourceFile_2, 0, 1, "first failure", "first-name"),
-            new RuleFailure(sourceFile_2, 2, 3, "&<>'\" should be escaped", "escape"),
-            new RuleFailure(sourceFile_2, maxPosition_2 - 1, maxPosition_2, "last failure", "last-name"),
+            new RuleFailure(sourceFile1, 0, 1, "first failure", "first-name"),
+            new RuleFailure(sourceFile1, 2, 3, "&<>'\" should be escaped", "escape"),
+            new RuleFailure(sourceFile1, maxPosition1 - 1, maxPosition1, "last failure", "last-name"),
+            new RuleFailure(sourceFile2, 0, 1, "first failure", "first-name"),
+            new RuleFailure(sourceFile2, 2, 3, "&<>'\" should be escaped", "escape"),
+            new RuleFailure(sourceFile2, maxPosition2 - 1, maxPosition2, "last failure", "last-name"),
         ];
         const expectedResult =
             '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">' +

--- a/test/formatters/checkstyleFormatterTests.ts
+++ b/test/formatters/checkstyleFormatterTests.ts
@@ -3,27 +3,40 @@ import * as ts from "typescript";
 import {IFormatter, RuleFailure, TestUtils} from "../lint";
 
 describe("Checkstyle Formatter", () => {
-    const TEST_FILE = "formatters/pmdFormatter.test.ts"; // reuse existing sample file
-    let sourceFile: ts.SourceFile;
+    const TEST_FILE_1 = "formatters/jsonFormatter.test.ts"; // reuse existing sample file
+    const TEST_FILE_2 = "formatters/pmdFormatter.test.ts"; // reuse existing sample file
+    let sourceFile_1: ts.SourceFile;
+    let sourceFile_2: ts.SourceFile;
     let formatter: IFormatter;
 
     before(() => {
         const Formatter = TestUtils.getFormatter("checkstyle");
-        sourceFile = TestUtils.getSourceFile(TEST_FILE);
+        sourceFile_1 = TestUtils.getSourceFile(TEST_FILE_1);
+        sourceFile_2 = TestUtils.getSourceFile(TEST_FILE_2);
         formatter = new Formatter();
     });
 
     it("formats failures", () => {
-        const maxPosition = sourceFile.getFullWidth();
+        const maxPosition_1 = sourceFile_1.getFullWidth();
+        const maxPosition_2 = sourceFile_2.getFullWidth();
 
         const failures = [
-            new RuleFailure(sourceFile, 0, 1, "first failure", "first-name"),
-            new RuleFailure(sourceFile, 2, 3, "&<>'\" should be escaped", "escape"),
-            new RuleFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name"),
+            new RuleFailure(sourceFile_1, 0, 1, "first failure", "first-name"),
+            new RuleFailure(sourceFile_1, 2, 3, "&<>'\" should be escaped", "escape"),
+            new RuleFailure(sourceFile_1, maxPosition_1 - 1, maxPosition_1, "last failure", "last-name"),
+            new RuleFailure(sourceFile_2, 0, 1, "first failure", "first-name"),
+            new RuleFailure(sourceFile_2, 2, 3, "&<>'\" should be escaped", "escape"),
+            new RuleFailure(sourceFile_2, maxPosition_2 - 1, maxPosition_2, "last failure", "last-name"),
         ];
         const expectedResult =
             '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">' +
-            `<file name="${TEST_FILE}">` +
+            `<file name="${TEST_FILE_1}">` +
+            '<error line="1" column="1" severity="warning" message="first failure" source="failure.tslint.first-name" />' +
+            '<error line="1" column="3" severity="warning" message="&amp;&lt;&gt;&#39;&quot; should be escaped" ' +
+            'source="failure.tslint.escape" />' +
+            '<error line="6" column="3" severity="warning" message="last failure" source="failure.tslint.last-name" />' +
+            "</file>" +
+            `<file name="${TEST_FILE_2}">` +
             '<error line="1" column="1" severity="warning" message="first failure" source="failure.tslint.first-name" />' +
             '<error line="1" column="3" severity="warning" message="&amp;&lt;&gt;&#39;&quot; should be escaped" ' +
             'source="failure.tslint.escape" />' +


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### What changes did you make?

Found an issue when integrating tslint with jenkins (using checkstyle formatter), the formatter did not generate separate file nodes in the outputted XML, instead simply reporting all errors under the first file.

To fix this I:
- Modified checkstyleFormatter.ts to sort failures by filename, and generate file nodes for each unique filename
- Modified test case to test failures in multiple files

#### Is there anything you'd like reviewers to focus on?

The checkstyleFormatter test was reusing another formatter's test input file, I've followed this pattern to add a second file in the test. It might be better to create two test input files specifically for the checkstyleFormatter...