### PR TITLE
Simplify code for adding failures

### DIFF
--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -81,6 +81,21 @@ export class RuleWalker extends SyntaxWalker {
         }
     }
 
+    /** Add a failure with any arbitrary span. Prefer `addFailureAtNode` if possible. */
+    public addFailureAt(start: number, width: number, failure: string, fix?: Fix) {
+        this.addFailure(this.createFailure(start, width, failure, fix));
+    }
+
+    /** Like `addFailureAt` but uses start and end instead of start and width. */
+    public addFailureFromStartToEnd(start: number, end: number, failure: string, fix?: Fix) {
+        this.addFailureAt(start, end - start, failure, fix);
+    }
+
+    /** Add a failure using a node's span. */
+    public addFailureAtNode(node: ts.Node, failure: string, fix?: Fix) {
+        this.addFailureAt(node.getStart(), node.getWidth(), failure, fix);
+    }
+
     public createReplacement(start: number, length: number, text: string): Replacement {
         return new Replacement(start, length, text);
     }

--- a/src/rules/adjacentOverloadSignaturesRule.ts
+++ b/src/rules/adjacentOverloadSignaturesRule.ts
@@ -99,8 +99,7 @@ class AdjacentOverloadSignaturesWalker extends Lint.RuleWalker {
             const name = getOverloadName(node);
             if (name !== undefined) {
                 if (name in seen && last !== name) {
-                    this.addFailure(this.createFailure(node.getStart(), node.getWidth(),
-                        Rule.FAILURE_STRING_FACTORY(name)));
+                    this.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(name));
                 }
                 seen[name] = true;
             }

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -111,7 +111,7 @@ class AlignWalker extends Lint.RuleWalker {
         for (let node of nodes.slice(1)) {
             const curPos = getPosition(node);
             if (curPos.line !== prevPos.line && curPos.character !== alignToColumn) {
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), kind + Rule.FAILURE_STRING_SUFFIX));
+                this.addFailureAtNode(node, kind + Rule.FAILURE_STRING_SUFFIX);
                 break;
             }
             prevPos = curPos;

--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -52,7 +52,7 @@ class ArrayTypeWalker extends Lint.RuleWalker {
                 // Delete the square brackets and replace with an angle bracket
                 this.createReplacement(typeName.getEnd() - parens, node.getEnd() - typeName.getEnd() + parens, ">"),
             ]);
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), failureString, fix));
+            this.addFailureAtNode(node, failureString, fix);
         }
 
         super.visitArrayType(node);
@@ -68,7 +68,7 @@ class ArrayTypeWalker extends Lint.RuleWalker {
                 const fix = new Lint.Fix(Rule.metadata.ruleName, [
                     this.createReplacement(node.getStart(), node.getWidth(), "any[]"),
                 ]);
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), failureString, fix));
+                this.addFailureAtNode(node, failureString, fix);
             } else if (typeArgs && typeArgs.length === 1 && (!this.hasOption(OPTION_ARRAY_SIMPLE) || this.isSimpleType(typeArgs[0]))) {
                 const type = typeArgs[0];
                 const typeStart = type.getStart();
@@ -81,7 +81,7 @@ class ArrayTypeWalker extends Lint.RuleWalker {
                     // Delete the last angle bracket and replace with square brackets
                     this.createReplacement(typeEnd, node.getEnd() - typeEnd, (parens ? ")" : "") + "[]"),
                 ]);
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), failureString, fix));
+                this.addFailureAtNode(node, failureString, fix);
             }
         }
 

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -61,7 +61,7 @@ class ArrowParensWalker extends Lint.RuleWalker {
                 && !isGenerics && node.flags !== ts.NodeFlags.Async) {
 
                 const fix = new Lint.Fix(Rule.metadata.ruleName, [new Lint.Replacement(position, width, `(${parameter.getText()})`)]);
-                this.addFailure(this.createFailure(position, width, Rule.FAILURE_STRING, fix));
+                this.addFailureAt(position, width, Rule.FAILURE_STRING, fix);
             }
         }
         super.visitArrowFunction(node);

--- a/src/rules/banRule.ts
+++ b/src/rules/banRule.ts
@@ -25,7 +25,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "ban",
         description: "Bans the use of specific functions or global methods.",
         optionsDescription: Lint.Utils.dedent`
-            A list of \`['object', 'method', 'optional explanation here']\` or \`['globalMethod']\` which ban \`object.method()\` 
+            A list of \`['object', 'method', 'optional explanation here']\` or \`['globalMethod']\` which ban \`object.method()\`
             or respectively \`globalMethod()\`.`,
         options: {
             type: "list",
@@ -36,7 +36,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 maxLength: 3,
             },
         },
-        optionExamples: [`[true, ["someGlobalMethod"], ["someObject", "someFunction"], 
+        optionExamples: [`[true, ["someGlobalMethod"], ["someObject", "someFunction"],
                           ["someObject", "otherFunction", "Optional explanation"]]`],
         type: "functionality",
         typescriptOnly: false,
@@ -99,12 +99,8 @@ export class BanFunctionWalker extends Lint.RuleWalker {
             if (secondChild.kind === ts.SyntaxKind.DotToken) {
                 for (const bannedFunction of this.bannedFunctions) {
                     if (leftSideExpression === bannedFunction[0] && rightSideExpression === bannedFunction[1]) {
-                        const failure = this.createFailure(
-                            expression.getStart(),
-                            expression.getWidth(),
-                            Rule.FAILURE_STRING_FACTORY(`${leftSideExpression}.${rightSideExpression}`, bannedFunction[2]),
-                        );
-                        this.addFailure(failure);
+                        const failure = Rule.FAILURE_STRING_FACTORY(`${leftSideExpression}.${rightSideExpression}`, bannedFunction[2]);
+                        this.addFailureAtNode(expression, failure);
                     }
                 }
             }
@@ -115,8 +111,7 @@ export class BanFunctionWalker extends Lint.RuleWalker {
         if (expression.kind === ts.SyntaxKind.Identifier) {
             const identifierName = (<ts.Identifier> expression).text;
             if (this.bannedGlobalFunctions.indexOf(identifierName) !== -1) {
-                this.addFailure(this.createFailure(expression.getStart(), expression.getWidth(),
-                    Rule.FAILURE_STRING_FACTORY(`${identifierName}`)));
+                this.addFailureAtNode(expression, Rule.FAILURE_STRING_FACTORY(`${identifierName}`));
             }
 
         }

--- a/src/rules/classNameRule.ts
+++ b/src/rules/classNameRule.ts
@@ -46,7 +46,7 @@ class NameWalker extends Lint.RuleWalker {
         if (node.name != null) {
             const className = node.name.getText();
             if (!this.isPascalCased(className)) {
-                this.addFailureAt(node.name.getStart(), node.name.getWidth());
+                this.addFailureAtNode(node.name, Rule.FAILURE_STRING);
             }
         }
 
@@ -56,7 +56,7 @@ class NameWalker extends Lint.RuleWalker {
     public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
         const interfaceName = node.name.getText();
         if (!this.isPascalCased(interfaceName)) {
-            this.addFailureAt(node.name.getStart(), node.name.getWidth());
+            this.addFailureAtNode(node.name, Rule.FAILURE_STRING);
         }
 
         super.visitInterfaceDeclaration(node);
@@ -69,10 +69,5 @@ class NameWalker extends Lint.RuleWalker {
 
         const firstCharacter = name.charAt(0);
         return ((firstCharacter === firstCharacter.toUpperCase()) && name.indexOf("_") === -1);
-    }
-
-    private addFailureAt(position: number, width: number) {
-        const failure = this.createFailure(position, width, Rule.FAILURE_STRING);
-        this.addFailure(failure);
     }
 }

--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -78,20 +78,17 @@ class CommentWalker extends Lint.SkippableTokenAwareRuleWalker {
                 const width = commentText.length - 2;
                 if (this.hasOption(OPTION_SPACE)) {
                     if (!startsWithSpace(commentText)) {
-                        const leadingSpaceFailure = this.createFailure(startPosition, width, Rule.LEADING_SPACE_FAILURE);
-                        this.addFailure(leadingSpaceFailure);
+                        this.addFailureAt(startPosition, width, Rule.LEADING_SPACE_FAILURE);
                     }
                 }
                 if (this.hasOption(OPTION_LOWERCASE)) {
                     if (!startsWithLowercase(commentText)) {
-                        const lowercaseFailure = this.createFailure(startPosition, width, Rule.LOWERCASE_FAILURE);
-                        this.addFailure(lowercaseFailure);
+                        this.addFailureAt(startPosition, width, Rule.LOWERCASE_FAILURE);
                     }
                 }
                 if (this.hasOption(OPTION_UPPERCASE)) {
                     if (!startsWithUppercase(commentText) && !isEnableDisableFlag(commentText)) {
-                        const uppercaseFailure = this.createFailure(startPosition, width, Rule.UPPERCASE_FAILURE);
-                        this.addFailure(uppercaseFailure);
+                        this.addFailureAt(startPosition, width, Rule.UPPERCASE_FAILURE);
                     }
                 }
             }

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -107,15 +107,15 @@ export class CompletedDocsWalker extends Lint.ProgramAwareRuleWalker {
         const comments = this.getTypeChecker().getSymbolAtLocation(node.name).getDocumentationComment();
 
         if (comments.map((comment) => comment.text).join("").trim() === "") {
-            this.addFailure(this.createDocumentationFailure(node, nodeToCheck));
+            this.addDocumentationFailure(node, nodeToCheck);
         }
     }
 
-    private createDocumentationFailure(node: ts.Declaration, nodeToCheck: string): Lint.RuleFailure {
+    private addDocumentationFailure(node: ts.Declaration, nodeToCheck: string): void {
         const start = node.getStart();
         const width = node.getText().split(/\r|\n/g)[0].length;
         const description = nodeToCheck[0].toUpperCase() + nodeToCheck.substring(1) + Rule.FAILURE_STRING_EXIST;
 
-        return this.createFailure(start, width, description);
+        this.addFailureAt(start, width, description);
     }
 }

--- a/src/rules/curlyRule.ts
+++ b/src/rules/curlyRule.ts
@@ -56,7 +56,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class CurlyWalker extends Lint.RuleWalker {
     public visitForInStatement(node: ts.ForInStatement) {
         if (!isStatementBraced(node.statement)) {
-            this.addFailureForNode(node, Rule.FOR_FAILURE_STRING);
+            this.addFailureAtNode(node, Rule.FOR_FAILURE_STRING);
         }
 
         super.visitForInStatement(node);
@@ -64,7 +64,7 @@ class CurlyWalker extends Lint.RuleWalker {
 
     public visitForOfStatement(node: ts.ForOfStatement) {
         if (!isStatementBraced(node.statement)) {
-            this.addFailureForNode(node, Rule.FOR_FAILURE_STRING);
+            this.addFailureAtNode(node, Rule.FOR_FAILURE_STRING);
         }
 
         super.visitForOfStatement(node);
@@ -72,7 +72,7 @@ class CurlyWalker extends Lint.RuleWalker {
 
     public visitForStatement(node: ts.ForStatement) {
         if (!isStatementBraced(node.statement)) {
-            this.addFailureForNode(node, Rule.FOR_FAILURE_STRING);
+            this.addFailureAtNode(node, Rule.FOR_FAILURE_STRING);
         }
 
         super.visitForStatement(node);
@@ -80,11 +80,7 @@ class CurlyWalker extends Lint.RuleWalker {
 
     public visitIfStatement(node: ts.IfStatement) {
         if (!isStatementBraced(node.thenStatement)) {
-            this.addFailure(this.createFailure(
-                node.getStart(),
-                node.thenStatement.getEnd() - node.getStart(),
-                Rule.IF_FAILURE_STRING,
-            ));
+            this.addFailureFromStartToEnd(node.getStart(), node.thenStatement.getEnd(), Rule.IF_FAILURE_STRING);
         }
 
         if (node.elseStatement != null
@@ -94,11 +90,7 @@ class CurlyWalker extends Lint.RuleWalker {
             // find the else keyword to place the error appropriately
             const elseKeywordNode = node.getChildren().filter((child) => child.kind === ts.SyntaxKind.ElseKeyword)[0];
 
-            this.addFailure(this.createFailure(
-                elseKeywordNode.getStart(),
-                node.elseStatement.getEnd() - elseKeywordNode.getStart(),
-                Rule.ELSE_FAILURE_STRING,
-            ));
+            this.addFailureFromStartToEnd(elseKeywordNode.getStart(), node.elseStatement.getEnd(), Rule.ELSE_FAILURE_STRING);
         }
 
         super.visitIfStatement(node);
@@ -106,7 +98,7 @@ class CurlyWalker extends Lint.RuleWalker {
 
     public visitDoStatement(node: ts.DoStatement) {
         if (!isStatementBraced(node.statement)) {
-            this.addFailureForNode(node, Rule.DO_FAILURE_STRING);
+            this.addFailureAtNode(node, Rule.DO_FAILURE_STRING);
         }
 
         super.visitDoStatement(node);
@@ -114,14 +106,10 @@ class CurlyWalker extends Lint.RuleWalker {
 
     public visitWhileStatement(node: ts.WhileStatement) {
         if (!isStatementBraced(node.statement)) {
-            this.addFailureForNode(node, Rule.WHILE_FAILURE_STRING);
+            this.addFailureAtNode(node, Rule.WHILE_FAILURE_STRING);
         }
 
         super.visitWhileStatement(node);
-    }
-
-    private addFailureForNode(node: ts.Node, failure: string) {
-        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), failure));
     }
 }
 

--- a/src/rules/cyclomaticComplexityRule.ts
+++ b/src/rules/cyclomaticComplexityRule.ts
@@ -203,7 +203,7 @@ class CyclomaticComplexityWalker extends Lint.RuleWalker {
                 failureString = Rule.ANONYMOUS_FAILURE_STRING(this.threshold, complexity);
             }
 
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), failureString));
+            this.addFailureAtNode(node, failureString);
         }
     }
 

--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -49,12 +49,12 @@ class FileHeaderWalker extends Lint.RuleWalker {
             // check for a comment
             const match = text.match(this.commentRegexp);
             if (!match) {
-                this.addFailure(this.createFailure(offset, 0, Rule.FAILURE_STRING));
+                this.addFailureAt(offset, 0, Rule.FAILURE_STRING);
             } else {
                 // either the third or fourth capture group contains the comment contents
                 const comment = match[2] ? match[2] : match[3];
                 if (comment.search(this.headerRegexp) < 0) {
-                    this.addFailure(this.createFailure(offset, 0, Rule.FAILURE_STRING));
+                    this.addFailureAt(offset, 0, Rule.FAILURE_STRING);
                 }
             }
         }

--- a/src/rules/forinRule.ts
+++ b/src/rules/forinRule.ts
@@ -86,8 +86,7 @@ class ForInWalker extends Lint.RuleWalker {
             }
         }
 
-        const failure = this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING);
-        this.addFailure(failure);
+        this.addFailureAtNode(node, Rule.FAILURE_STRING);
     }
 }
 

--- a/src/rules/indentRule.ts
+++ b/src/rules/indentRule.ts
@@ -136,7 +136,7 @@ class IndentWalker extends Lint.RuleWalker {
             }
 
             if (fullLeadingWhitespace.match(this.regExp)) {
-                this.addFailure(this.createFailure(lineStart, fullLeadingWhitespace.length, this.failureString));
+                this.addFailureAt(lineStart, fullLeadingWhitespace.length, this.failureString);
             }
         }
         // no need to call super to visit the rest of the nodes, so don't call super here

--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -59,11 +59,11 @@ class NameWalker extends Lint.RuleWalker {
 
         if (always) {
             if (!this.startsWithI(interfaceName)) {
-                this.addFailureAt(node.name.getStart(), node.name.getWidth(), Rule.FAILURE_STRING);
+                this.addFailureAtNode(node.name, Rule.FAILURE_STRING);
             }
         } else if (this.hasOption(OPTION_NEVER)) {
             if (this.hasPrefixI(interfaceName)) {
-                this.addFailureAt(node.name.getStart(), node.name.getWidth(), Rule.FAILURE_STRING_NO_PREFIX);
+                this.addFailureAtNode(node.name, Rule.FAILURE_STRING_NO_PREFIX);
             }
         }
 
@@ -103,10 +103,4 @@ class NameWalker extends Lint.RuleWalker {
 
         return true;
     }
-
-    private addFailureAt(position: number, width: number, failureString: string) {
-        const failure = this.createFailure(position, width, failureString);
-        this.addFailure(failure);
-    }
-
 }

--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -119,9 +119,4 @@ class JsdocWalker extends Lint.SkippableTokenAwareRuleWalker {
             }
         }
     }
-
-    private addFailureAt(currentPosition: number, width: number, failureString: string) {
-        const failure = this.createFailure(currentPosition, width, failureString);
-        this.addFailure(failure);
-    }
 }

--- a/src/rules/labelPositionRule.ts
+++ b/src/rules/labelPositionRule.ts
@@ -53,8 +53,7 @@ class LabelPositionWalker extends Lint.RuleWalker {
                 && statement.kind !== ts.SyntaxKind.ForOfStatement
                 && statement.kind !== ts.SyntaxKind.WhileStatement
                 && statement.kind !== ts.SyntaxKind.SwitchStatement) {
-            const failure = this.createFailure(node.label.getStart(), node.label.getWidth(), Rule.FAILURE_STRING);
-            this.addFailure(failure);
+            this.addFailureAtNode(node.label, Rule.FAILURE_STRING);
         }
         super.visitLabeledStatement(node);
     }

--- a/src/rules/maxClassesPerFileRule.ts
+++ b/src/rules/maxClassesPerFileRule.ts
@@ -67,7 +67,7 @@ class MaxClassesPerFileWalker extends Lint.RuleWalker {
         this.classCount++;
         if (this.classCount > this.maxClassCount) {
             const msg = Rule.FAILURE_STRING_FACTORY(this.maxClassCount);
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), msg));
+            this.addFailureAtNode(node, msg);
         }
     }
 }

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -130,7 +130,7 @@ export class MemberAccessWalker extends Lint.RuleWalker {
             });
 
             const failureString = Rule.FAILURE_STRING_FACTORY(memberType, memberName, publicOnly);
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), failureString));
+            this.addFailureAtNode(node, failureString);
         }
     }
 }

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -296,12 +296,8 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
 
     private checkModifiersAndSetPrevious(node: ts.Node, currentMember: IModifiers) {
         if (!this.canAppearAfter(this.previousMember, currentMember)) {
-            const failure = this.createFailure(
-                node.getStart(),
-                node.getWidth(),
-                `Declaration of ${toString(currentMember)} not allowed to appear after declaration of ${toString(this.previousMember)}`,
-            );
-            this.addFailure(failure);
+            this.addFailureAtNode(node,
+                `Declaration of ${toString(currentMember)} not allowed to appear after declaration of ${toString(this.previousMember)}`);
         }
         this.previousMember = currentMember;
     }
@@ -365,11 +361,7 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
 
                     const errorLine1 = `Declaration of ${nodeType} not allowed after declaration of ${prevNodeType}. ` +
                         `Instead, this should come ${locationHint}.`;
-                    this.addFailure(this.createFailure(
-                        node.getStart(),
-                        node.getWidth(),
-                        errorLine1,
-                    ));
+                    this.addFailureAtNode(node, errorLine1);
                 } else {
                     // keep track of last good node
                     prevRank = rank;

--- a/src/rules/newParensRule.ts
+++ b/src/rules/newParensRule.ts
@@ -44,7 +44,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NewParensWalker extends Lint.RuleWalker {
     public visitNewExpression(node: ts.NewExpression) {
         if (node.arguments === undefined) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         super.visitNewExpression(node);
     }

--- a/src/rules/noAngleBracketTypeAssertionRule.ts
+++ b/src/rules/noAngleBracketTypeAssertionRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoAngleBracketTypeAssertionWalker extends Lint.RuleWalker {
     public visitTypeAssertionExpression(node: ts.TypeAssertion) {
-        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        this.addFailureAtNode(node, Rule.FAILURE_STRING);
         super.visitTypeAssertionExpression(node);
     }
 }

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -42,7 +42,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoAnyWalker extends Lint.RuleWalker {
     public visitAnyKeyword(node: ts.Node) {
-        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        this.addFailureAtNode(node, Rule.FAILURE_STRING);
         super.visitAnyKeyword(node);
     }
 }

--- a/src/rules/noArgRule.ts
+++ b/src/rules/noArgRule.ts
@@ -51,7 +51,7 @@ class NoArgWalker extends Lint.RuleWalker {
         if (expression.kind === ts.SyntaxKind.Identifier && name.text === "callee") {
             const identifierExpression = expression as ts.Identifier;
             if (identifierExpression.text === "arguments") {
-                this.addFailure(this.createFailure(expression.getStart(), expression.getWidth(), Rule.FAILURE_STRING));
+                this.addFailureAtNode(expression, Rule.FAILURE_STRING);
             }
         }
 

--- a/src/rules/noBitwiseRule.ts
+++ b/src/rules/noBitwiseRule.ts
@@ -63,7 +63,7 @@ class NoBitwiseWalker extends Lint.RuleWalker {
             case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:
             case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
             case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+                this.addFailureAtNode(node, Rule.FAILURE_STRING);
                 break;
             default:
                 break;
@@ -73,7 +73,7 @@ class NoBitwiseWalker extends Lint.RuleWalker {
 
     public visitPrefixUnaryExpression(node: ts.PrefixUnaryExpression) {
         if (node.operator === ts.SyntaxKind.TildeToken) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         super.visitPrefixUnaryExpression(node);
     }

--- a/src/rules/noConditionalAssignmentRule.ts
+++ b/src/rules/noConditionalAssignmentRule.ts
@@ -90,7 +90,7 @@ class NoConditionalAssignmentWalker extends Lint.RuleWalker {
 
     private checkForAssignment(expression: ts.BinaryExpression) {
         if (isAssignmentToken(expression.operatorToken)) {
-            this.addFailure(this.createFailure(expression.getStart(), expression.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(expression, Rule.FAILURE_STRING);
         }
     }
 }

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -94,7 +94,7 @@ class NoConsecutiveBlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
             .map((arr) => arr[0])
             .forEach((startLineNum: number) => {
                 let startCharPos = node.getPositionOfLineAndCharacter(startLineNum + 1, 0);
-                this.addFailure(this.createFailure(startCharPos, 1, failureMessage));
+                this.addFailureAt(startCharPos, 1, failureMessage);
             });
     }
 }

--- a/src/rules/noConstructRule.ts
+++ b/src/rules/noConstructRule.ts
@@ -56,8 +56,7 @@ class NoConstructWalker extends Lint.RuleWalker {
             const identifier = <ts.Identifier> node.expression;
             const constructorName = identifier.text;
             if (NoConstructWalker.FORBIDDEN_CONSTRUCTORS.indexOf(constructorName) !== -1) {
-                const failure = this.createFailure(node.getStart(), identifier.getEnd() - node.getStart(), Rule.FAILURE_STRING);
-                this.addFailure(failure);
+                this.addFailureAt(node.getStart(), identifier.getEnd() - node.getStart(), Rule.FAILURE_STRING);
             }
         }
         super.visitNewExpression(node);

--- a/src/rules/noDebuggerRule.ts
+++ b/src/rules/noDebuggerRule.ts
@@ -43,7 +43,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoDebuggerWalker extends Lint.RuleWalker {
     public visitDebuggerStatement(node: ts.Statement) {
         const debuggerKeywordNode = node.getChildAt(0);
-        this.addFailure(this.createFailure(debuggerKeywordNode.getStart(), debuggerKeywordNode.getWidth(), Rule.FAILURE_STRING));
+        this.addFailureAtNode(debuggerKeywordNode, Rule.FAILURE_STRING);
         super.visitDebuggerStatement(node);
    }
 }

--- a/src/rules/noDefaultExportRule.ts
+++ b/src/rules/noDefaultExportRule.ts
@@ -48,7 +48,7 @@ class NoDefaultExportWalker extends Lint.RuleWalker {
     public visitExportAssignment(node: ts.ExportAssignment) {
         const exportMember = node.getChildAt(1);
         if (exportMember != null && exportMember.kind === ts.SyntaxKind.DefaultKeyword) {
-            this.addFailure(this.createFailure(exportMember.getStart(), exportMember.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(exportMember, Rule.FAILURE_STRING);
         }
         super.visitExportAssignment(node);
     }
@@ -61,7 +61,7 @@ class NoDefaultExportWalker extends Lint.RuleWalker {
                 nodes.length === 2 &&
                 nodes[0].kind === ts.SyntaxKind.ExportKeyword &&
                 nodes[1].kind === ts.SyntaxKind.DefaultKeyword) {
-                    this.addFailure(this.createFailure(nodes[1].getStart(), nodes[1].getWidth(), Rule.FAILURE_STRING));
+                    this.addFailureAtNode(nodes[1], Rule.FAILURE_STRING);
             }
         }
         super.visitNode(node);

--- a/src/rules/noDuplicateVariableRule.ts
+++ b/src/rules/noDuplicateVariableRule.ts
@@ -98,15 +98,10 @@ class NoDuplicateVariableWalker extends Lint.BlockScopeAwareRuleWalker<{}, Scope
         const currentBlockScope = this.getCurrentBlockScope();
 
         if (currentBlockScope.varNames.indexOf(variableName) >= 0) {
-            this.addFailureOnIdentifier(variableIdentifier);
+            this.addFailureAtNode(variableIdentifier, Rule.FAILURE_STRING_FACTORY(variableIdentifier.text));
         } else {
             currentBlockScope.varNames.push(variableName);
         }
-    }
-
-    private addFailureOnIdentifier(ident: ts.Identifier) {
-        const failureString = Rule.FAILURE_STRING_FACTORY(ident.text);
-        this.addFailure(this.createFailure(ident.getStart(), ident.getWidth(), failureString));
     }
 }
 

--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -53,7 +53,7 @@ class BlockWalker extends Lint.RuleWalker {
         const isSkipped = this.ignoredBlocks.indexOf(node) !== -1;
 
         if (node.statements.length <= 0 && !hasCommentAfter && !hasCommentBefore && !isSkipped) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
 
         super.visitBlock(node);

--- a/src/rules/noEvalRule.ts
+++ b/src/rules/noEvalRule.ts
@@ -49,7 +49,7 @@ class NoEvalWalker extends Lint.RuleWalker {
         if (expression.kind === ts.SyntaxKind.Identifier) {
             const expressionName = (<ts.Identifier> expression).text;
             if (expressionName === "eval") {
-                this.addFailure(this.createFailure(expression.getStart(), expression.getWidth(), Rule.FAILURE_STRING));
+                this.addFailureAtNode(expression, Rule.FAILURE_STRING);
             }
         }
 

--- a/src/rules/noForInArrayRule.ts
+++ b/src/rules/noForInArrayRule.ts
@@ -67,7 +67,7 @@ class NoForInArrayWalker extends Lint.ProgramAwareRuleWalker {
         /* tslint:enable:no-bitwise */
 
         if (isArrayType || isStringType) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
 
         super.visitForInStatement(node);

--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -100,7 +100,7 @@ class NoInferrableTypesWalker extends Lint.RuleWalker {
             }
 
             if (failure != null) {
-                this.addFailure(this.createFailure(node.type.getStart(), node.type.getWidth(), Rule.FAILURE_STRING_FACTORY(failure)));
+                this.addFailureAtNode(node.type, Rule.FAILURE_STRING_FACTORY(failure));
             }
         }
     }

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -58,7 +58,7 @@ class NoInferredEmptyObjectTypeRule extends Lint.ProgramAwareRuleWalker {
                 let typeArgs = objType.typeArguments as ts.ObjectType[];
                 typeArgs.forEach((a) => {
                     if (this.isEmptyObjectInterface(a)) {
-                        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.EMPTY_INTERFACE_INSTANCE));
+                        this.addFailureAtNode(node, Rule.EMPTY_INTERFACE_INSTANCE);
                     }
                 });
             }
@@ -71,7 +71,7 @@ class NoInferredEmptyObjectTypeRule extends Lint.ProgramAwareRuleWalker {
             let callSig = this.checker.getResolvedSignature(node);
             let retType = this.checker.getReturnTypeOfSignature(callSig) as ts.TypeReference;
             if (this.isEmptyObjectInterface(retType)) {
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.EMPTY_INTERFACE_FUNCTION));
+                this.addFailureAtNode(node, Rule.EMPTY_INTERFACE_FUNCTION);
             }
         }
         super.visitCallExpression(node);

--- a/src/rules/noInternalModuleRule.ts
+++ b/src/rules/noInternalModuleRule.ts
@@ -44,7 +44,7 @@ class NoInternalModuleWalker extends Lint.RuleWalker {
     public visitModuleDeclaration(node: ts.ModuleDeclaration) {
         if (this.isInternalModuleDeclaration(node)) {
             const start = this.getStartBeforeModule(node);
-            this.addFailure(this.createFailure(node.getStart() + start, "module".length, Rule.FAILURE_STRING));
+            this.addFailureAt(node.getStart() + start, "module".length, Rule.FAILURE_STRING);
         }
         super.visitModuleDeclaration(node);
     }

--- a/src/rules/noInvalidThisRule.ts
+++ b/src/rules/noInvalidThisRule.ts
@@ -79,12 +79,12 @@ class NoInvalidThisWalker extends Lint.ScopeAwareRuleWalker<Scope> {
         });
 
         if (inClass === 0) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_OUTSIDE));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING_OUTSIDE);
         }
 
         const checkFuncInMethod = this.hasOption(DEPRECATED_OPTION_FUNCTION_IN_METHOD) || this.hasOption(OPTION_FUNCTION_IN_METHOD);
         if (checkFuncInMethod && inClass > 0 && inFunction > inClass) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_INSIDE));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING_INSIDE);
         }
     }
 

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -85,7 +85,7 @@ class NoMagicNumbersWalker extends Lint.RuleWalker {
         if (node.kind === ts.SyntaxKind.NumericLiteral && !Rule.ALLOWED_NODES[node.parent.kind] || isUnary) {
             let text = node.getText();
             if (!this.allowed[text]) {
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+                this.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
         }
         if (!isUnary) {

--- a/src/rules/noMergeableNamespaceRule.ts
+++ b/src/rules/noMergeableNamespaceRule.ts
@@ -61,7 +61,7 @@ class NoMergeableNamespaceWalker extends Lint.RuleWalker {
 
         if (highlights == null || highlights[0].highlightSpans.length > 1) {
             const failureString = Rule.failureStringFactory(name, this.findLocationToMerge(position, highlights[0].highlightSpans));
-            this.addFailure(this.createFailure(position, name.length, failureString));
+            this.addFailureAt(position, name.length, failureString);
         }
     }
 

--- a/src/rules/noNamespaceRule.ts
+++ b/src/rules/noNamespaceRule.ts
@@ -79,6 +79,6 @@ class NoNamespaceWalker extends Lint.RuleWalker {
             return;
         }
 
-        this.addFailure(this.createFailure(decl.getStart(), decl.getWidth(), Rule.FAILURE_STRING));
+        this.addFailureAtNode(decl, Rule.FAILURE_STRING);
     }
 }

--- a/src/rules/noNullKeywordRule.ts
+++ b/src/rules/noNullKeywordRule.ts
@@ -48,7 +48,7 @@ class NullWalker extends Lint.RuleWalker {
     public visitNode(node: ts.Node) {
         super.visitNode(node);
         if (node.kind === ts.SyntaxKind.NullKeyword && !isPartOfType(node)) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
     }
 }

--- a/src/rules/noParameterPropertiesRule.ts
+++ b/src/rules/noParameterPropertiesRule.ts
@@ -51,8 +51,7 @@ export class NoParameterPropertiesWalker extends Lint.RuleWalker {
             if (parameter.modifiers != null && parameter.modifiers.length > 0) {
                 const errorMessage = Rule.FAILURE_STRING_FACTORY((parameter.name as ts.Identifier).text);
                 const lastModifier = parameter.modifiers[parameter.modifiers.length - 1];
-                const position = lastModifier.getEnd() - parameter.getStart();
-                this.addFailure(this.createFailure(parameter.getStart(), position, errorMessage));
+                this.addFailureFromStartToEnd(parameter.getStart(), lastModifier.getEnd(), errorMessage);
             }
         }
         super.visitConstructorDeclaration(node);

--- a/src/rules/noReferenceRule.ts
+++ b/src/rules/noReferenceRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoReferenceWalker extends Lint.RuleWalker {
     public visitSourceFile(node: ts.SourceFile) {
         for (let ref of node.referencedFiles) {
-            this.addFailure(this.createFailure(ref.pos, ref.end - ref.pos, Rule.FAILURE_STRING));
+            this.addFailureFromStartToEnd(ref.pos, ref.end, Rule.FAILURE_STRING);
         }
     }
 }

--- a/src/rules/noRequireImportsRule.ts
+++ b/src/rules/noRequireImportsRule.ts
@@ -45,7 +45,7 @@ class NoRequireImportsWalker extends Lint.RuleWalker {
         if (node.arguments != null && node.expression != null) {
             const callExpressionText = node.expression.getText(this.getSourceFile());
             if (callExpressionText === "require") {
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+                this.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
         }
         super.visitCallExpression(node);
@@ -54,7 +54,7 @@ class NoRequireImportsWalker extends Lint.RuleWalker {
     public visitImportEqualsDeclaration(node: ts.ImportEqualsDeclaration) {
         const {moduleReference} = node;
         if (moduleReference.kind === ts.SyntaxKind.ExternalModuleReference) {
-            this.addFailure(this.createFailure(moduleReference.getStart(), moduleReference.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(moduleReference, Rule.FAILURE_STRING);
         }
         super.visitImportEqualsDeclaration(node);
     }

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -156,7 +156,7 @@ class NoShadowedVariableWalker extends Lint.BlockScopeAwareRuleWalker<ScopeInfo,
 
     private addFailureOnIdentifier(ident: ts.Identifier) {
         const failureString = Rule.FAILURE_STRING_FACTORY(ident.text);
-        this.addFailure(this.createFailure(ident.getStart(), ident.getWidth(), failureString));
+        this.addFailureAtNode(ident, failureString);
     }
 }
 

--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -52,7 +52,7 @@ class NoStringLiteralWalker extends Lint.RuleWalker {
 
                 // only create a failure if the identifier is valid, in which case there's no need to use string literals
                 if (isValidIdentifier(unquotedAccessorText)) {
-                    this.addFailure(this.createFailure(argument.getStart(), argument.getWidth(), Rule.FAILURE_STRING));
+                    this.addFailureAtNode(argument, Rule.FAILURE_STRING);
                 }
             }
         }

--- a/src/rules/noSwitchCaseFallThroughRule.ts
+++ b/src/rules/noSwitchCaseFallThroughRule.ts
@@ -80,18 +80,13 @@ export class NoSwitchCaseFallThroughWalker extends Lint.RuleWalker {
                 // last item doesn't need a break
                 if (isFallingThrough && switchClause.statements.length > 0 && ((switchClauses.length - 1) > i)) {
                     if (!isFallThroughAllowed(switchClauses[i + 1])) {
-                        this.addFailure(this.createFailure(
-                            switchClauses[i + 1].getStart(),
-                            "case".length,
-                            `${Rule.FAILURE_STRING_PART}'case'`,
-                        ));
+                        this.addFailureAt(switchClauses[i + 1].getStart(), "case".length, `${Rule.FAILURE_STRING_PART}'case'`);
                     }
                 }
             } else {
                 // case statement falling through a default
                 if (isFallingThrough && !isFallThroughAllowed(child)) {
-                    const failureString = Rule.FAILURE_STRING_PART + "'default'";
-                    this.addFailure(this.createFailure(switchClauses[i].getStart(), "default".length, failureString));
+                    this.addFailureAt(switchClauses[i].getStart(), "default".length, Rule.FAILURE_STRING_PART + "'default'");
                 }
             }
         });

--- a/src/rules/noTrailingWhitespaceRule.ts
+++ b/src/rules/noTrailingWhitespaceRule.ts
@@ -57,9 +57,7 @@ class NoTrailingWhitespaceWalker extends Lint.SkippableTokenAwareRuleWalker {
 
             if (scanner.getToken() === ts.SyntaxKind.NewLineTrivia) {
                 if (lastSeenWasWhitespace) {
-                    const width = scanner.getStartPos() - lastSeenWhitespacePosition;
-                    const failure = this.createFailure(lastSeenWhitespacePosition, width, Rule.FAILURE_STRING);
-                    this.addFailure(failure);
+                    this.addFailureFromStartToEnd(lastSeenWhitespacePosition, scanner.getStartPos(), Rule.FAILURE_STRING);
                 }
                 lastSeenWasWhitespace = false;
             } else if (scanner.getToken() === ts.SyntaxKind.WhitespaceTrivia) {

--- a/src/rules/noUnsafeFinallyRule.ts
+++ b/src/rules/noUnsafeFinallyRule.ts
@@ -94,8 +94,7 @@ class NoReturnInFinallyScopeAwareWalker extends Lint.ScopeAwareRuleWalker<IFinal
             return;
         }
 
-        this.addFailure(
-            this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_FACTORY(Rule.FAILURE_TYPE_BREAK)));
+        this.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(Rule.FAILURE_TYPE_BREAK));
     }
 
     protected visitContinueStatement(node: ts.BreakOrContinueStatement) {
@@ -104,8 +103,7 @@ class NoReturnInFinallyScopeAwareWalker extends Lint.ScopeAwareRuleWalker<IFinal
             return;
         }
 
-        this.addFailure(
-            this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_FACTORY(Rule.FAILURE_TYPE_CONTINUE)));
+        this.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(Rule.FAILURE_TYPE_CONTINUE));
     }
 
     protected visitLabeledStatement(node: ts.LabeledStatement) {
@@ -120,8 +118,7 @@ class NoReturnInFinallyScopeAwareWalker extends Lint.ScopeAwareRuleWalker<IFinal
             return;
         }
 
-        this.addFailure(
-            this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_FACTORY(Rule.FAILURE_TYPE_RETURN)));
+        this.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(Rule.FAILURE_TYPE_RETURN));
     }
 
     protected visitThrowStatement(node: ts.ThrowStatement): void {
@@ -130,8 +127,7 @@ class NoReturnInFinallyScopeAwareWalker extends Lint.ScopeAwareRuleWalker<IFinal
             return;
         }
 
-        this.addFailure(
-            this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING_FACTORY(Rule.FAILURE_TYPE_THROW)));
+        this.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(Rule.FAILURE_TYPE_THROW));
     }
 
     public createScope(node: ts.Node): IFinallyScope {

--- a/src/rules/noUnusedExpressionRule.ts
+++ b/src/rules/noUnusedExpressionRule.ts
@@ -169,7 +169,7 @@ export class NoUnusedExpressionWalker extends Lint.RuleWalker {
                 || kind === ts.SyntaxKind.AwaitExpression;
 
             if (!isValidStandaloneExpression && !NoUnusedExpressionWalker.isDirective(node)) {
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+                this.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
         }
     }

--- a/src/rules/noUnusedNewRule.ts
+++ b/src/rules/noUnusedNewRule.ts
@@ -68,7 +68,7 @@ class NoUnusedNewWalker extends NoUnusedExpressionWalker {
                 || kind === ts.SyntaxKind.AwaitExpression;
 
             if (!isValidStandaloneExpression && !NoUnusedExpressionWalker.isDirective(node)) {
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+                this.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
         }
     }

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -441,7 +441,7 @@ class NoUnusedVariablesWalker extends Lint.RuleWalker {
         return (highlights != null && highlights[0].highlightSpans.length > 1) || this.isIgnored(name);
     }
 
-    private fail(type: string, name: string, position: number, replacements?: Lint.Replacement[]) {
+    private fail(type: string, name: string, position: number, replacements: Lint.Replacement[]) {
         let fix: Lint.Fix;
         if (replacements && replacements.length) {
             fix = new Lint.Fix(Rule.metadata.ruleName, replacements);

--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -127,7 +127,7 @@ class NoUseBeforeDeclareWalker extends Lint.ScopeAwareRuleWalker<VisitedVariable
                     const referencePosition = highlightSpan.textSpan.start;
                     if (referencePosition < position && !this.isImportedPropertyName(referencePosition)) {
                         const failureString = Rule.FAILURE_STRING_PREFIX + name + Rule.FAILURE_STRING_POSTFIX;
-                        this.addFailure(this.createFailure(referencePosition, name.length, failureString));
+                        this.addFailureAt(referencePosition, name.length, failureString);
                     }
                 }
             }

--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -45,8 +45,7 @@ class NoVarKeywordWalker extends Lint.RuleWalker {
     public visitVariableStatement(node: ts.VariableStatement) {
         if (!Lint.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
                 && !Lint.isBlockScopedVariable(node)) {
-            this.addFailure(this.createFailure(node.declarationList.getStart(), "var".length, Rule.FAILURE_STRING,
-                 this.fix(node.declarationList)));
+            this.addFailureAt(node.declarationList.getStart(), "var".length, Rule.FAILURE_STRING, this.fix(node.declarationList));
         }
 
         super.visitVariableStatement(node);
@@ -70,7 +69,7 @@ class NoVarKeywordWalker extends Lint.RuleWalker {
     private handleInitializerNode(node: ts.VariableDeclarationList | ts.Expression) {
         if (node && node.kind === ts.SyntaxKind.VariableDeclarationList &&
                 !(Lint.isNodeFlagSet(node, ts.NodeFlags.Let) || Lint.isNodeFlagSet(node, ts.NodeFlags.Const))) {
-            this.addFailure(this.createFailure(node.getStart(), "var".length, Rule.FAILURE_STRING, this.fix(node)));
+            this.addFailureAt(node.getStart(), "var".length, Rule.FAILURE_STRING, this.fix(node));
         }
     }
 

--- a/src/rules/noVarRequiresRule.ts
+++ b/src/rules/noVarRequiresRule.ts
@@ -55,7 +55,7 @@ class NoVarRequiresWalker extends Lint.ScopeAwareRuleWalker<{}> {
             const identifierName = (<ts.Identifier> expression).text;
             if (identifierName === "require") {
                 // if we're calling (invoking) require, then it's not part of an import statement
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+                this.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
         }
 

--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -46,7 +46,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`"always"\`: Property names should always be quoted. (This is the default.)
             * \`"as-needed"\`: Only property names which require quotes may be quoted (e.g. those with spaces in them).
             * \`"consistent"\`: Property names should either all be quoted or unquoted.
-            * \`"consistent-as-needed"\`: If any property name requires quotes, then all properties must be quoted. Otherwise, no 
+            * \`"consistent-as-needed"\`: If any property name requires quotes, then all properties must be quoted. Otherwise, no
             property names may be quoted.
 
             For ES6, computed property names (\`{[name]: value}\`) and methods (\`{foo() {}}\`) never need
@@ -151,7 +151,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
             const hasQuotedProperties = state.hasQuotesNeededProperty || state.quotesNotNeededProperties.length > 0;
             const hasUnquotedProperties = state.unquotedProperties.length > 0;
             if (hasQuotedProperties && hasUnquotedProperties) {
-                this.addFailure(this.createFailure(node.getStart(), 1, Rule.INCONSISTENT_PROPERTY));
+                this.addFailureAt(node.getStart(), 1, Rule.INCONSISTENT_PROPERTY);
             }
         }
 

--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -32,7 +32,7 @@ class ObjectLiteralShorthandWalker extends Lint.RuleWalker {
         if (name.kind === ts.SyntaxKind.Identifier &&
             value.kind === ts.SyntaxKind.Identifier &&
             name.getText() === value.getText()) {
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.LONGHAND_PROPERTY));
+                this.addFailureAtNode(node, Rule.LONGHAND_PROPERTY);
         }
 
         if (value.kind === ts.SyntaxKind.FunctionExpression) {
@@ -41,7 +41,7 @@ class ObjectLiteralShorthandWalker extends Lint.RuleWalker {
                 return;  // named function expressions are OK.
             }
 
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.LONGHAND_METHOD));
+            this.addFailureAtNode(node, Rule.LONGHAND_METHOD);
         }
 
         super.visitPropertyAssignment(node);

--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -74,7 +74,7 @@ class ObjectLiteralSortKeysWalker extends Lint.RuleWalker {
                 const key = keyNode.text;
                 if (key < lastSortedKey) {
                     const failureString = Rule.FAILURE_STRING_FACTORY(key);
-                    this.addFailure(this.createFailure(keyNode.getStart(), keyNode.getWidth(), failureString));
+                    this.addFailureAtNode(keyNode, failureString);
                     this.sortedStateStack[this.sortedStateStack.length - 1] = false;
                 } else {
                     this.lastSortedKeyStack[this.lastSortedKeyStack.length - 1] = key;

--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -87,8 +87,7 @@ class OneLineWalker extends Lint.RuleWalker {
                 const thenStatementEndLine = sourceFile.getLineAndCharacterOfPosition(thenStatement.getEnd()).line;
                 const elseKeywordLine = sourceFile.getLineAndCharacterOfPosition(elseKeyword.getStart()).line;
                 if (thenStatementEndLine !== elseKeywordLine) {
-                    const failure = this.createFailure(elseKeyword.getStart(), elseKeyword.getWidth(), Rule.ELSE_FAILURE_STRING);
-                    this.addFailure(failure);
+                    this.addFailureAtNode(elseKeyword, Rule.ELSE_FAILURE_STRING);
                 }
             }
         }
@@ -121,8 +120,7 @@ class OneLineWalker extends Lint.RuleWalker {
             const tryClosingBraceLine = sourceFile.getLineAndCharacterOfPosition(tryClosingBrace.getEnd()).line;
             const catchKeywordLine = sourceFile.getLineAndCharacterOfPosition(catchKeyword.getStart()).line;
             if (tryClosingBraceLine !== catchKeywordLine) {
-                const failure = this.createFailure(catchKeyword.getStart(), catchKeyword.getWidth(), Rule.CATCH_FAILURE_STRING);
-                this.addFailure(failure);
+                this.addFailureAtNode(catchKeyword, Rule.CATCH_FAILURE_STRING);
             }
         }
 
@@ -136,8 +134,7 @@ class OneLineWalker extends Lint.RuleWalker {
                 const closingBraceLine = sourceFile.getLineAndCharacterOfPosition(closingBrace.getEnd()).line;
                 const finallyKeywordLine = sourceFile.getLineAndCharacterOfPosition(finallyKeyword.getStart()).line;
                 if (closingBraceLine !== finallyKeywordLine) {
-                    const failure = this.createFailure(finallyKeyword.getStart(), finallyKeyword.getWidth(), Rule.FINALLY_FAILURE_STRING);
-                    this.addFailure(failure);
+                    this.addFailureAtNode(finallyKeyword, Rule.FINALLY_FAILURE_STRING);
                 }
             }
         }
@@ -296,16 +293,16 @@ class OneLineWalker extends Lint.RuleWalker {
         const sourceFile = previousNode.getSourceFile();
         const previousNodeLine = sourceFile.getLineAndCharacterOfPosition(previousNode.getEnd()).line;
         const openBraceLine = sourceFile.getLineAndCharacterOfPosition(openBraceToken.getStart()).line;
-        let failure: Lint.RuleFailure;
+        let failure: string;
 
         if (this.hasOption(OPTION_BRACE) && previousNodeLine !== openBraceLine) {
-            failure = this.createFailure(openBraceToken.getStart(), openBraceToken.getWidth(), Rule.BRACE_FAILURE_STRING);
+            failure = Rule.BRACE_FAILURE_STRING;
         } else if (this.hasOption(OPTION_WHITESPACE) && previousNode.getEnd() === openBraceToken.getStart()) {
-            failure = this.createFailure(openBraceToken.getStart(), openBraceToken.getWidth(), Rule.WHITESPACE_FAILURE_STRING);
+            failure = Rule.WHITESPACE_FAILURE_STRING;
         }
 
         if (failure) {
-            this.addFailure(failure);
+            this.addFailureAtNode(openBraceToken, failure);
         }
     }
 }

--- a/src/rules/oneVariablePerDeclarationRule.ts
+++ b/src/rules/oneVariablePerDeclarationRule.ts
@@ -58,7 +58,7 @@ class OneVariablePerDeclarationWalker extends Lint.RuleWalker {
         const { declarationList } = node;
 
         if (declarationList.declarations.length > 1) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
 
         super.visitVariableStatement(node);
@@ -72,7 +72,7 @@ class OneVariablePerDeclarationWalker extends Lint.RuleWalker {
                 && initializer != null
                 && initializer.kind === ts.SyntaxKind.VariableDeclarationList
                 && initializer.declarations.length > 1) {
-            this.addFailure(this.createFailure(initializer.getStart(), initializer.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(initializer, Rule.FAILURE_STRING);
         }
 
         super.visitForStatement(node);

--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -69,7 +69,7 @@ class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
 
     private failUnlessExempt(node: ts.FunctionLikeDeclaration) {
         if (!functionIsExempt(node)) {
-            this.addFailure(this.createFailure(node.getStart(), "function".length, Rule.FAILURE_STRING));
+            this.addFailureAt(node.getStart(), "function".length, Rule.FAILURE_STRING);
         }
     }
 }

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -176,8 +176,7 @@ class OrderedImportsWalker extends Lint.RuleWalker {
 
         if (previousSource && compare(source, previousSource) === -1) {
             this.lastFix = new Lint.Fix(Rule.metadata.ruleName, []);
-            const ruleFailure = this.createFailure(node.getStart(), node.getWidth(), Rule.IMPORT_SOURCES_UNORDERED, this.lastFix);
-            this.addFailure(ruleFailure);
+            this.addFailureAtNode(node, Rule.IMPORT_SOURCES_UNORDERED, this.lastFix);
         }
 
         super.visitImportDeclaration(node);
@@ -202,12 +201,7 @@ class OrderedImportsWalker extends Lint.RuleWalker {
             }
 
             this.lastFix = new Lint.Fix(Rule.metadata.ruleName, []);
-            const ruleFailure = this.createFailure(
-                a.getStart(),
-                b.getEnd() - a.getStart(),
-                Rule.NAMED_IMPORTS_UNORDERED,
-                this.lastFix);
-            this.addFailure(ruleFailure);
+            this.addFailureFromStartToEnd(a.getStart(), b.getEnd(), Rule.NAMED_IMPORTS_UNORDERED, this.lastFix);
         }
 
         super.visitNamedImports(node);
@@ -269,7 +263,7 @@ class ImportsBlock {
         });
     }
 
-    // replaces the named imports on the most recent import declaration    
+    // replaces the named imports on the most recent import declaration
     public replaceNamedImports(fileOffset: number, length: number, replacement: string) {
         const importDeclaration = this.getLastImportDeclaration();
         if (importDeclaration == null) {
@@ -293,7 +287,7 @@ class ImportsBlock {
         return this.getLastImportDeclaration().sourcePath;
     }
 
-    // creates a Lint.Replacement object with ordering fixes for the entire block    
+    // creates a Lint.Replacement object with ordering fixes for the entire block
     public getReplacement() {
         if (this.importDeclarations.length === 0) {
             return null;
@@ -305,7 +299,7 @@ class ImportsBlock {
         return new Lint.Replacement(start, end - start, fixedText);
     }
 
-    // gets the offset immediately after the end of the previous declaration to include comment above  
+    // gets the offset immediately after the end of the previous declaration to include comment above
     private getStartOffset(node: ts.ImportDeclaration) {
         if (this.importDeclarations.length === 0) {
             return node.getStart();

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -63,12 +63,7 @@ class PreferConstWalker extends Lint.BlockScopeAwareRuleWalker<{}, ScopeInfo> {
                 fix = new Lint.Fix(Rule.metadata.ruleName, [replacement]);
                 seenLetStatements[usage.letStatement.getStart().toString()] = true;
             }
-            this.addFailure(this.createFailure(
-                usage.identifier.getStart(),
-                usage.identifier.getWidth(),
-                Rule.FAILURE_STRING_FACTORY(usage.identifier.text),
-                fix,
-            ));
+            this.addFailureAtNode(usage.identifier, Rule.FAILURE_STRING_FACTORY(usage.identifier.text), fix);
         }
     }
 

--- a/src/rules/preferForOfRule.ts
+++ b/src/rules/preferForOfRule.ts
@@ -75,9 +75,7 @@ class PreferForOfWalker extends Lint.RuleWalker {
         if (indexVariableName != null) {
             const incrementorState = this.incrementorMap[indexVariableName];
             if (incrementorState.onlyArrayReadAccess) {
-                const length = incrementorState.forLoopEndPosition - node.getStart();
-                const failure = this.createFailure(node.getStart(), length, Rule.FAILURE_STRING);
-                this.addFailure(failure);
+                this.addFailureFromStartToEnd(node.getStart(), incrementorState.forLoopEndPosition, Rule.FAILURE_STRING);
             }
 
             // remove current `for` loop state

--- a/src/rules/promiseFunctionAsyncRule.ts
+++ b/src/rules/promiseFunctionAsyncRule.ts
@@ -79,7 +79,7 @@ class PromiseAsyncWalker extends Lint.ProgramAwareRuleWalker {
             : node.getWidth();
 
         if (isPromise && !isAsync) {
-            this.addFailure(this.createFailure(node.getStart(), signatureEnd, Rule.FAILURE_STRING));
+            this.addFailureAt(node.getStart(), signatureEnd, Rule.FAILURE_STRING);
         }
     }
 }

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -121,7 +121,7 @@ class QuotemarkWalker extends Lint.RuleWalker {
                     + expectedQuoteMark;
 
                 const fix = new Lint.Fix(Rule.metadata.ruleName, [ new Lint.Replacement(position, width, newText) ]);
-                this.addFailure(this.createFailure(position, width, failureMessage, fix));
+                this.addFailureAt(position, width, failureMessage, fix);
             }
         }
 

--- a/src/rules/radixRule.ts
+++ b/src/rules/radixRule.ts
@@ -25,7 +25,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "radix",
         description: "Requires the radix parameter to be specified when calling `parseInt`.",
         rationale: Lint.Utils.dedent`
-            From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt): 
+            From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt):
             > Always specify this parameter to eliminate reader confusion and to guarantee predictable behavior.
             > Different implementations produce different results when a radix is not specified, usually defaulting the value to 10.`,
         optionsDescription: "Not configurable.",
@@ -51,7 +51,7 @@ class RadixWalker extends Lint.RuleWalker {
         if (expression.kind === ts.SyntaxKind.Identifier
                 && node.getFirstToken().getText() === "parseInt"
                 && node.arguments.length < 2) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
 
         super.visitCallExpression(node);

--- a/src/rules/restrictPlusOperandsRule.ts
+++ b/src/rules/restrictPlusOperandsRule.ts
@@ -55,11 +55,10 @@ class RestrictPlusOperandsWalker extends Lint.ProgramAwareRuleWalker {
 
             if (leftType !== rightType) {
                 // mismatched types
-                this.addFailure(this.createFailure(position, width, Rule.MISMATCHED_TYPES_FAILURE));
+                this.addFailureAt(position, width, Rule.MISMATCHED_TYPES_FAILURE);
             } else if (leftType !== "number" && leftType !== "string") {
                 // adding unsupported types
-                const failureString = Rule.UNSUPPORTED_TYPE_FAILURE_FACTORY(leftType);
-                this.addFailure(this.createFailure(position, width, failureString));
+                this.addFailureAt(position, width, Rule.UNSUPPORTED_TYPE_FAILURE_FACTORY(leftType));
             }
         }
 

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -175,7 +175,7 @@ class SemicolonWalker extends Lint.RuleWalker {
             const fix = new Lint.Fix(Rule.metadata.ruleName, [
                 this.appendText(failureStart, ";"),
             ]);
-            this.addFailure(this.createFailure(failureStart, 0, Rule.FAILURE_STRING_MISSING, fix));
+            this.addFailureAt(failureStart, 0, Rule.FAILURE_STRING_MISSING, fix);
         } else if (never && hasSemicolon) {
             const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, sourceFile.text);
             scanner.setTextPos(position);
@@ -191,7 +191,7 @@ class SemicolonWalker extends Lint.RuleWalker {
                 const fix = new Lint.Fix(Rule.metadata.ruleName, [
                     this.deleteText(failureStart, 1),
                 ]);
-                this.addFailure(this.createFailure(failureStart, 1, Rule.FAILURE_STRING_UNNECESSARY, fix));
+                this.addFailureAt(failureStart, 1, Rule.FAILURE_STRING_UNNECESSARY, fix);
             }
         }
     }

--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -64,14 +64,14 @@ class StrictBooleanExpressionsRule extends Lint.ProgramAwareRuleWalker {
             let rhsType = this.checker.getTypeAtLocation(rhsExpression);
             if (!this.isBooleanType(lhsType)) {
                 if (lhsExpression.kind !== ts.SyntaxKind.BinaryExpression) {
-                    this.addFailure(this.createFailure(lhsExpression.getStart(), lhsExpression.getWidth(), Rule.BINARY_EXPRESSION_ERROR));
+                    this.addFailureAtNode(lhsExpression, Rule.BINARY_EXPRESSION_ERROR);
                 } else {
                     this.visitBinaryExpression(<ts.BinaryExpression> lhsExpression);
                 }
             }
             if (!this.isBooleanType(rhsType)) {
                 if (rhsExpression.kind !== ts.SyntaxKind.BinaryExpression) {
-                    this.addFailure(this.createFailure(rhsExpression.getStart(), rhsExpression.getWidth(), Rule.BINARY_EXPRESSION_ERROR));
+                    this.addFailureAtNode(rhsExpression, Rule.BINARY_EXPRESSION_ERROR);
                 } else {
                     this.visitBinaryExpression(<ts.BinaryExpression> rhsExpression);
                 }
@@ -86,7 +86,7 @@ class StrictBooleanExpressionsRule extends Lint.ProgramAwareRuleWalker {
             let expr = node.operand;
             let expType = this.checker.getTypeAtLocation(expr);
             if (!this.isBooleanType(expType)) {
-                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.UNARY_EXPRESSION_ERROR));
+                this.addFailureAtNode(node, Rule.UNARY_EXPRESSION_ERROR);
             }
         }
         super.visitPrefixUnaryExpression(node);
@@ -111,7 +111,7 @@ class StrictBooleanExpressionsRule extends Lint.ProgramAwareRuleWalker {
         let cexp = node.condition;
         let expType = this.checker.getTypeAtLocation(cexp);
         if (!this.isBooleanType(expType)) {
-            this.addFailure(this.createFailure(cexp.getStart(), cexp.getWidth(), Rule.CONDITIONAL_EXPRESSION_ERROR));
+            this.addFailureAtNode(cexp, Rule.CONDITIONAL_EXPRESSION_ERROR);
         }
         super.visitConditionalExpression(node);
     }
@@ -120,7 +120,7 @@ class StrictBooleanExpressionsRule extends Lint.ProgramAwareRuleWalker {
         let cexp = node.condition;
         let expType = this.checker.getTypeAtLocation(cexp);
         if (!this.isBooleanType(expType)) {
-            this.addFailure(this.createFailure(cexp.getStart(), cexp.getWidth(), `For ${Rule.STATEMENT_ERROR}`));
+            this.addFailureAtNode(cexp, `For ${Rule.STATEMENT_ERROR}`);
         }
         super.visitForStatement(node);
     }
@@ -129,23 +129,24 @@ class StrictBooleanExpressionsRule extends Lint.ProgramAwareRuleWalker {
         let bexp = node.expression;
         let expType = this.checker.getTypeAtLocation(bexp);
         if (!this.isBooleanType(expType)) {
-            switch (node.kind) {
-            case ts.SyntaxKind.IfStatement:
-                this.addFailure(this.createFailure(bexp.getStart(), bexp.getWidth(), `If ${Rule.STATEMENT_ERROR}`));
-                break;
-            case ts.SyntaxKind.DoStatement:
-                this.addFailure(this.createFailure(bexp.getStart(), bexp.getWidth(), `Do-While ${Rule.STATEMENT_ERROR}`));
-                break;
-            case ts.SyntaxKind.WhileStatement:
-                this.addFailure(this.createFailure(bexp.getStart(), bexp.getWidth(), `While ${Rule.STATEMENT_ERROR}`));
-                break;
-            default:
-                throw new Error("Unknown Syntax Kind");
-            }
+            this.addFailureAtNode(bexp, `${failureTextForKind(node.kind)} ${Rule.STATEMENT_ERROR}`);
         }
     }
 
     private isBooleanType(btype: ts.Type): boolean {
         return utils.isTypeFlagSet(btype, ts.TypeFlags.BooleanLike);
+    }
+}
+
+function failureTextForKind(kind: ts.SyntaxKind) {
+    switch (kind) {
+        case ts.SyntaxKind.IfStatement:
+            return "If";
+        case ts.SyntaxKind.DoStatement:
+            return "Do-While";
+        case ts.SyntaxKind.WhileStatement:
+            return "While";
+        default:
+            throw new Error("Unknown Syntax Kind");
     }
 }

--- a/src/rules/switchDefaultRule.ts
+++ b/src/rules/switchDefaultRule.ts
@@ -44,7 +44,7 @@ export class SwitchDefaultWalker extends Lint.RuleWalker {
         const hasDefaultCase = node.caseBlock.clauses.some((clause) => clause.kind === ts.SyntaxKind.DefaultClause);
 
         if (!hasDefaultCase) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
 
         super.visitSwitchStatement(node);

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -247,13 +247,13 @@ class TrailingCommaWalker extends Lint.RuleWalker {
                     const fix = new Lint.Fix(Rule.metadata.ruleName, [
                         this.deleteText(failureStart, 1),
                     ]);
-                    this.addFailure(this.createFailure(failureStart, 1, Rule.FAILURE_STRING_NEVER, fix));
+                    this.addFailureAt(failureStart, 1, Rule.FAILURE_STRING_NEVER, fix);
                 } else if (!hasTrailingComma && option === "always") {
                     const failureStart = lastGrandChild.getEnd();
                     const fix = new Lint.Fix(Rule.metadata.ruleName, [
                         this.appendText(failureStart, ","),
                     ]);
-                    this.addFailure(this.createFailure(failureStart - 1, 1, Rule.FAILURE_STRING_ALWAYS, fix));
+                    this.addFailureAt(failureStart - 1, 1, Rule.FAILURE_STRING_ALWAYS, fix);
                 }
             }
         }

--- a/src/rules/tripleEqualsRule.ts
+++ b/src/rules/tripleEqualsRule.ts
@@ -74,10 +74,10 @@ class ComparisonWalker extends Lint.RuleWalker {
     private handleOperatorToken(position: number, operator: ts.SyntaxKind) {
         switch (operator) {
             case ts.SyntaxKind.EqualsEqualsToken:
-                this.addFailure(this.createFailure(position, ComparisonWalker.COMPARISON_OPERATOR_WIDTH, Rule.EQ_FAILURE_STRING));
+                this.addFailureAt(position, ComparisonWalker.COMPARISON_OPERATOR_WIDTH, Rule.EQ_FAILURE_STRING);
                 break;
             case ts.SyntaxKind.ExclamationEqualsToken:
-                this.addFailure(this.createFailure(position, ComparisonWalker.COMPARISON_OPERATOR_WIDTH, Rule.NEQ_FAILURE_STRING));
+                this.addFailureAt(position, ComparisonWalker.COMPARISON_OPERATOR_WIDTH, Rule.NEQ_FAILURE_STRING);
                 break;
             default:
                 break;

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -210,8 +210,7 @@ class TypedefWalker extends Lint.RuleWalker {
             if (name != null && name.kind === ts.SyntaxKind.Identifier) {
                 ns = `: '${(<ts.Identifier> name).text}'`;
             }
-            let failure = this.createFailure(location, 1, "expected " + option + ns + " to have a typedef");
-            this.addFailure(failure);
+            this.addFailureAt(location, 1, "expected " + option + ns + " to have a typedef");
         }
     }
 }

--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -297,7 +297,7 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
             (optionValue === "onespace" || optionValue === "space");
 
         if (isFailure) {
-            this.addFailure(this.createFailure(failurePos, 1, message));
+            this.addFailureAt(failurePos, 1, message);
         }
     }
 }

--- a/src/rules/useIsnanRule.ts
+++ b/src/rules/useIsnanRule.ts
@@ -46,7 +46,7 @@ class UseIsnanRuleWalker extends Lint.RuleWalker {
     protected visitBinaryExpression(node: ts.BinaryExpression): void {
         if ((this.isExpressionNaN(node.left) || this.isExpressionNaN(node.right))
                 && node.operatorToken.kind !== ts.SyntaxKind.EqualsToken) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING + node.getText()));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING + node.getText());
         }
         super.visitBinaryExpression(node);
     }

--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -146,7 +146,7 @@ class VariableNameWalker extends Lint.RuleWalker {
         }
 
         if (this.shouldCheckFormat && !this.isCamelCase(variableName) && !isUpperCase(variableName)) {
-            this.addFailure(this.createFailure(name.getStart(), name.getWidth(), Rule.FORMAT_FAILURE));
+            this.addFailureAtNode(name, Rule.FORMAT_FAILURE);
         }
     }
 
@@ -154,7 +154,7 @@ class VariableNameWalker extends Lint.RuleWalker {
         const variableName = name.text;
 
         if (this.shouldBanKeywords && BANNED_KEYWORDS.indexOf(variableName) !== -1) {
-            this.addFailure(this.createFailure(name.getStart(), name.getWidth(), Rule.KEYWORD_FAILURE));
+            this.addFailureAtNode(name, Rule.KEYWORD_FAILURE);
         }
     }
 

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -87,8 +87,7 @@ class WhitespaceWalker extends Lint.SkippableTokenAwareRuleWalker {
             if (tokenKind === ts.SyntaxKind.WhitespaceTrivia || tokenKind === ts.SyntaxKind.NewLineTrivia) {
                 prevTokenShouldBeFollowedByWhitespace = false;
             } else if (prevTokenShouldBeFollowedByWhitespace) {
-                const failure = this.createFailure(startPos, 1, Rule.FAILURE_STRING);
-                this.addFailure(failure);
+                this.addFailureAt(startPos, 1, Rule.FAILURE_STRING);
                 prevTokenShouldBeFollowedByWhitespace = false;
             }
 
@@ -260,7 +259,7 @@ class WhitespaceWalker extends Lint.SkippableTokenAwareRuleWalker {
         if (nextTokenType !== ts.SyntaxKind.WhitespaceTrivia
                 && nextTokenType !== ts.SyntaxKind.NewLineTrivia
                 && nextTokenType !== ts.SyntaxKind.EndOfFileToken) {
-            this.addFailure(this.createFailure(position, 1, Rule.FAILURE_STRING));
+            this.addFailureAt(position, 1, Rule.FAILURE_STRING);
         }
     }
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update
- [X] Code improvement

#### What changes did you make?

This greatly simplifies how to add new rule failures, using just a few helper functions.
Only 2 rules remain that directly call `createFailure`; these two keep their own list of failures and do complex things with them.  All other rules were just creating a failure and immediately adding it, so those steps can be combined.
