### PR TITLE
[WIP] empty object type inference

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -135,6 +135,15 @@ export function isNodeFlagSet(node: ts.Node, flagToCheck: ts.NodeFlags): boolean
 }
 
 /**
+ * Bitwise check for type flags.
+ */
+export function isTypeFlagSet(typ: ts.Type, flagToCheck: ts.TypeFlags): boolean {
+    /* tslint:disable:no-bitwise */
+    return (typ.flags & flagToCheck) !== 0;
+    /* tslint:enable:no-bitwise */
+}
+
+/**
  * @returns true if decl is a nested module declaration, i.e. represents a segment of a dotted module path.
  */
 export function isNestedModuleDeclaration(decl: ts.ModuleDeclaration) {

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../index";
+import * as utils from "../language/utils";
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-inferred-empty-object-type",
+        description: "Disallow type inference of {} (empty object type) at function and constructor call sites",
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "functionality",
+        typescriptOnly: true,
+        requiresTypeInfo: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static EMPTY_INTERFACE_INSTANCE = "Explicit type parameter needs to be provided to the constructor";
+    public static EMPTY_INTERFACE_FUNCTION = "Explicit type parameter needs to be provided to the function call";
+
+    public applyWithProgram(srcFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoInferredEmptyObjectTypeRule(srcFile, this.getOptions(), langSvc.getProgram()));
+    }
+}
+
+class NoInferredEmptyObjectTypeRule extends Lint.ProgramAwareRuleWalker {
+    private checker: ts.TypeChecker;
+
+    constructor(srcFile: ts.SourceFile, lintOptions: Lint.IOptions, program: ts.Program) {
+        super(srcFile, lintOptions, program);
+        this.checker = this.getTypeChecker();
+    }
+
+    public visitNewExpression(node: ts.NewExpression): void {
+        let nodeTypeArgs = node.typeArguments;
+        let isObjectReference = (o: ts.TypeReference) => utils.isTypeFlagSet(o, ts.TypeFlags.Reference);
+        if (nodeTypeArgs === undefined) {
+            let objType = this.checker.getTypeAtLocation(node) as ts.TypeReference;
+            if (isObjectReference(objType) && objType.typeArguments !== undefined) {
+                let typeArgs = objType.typeArguments as ts.ObjectType[];
+                typeArgs.forEach((a) => {
+                    if (this.isEmptyObjectInterface(a)) {
+                        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.EMPTY_INTERFACE_INSTANCE));
+                    }
+                });
+            }
+        }
+        super.visitNewExpression(node);
+    }
+
+    public visitCallExpression(node: ts.CallExpression): void {
+        if (node.typeArguments === undefined) {
+            let callSig = this.checker.getResolvedSignature(node);
+            let retType = this.checker.getReturnTypeOfSignature(callSig) as ts.TypeReference;
+            if (this.isEmptyObjectInterface(retType)) {
+                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.EMPTY_INTERFACE_FUNCTION));
+            }
+        }
+        super.visitCallExpression(node);
+    }
+
+    private isEmptyObjectInterface(objType: ts.ObjectType): boolean {
+        let isAnonymous = utils.isTypeFlagSet(objType, ts.TypeFlags.Anonymous);
+        let hasProblematicCallSignatures = false;
+        let hasProperties = (objType.getProperties() !== undefined && objType.getProperties().length > 0);
+        let hasNumberIndexType = objType.getNumberIndexType() !== undefined;
+        let hasStringIndexType = objType.getStringIndexType() !== undefined;
+        let callSig = objType.getCallSignatures();
+        if (callSig !== undefined && callSig.length > 0) {
+            let isClean = callSig.every((sig) => {
+                let csigRetType = this.checker.getReturnTypeOfSignature(sig) as ts.TypeReference;
+                return this.isEmptyObjectInterface(csigRetType);
+            });
+            if (!isClean) {
+                hasProblematicCallSignatures = true;
+            }
+        }
+        return (isAnonymous && !hasProblematicCallSignatures && !hasProperties && !hasNumberIndexType && !hasStringIndexType);
+    }
+}

--- a/test/rules/no-inferred-empty-object-type/test.ts.lint
+++ b/test/rules/no-inferred-empty-object-type/test.ts.lint
@@ -1,0 +1,86 @@
+let s: string;
+let n: number;
+let o: Object;
+let l: { a: number, b: string };
+let t: [number, string];
+let p: Wrapper<string>;
+let f: () => void;
+type EmptyFunc = () => void;
+let voidFunc: () => void;
+let stringFunc: () => string;
+function WrapperFunc<T>(x?: T): T {
+	return x;
+}
+function CurriedFunc<T>(h?: () => T): () => T {
+	return h;
+}
+function MultiParamFunction<T, U>(x?: T, y?: U): T {
+	return x;
+}
+class Wrapper<T> {
+	val: T;
+}
+class MultiParamsClass<U, T> {
+	val1: T;
+	val2: U;
+}
+
+/* Bad */
+WrapperFunc();
+~~~~~~~~~~~~~  [Explicit type parameter needs to be provided to the function call]
+CurriedFunc();
+~~~~~~~~~~~~~  [Explicit type parameter needs to be provided to the function call]
+MultiParamFunction();
+~~~~~~~~~~~~~~~~~~~~  [Explicit type parameter needs to be provided to the function call]
+new Wrapper();
+~~~~~~~~~~~~~  [Explicit type parameter needs to be provided to the constructor]
+new MultiParamsClass();
+~~~~~~~~~~~~~~~~~~~~~~  [Explicit type parameter needs to be provided to the constructor]
+
+/* Good */
+WrapperFunc<Object>();
+WrapperFunc<string>();
+WrapperFunc<number>();
+WrapperFunc(s);
+WrapperFunc(n);
+WrapperFunc(o);
+WrapperFunc(l);
+WrapperFunc(t);
+WrapperFunc(p);
+WrapperFunc(f);
+WrapperFunc<() => {}>();
+
+WrapperFunc<() => void>();
+WrapperFunc<{ a: number }>();
+WrapperFunc<{ [x: number]: string }>();
+WrapperFunc<{ [x: string]: string }>();
+
+CurriedFunc(voidFunc);
+CurriedFunc(stringFunc);
+
+MultiParamFunction<string, {}>();
+MultiParamFunction<{}, number>();
+MultiParamFunction<string, number>();
+MultiParamFunction<{ a: number }, string>();
+MultiParamFunction<() => {}, () => void>();
+MultiParamFunction<() => void, () => {}>();
+MultiParamFunction<() => void, () => void>();
+MultiParamFunction<{ [x: number]: string }, () => void>();
+MultiParamFunction<{ [x: string]: string }, number>();
+
+new Wrapper<string>();
+new Wrapper<() => void>();
+new Wrapper<() => {}>();
+new Wrapper<{ a: number }>();
+new Wrapper<{ [x: number]: string }>();
+new Wrapper<{ [x: string]: string }>();
+
+new MultiParamsClass<string, {}>();
+new MultiParamsClass<{}, number>();
+new MultiParamsClass<string, number>();
+new MultiParamsClass<{ a: number }, string>();
+new MultiParamsClass<() => {}, () => void>();
+new MultiParamsClass<() => void, () => {}>();
+new MultiParamsClass<() => void, () => void>();
+new MultiParamsClass<{ [x: number]: string }, () => void>();
+new MultiParamsClass<{ [x: string]: string }, number>();

--- a/test/rules/no-inferred-empty-object-type/tslint.json
+++ b/test/rules/no-inferred-empty-object-type/tslint.json
@@ -1,0 +1,8 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "no-inferred-empty-object-type": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #720 
- [x] New feature, bugfix, or enhancement
- [x] Includes tests
- [x] Documentation update

Introduced a rule which checks for type inference being {} (empty object type) and then throws an error, this PR is based on discussions in the issue mentioned above. @myitcv any comments on how we can improve this?


