### PR TITLE
Handle eof in line switches

### DIFF
--- a/src/enableDisableRules.ts
+++ b/src/enableDisableRules.ts
@@ -64,9 +64,13 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
     }
 
     private getStartOfLinePosition(node: ts.SourceFile, position: number, lineOffset = 0) {
-        return node.getPositionOfLineAndCharacter(
-            node.getLineAndCharacterOfPosition(position).line + lineOffset, 0,
-        );
+        const line = ts.getLineAndCharacterOfPosition(node, position).line + lineOffset;
+        const lineStarts = node.getLineStarts();
+        if (line >= lineStarts.length) {
+            // next line ends with eof or there is no next line
+            return node.getFullWidth();
+        }
+        return lineStarts[line];
     }
 
     private switchRuleState(ruleName: string, isEnabled: boolean, start: number, end?: number): void {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1899
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

To get the end of the `next-line` switch, tslint searches for the start of the line after the next line. If there is no such line, tslint crashed.
This change checks, if the line in question exists. You can now use the next-line switch without even having a next line (which doesn't make sense at first glance, but is useful when linting live during development)

#### Is there anything you'd like reviewers to focus on?

(optional)
