### PR TITLE
Add more simple types

### DIFF
--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -94,10 +94,12 @@ class ArrayTypeWalker extends Lint.RuleWalker {
             case ts.SyntaxKind.ArrayType:
             case ts.SyntaxKind.BooleanKeyword:
             case ts.SyntaxKind.NullKeyword:
+            case ts.SyntaxKind.UndefinedKeyword:
             case ts.SyntaxKind.NumberKeyword:
             case ts.SyntaxKind.StringKeyword:
             case ts.SyntaxKind.SymbolKeyword:
             case ts.SyntaxKind.VoidKeyword:
+            case ts.SyntaxKind.NeverKeyword:
                 return true;
             case ts.SyntaxKind.TypeReference:
                 // TypeReferences must be non-generic or be another Array with a simple type

--- a/test/rules/array-type/array-simple/test.ts.fix
+++ b/test/rules/array-type/array-simple/test.ts.fix
@@ -1,4 +1,4 @@
-let x: number[] = [1] as number[];
+let x: undefined[] = [undefined] as undefined[];
 let y: string[] = <string[]>["2"];
 let z: any[] = [3, "4"];
 

--- a/test/rules/array-type/array-simple/test.ts.lint
+++ b/test/rules/array-type/array-simple/test.ts.lint
@@ -1,5 +1,5 @@
-let x: Array<number> = [1] as number[];
-       ~~~~~~~~~~~~~                    [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
+let x: Array<undefined> = [undefined] as undefined[];
+       ~~~~~~~~~~~~~~~~                               [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
 let y: string[] = <Array<string>>["2"];
                    ~~~~~~~~~~~~~        [Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.]
 let z: Array = [3, "4"];

--- a/test/rules/array-type/array/test.ts.fix
+++ b/test/rules/array-type/array/test.ts.fix
@@ -1,4 +1,4 @@
-let x: number[] = [1] as number[];
+let x: undefined[] = [undefined] as undefined[];
 let y: string[] = <string[]>["2"];
 let z: any[] = [3, "4"];
 

--- a/test/rules/array-type/array/test.ts.lint
+++ b/test/rules/array-type/array/test.ts.lint
@@ -1,5 +1,5 @@
-let x: Array<number> = [1] as number[];
-       ~~~~~~~~~~~~~                    [Array type using 'Array<T>' is forbidden. Use 'T[]' instead.]
+let x: Array<undefined> = [undefined] as undefined[];
+       ~~~~~~~~~~~~~~~~                               [Array type using 'Array<T>' is forbidden. Use 'T[]' instead.]
 let y: string[] = <Array<string>>["2"];
                    ~~~~~~~~~~~~~        [Array type using 'Array<T>' is forbidden. Use 'T[]' instead.]
 let z: Array = [3, "4"];


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update **(Not needed)**


#### What changes did you make?

Consider the `undefined` and `never` types to be simple types. This allows writing `undefined[]` or `never[]`.
The second commit changes tests to prove that I changed something. Could be removed if you think it's ugly.

[rule-update] `array-type` now consider `undefined` and `never` as simple types, allowing `undefined[]` and `never[]`