### PR TITLE
Make fix for quotemark rule more readable

### DIFF
--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -53,8 +53,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static SINGLE_QUOTE_FAILURE = "\" should be '";
-    public static DOUBLE_QUOTE_FAILURE = "' should be \"";
+    public static SINGLE_QUOTE_FAILURE = " \" should be '.";
+    public static DOUBLE_QUOTE_FAILURE = " ' should be \".";
 
     public isEnabled(): boolean {
         if (super.isEnabled()) {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

In vscode, the string for implementing the fix looks like
```
Fix "' should be ""
```

and this isn't very readable. So I added spaces, punctuation to make the fix-text more readable.

#### Is there anything you'd like reviewers to focus on?

Do you have some other ideas for how to make the fix-text more readable?
