### PR TITLE
Consider rest operator in object literal in `object-literal-key-quotes` rule

### DIFF
--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -101,7 +101,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
                 }
                 break;
             case "consistent-as-needed":
-                if (properties.some(({ name }) => name.kind === ts.SyntaxKind.StringLiteral && propertyNeedsQuotes(name.text))) {
+                if (properties.some(({ name }) => name !== undefined && name.kind === ts.SyntaxKind.StringLiteral && propertyNeedsQuotes(name.text))) {
                     this.allMustHaveQuotes(properties);
                 } else {
                     this.noneMayHaveQuotes(properties, true);
@@ -116,7 +116,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
 
     private allMustHaveQuotes(properties: ts.ObjectLiteralElementLike[]) {
         for (const { name } of properties) {
-            if (name.kind !== ts.SyntaxKind.StringLiteral && name.kind !== ts.SyntaxKind.ComputedPropertyName) {
+            if (name !== undefined && name.kind !== ts.SyntaxKind.StringLiteral && name.kind !== ts.SyntaxKind.ComputedPropertyName) {
                 this.addFailureAtNode(name, Rule.UNQUOTED_PROPERTY(name.getText()));
             }
         }
@@ -124,7 +124,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
 
     private noneMayHaveQuotes(properties: ts.ObjectLiteralElementLike[], noneNeedQuotes?: boolean) {
         for (const { name } of properties) {
-            if (name.kind === ts.SyntaxKind.StringLiteral && (noneNeedQuotes || !propertyNeedsQuotes(name.text))) {
+            if (name !== undefined && name.kind === ts.SyntaxKind.StringLiteral && (noneNeedQuotes || !propertyNeedsQuotes(name.text))) {
                 this.addFailureAtNode(name, Rule.UNNEEDED_QUOTES(name.text));
             }
         }

--- a/test/rules/object-literal-key-quotes/as-needed/test.ts.lint
+++ b/test/rules/object-literal-key-quotes/as-needed/test.ts.lint
@@ -20,4 +20,5 @@ const o = {
   "true": 0, // failure
   ~~~~~~  [Unnecessarily quoted property 'true' found.]
   '': 'always quote the empty string',
+  ...{},
 };

--- a/test/rules/object-literal-key-quotes/consistent-as-needed/test.ts.lint
+++ b/test/rules/object-literal-key-quotes/consistent-as-needed/test.ts.lint
@@ -48,3 +48,6 @@ const u = {
     ~~~~~     [Unnecessarily quoted property 'egg' found.]
   }
 };
+const v = {
+    ...o,
+};


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1916
- [x] bugfix
  - [x] Includes tests
- [x] Documentation update **I think this change does not need document update**

#### What changes did you make?

Check an object's property has a name actually because property expanding with rest operator does not have a name.

#### Is there anything you'd like reviewers to focus on?

nothing special
