### PR TITLE
Add CodeFrame Formatter

### DIFF
--- a/docs/_data/formatters.json
+++ b/docs/_data/formatters.json
@@ -7,6 +7,13 @@
     "consumer": "machine"
   },
   {
+    "formatterName": "codeFrame",
+    "description": "Framed formatter which creates a frame of error code.",
+    "descriptionDetails": "\nPrints syntax highlighted code in a frame with a pointer to where\nexactly lint error is happening.",
+    "sample": "\nsrc/components/Payment.tsx\nParentheses are required around the parameters of an arrow function definition (arrow-parens)\n  21 |     public componentDidMount() {\n  22 |         this.input.focus();\n> 23 |         loadStripe().then(Stripe => Stripe.pay());\n     |                          ^\n  24 |     }\n  25 |\n  26 |     public render() {",
+    "consumer": "human"
+  },
+  {
     "formatterName": "filesList",
     "description": "Lists files containing lint errors.",
     "sample": "directory/myFile.ts",
@@ -43,13 +50,6 @@
     "description": "Human-readable formatter which creates stylish messages.",
     "descriptionDetails": "\nThe output matches that produced by eslint's stylish formatter. Its readability\nenhanced through spacing and colouring",
     "sample": "\nmyFile.ts\n1:14  semicolon  Missing semicolon",
-    "consumer": "human"
-  },
-  {
-    "formatterName": "codeFrame",
-    "description": "Framed formatter which creates a frame of error code.",
-    "descriptionDetails": "\nPrints syntax highlighted code in a frame with a pointer to where\nexactly lint error is happening.",
-    "sample": "",
     "consumer": "human"
   },
   {

--- a/docs/_data/formatters.json
+++ b/docs/_data/formatters.json
@@ -46,6 +46,13 @@
     "consumer": "human"
   },
   {
+    "formatterName": "codeFrame",
+    "description": "Framed formatter which creates a frame of error code.",
+    "descriptionDetails": "\nPrints syntax highlighted code in a frame with a pointer to where\nexactly lint error is happening.",
+    "sample": "",
+    "consumer": "human"
+  },
+  {
     "formatterName": "verbose",
     "description": "The human-readable formatter which includes the rule name in messages.",
     "descriptionDetails": "The output is the same as the prose formatter with the rule name included",

--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -1072,6 +1072,18 @@
     "typescriptOnly": false
   },
   {
+    "ruleName": "prefer-const",
+    "description": "Requires that variable declarations use `const` instead of `let` if possible.",
+    "descriptionDetails": "\nIf a variable is only assigned to once when it is declared, it should be declared using 'const'",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false
+  },
+  {
     "ruleName": "prefer-for-of",
     "description": "Recommends a 'for-of' loop over a standard 'for' loop if the index is only used to access the array being iterated.",
     "rationale": "A for(... of ...) loop is easier to implement and read when the index is not needed.",
@@ -1082,6 +1094,19 @@
     ],
     "type": "typescript",
     "typescriptOnly": false
+  },
+  {
+    "ruleName": "promise-function-async",
+    "description": "Requires any function or method that returns a promise to be marked async.",
+    "rationale": "\nEnsures that each function is only capable of 1) returning a rejected promise, or 2)\nthrowing an Error object. In contrast, non-`async` `Promise`-returning functions\nare technically capable of either. This practice removes a requirement for consuming\ncode to handle both cases.\n        ",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "requiresTypeInfo": true
   },
   {
     "ruleName": "quotemark",

--- a/docs/formatters/codeFrame/index.html
+++ b/docs/formatters/codeFrame/index.html
@@ -1,0 +1,22 @@
+---
+formatterName: codeFrame
+description: Framed formatter which creates a frame of error code.
+descriptionDetails: |-
+
+  Prints syntax highlighted code in a frame with a pointer to where
+  exactly lint error is happening.
+sample: |-
+
+  src/components/Payment.tsx
+  Parentheses are required around the parameters of an arrow function definition (arrow-parens)
+    21 |     public componentDidMount() {
+    22 |         this.input.focus();
+  > 23 |         loadStripe().then(Stripe => Stripe.pay());
+       |                          ^
+    24 |     }
+    25 |
+    26 |     public render() {
+consumer: human
+layout: formatter
+title: 'Formatter: codeFrame'
+---

--- a/docs/usage/cli/index.md
+++ b/docs/usage/cli/index.md
@@ -39,7 +39,7 @@ Options:
 --project             tsconfig.json file
 -r, --rules-dir       rules directory
 -s, --formatters-dir  formatters directory
--t, --format          output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist)  [default: "prose"]
+-t, --format          output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)  [default: "prose"]
 --test                test that tslint produces the correct output for the specified directory
 --type-check          enable type checking when linting a project
 -v, --version         current version

--- a/src/formatters/codeFrameFormatter.ts
+++ b/src/formatters/codeFrameFormatter.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AbstractFormatter} from "../language/formatter/abstractFormatter";
+import {IFormatterMetadata} from "../language/formatter/formatter";
+import {RuleFailure} from "../language/rule/rule";
+
+import * as colors from "colors";
+// TODO: once types for babel-code-frame are published, add it as a dependency and use import
+// @types/babel-code-frame PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/13102
+// tslint:disable-next-line:no-var-requires
+const codeFrame = require("babel-code-frame");
+
+import * as Utils from "../utils";
+
+export class Formatter extends AbstractFormatter {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: IFormatterMetadata = {
+        formatterName: "codeFrame",
+        description: "Framed formatter which creates a frame of error code.",
+        descriptionDetails: Utils.dedent`
+            Prints syntax highlighted code in a frame with a pointer to where
+            exactly lint error is happening.`,
+        sample: Utils.dedent`
+            src/components/Payment.tsx
+            Parentheses are required around the parameters of an arrow function definition (arrow-parens)
+              21 |     public componentDidMount() {
+              22 |         this.input.focus();
+            > 23 |         loadStripe().then(Stripe => Stripe.pay());
+                 |                          ^
+              24 |     }
+              25 |
+              26 |     public render() {`,
+        consumer: "human",
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public format(failures: RuleFailure[]): string {
+        if (typeof failures[0] === "undefined") {
+            return "\n";
+        }
+
+        const outputLines: string[] = [];
+
+        let currentFile: string;
+
+        for (const failure of failures) {
+            const fileName = failure.getFileName();
+
+            // Output the name of each file once
+            if (currentFile !== fileName) {
+                outputLines.push("");
+                outputLines.push(fileName);
+                currentFile = fileName;
+            }
+
+            let failureString = failure.getFailure();
+            failureString     = colors.red(failureString);
+
+            // Rule
+            let ruleName = failure.getRuleName();
+            ruleName = colors.gray(`(${ruleName})`);
+
+            // Frame
+            const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
+            const frame = codeFrame(
+                failure.getRawLines(),
+                lineAndCharacter.line + 1, // babel-code-frame is 1 index
+                lineAndCharacter.character,
+                {
+                    forceColor: colors.enabled,
+                    highlightCode: true,
+                },
+            );
+
+            // Ouput
+            outputLines.push(`${failureString} ${ruleName}`);
+            outputLines.push(frame);
+            outputLines.push("");
+        }
+
+        // Removes initial blank line
+        if (outputLines[0] === "") {
+            outputLines.shift();
+        }
+
+        return outputLines.join("\n") + "\n";
+    }
+}

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -21,3 +21,4 @@ export { Formatter as ProseFormatter } from "./proseFormatter";
 export { Formatter as VerboseFormatter } from "./verboseFormatter";
 export { Formatter as StylishFormatter } from "./stylishFormatter";
 export { Formatter as FileslistFormatter } from "./fileslistFormatter";
+export { Formatter as CodeFrameFormatter } from "./codeFrameFormatter";

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -190,6 +190,7 @@ export class RuleFailure {
     private fileName: string;
     private startPosition: RuleFailurePosition;
     private endPosition: RuleFailurePosition;
+    private rawLines: string;
 
     constructor(private sourceFile: ts.SourceFile,
                 start: number,
@@ -201,6 +202,7 @@ export class RuleFailure {
         this.fileName = sourceFile.fileName;
         this.startPosition = this.createFailurePosition(start);
         this.endPosition = this.createFailurePosition(end);
+        this.rawLines = sourceFile.text;
     }
 
     public getFileName() {
@@ -229,6 +231,10 @@ export class RuleFailure {
 
     public getFix() {
         return this.fix;
+    }
+
+    public getRawLines() {
+        return this.rawLines;
     }
 
     public toJson(): any {

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -83,7 +83,7 @@ const processed = optimist
         "t": {
             alias: "format",
             default: "prose",
-            describe: "output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist)",
+            describe: "output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)",
             type: "string",
         },
         "test": {

--- a/test/files/formatters/codeFrameFormatter.test.ts
+++ b/test/files/formatters/codeFrameFormatter.test.ts
@@ -1,0 +1,9 @@
+module CodeFrameModule {
+    export class CodeFrameClass {
+        private name: string;
+
+        constructor(name: string) {
+            this.name = name;
+        }
+    }
+}

--- a/test/formatters/codeFrameFormatterTests.ts
+++ b/test/formatters/codeFrameFormatterTests.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as colors from "colors";
+
+import * as ts from "typescript";
+
+import {IFormatter, RuleFailure, TestUtils} from "../lint";
+
+describe("CodeFrame Formatter", () => {
+    const TEST_FILE = "formatters/codeFrameFormatter.test.ts";
+    let sourceFile: ts.SourceFile;
+    let formatter: IFormatter;
+
+    before(() => {
+        const Formatter = TestUtils.getFormatter("codeFrame");
+        sourceFile = TestUtils.getSourceFile(TEST_FILE);
+        formatter = new Formatter();
+    });
+
+    it("formats failures", () => {
+        const maxPosition = sourceFile.getFullWidth();
+
+        const failures = [
+            new RuleFailure(sourceFile, 0, 1, "first failure", "first-name"),
+            new RuleFailure(sourceFile, 2, 3, "&<>'\" should be escaped", "escape"),
+            new RuleFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name"),
+            new RuleFailure(sourceFile, 0, maxPosition, "full failure", "full-name"),
+        ];
+
+        const expectedResultPlain =
+            `formatters/codeFrameFormatter.test.ts
+            first failure (first-name)
+            > 1 | module CodeFrameModule {
+            2 |     export class CodeFrameClass {
+            3 |         private name: string;
+            4 |
+
+            &<>'" should be escaped (escape)
+            > 1 | module CodeFrameModule {
+                |  ^
+            2 |     export class CodeFrameClass {
+            3 |         private name: string;
+            4 |
+
+            last failure (last-name)
+            7 |         }
+            8 |     }
+            >  9 | }
+                | ^
+            10 |
+
+            full failure (full-name)
+            > 1 | module CodeFrameModule {
+            2 |     export class CodeFrameClass {
+            3 |         private name: string;
+            4 |
+
+        `;
+
+        const expectedResultColored =
+            `formatters/codeFrameFormatter.test.ts
+            \u001b[31mfirst failure\u001b[39m \u001b[90m(first-name)\u001b[39m
+            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {
+            \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {
+            \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m
+            \u001b[90m 4 | \u001b[39m\u001b[0m
+
+            \u001b[31m&<>'\" should be escaped\u001b[39m \u001b[90m(escape)\u001b[39m
+            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {
+            \u001b[90m   | \u001b[39m \u001b[31m\u001b[1m^\u001b[22m\u001b[39m
+            \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {
+            \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m
+            \u001b[90m 4 | \u001b[39m\u001b[0m
+
+            \u001b[31mlast failure\u001b[39m \u001b[90m(last-name)\u001b[39m
+            \u001b[0m \u001b[90m  7 | \u001b[39m        }
+            \u001b[90m  8 | \u001b[39m    }
+            \u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  9 | \u001b[39m}
+            \u001b[90m    | \u001b[39m\u001b[31m\u001b[1m^\u001b[22m\u001b[39m
+            \u001b[90m 10 | \u001b[39m\u001b[0m
+
+            \u001b[31mfull failure\u001b[39m \u001b[90m(full-name)\u001b[39m
+            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {
+            \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {
+            \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m
+            \u001b[90m 4 | \u001b[39m\u001b[0m
+
+        `;
+
+        /** Convert output lines to an array of trimmed lines for easier comparing */
+        function toTrimmedLines(lines: string): string[] {
+            return lines.split("\n").map((line) => line.trim());
+        }
+
+        const expectedResult = toTrimmedLines(colors.enabled ? expectedResultColored : expectedResultPlain);
+        const result = toTrimmedLines(formatter.format(failures));
+
+        assert.deepEqual(result, expectedResult);
+    });
+
+    it("handles no failures", () => {
+        const result = formatter.format([]);
+        assert.equal(result, "\n");
+    });
+});


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1683 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### What changes did you make?

Add the new `codeFrame` formatter.

This is how it looks on real code: 

<img width="864" alt="screen shot 2016-12-04 at 10 45 18 pm" src="https://cloud.githubusercontent.com/assets/543633/20875944/63c1a15a-ba73-11e6-90e3-2e89d0f834c4.png">


#### Is there anything you'd like reviewers to focus on?

A questions: Do you have a place to define modules for npm dependencies that don't have `@types` yet? I like to use `import` for babel-code-frame
