### PR TITLE
Treat a property `foo: () => void` like `foo = () => {}`: as a method declaration.

### DIFF
--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -262,8 +262,9 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
     }
 
     public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
-        const { initializer } = node;
-        const isFunction = initializer != null
+        const { initializer, type } = node;
+        const isFunction = type && type.kind === ts.SyntaxKind.FunctionType
+            || initializer != null
             && (initializer.kind === ts.SyntaxKind.ArrowFunction || initializer.kind === ts.SyntaxKind.FunctionExpression);
         this.checkModifiersAndSetPrevious(node, getModifiers(isFunction, node.modifiers));
         this.pushMember(getNodeAndModifiers(node, isFunction));

--- a/test/rules/member-ordering/method/test.ts.lint
+++ b/test/rules/member-ordering/method/test.ts.lint
@@ -28,8 +28,8 @@ interface IArrowMethods {
 
 class ArrowMethods {
     public a = 5;
-    private callback: () => void
     public b = "foo";
+    private callback: () => void;
     public c() {}
     public d = () => {};
     public e = function() {};

--- a/test/rules/member-ordering/order/fields-first/test.ts.lint
+++ b/test/rules/member-ordering/order/fields-first/test.ts.lint
@@ -10,10 +10,11 @@ class Good {
     protected static h() {}
     private static i = () => {};
     j = () => {};
+    jj: () => void;
     protected k() {};
     private l = () => {};
 }
-    
+
 interface IGood {
     foo: number;
     arrowsAreFields: () => void;

--- a/test/rules/member-ordering/order/instance-sandwich/test.ts.lint
+++ b/test/rules/member-ordering/order/instance-sandwich/test.ts.lint
@@ -7,13 +7,14 @@ class Good {
     private f = foo();
     constructor() {}
     j = () => {};
+    jj: () => void;
     protected k() {};
     private l = () => {};
     public static g() {}
     protected static h() {}
     private static i = () => {};
 }
-    
+
 interface IGood {
     foo: number;
     arrowsAreFields: () => void;

--- a/test/rules/member-ordering/order/statics-first/test.ts.lint
+++ b/test/rules/member-ordering/order/statics-first/test.ts.lint
@@ -10,10 +10,11 @@ class Good {
     private f = foo();
     constructor() {}
     j = () => {};
+    jj: () => void;
     protected k() {};
     private l = () => {};
 }
-    
+
 interface IGood {
     foo: number;
     arrowsAreFields: () => void;


### PR DESCRIPTION
Fixes #1156

#### PR checklist

- [X] Addresses an existing issue: #1156
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update (may be needed, but current documentation doesn't seem to mention anything about #969)

#### What changes did you make?

Consider a property with a function type the same way as a property initialized to an arrow function.

#### Is there anything you'd like reviewers to focus on?

This is a breaking change, since people with this rule enabled will have to move all function-typed properties.
Maybe this should be put under an option. We can't really detect whether a property is meant to be used as an assignable field or as something to be mixed in to the prototype. However, it does seem more consistent with #969.