### PR TITLE
Add `no-void-expression` rule

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -59,10 +59,16 @@
     "ruleName": "arrow-parens",
     "description": "Requires parentheses around the parameters of arrow function definitions.",
     "rationale": "Maintains stylistic consistency with other arrow function definitions.",
-    "optionsDescription": "Not configurable.",
-    "options": null,
+    "optionsDescription": "\nif `avoid-on-single-parameter` is specified, then arrow functions with one parameter \nmust not have parentheses if removing them is allowed by TypeScript.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "avoid-on-single-parameter"
+      ]
+    },
     "optionExamples": [
-      "true"
+      "true",
+      "[true, avoid-on-single-parameter]"
     ],
     "type": "style",
     "typescriptOnly": false
@@ -280,7 +286,7 @@
   },
   {
     "ruleName": "interface-over-type-literal",
-    "description": "Prefer an interface declaration over `type T = { ... }`",
+    "description": "Prefer an interface declaration over a type literal (`type T = { ... }`)",
     "rationale": "style",
     "optionsDescription": "Not configurable.",
     "options": null,
@@ -997,6 +1003,15 @@
     ],
     "type": "typescript",
     "typescriptOnly": true
+  },
+  {
+    "ruleName": "no-void-expression",
+    "description": "Requires expressions of type `void` to appear in statement position.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "requiresTypeInfo": true,
+    "type": "functionality",
+    "typescriptOnly": false
   },
   {
     "ruleName": "object-literal-key-quotes",

--- a/docs/rules/arrow-parens/index.html
+++ b/docs/rules/arrow-parens/index.html
@@ -2,13 +2,26 @@
 ruleName: arrow-parens
 description: Requires parentheses around the parameters of arrow function definitions.
 rationale: Maintains stylistic consistency with other arrow function definitions.
-optionsDescription: Not configurable.
-options: null
+optionsDescription: |-
+
+  if `avoid-on-single-parameter` is specified, then arrow functions with one parameter 
+  must not have parentheses if removing them is allowed by TypeScript.
+options:
+  type: string
+  enum:
+    - avoid-on-single-parameter
 optionExamples:
   - 'true'
+  - '[true, avoid-on-single-parameter]'
 type: style
 typescriptOnly: false
 layout: rule
 title: 'Rule: arrow-parens'
-optionsJSON: 'null'
+optionsJSON: |-
+  {
+    "type": "string",
+    "enum": [
+      "avoid-on-single-parameter"
+    ]
+  }
 ---

--- a/docs/rules/interface-over-type-literal/index.html
+++ b/docs/rules/interface-over-type-literal/index.html
@@ -1,6 +1,6 @@
 ---
 ruleName: interface-over-type-literal
-description: 'Prefer an interface declaration over `type T = { ... }`'
+description: 'Prefer an interface declaration over a type literal (`type T = { ... }`)'
 rationale: style
 optionsDescription: Not configurable.
 options: null

--- a/docs/rules/no-void-expression/index.html
+++ b/docs/rules/no-void-expression/index.html
@@ -1,0 +1,12 @@
+---
+ruleName: no-void-expression
+description: Requires expressions of type `void` to appear in statement position.
+optionsDescription: Not configurable.
+options: null
+requiresTypeInfo: true
+type: functionality
+typescriptOnly: false
+layout: rule
+title: 'Rule: no-void-expression'
+optionsJSON: 'null'
+---

--- a/src/rules/noVoidExpressionRule.ts
+++ b/src/rules/noVoidExpressionRule.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+import { isTypeFlagSet } from "../language/utils";
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-void-expression",
+        description: "Requires expressions of type `void` to appear in statement position.",
+        optionsDescription: "Not configurable.",
+        options: null,
+        requiresTypeInfo: true,
+        type: "functionality",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Expression has type `void`. Put it on its own line as a statement.";
+
+    public applyWithProgram(sourceFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
+        return this.applyWithWalker(new Walker(sourceFile, this.getOptions(), langSvc.getProgram()));
+    }
+}
+
+class Walker extends Lint.ProgramAwareRuleWalker {
+    public visitNode(node: ts.Node) {
+        if (isPossiblyVoidExpression(node) && node.parent!.kind !== ts.SyntaxKind.ExpressionStatement && this.isVoid(node)) {
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
+        }
+        super.visitNode(node);
+    }
+
+    private isVoid(node: ts.Node): boolean {
+        return isTypeFlagSet(this.getTypeChecker().getTypeAtLocation(node), ts.TypeFlags.Void);
+    }
+}
+
+function isPossiblyVoidExpression(node: ts.Node): boolean {
+    switch (node.kind) {
+        case ts.SyntaxKind.AwaitExpression:
+        case ts.SyntaxKind.CallExpression:
+        case ts.SyntaxKind.TaggedTemplateExpression:
+            return true;
+        default:
+            return false;
+    }
+}

--- a/test/rules/no-void-expression/test.js.lint
+++ b/test/rules/no-void-expression/test.js.lint
@@ -1,0 +1,14 @@
+function doIt() {}
+async function doAsync() {}
+function print(strs) {}
+
+async function f() {
+    const x = doIt();
+              ~~~~~~  [0]
+    console.log(await doAsync());
+                ~~~~~~~~~~~~~~~  [0]
+    return print``;
+           ~~~~~~~  [0]
+}
+
+[0]: Expression has type `void`. Put it on its own line as a statement.

--- a/test/rules/no-void-expression/test.ts.lint
+++ b/test/rules/no-void-expression/test.ts.lint
@@ -1,0 +1,14 @@
+async function f(): Promise<void> {
+    const x = doIt();
+              ~~~~~~  [0]
+    console.log(await doAsync());
+                ~~~~~~~~~~~~~~~  [0]
+    return print``;
+           ~~~~~~~  [0]
+}
+
+declare function doIt(): void;
+declare function doAsync(): Promise<void>;
+declare function print(strs: TemplateStringsArray): void;
+
+[0]: Expression has type `void`. Put it on its own line as a statement.

--- a/test/rules/no-void-expression/tsconfig.json
+++ b/test/rules/no-void-expression/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "allowJs": true
+    }
+}

--- a/test/rules/no-void-expression/tslint.json
+++ b/test/rules/no-void-expression/tslint.json
@@ -1,0 +1,11 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "no-void-expression": true
+  },
+  "jsRules": {
+    "no-void-expression": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1383
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### What changes did you make?

Added the `no-void-expression` rule, which requires that any expression of type `void` go on its own line as a statement.