### PR TITLE
Add package.json scripts for easier development

### DIFF
--- a/docs/develop/contributing/index.md
+++ b/docs/develop/contributing/index.md
@@ -13,6 +13,8 @@ npm run compile
 npm run test
 ```
 
+From there you can use `npm run test:watch` and `npm run test:rules -- my-rule-name` to try out changes to a rule.
+
 #### `next` branch
 
 The [`next` branch of the TSLint repo](https://github.com/palantir/tslint/tree/next) tracks the latest TypeScript

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:pre": "cd ./test/config && npm install",
     "test:mocha": "mocha --reporter spec --colors \"build/test/**/*Tests.js\" build/test/assert.js",
     "test:rules": "node ./build/test/ruleTestRunner.js",
+    "test:watch": "tsc -p test --watch",
     "verify": "npm-run-all clean compile lint test docs"
   },
   "dependencies": {

--- a/test/ruleTestRunner.ts
+++ b/test/ruleTestRunner.ts
@@ -23,12 +23,18 @@ import {consoleTestResultHandler, runTest} from "../src/test";
 // needed to get colors to show up when passing through Grunt
 (colors as any).enabled = true;
 
+let testDirectories = glob.sync("test/rules/**/tslint.json").map(path.dirname);
+const ruleRegexp = process.argv[2];
+if (ruleRegexp) {
+    const rgx = new RegExp(ruleRegexp);
+    testDirectories = testDirectories.filter(dir => rgx.test(dir));
+}
+
 /* tslint:disable:no-console */
 console.log();
-console.log(colors.underline("Testing Lint Rules:"));
+const matching = ruleRegexp ? ` matching '${ruleRegexp}'` : "";
+console.log(colors.underline(`Testing Lint Rules${matching}:`));
 /* tslint:enable:no-console */
-
-const testDirectories = glob.sync("test/rules/**/tslint.json").map(path.dirname);
 
 for (const testDirectory of testDirectories) {
     const results = runTest(testDirectory);


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update
- [X] Infrastructure

#### What changes did you make?

Added scripts allowing one to run the compiler in `--watch` mode and run specific tests.

#### Is there anything you'd like reviewers to focus on?

* Another idea: could `ruleTestRunner` generate mocha tests? Then we could use mocha's builtin functionality for filtering tests.
* Why does the `test` directory feature its own compilation of `src`, anyway? I was confused when recompiling `src` didn't affect tests.