### PR TITLE
Add fix for object-literal-key-quotes

### DIFF
--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -97,6 +97,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
                 break;
             case "consistent":
                 if (quotesAreInconsistent(properties)) {
+                    // No fix -- don't know if they would want to add quotes or remove them.
                     this.addFailureAt(node.getStart(), 1, Rule.INCONSISTENT_PROPERTY);
                 }
                 break;
@@ -119,7 +120,8 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
     private allMustHaveQuotes(properties: ts.ObjectLiteralElementLike[]) {
         for (const { name } of properties) {
             if (name !== undefined && name.kind !== ts.SyntaxKind.StringLiteral && name.kind !== ts.SyntaxKind.ComputedPropertyName) {
-                this.addFailureAtNode(name, Rule.UNQUOTED_PROPERTY(name.getText()));
+                const fix = this.fix(this.appendText(name.getStart(), '"'), this.appendText(name.getEnd(), '"'));
+                this.addFailureAtNode(name, Rule.UNQUOTED_PROPERTY(name.getText()), fix);
             }
         }
     }
@@ -127,9 +129,14 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
     private noneMayHaveQuotes(properties: ts.ObjectLiteralElementLike[], noneNeedQuotes?: boolean) {
         for (const { name } of properties) {
             if (name !== undefined && name.kind === ts.SyntaxKind.StringLiteral && (noneNeedQuotes || !propertyNeedsQuotes(name.text))) {
-                this.addFailureAtNode(name, Rule.UNNEEDED_QUOTES(name.text));
+                const fix = this.fix(this.deleteText(name.getStart(), 1), this.deleteText(name.getEnd() - 1, 1));
+                this.addFailureAtNode(name, Rule.UNNEEDED_QUOTES(name.text), fix);
             }
         }
+    }
+
+    private fix(...replacements: Lint.Replacement[]) {
+        return new Lint.Fix(Rule.metadata.ruleName, replacements);
     }
 }
 

--- a/test/rules/object-literal-key-quotes/always/test.js.fix
+++ b/test/rules/object-literal-key-quotes/always/test.js.fix
@@ -1,0 +1,18 @@
+const o = {
+  'hello': 123,
+  "goodbye": 234, // failure
+  "quote": 345,
+  "needs quote": 789,
+  "hyphens-need-quotes": null,
+  [computed]: 456,
+  "123": "hello", // failure
+  "1e4": "something", // failure
+  ".123": "float", // failure
+  '123': 'numbers do not need quotes',
+  '010': 'but this one does.',
+  '.123': 'as does this one',
+  "fn"() { return },
+  "true": 0, // failure
+  "0x0": 0,
+  "true": 0,
+};

--- a/test/rules/object-literal-key-quotes/always/test.ts.fix
+++ b/test/rules/object-literal-key-quotes/always/test.ts.fix
@@ -1,0 +1,18 @@
+const o = {
+  'hello': 123,
+  "goodbye": 234, // failure
+  "quote": 345,
+  "needs quote": 789,
+  "hyphens-need-quotes": null,
+  [computed]: 456,
+  "123": "hello", // failure
+  "1e4": "something", // failure
+  ".123": "float", // failure
+  '123': 'numbers do not need quotes',
+  '010': 'but this one does.',
+  '.123': 'as does this one',
+  "fn"() { return },
+  "true": 0, // failure
+  "0x0": 0,
+  "true": 0,
+};

--- a/test/rules/object-literal-key-quotes/as-needed/test.js.fix
+++ b/test/rules/object-literal-key-quotes/as-needed/test.js.fix
@@ -1,0 +1,19 @@
+const o = {
+  hello: 123, // failure
+  goodbye: 234,
+  quote: 345, // failure
+  "needs quote": 789,
+  "hyphens-need-quotes": null,
+  [computed]: 456,
+  123: "hello",
+  1e4: "something",
+  .123: "float",
+  123: 'numbers do not need quotes', // failure
+  '010': 'but this one does.',
+  '.123': 'as does this one',
+  fn() { return },
+  true: 0,
+  "0x0": 0,
+  true: 0, // failure
+  '': 'always quote the empty string',
+};

--- a/test/rules/object-literal-key-quotes/as-needed/test.ts.fix
+++ b/test/rules/object-literal-key-quotes/as-needed/test.ts.fix
@@ -1,0 +1,20 @@
+const o = {
+  hello: 123, // failure
+  goodbye: 234,
+  quote: 345, // failure
+  "needs quote": 789,
+  "hyphens-need-quotes": null,
+  [computed]: 456,
+  123: "hello",
+  1e4: "something",
+  .123: "float",
+  123: 'numbers do not need quotes', // failure
+  '010': 'but this one does.',
+  '.123': 'as does this one',
+  fn() { return },
+  true: 0,
+  "0x0": 0,
+  true: 0, // failure
+  '': 'always quote the empty string',
+  ...{},
+};

--- a/test/rules/object-literal-key-quotes/consistent-as-needed/test.js.fix
+++ b/test/rules/object-literal-key-quotes/consistent-as-needed/test.js.fix
@@ -1,0 +1,41 @@
+
+const o = {
+  hello: 123,
+  bye: 45,
+};
+const v = {
+  hello: 123,
+  bye: 45,
+};
+const s = {
+  hello: 123,
+  bye: 45,
+};
+const r = {
+  "hello": 123,
+  "bye-bye": 45,
+};
+const p = {
+  hello: 123,
+  bye: 45,
+};
+const q = {
+  "hello": 123,
+  "bye-bye": 45,
+};
+const t = {
+  hello: 123,
+  bye-bye: 45,
+  nested: {
+    bird: 2,
+    egg: 3,
+  }
+};
+const u = {
+  hello: 123,
+  bye: 45,
+  nested: {
+    bird: 1,
+    egg: 2,
+  }
+};

--- a/test/rules/object-literal-key-quotes/consistent-as-needed/test.ts.fix
+++ b/test/rules/object-literal-key-quotes/consistent-as-needed/test.ts.fix
@@ -1,0 +1,44 @@
+
+const o = {
+  hello: 123,
+  bye: 45,
+};
+const v = {
+  hello: 123,
+  bye: 45,
+};
+const s = {
+  hello: 123,
+  bye: 45,
+};
+const r = {
+  "hello": 123,
+  "bye-bye": 45,
+};
+const p = {
+  hello: 123,
+  bye: 45,
+};
+const q = {
+  "hello": 123,
+  "bye-bye": 45,
+};
+const t = {
+  hello: 123,
+  bye-bye: 45,
+  nested: {
+    bird: 2,
+    egg: 3,
+  }
+};
+const u = {
+  hello: 123,
+  bye: 45,
+  nested: {
+    bird: 1,
+    egg: 2,
+  }
+};
+const v = {
+    ...o,
+};


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1911
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update
- [X] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Added fixes for `object-literal-key-quotes` (except in `consistent` mode, where a fix would be ambiguous).

#### Is there anything you'd like reviewers to focus on?

This always uses double quotes. Might it be possible to peer into the setting for `quotemark` and choose quotes accordingly?
