### PR TITLE
handle forward referenced in prefer-const rule

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -145,6 +145,24 @@ export function isNodeFlagSet(node: ts.Node, flagToCheck: ts.NodeFlags): boolean
 }
 
 /**
+ * Bitwise check for combined node flags.
+ */
+export function isCombinedNodeFlagSet(node: ts.Node, flagToCheck: ts.NodeFlags): boolean {
+    /* tslint:disable:no-bitwise */
+    return (ts.getCombinedNodeFlags(node) & flagToCheck) !== 0;
+    /* tslint:enable:no-bitwise */
+}
+
+/**
+ * Bitwise check for combined modifier flags.
+ */
+export function isCombinedModifierFlagSet(node: ts.Node, flagToCheck: ts.ModifierFlags): boolean {
+    /* tslint:disable:no-bitwise */
+    return (ts.getCombinedModifierFlags(node) & flagToCheck) !== 0;
+    /* tslint:enable:no-bitwise */
+}
+
+/**
  * Bitwise check for type flags.
  */
 export function isTypeFlagSet(type: ts.Type, flagToCheck: ts.TypeFlags): boolean {

--- a/src/language/walker/blockScopeAwareRuleWalker.ts
+++ b/src/language/walker/blockScopeAwareRuleWalker.ts
@@ -30,10 +30,10 @@ export abstract class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalk
         super(sourceFile, options);
 
         // initialize with global scope if file is not a module
-        this.blockScopeStack = this.fileIsModule ? [] : [this.createBlockScope()];
+        this.blockScopeStack = this.fileIsModule ? [] : [this.createBlockScope(sourceFile)];
     }
 
-    public abstract createBlockScope(): U;
+    public abstract createBlockScope(node: ts.Node): U;
 
     // get all block scopes available at this depth
     public getAllBlockScopes(): U[] {
@@ -62,7 +62,7 @@ export abstract class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalk
         const isNewBlockScope = this.isBlockScopeBoundary(node);
 
         if (isNewBlockScope) {
-            this.blockScopeStack.push(this.createBlockScope());
+            this.blockScopeStack.push(this.createBlockScope(node));
             this.onBlockScopeStart();
         }
 

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -87,8 +87,11 @@ class PreferConstWalker extends Lint.BlockScopeAwareRuleWalker<{}, ScopeInfo> {
             case ts.SyntaxKind.Block:
                 PreferConstWalker.collect((node as ts.Block).statements, scopeInfo);
                 break;
-            case ts.SyntaxKind.ModuleBlock:
-                PreferConstWalker.collect((node as ts.ModuleBlock).statements, scopeInfo);
+            case ts.SyntaxKind.ModuleDeclaration:
+                const body = (node as ts.ModuleDeclaration).body;
+                if (body && body.kind === ts.SyntaxKind.ModuleBlock) {
+                    PreferConstWalker.collect((body as ts.ModuleBlock).statements, scopeInfo);
+                }
                 break;
             case ts.SyntaxKind.ForStatement:
             case ts.SyntaxKind.ForOfStatement:

--- a/test/rules/prefer-const/test.ts.fix
+++ b/test/rules/prefer-const/test.ts.fix
@@ -129,3 +129,7 @@ function useOfForwardDecl() {
 }
 
 let forwardDecl: number;
+
+module E {
+    const x = 1;
+}

--- a/test/rules/prefer-const/test.ts.fix
+++ b/test/rules/prefer-const/test.ts.fix
@@ -133,3 +133,12 @@ let forwardDecl: number;
 module E {
     const x = 1;
 }
+
+switch (1) {
+    case 1:
+        const x = 1;
+        break;
+    case 2:
+        const y = 1;
+        break;
+}

--- a/test/rules/prefer-const/test.ts.fix
+++ b/test/rules/prefer-const/test.ts.fix
@@ -122,3 +122,10 @@ const arr = [];
 arr.push(0);
 arr[1] = 1;
 arr.length = 1;
+
+// reassignment of the forward declaration
+function useOfForwardDecl() {
+    forwardDecl = 1;
+}
+
+let forwardDecl: number;

--- a/test/rules/prefer-const/test.ts.lint
+++ b/test/rules/prefer-const/test.ts.lint
@@ -156,3 +156,14 @@ module E {
     let x = 1;
         ~      [Identifier 'x' is never reassigned; use 'const' instead of 'let'.]
 }
+
+switch (1) {
+    case 1:
+        let x = 1;
+            ~      [Identifier 'x' is never reassigned; use 'const' instead of 'let'.]
+        break;
+    case 2:
+        let y = 1;
+            ~      [Identifier 'y' is never reassigned; use 'const' instead of 'let'.]
+        break;
+}

--- a/test/rules/prefer-const/test.ts.lint
+++ b/test/rules/prefer-const/test.ts.lint
@@ -151,3 +151,8 @@ function useOfForwardDecl() {
 }
 
 let forwardDecl: number;
+
+module E {
+    let x = 1;
+        ~      [Identifier 'x' is never reassigned; use 'const' instead of 'let'.]
+}

--- a/test/rules/prefer-const/test.ts.lint
+++ b/test/rules/prefer-const/test.ts.lint
@@ -144,3 +144,10 @@ let arr = [];
 arr.push(0);
 arr[1] = 1;
 arr.length = 1;
+
+// reassignment of the forward declaration
+function useOfForwardDecl() {
+    forwardDecl = 1;
+}
+
+let forwardDecl: number;


### PR DESCRIPTION
fixes error related to usage of forward references in `prefer-const` rule
#### PR checklist

- [x] Addresses an existing issue: https://github.com/palantir/tslint/issues/1898
- [x] New feature, bugfix, or enhancement - bugfix
  - [x] Includes tests
- [ ] Documentation update - N/A

#### What changes did you make?
After this change list of variable declarations in block scope is collected immediately after entering the scope. This prevents cases when variable is syntactically located after its usage 

