### PR TITLE
Semicolon comma fix (fixes #1856) 

### DIFF
--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -101,7 +101,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
                 }
                 break;
             case "consistent-as-needed":
-                if (properties.some(({ name }) => name !== undefined 
+                if (properties.some(({ name }) => name !== undefined
                     && name.kind === ts.SyntaxKind.StringLiteral && propertyNeedsQuotes(name.text))) {
 
                     this.allMustHaveQuotes(properties);

--- a/test/rules/semicolon/always/test.ts.fix
+++ b/test/rules/semicolon/always/test.ts.fix
@@ -66,8 +66,8 @@ class MyClass {
 
 interface ITest {
     foo?: string;
-    bar: number;
-    qux: string;
+    bar: number; // handles comment
+    qux: string; // handles comment
     baz: boolean;
     readonly raz: number;
 }

--- a/test/rules/semicolon/always/test.ts.fix
+++ b/test/rules/semicolon/always/test.ts.fix
@@ -69,7 +69,6 @@ interface ITest {
     bar: number;
     qux: string;
     baz: boolean;
-
     readonly raz: number;
 }
 

--- a/test/rules/semicolon/always/test.ts.lint
+++ b/test/rules/semicolon/always/test.ts.lint
@@ -92,9 +92,8 @@ interface ITest {
     bar: number
                ~nil [Missing semicolon]
     qux: string,
-                ~nil [Missing semicolon]
+               ~nil [Interface properties should be separated by semicolons]
     baz: boolean;
-
     readonly raz: number;
 }
 

--- a/test/rules/semicolon/always/test.ts.lint
+++ b/test/rules/semicolon/always/test.ts.lint
@@ -89,9 +89,9 @@ class MyClass {
 interface ITest {
     foo?: string
                 ~nil [Missing semicolon]
-    bar: number
+    bar: number // handles comment
                ~nil [Missing semicolon]
-    qux: string,
+    qux: string, // handles comment
                ~nil [Interface properties should be separated by semicolons]
     baz: boolean;
     readonly raz: number;

--- a/test/rules/semicolon/enabled/test.ts.lint
+++ b/test/rules/semicolon/enabled/test.ts.lint
@@ -96,7 +96,7 @@ interface ITest {
     bar: number
                ~nil [Missing semicolon]
     qux: string,
-                ~nil [Missing semicolon]
+               ~nil [Interface properties should be separated by semicolons]
     baz: boolean;
 }
 

--- a/test/rules/semicolon/ignore-bound-class-methods/test.ts.fix
+++ b/test/rules/semicolon/ignore-bound-class-methods/test.ts.fix
@@ -67,6 +67,7 @@ class MyClass {
 interface ITest {
     foo?: string;
     bar: number;
+    qux: string;
     baz: boolean;
 }
 

--- a/test/rules/semicolon/ignore-bound-class-methods/test.ts.lint
+++ b/test/rules/semicolon/ignore-bound-class-methods/test.ts.lint
@@ -90,6 +90,8 @@ interface ITest {
                 ~nil [Missing semicolon]
     bar: number
                ~nil [Missing semicolon]
+    qux: string,
+               ~nil [Interface properties should be separated by semicolons]
     baz: boolean;
 }
 

--- a/test/rules/semicolon/ignore-interfaces/test.ts.fix
+++ b/test/rules/semicolon/ignore-interfaces/test.ts.fix
@@ -66,9 +66,8 @@ class MyClass {
 
 interface ITest {
     foo?: string
-
     bar: number
-
+    qux: string,
     baz: boolean;
 }
 

--- a/test/rules/semicolon/ignore-interfaces/test.ts.lint
+++ b/test/rules/semicolon/ignore-interfaces/test.ts.lint
@@ -88,9 +88,8 @@ class MyClass {
 
 interface ITest {
     foo?: string
-
     bar: number
-
+    qux: string,
     baz: boolean;
 }
 

--- a/test/rules/semicolon/never/test.ts.fix
+++ b/test/rules/semicolon/never/test.ts.fix
@@ -66,6 +66,7 @@ class MyClass {
 interface ITest {
     foo?: string
     bar: number
+    qux: string,
     baz: boolean
 }
 

--- a/test/rules/semicolon/never/test.ts.lint
+++ b/test/rules/semicolon/never/test.ts.lint
@@ -94,6 +94,7 @@ interface ITest {
                 ~ [Unnecessary semicolon]
     bar: number;
                ~ [Unnecessary semicolon]
+    qux: string,
     baz: boolean
 }
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1856
- [x] ~New feature,~ bugfix, ~or enhancement~
  - [x] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?
This PR adds new error if interface member has comma instead of semicolon after it and proper fix that replaces comma.
Developers still can use `ignore-interfaces` option to skip commas in interfaces.

Thanks to @greglo for failing test case.