### PR TITLE
Fix build

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -83,8 +83,8 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
                 getNewLine: () => "\n",
                 getSourceFile(filenameToGet: string) {
                     if (filenameToGet === this.getDefaultLibFileName()) {
-                        const fileText = fs.readFileSync(ts.getDefaultLibFilePath(compilerOptions)).toString();
-                        return ts.createSourceFile(filenameToGet, fileText, compilerOptions.target);
+                        const fileContent = fs.readFileSync(ts.getDefaultLibFilePath(compilerOptions)).toString();
+                        return ts.createSourceFile(filenameToGet, fileContent, compilerOptions.target);
                     } else if (filenameToGet === fileCompileName) {
                         return ts.createSourceFile(fileBasename, fileTextWithoutMarkup, compilerOptions.target, true);
                     } else if (fs.existsSync(path.resolve(path.dirname(fileToLint), filenameToGet))) {


### PR DESCRIPTION
Rename shadowed variable fileText to pass build.

Ref: #1919

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

Build fails because tslint 4.2 now complains about shadowed variable `fileText`, so I renamed it.
