### PR TITLE
Add "allow-named-functions" option for only-arrow-functions

### DIFF
--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -20,6 +20,7 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 
 const OPTION_ALLOW_DECLARATIONS = "allow-declarations";
+const OPTION_ALLOW_NAMED_FUNCTIONS = "allow-named-functions";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -28,20 +29,21 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Disallows traditional (non-arrow) function expressions.",
         rationale: "Traditional functions don't bind lexical scope, which can lead to unexpected behavior when accessing 'this'.",
         optionsDescription: Lint.Utils.dedent`
-            One argument may be optionally provided:
+            Two arguments may be optionally provided:
 
             * \`"${OPTION_ALLOW_DECLARATIONS}"\` allows standalone function declarations.
+            * \`"${OPTION_ALLOW_NAMED_FUNCTIONS}"\` allows the expression \`function foo() {}\` but not \`function() {}\`.
         `,
         options: {
             type: "array",
             items: {
                 type: "string",
-                enum: [OPTION_ALLOW_DECLARATIONS],
+                enum: [OPTION_ALLOW_DECLARATIONS, OPTION_ALLOW_NAMED_FUNCTIONS],
             },
             minLength: 0,
             maxLength: 1,
         },
-        optionExamples: ["true", `[true, "${OPTION_ALLOW_DECLARATIONS}"]`],
+        optionExamples: ["true", `[true, "${OPTION_ALLOW_DECLARATIONS}", "${OPTION_ALLOW_NAMED_FUNCTIONS}"]`],
         type: "typescript",
         typescriptOnly: false,
     };
@@ -63,7 +65,9 @@ class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
     }
 
     public visitFunctionExpression(node: ts.FunctionExpression) {
-        this.failUnlessExempt(node);
+        if (!(node.name && this.hasOption(OPTION_ALLOW_NAMED_FUNCTIONS))) {
+            this.failUnlessExempt(node);
+        }
         super.visitFunctionExpression(node);
     }
 

--- a/test/rules/only-arrow-functions/allow-named-functions/test.js.lint
+++ b/test/rules/only-arrow-functions/allow-named-functions/test.js.lint
@@ -1,0 +1,5 @@
+const x = function() {}
+          ~~~~~~~~      [0]
+const y = function y() {}
+
+[0]: non-arrow functions are forbidden

--- a/test/rules/only-arrow-functions/allow-named-functions/test.ts.lint
+++ b/test/rules/only-arrow-functions/allow-named-functions/test.ts.lint
@@ -1,0 +1,5 @@
+const x = function() {}
+          ~~~~~~~~      [0]
+const y = function y() {}
+
+[0]: non-arrow functions are forbidden

--- a/test/rules/only-arrow-functions/allow-named-functions/tslint.json
+++ b/test/rules/only-arrow-functions/allow-named-functions/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "only-arrow-functions": [true, "allow-named-functions"]
+  },
+  "jsRules": {
+    "only-arrow-functions": [true, "allow-named-functions"]
+  }
+}


### PR DESCRIPTION
Fixes #1509

#### PR checklist

- [X] Addresses an existing issue: #1509
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### What changes did you make?

Added an `allow-named-functions` option that allows function expressions with names.
