### PR TITLE
Fix preferConstRule failing with older TypeScript versions

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -197,3 +197,18 @@ export function unwrapParentheses(node: ts.Expression) {
     }
     return node;
 }
+
+/**
+ * Shim to look up NodeFlags or ModifierFlags depending on the TypeScript
+ * version, emitting a runtime error if neither can be found.
+ */
+export function isCombinedFlagSet(node: ts.Node, name: string): boolean {
+    if (ts.ModifierFlags && name in ts.ModifierFlags) {
+        return isCombinedModifierFlagSet(node, (<any> ts.ModifierFlags)[name]);
+    }
+    if (ts.NodeFlags && name in ts.NodeFlags) {
+        return isCombinedNodeFlagSet(node, (<any> ts.NodeFlags)[name]);
+    }
+
+    throw new Error(`Cannot find tag "${name}" in either ts.ModifierFlags or ts.NodeFlags`);
+}

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -17,7 +17,12 @@
 
 import * as ts from "typescript";
 import * as Lint from "../index";
-import {isAssignment, isCombinedModifierFlagSet, isCombinedNodeFlagSet, unwrapParentheses} from "../language/utils";
+import {
+    isAssignment,
+    isCombinedFlagSet,
+    isCombinedNodeFlagSet,
+    unwrapParentheses
+} from '../language/utils';
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -54,7 +59,7 @@ class PreferConstWalker extends Lint.BlockScopeAwareRuleWalker<{}, ScopeInfo> {
     }
 
     private static collectInVariableDeclarationList(node: ts.VariableDeclarationList, scopeInfo: ScopeInfo) {
-        if (isCombinedNodeFlagSet(node, ts.NodeFlags.Let) && !isCombinedModifierFlagSet(node, ts.ModifierFlags.Export)) {
+        if (isCombinedNodeFlagSet(node, ts.NodeFlags.Let) && !isCombinedFlagSet(node, 'Export')) {
             for (const decl of node.declarations) {
                 PreferConstWalker.addDeclarationName(decl.name, node, scopeInfo);
             }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1936
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### What changes did you make?

A change introduced in https://github.com/palantir/tslint/pull/1908 broke builds for TypeScript versions converted by tslint's supported version range (running Angular and AoT our setup requires `2.0.10`). This is a bit of a duct-tape to fix that.

#### Is there anything you'd like reviewers to focus on?

In the future CI should test all minor TypeScript versions in the supported range.
