### PR TITLE
strict boolean expressions

### DIFF
--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../index";
+import * as utils from "../language/utils";
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "strict-boolean-expressions",
+        description: `Usage of && or || operators should be with boolean operands and
+expressions in If, Do, While and For statements should be of type boolean`,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "functionality",
+        typescriptOnly: true,
+        requiresTypeInfo: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static BINARY_EXPRESSION_ERROR = "Operands for the && or || operator should be of type boolean";
+    public static UNARY_EXPRESSION_ERROR = "Operand for the ! operator should be of type boolean";
+    public static STATEMENT_ERROR = "statement condition needs to be a boolean expression or literal";
+    public static CONDITIONAL_EXPRESSION_ERROR = "Condition needs to be a boolean expression or literal";
+
+    public applyWithProgram(srcFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
+        return this.applyWithWalker(new StrictBooleanExpressionsRule(srcFile, this.getOptions(), langSvc.getProgram()));
+    }
+}
+
+type StatementType = ts.IfStatement|ts.DoStatement|ts.WhileStatement;
+
+class StrictBooleanExpressionsRule extends Lint.ProgramAwareRuleWalker {
+    private checker: ts.TypeChecker;
+
+    constructor(srcFile: ts.SourceFile, lintOptions: Lint.IOptions, program: ts.Program) {
+        super(srcFile, lintOptions, program);
+        this.checker = this.getTypeChecker();
+    }
+
+    public visitBinaryExpression(node: ts.BinaryExpression) {
+        let isAndAndBinaryOperator = node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken;
+        let isOrOrBinaryOperator = node.operatorToken.kind === ts.SyntaxKind.BarBarToken;
+        if (isAndAndBinaryOperator || isOrOrBinaryOperator) {
+            let lhsExpression = node.left;
+            let lhsType = this.checker.getTypeAtLocation(lhsExpression);
+            let rhsExpression = node.right;
+            let rhsType = this.checker.getTypeAtLocation(rhsExpression);
+            if (!this.isBooleanType(lhsType)) {
+                if (lhsExpression.kind !== ts.SyntaxKind.BinaryExpression) {
+                    this.addFailure(this.createFailure(lhsExpression.getStart(), lhsExpression.getWidth(), Rule.BINARY_EXPRESSION_ERROR));
+                } else {
+                    this.visitBinaryExpression(<ts.BinaryExpression> lhsExpression);
+                }
+            }
+            if (!this.isBooleanType(rhsType)) {
+                if (rhsExpression.kind !== ts.SyntaxKind.BinaryExpression) {
+                    this.addFailure(this.createFailure(rhsExpression.getStart(), rhsExpression.getWidth(), Rule.BINARY_EXPRESSION_ERROR));
+                } else {
+                    this.visitBinaryExpression(<ts.BinaryExpression> rhsExpression);
+                }
+            }
+        }
+        super.visitBinaryExpression(node);
+    }
+
+    public visitPrefixUnaryExpression(node: ts.PrefixUnaryExpression) {
+        let isExclamationOperator = node.operator === ts.SyntaxKind.ExclamationToken;
+        if (isExclamationOperator) {
+            let expr = node.operand;
+            let expType = this.checker.getTypeAtLocation(expr);
+            if (!this.isBooleanType(expType)) {
+                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.UNARY_EXPRESSION_ERROR));
+            }
+        }
+        super.visitPrefixUnaryExpression(node);
+    }
+
+    public visitIfStatement(node: ts.IfStatement) {
+        this.checkStatement(node);
+        super.visitIfStatement(node);
+    }
+
+    public visitWhileStatement(node: ts.WhileStatement) {
+        this.checkStatement(node);
+        super.visitWhileStatement(node);
+    }
+
+    public visitDoStatement(node: ts.DoStatement) {
+        this.checkStatement(node);
+        super.visitDoStatement(node);
+    }
+
+    public visitConditionalExpression(node: ts.ConditionalExpression) {
+        let cexp = node.condition;
+        let expType = this.checker.getTypeAtLocation(cexp);
+        if (!this.isBooleanType(expType)) {
+            this.addFailure(this.createFailure(cexp.getStart(), cexp.getWidth(), Rule.CONDITIONAL_EXPRESSION_ERROR));
+        }
+        super.visitConditionalExpression(node);
+    }
+
+    public visitForStatement(node: ts.ForStatement) {
+        let cexp = node.condition;
+        let expType = this.checker.getTypeAtLocation(cexp);
+        if (!this.isBooleanType(expType)) {
+            this.addFailure(this.createFailure(cexp.getStart(), cexp.getWidth(), `For ${Rule.STATEMENT_ERROR}`));
+        }
+        super.visitForStatement(node);
+    }
+
+    private checkStatement(node: StatementType) {
+        let bexp = node.expression;
+        let expType = this.checker.getTypeAtLocation(bexp);
+        if (!this.isBooleanType(expType)) {
+            switch (node.kind) {
+            case ts.SyntaxKind.IfStatement:
+                this.addFailure(this.createFailure(bexp.getStart(), bexp.getWidth(), `If ${Rule.STATEMENT_ERROR}`));
+                break;
+            case ts.SyntaxKind.DoStatement:
+                this.addFailure(this.createFailure(bexp.getStart(), bexp.getWidth(), `Do-While ${Rule.STATEMENT_ERROR}`));
+                break;
+            case ts.SyntaxKind.WhileStatement:
+                this.addFailure(this.createFailure(bexp.getStart(), bexp.getWidth(), `While ${Rule.STATEMENT_ERROR}`));
+                break;
+            default:
+                throw new Error("Unknown Syntax Kind");
+            }
+        }
+    }
+
+    private isBooleanType(btype: ts.Type): boolean {
+        return utils.isTypeFlagSet(btype, ts.TypeFlags.BooleanLike);
+    }
+}

--- a/test/rules/strict-boolean-expressions/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/test.ts.lint
@@ -1,0 +1,179 @@
+class C { }
+enum MyEnum {
+	A, B, C
+}
+let anyType: {};
+let boolType: boolean;
+let bwrapType: Boolean;
+let numType = 9;
+let strType = "string";
+let objType = new Object();
+let classType = new C();
+let enumType = MyEnum.A;
+let boolFn = () => { return true; };
+let strFn = () => { return strType; };
+let numFn = () => { return numType; };
+let boolExpr = (strType !== undefined);
+
+/*** Binary Expressions ***/
+/*** Invalid Boolean Expressions ***/
+classType && boolType;
+~~~~~~~~~              [Operands for the && or || operator should be of type boolean]
+anyType && boolType;
+~~~~~~~              [Operands for the && or || operator should be of type boolean]
+numType && boolType;
+~~~~~~~              [Operands for the && or || operator should be of type boolean]
+boolType && strType;
+            ~~~~~~~  [Operands for the && or || operator should be of type boolean]
+boolType && objType && enumType;
+            ~~~~~~~              [Operands for the && or || operator should be of type boolean]
+                       ~~~~~~~~  [Operands for the && or || operator should be of type boolean]
+bwrapType && boolType;
+~~~~~~~~~              [Operands for the && or || operator should be of type boolean]
+
+boolType || classType;
+            ~~~~~~~~~  [Operands for the && or || operator should be of type boolean]
+boolType || anyType;
+            ~~~~~~~  [Operands for the && or || operator should be of type boolean]
+boolType || numType;
+            ~~~~~~~  [Operands for the && or || operator should be of type boolean]
+strType || boolType;
+~~~~~~~              [Operands for the && or || operator should be of type boolean]
+bwrapType || boolType;
+~~~~~~~~~              [Operands for the && or || operator should be of type boolean]
+objType || boolType || enumType;
+~~~~~~~                          [Operands for the && or || operator should be of type boolean]
+                       ~~~~~~~~  [Operands for the && or || operator should be of type boolean]
+
+boolExpr && strType;
+            ~~~~~~~  [Operands for the && or || operator should be of type boolean]
+numType || boolExpr;
+~~~~~~~              [Operands for the && or || operator should be of type boolean]
+numType && boolExpr || strType;
+~~~~~~~                         [Operands for the && or || operator should be of type boolean]
+                       ~~~~~~~  [Operands for the && or || operator should be of type boolean]
+bwrapType || boolExpr && bwrapType;
+~~~~~~~~~                           [Operands for the && or || operator should be of type boolean]
+                         ~~~~~~~~~  [Operands for the && or || operator should be of type boolean]
+
+/*** Valid Boolean Expressions ***/
+boolType && boolType;
+boolExpr || boolType;
+(numType > 0) && boolFn();
+(strType !== "bool") && boolExpr;
+(numType > 0) && (strType !== "bool");
+(strType !== undefined) || (numType < 0);
+
+/*** ConditionalExpression ***/
+/*** Invalid ***/
+strType ? strType : numType;
+~~~~~~~                      [Condition needs to be a boolean expression or literal]
+numType ? numType : numFn();
+~~~~~~~                      [Condition needs to be a boolean expression or literal]
+objType ? objType : boolExpr;
+~~~~~~~                       [Condition needs to be a boolean expression or literal]
+classType ? strType : undefined;
+~~~~~~~~~                        [Condition needs to be a boolean expression or literal]
+bwrapType ? 1 : 0;
+~~~~~~~~~          [Condition needs to be a boolean expression or literal]
+enumType ? 0 : 1;
+~~~~~~~~          [Condition needs to be a boolean expression or literal]
+
+/*** Valid ***/
+boolFn() ? numType : strType;
+boolType ? strType : undefined;
+
+/*** PrefixUnary Expressions ***/
+/*** Invalid ***/
+!!numType;
+ ~~~~~~~~  [Operand for the ! operator should be of type boolean]
+!strType;
+~~~~~~~~  [Operand for the ! operator should be of type boolean]
+!objType;
+~~~~~~~~  [Operand for the ! operator should be of type boolean]
+!enumType;
+~~~~~~~~~  [Operand for the ! operator should be of type boolean]
+!!classType;
+ ~~~~~~~~~~  [Operand for the ! operator should be of type boolean]
+!bwrapType;
+~~~~~~~~~~  [Operand for the ! operator should be of type boolean]
+!!undefined;
+ ~~~~~~~~~~  [Operand for the ! operator should be of type boolean]
+
+/*** Valid ***/
+!!boolFn();
+!boolExpr;
+!!boolType;
+
+/*** If Statement ***/
+/*** Invalid ***/
+if (numType) { /* statements */ }
+    ~~~~~~~                       [If statement condition needs to be a boolean expression or literal]
+if (objType) { /* statements */ }
+    ~~~~~~~                       [If statement condition needs to be a boolean expression or literal]
+if (strType) { /* statements */ }
+    ~~~~~~~                       [If statement condition needs to be a boolean expression or literal]
+if (bwrapType) { /* statements */ }
+    ~~~~~~~~~                       [If statement condition needs to be a boolean expression or literal]
+if (strFn()) { /* statements */ }
+    ~~~~~~~                       [If statement condition needs to be a boolean expression or literal]
+if (MyEnum.A) { /* statements */ }
+    ~~~~~~~~                       [If statement condition needs to be a boolean expression or literal]
+if (classType) { /* statements */ }
+    ~~~~~~~~~                       [If statement condition needs to be a boolean expression or literal]
+
+/*** Valid ***/
+if (boolFn()) { /* statements */ }
+if (boolExpr) { /* statements */ }
+if (boolType) { /* statements */ }
+
+/*** While Statement ***/
+/*** Invalid ***/
+while (numType) { /* statements */ }
+       ~~~~~~~                       [While statement condition needs to be a boolean expression or literal]
+while (objType) { /* statements */ }
+       ~~~~~~~                       [While statement condition needs to be a boolean expression or literal]
+while (strType) { /* statements */ }
+       ~~~~~~~                       [While statement condition needs to be a boolean expression or literal]
+while (strFn()) { /* statements */ }
+       ~~~~~~~                       [While statement condition needs to be a boolean expression or literal]
+while (bwrapType) { /* statements */ }
+       ~~~~~~~~~                       [While statement condition needs to be a boolean expression or literal]
+while (MyEnum.A) { /* statements */ }
+       ~~~~~~~~                       [While statement condition needs to be a boolean expression or literal]
+while (classType) { /* statements */ }
+       ~~~~~~~~~                       [While statement condition needs to be a boolean expression or literal]
+
+/*** Valid ***/
+while (boolFn()) { /* statements */ }
+while (boolExpr) { /* statements */ }
+while (boolType) { /* statements */ }
+
+/*** Do Statement ***/
+/*** Invalid ***/
+do { /* statements */ } while (numType);
+                               ~~~~~~~   [Do-While statement condition needs to be a boolean expression or literal]
+do { /* statements */ } while (objType);
+                               ~~~~~~~   [Do-While statement condition needs to be a boolean expression or literal]
+do { /* statements */ } while (strType);
+                               ~~~~~~~   [Do-While statement condition needs to be a boolean expression or literal]
+do { /* statements */ } while (bwrapType);
+                               ~~~~~~~~~   [Do-While statement condition needs to be a boolean expression or literal]
+do { /* statements */ } while (strFn());
+                               ~~~~~~~   [Do-While statement condition needs to be a boolean expression or literal]
+do { /* statements */ } while (MyEnum.A);
+                               ~~~~~~~~   [Do-While statement condition needs to be a boolean expression or literal]
+do { /* statements */ } while (classType);
+                               ~~~~~~~~~   [Do-While statement condition needs to be a boolean expression or literal]
+
+/*** Valid ***/
+do { /* statements */ } while (boolFn());
+do { /* statements */ } while (boolExpr);
+do { /* statements */ } while (boolType);
+
+/*** For Statement ***/
+/*** Invalid ***/
+for (let j = 0; j; j++) { /* statements */ }
+                ~                            [For statement condition needs to be a boolean expression or literal]
+/*** Valid ***/
+for (let j = 0; j > numType; j++) { /* statements */ }

--- a/test/rules/strict-boolean-expressions/tslint.json
+++ b/test/rules/strict-boolean-expressions/tslint.json
@@ -1,0 +1,8 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "strict-boolean-expressions": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #253 
- [x] New feature, bugfix, or enhancement
- [x] Includes tests
- [x] Documentation update

Introduced a rule to type check boolean expressions using type aware rules. This rule checks if the given binary expression, if statement, while statement or for statement comprises of correctly formed boolean expressions or literals. This is a first cut of the implementation and would like to get feedback on how to improve this and finally make this rule a part of the tslint rule set.
@myitcv tagging you here since we both discussed this rule offline, @adidahiya any feedback is welcome on how we can improve this.