### PR TITLE
Simplify no-namespace implementation and add tests for `declare global` and declaration files.

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -59,10 +59,16 @@
     "ruleName": "arrow-parens",
     "description": "Requires parentheses around the parameters of arrow function definitions.",
     "rationale": "Maintains stylistic consistency with other arrow function definitions.",
-    "optionsDescription": "Not configurable.",
-    "options": null,
+    "optionsDescription": "\nif `avoid-on-single-parameter` is specified, then arrow functions with one parameter \nmust not have parentheses if removing them is allowed by TypeScript.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "avoid-on-single-parameter"
+      ]
+    },
     "optionExamples": [
-      "true"
+      "true",
+      "[true, avoid-on-single-parameter]"
     ],
     "type": "style",
     "typescriptOnly": false
@@ -280,7 +286,7 @@
   },
   {
     "ruleName": "interface-over-type-literal",
-    "description": "Prefer an interface declaration over `type T = { ... }`",
+    "description": "Prefer an interface declaration over a type literal (`type T = { ... }`)",
     "rationale": "style",
     "optionsDescription": "Not configurable.",
     "options": null,

--- a/docs/rules/arrow-parens/index.html
+++ b/docs/rules/arrow-parens/index.html
@@ -2,13 +2,26 @@
 ruleName: arrow-parens
 description: Requires parentheses around the parameters of arrow function definitions.
 rationale: Maintains stylistic consistency with other arrow function definitions.
-optionsDescription: Not configurable.
-options: null
+optionsDescription: |-
+
+  if `avoid-on-single-parameter` is specified, then arrow functions with one parameter 
+  must not have parentheses if removing them is allowed by TypeScript.
+options:
+  type: string
+  enum:
+    - avoid-on-single-parameter
 optionExamples:
   - 'true'
+  - '[true, avoid-on-single-parameter]'
 type: style
 typescriptOnly: false
 layout: rule
 title: 'Rule: arrow-parens'
-optionsJSON: 'null'
+optionsJSON: |-
+  {
+    "type": "string",
+    "enum": [
+      "avoid-on-single-parameter"
+    ]
+  }
 ---

--- a/docs/rules/interface-over-type-literal/index.html
+++ b/docs/rules/interface-over-type-literal/index.html
@@ -1,6 +1,6 @@
 ---
 ruleName: interface-over-type-literal
-description: 'Prefer an interface declaration over `type T = { ... }`'
+description: 'Prefer an interface declaration over a type literal (`type T = { ... }`)'
 rationale: style
 optionsDescription: Not configurable.
 options: null

--- a/test/rules/no-namespace/allow-declarations/test.d.ts.lint
+++ b/test/rules/no-namespace/allow-declarations/test.d.ts.lint
@@ -1,0 +1,1 @@
+namespace N { }

--- a/test/rules/no-namespace/allow-declarations/test.ts.lint
+++ b/test/rules/no-namespace/allow-declarations/test.ts.lint
@@ -1,3 +1,5 @@
+declare global {}
+
 declare namespace Foo {
     // Allowed because namespaces nested in ambients are implicitly ambient.
     namespace Foo {

--- a/test/rules/no-namespace/default/test.d.ts.lint
+++ b/test/rules/no-namespace/default/test.d.ts.lint
@@ -1,0 +1,2 @@
+namespace N { }
+~~~~~~~~~~~~~~~ ['namespace' and 'module' are disallowed]


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1833
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update (N/A)

#### What changes did you make?

Simplified the `no-namespace` implementation.

#### Is there anything you'd like reviewers to focus on?

It no longer recurses through modules.
No need to recurse through declarations because they can only contain other declarations.
No need to recurse through non-declarations because we would have added a failure for the root namespace anyway.

**EDIT**: actually, it looks like this does *not* fix #1833. That was already fixed, probably by #1836.