### PR TITLE
Support object-destructuring mutation in prefer-const

### DIFF
--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -113,6 +113,22 @@ class PreferConstWalker extends Lint.BlockScopeAwareRuleWalker<{}, ScopeInfo> {
                 // recursively unwrap destructuring arrays
                 this.handleLHSExpression(child);
             });
+        } else if (node.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+            for (const prop of (node as ts.ObjectLiteralExpression).properties) {
+                switch (prop.kind) {
+                    case ts.SyntaxKind.PropertyAssignment:
+                        this.handleLHSExpression(prop.initializer);
+                        break;
+                    case ts.SyntaxKind.ShorthandPropertyAssignment:
+                        this.handleLHSExpression(prop.name);
+                        break;
+                    case ts.SyntaxKind.SpreadAssignment:
+                        this.handleLHSExpression(prop.expression);
+                        break;
+                    default:
+                        break;
+                }
+            }
         }
     }
 

--- a/test/rules/prefer-const/test.ts.fix
+++ b/test/rules/prefer-const/test.ts.fix
@@ -22,8 +22,15 @@ let c3 = 1, c4 = 2; // 1 failure
 c3 = 4;
 
 // destructuring
-let destructLater = 4;
-[destructLater] = 5;
+{
+    let destructLater = 4;
+    [destructLater] = 5;
+    let a: number;
+    let b: number;
+    let c: any;
+    ({ eh: a, b, ...c } = { eh: 0, b: 1 });
+}
+
 let {h, i} = {h: 1, i: 1}; // failure for 'h'
 let [j, k] = [1, 1]; // failure for 'j'
 let [x1, x3] = [1, 2], [x2] = [3]; // failure for x1, x3

--- a/test/rules/prefer-const/test.ts.lint
+++ b/test/rules/prefer-const/test.ts.lint
@@ -26,8 +26,15 @@ let c3 = 1, c4 = 2; // 1 failure
 c3 = 4;
 
 // destructuring
-let destructLater = 4;
-[destructLater] = 5;
+{
+    let destructLater = 4;
+    [destructLater] = 5;
+    let a: number;
+    let b: number;
+    let c: any;
+    ({ eh: a, b, ...c } = { eh: 0, b: 1 });
+}
+
 let {h, i} = {h: 1, i: 1}; // failure for 'h'
      ~                                        [Identifier 'h' is never reassigned; use 'const' instead of 'let'.]
 let [j, k] = [1, 1]; // failure for 'j'


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1898 (partial fix)
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update (N/A)

#### What changes did you make?

Supported `({ x } = obj)` mutation statements in the `prefer-const` rule.