### PR TITLE
Add `no-empty-interface` rule

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -162,7 +162,7 @@
   {
     "ruleName": "cyclomatic-complexity",
     "description": "Enforces a threshold of cyclomatic complexity.",
-    "descriptionDetails": "\nCyclomatic complexity is assessed for each function of any type. A starting value of 1\nis assigned and this value is then incremented for every statement which can branch the\ncontrol flow within the function. The following statements and expressions contribute\nto cyclomatic complexity:\n* `catch`\n* `if` and `? :`\n* `||` and `&&` due to short-circuit evaluation\n* `for`, `for in` and `for of` loops\n* `while` and `do while` loops",
+    "descriptionDetails": "\nCyclomatic complexity is assessed for each function of any type. A starting value of 20\nis assigned and this value is then incremented for every statement which can branch the\ncontrol flow within the function. The following statements and expressions contribute\nto cyclomatic complexity:\n* `catch`\n* `if` and `? :`\n* `||` and `&&` due to short-circuit evaluation\n* `for`, `for in` and `for of` loops\n* `while` and `do while` loops",
     "rationale": "\nCyclomatic complexity is a code metric which indicates the level of complexity in a\nfunction. High cyclomatic complexity indicates confusing code which may be prone to\nerrors or difficult to modify.",
     "optionsDescription": "\nAn optional upper limit for cyclomatic complexity can be specified. If no limit option\nis provided a default value of $(Rule.DEFAULT_THRESHOLD) will be used.",
     "options": {
@@ -599,6 +599,18 @@
     ],
     "type": "functionality",
     "typescriptOnly": false
+  },
+  {
+    "ruleName": "no-empty-interface",
+    "description": "Forbids empty interfaces.",
+    "rationale": "An empty interface is equivalent to its supertype (or `{}`).",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "typescript",
+    "typescriptOnly": true
   },
   {
     "ruleName": "no-empty",

--- a/docs/rules/cyclomatic-complexity/index.html
+++ b/docs/rules/cyclomatic-complexity/index.html
@@ -3,7 +3,7 @@ ruleName: cyclomatic-complexity
 description: Enforces a threshold of cyclomatic complexity.
 descriptionDetails: |-
 
-  Cyclomatic complexity is assessed for each function of any type. A starting value of 1
+  Cyclomatic complexity is assessed for each function of any type. A starting value of 20
   is assigned and this value is then incremented for every statement which can branch the
   control flow within the function. The following statements and expressions contribute
   to cyclomatic complexity:

--- a/docs/rules/no-empty-interface/index.html
+++ b/docs/rules/no-empty-interface/index.html
@@ -1,0 +1,14 @@
+---
+ruleName: no-empty-interface
+description: Forbids empty interfaces.
+rationale: 'An empty interface is equivalent to its supertype (or `{}`).'
+optionsDescription: Not configurable.
+options: null
+optionExamples:
+  - 'true'
+type: typescript
+typescriptOnly: true
+layout: rule
+title: 'Rule: no-empty-interface'
+optionsJSON: 'null'
+---

--- a/src/rules/noEmptyInterfaceRule.ts
+++ b/src/rules/noEmptyInterfaceRule.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-empty-interface",
+        description: "Forbids empty interfaces.",
+        rationale: "An empty interface is equivalent to its supertype (or `{}`).",
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "typescript",
+        typescriptOnly: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "An empty interface is equivalent to `{}`.";
+    public static FAILURE_STRING_FOR_EXTENDS = "An interface declaring no members is equivalent to its supertype.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+    }
+}
+
+class Walker extends Lint.RuleWalker {
+    public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
+        if (node.members.length === 0) {
+            this.addFailureAtNode(node.name, node.heritageClauses ? Rule.FAILURE_STRING_FOR_EXTENDS : Rule.FAILURE_STRING);
+        }
+        super.visitInterfaceDeclaration(node);
+    }
+}

--- a/test/rules/no-empty-interface/test.ts.lint
+++ b/test/rules/no-empty-interface/test.ts.lint
@@ -1,0 +1,7 @@
+interface I { }
+          ~     [An empty interface is equivalent to `{}`.]
+
+interface J extends I { }
+          ~               [An interface declaring no members is equivalent to its supertype.]
+
+interface K { x: number; }

--- a/test/rules/no-empty-interface/tslint.json
+++ b/test/rules/no-empty-interface/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-empty-interface": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1844
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### What changes did you make?

Added the `no-empty-interface` rule. This forbids interfaces with no members.

#### Is there anything you'd like reviewers to focus on?

If `docs` is generated from `src`, why is it checked in?
Also, should this be part of `tslint:latest`?