### PR TITLE
Allow consecutive blank lines in template strings

### DIFF
--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -64,9 +64,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
-class NoConsecutiveBlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
-    public visitSourceFile(node: ts.SourceFile) {
-        super.visitSourceFile(node);
+class NoConsecutiveBlankLinesWalker extends Lint.RuleWalker {
+    public walk(node: ts.SourceFile) {
+        const templateIntervals = this.getTemplateIntervals(node);
+        const lineStarts = node.getLineStarts();
 
         const options = this.getOptions();
         const allowedBlanks = options && options[0] || Rule.DEFAULT_ALLOWED_BLANKS;
@@ -92,9 +93,25 @@ class NoConsecutiveBlankLinesWalker extends Lint.SkippableTokenAwareRuleWalker {
         sequences
             .filter((arr) => arr.length > allowedBlanks)
             .map((arr) => arr[0])
-            .forEach((startLineNum: number) => {
-                let startCharPos = node.getPositionOfLineAndCharacter(startLineNum + 1, 0);
-                this.addFailureAt(startCharPos, 1, failureMessage);
-            });
+            .map((startLineNum: number) => this.createFailure(lineStarts[startLineNum + 1], 1, failureMessage))
+            .filter((failure) => !Lint.doesIntersect(failure, templateIntervals))
+            .forEach((failure) => this.addFailure(failure));
+    }
+
+    private getTemplateIntervals(sourceFile: ts.SourceFile): Lint.IDisabledInterval[] {
+        const intervals: Lint.IDisabledInterval[] = [];
+        const cb = (node: ts.Node) => {
+            if (node.kind >= ts.SyntaxKind.FirstTemplateToken &&
+                node.kind <= ts.SyntaxKind.LastTemplateToken) {
+                intervals.push({
+                    endPosition: node.getEnd(),
+                    startPosition: node.getStart(sourceFile),
+                });
+            } else {
+                ts.forEachChild(node, cb);
+            }
+        };
+        ts.forEachChild(sourceFile, cb);
+        return intervals;
     }
 }

--- a/test/rules/no-consecutive-blank-lines/default/test.ts.lint
+++ b/test/rules/no-consecutive-blank-lines/default/test.ts.lint
@@ -30,3 +30,13 @@ class Clazz { // comment
 ~ [Consecutive blank lines are forbidden]
 		
 		
+let foo = `
+ 
+ 
+`;
+
+let bar = `${bar
+ 
+ 
+~ [Consecutive blank lines are forbidden]
+}`;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1886 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### What changes did you make?

Find all template strings in AST and use their start and end position as disabled interval to filter failures.

Expressions inside the template string are still checked for consecutive blank lines. See added test cases.
