### PR TITLE
Remove extra bracket in completed-docs example

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -35,7 +35,7 @@ export class Rule extends Lint.Rules.TypedRule {
                 enum: ["classes", "functions", "methods", "properties"],
             },
         },
-        optionExamples: ["true", `[true, ["classes", "functions"]`],
+        optionExamples: ["true", `[true, "classes", "functions"]`],
         type: "style",
         typescriptOnly: false,
     };


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### What changes did you make?

Explained in title -- solely documentation; no code changes.

---

If you assume (wrongly) as I did, that the implied format is `[true, ["classes", "methods"]]`, the rule will "run" with all check types disabled. Oops. :D