### PR TITLE
Fix string quotes on docs rule array-type

### DIFF
--- a/docs/rules/array-type/index.html
+++ b/docs/rules/array-type/index.html
@@ -15,9 +15,9 @@ options:
     - generic
     - array-simple
 optionExamples:
-  - '[true, array]'
-  - '[true, generic]'
-  - '[true, array-simple]'
+  - '[true, "array"]'
+  - '[true, "generic"]'
+  - '[true, "array-simple"]'
 type: style
 typescriptOnly: true
 layout: rule

--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -21,7 +21,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "string",
             enum: [OPTION_ARRAY, OPTION_GENERIC, OPTION_ARRAY_SIMPLE],
         },
-        optionExamples: [`[true, ${OPTION_ARRAY}]`, `[true, ${OPTION_GENERIC}]`, `[true, ${OPTION_ARRAY_SIMPLE}]`],
+        optionExamples: [`[true, "${OPTION_ARRAY}"]`, `[true, "${OPTION_GENERIC}"]`, `[true, "${OPTION_ARRAY_SIMPLE}"]`],
         type: "style",
         typescriptOnly: true,
     };


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
- [ ] Includes tests
- [x] Documentation update

#### What changes did you make?

The generated docs page for this rule is missing string quotes, so a copy/paste of the rule into `tslint.json` fails.

#### Is there anything you'd like reviewers to focus on?

(optional)

