### PR TITLE
arrow-parens: Allow binding patterns `([x, y]) => ...` and `({x, y}) => ...` to have parens

### DIFF
--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -1,4 +1,6 @@
 // valid case
+var a = ([x, y]) => {};
+var aa = ({x, y}) => {};
 var b = (a: number) => {};
 var c = (a, b) => {};
 var f = (...rest) => {};

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -18,7 +18,7 @@ var piyo = <T, U>(method: () => T) => {
     method();
 };
 const validAsync = async (param: any) => {};
-const validAsync = async (param) => {};
+const invalidAsync = async param => {};
 
 var e = (a => {})(1);
 var f = ab => {};

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -18,10 +18,10 @@ var piyo = <T, U>(method: () => T) => {
     method();
 };
 const validAsync = async (param: any) => {};
-const invalidAsync = async param => {};
 
 var e = (a => {})(1);
 var f = ab => {};
 
 // invalid case
 var a = a => {};
+const invalidAsync = async param => {};

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -1,4 +1,6 @@
 // valid case
+var a = ([x, y]) => {};
+var aa = ({x, y}) => {};
 var b = (a: number) => {};
 var c = (a, b) => {};
 var f = (...rest) => {};

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -18,8 +18,6 @@ var piyo = <T, U>(method: () => T) => {
     method();
 };
 const validAsync = async (param: any) => {};
-const invalidAsync = async (param) => {};
-                            ~~~~~ [0]
 
 var e = (a => {})(1);
 var f = ab => {};
@@ -27,5 +25,7 @@ var f = ab => {};
 // invalid case
 var a = (a) => {};
          ~         [0]
+const invalidAsync = async (param) => {};
+                            ~~~~~ [0]
 
 [0]: Parentheses are prohibited around the parameter in this single parameter arrow function

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -18,11 +18,14 @@ var piyo = <T, U>(method: () => T) => {
     method();
 };
 const validAsync = async (param: any) => {};
-const validAsync = async (param) => {};
+const invalidAsync = async (param) => {};
+                            ~~~~~ [0]
 
 var e = (a => {})(1);
 var f = ab => {};
 
 // invalid case
 var a = (a) => {};
-         ~         [Parentheses are prohibited around the parameter in this single parameter arrow function]
+         ~         [0]
+
+[0]: Parentheses are prohibited around the parameter in this single parameter arrow function


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1955
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update
- [X] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Allowed binding patterns in `arrow-parens`.

#### Is there anything you'd like reviewers to focus on?

Why are async functions excluded from this rule?
**EDIT**: Looks like that was a kludge (#1479). Added support for async functions.