### PR TITLE
Don't error for misplaced braces for 'else' if there are no braces

### DIFF
--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -69,7 +69,8 @@ class OneLineWalker extends Lint.RuleWalker {
     public visitIfStatement(node: ts.IfStatement) {
         const sourceFile = node.getSourceFile();
         const thenStatement = node.thenStatement;
-        if (thenStatement.kind === ts.SyntaxKind.Block) {
+        const thenIsBlock = thenStatement.kind === ts.SyntaxKind.Block;
+        if (thenIsBlock) {
             const expressionCloseParen = node.getChildAt(3);
             const thenOpeningBrace = thenStatement.getChildAt(0);
             this.handleOpeningBrace(expressionCloseParen, thenOpeningBrace);
@@ -83,7 +84,7 @@ class OneLineWalker extends Lint.RuleWalker {
                 const elseOpeningBrace = elseStatement.getChildAt(0);
                 this.handleOpeningBrace(elseKeyword, elseOpeningBrace);
             }
-            if (this.hasOption(OPTION_ELSE)) {
+            if (thenIsBlock && this.hasOption(OPTION_ELSE)) {
                 const thenStatementEndLine = sourceFile.getLineAndCharacterOfPosition(thenStatement.getEnd()).line;
                 const elseKeywordLine = sourceFile.getLineAndCharacterOfPosition(elseKeyword.getStart()).line;
                 if (thenStatementEndLine !== elseKeywordLine) {

--- a/test/rules/one-line/all/test.js.lint
+++ b/test/rules/one-line/all/test.js.lint
@@ -108,3 +108,9 @@ let geoConfig
     timeout: 5000,
     enableHighAccuracy: false
 };
+
+// No error if there are no braces
+if (true)
+    true;
+else
+    false;

--- a/test/rules/one-line/all/test.ts.lint
+++ b/test/rules/one-line/all/test.ts.lint
@@ -143,3 +143,9 @@ let geoConfig: {
 
 declare module "*";
 declare module "someLibrary/*";
+
+// No error if there are no braces
+if (true)
+    true;
+else
+    false;

--- a/test/rules/one-line/none/test.js.lint
+++ b/test/rules/one-line/none/test.js.lint
@@ -64,7 +64,7 @@ while(x < 10){
     x++;
 }
 
-class BarBooBaz 
+class BarBooBaz
 {
 
 }
@@ -90,3 +90,9 @@ let geoConfig
     timeout: 5000,
     enableHighAccuracy: false
 };
+
+// No error if there are no braces
+if (true)
+    true;
+else
+    false;

--- a/test/rules/one-line/none/test.ts.lint
+++ b/test/rules/one-line/none/test.ts.lint
@@ -86,7 +86,7 @@ function f():
     return 5;
 }
 
-class BarBooBaz 
+class BarBooBaz
 {
 
 }
@@ -122,3 +122,9 @@ let geoConfig: {
 
 declare module "*";
 declare module "someLibrary/*";
+
+// No error if there are no braces
+if (true)
+    true;
+else
+    false;


### PR DESCRIPTION
Fixes #400.

#### PR checklist

- [X] Addresses an existing issue: #400
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### What changes did you make?

Stop `one-line` from reporting an error for `else` when there are no braces.