### PR TITLE
Fix only-arrow-functions

### DIFF
--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -58,7 +58,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-        if (!this.hasOption(OPTION_ALLOW_DECLARATIONS)) {
+        if (!this.hasOption(OPTION_ALLOW_DECLARATIONS) && !this.hasOption(OPTION_ALLOW_NAMED_FUNCTIONS)) {
             this.failUnlessExempt(node);
         }
         super.visitFunctionDeclaration(node);

--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -82,19 +82,8 @@ class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
 
     private failUnlessExempt(node: ts.FunctionLikeDeclaration) {
         if (!functionIsExempt(node)) {
-            this.addFailureAtNode(this.getFunctionKeyword(node), Rule.FAILURE_STRING);
+            this.addFailureAtNode(Lint.childOfKind(node, ts.SyntaxKind.FunctionKeyword)!, Rule.FAILURE_STRING);
         }
-    }
-
-    private getFunctionKeyword(node: ts.FunctionLikeDeclaration): ts.Node {
-        let functionKeyword: ts.Node|undefined = undefined;
-        for (const child of node.getChildren(this.getSourceFile())) {
-            if (child.kind === ts.SyntaxKind.FunctionKeyword) {
-                functionKeyword = child;
-                break;
-            }
-        }
-        return functionKeyword!;
     }
 }
 

--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -62,8 +62,8 @@ class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);
-        this.allowDeclarations = options.ruleArguments.indexOf(OPTION_ALLOW_DECLARATIONS) !== -1;
-        this.allowNamedFunctions = options.ruleArguments.indexOf(OPTION_ALLOW_NAMED_FUNCTIONS) !== -1;
+        this.allowDeclarations = this.hasOption(OPTION_ALLOW_DECLARATIONS);
+        this.allowNamedFunctions = this.hasOption(OPTION_ALLOW_NAMED_FUNCTIONS);
     }
 
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {

--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -57,15 +57,24 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
+    private allowDeclarations: boolean;
+    private allowNamedFunctions: boolean;
+
+    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+        super(sourceFile, options);
+        this.allowDeclarations = options.ruleArguments.indexOf(OPTION_ALLOW_DECLARATIONS) !== -1;
+        this.allowNamedFunctions = options.ruleArguments.indexOf(OPTION_ALLOW_NAMED_FUNCTIONS) !== -1;
+    }
+
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
-        if (!this.hasOption(OPTION_ALLOW_DECLARATIONS) && !this.hasOption(OPTION_ALLOW_NAMED_FUNCTIONS)) {
+        if (!this.allowDeclarations && !this.allowNamedFunctions) {
             this.failUnlessExempt(node);
         }
         super.visitFunctionDeclaration(node);
     }
 
     public visitFunctionExpression(node: ts.FunctionExpression) {
-        if (!(node.name && this.hasOption(OPTION_ALLOW_NAMED_FUNCTIONS))) {
+        if (node.name === undefined || !this.allowNamedFunctions) {
             this.failUnlessExempt(node);
         }
         super.visitFunctionExpression(node);

--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -73,8 +73,19 @@ class OnlyArrowFunctionsWalker extends Lint.RuleWalker {
 
     private failUnlessExempt(node: ts.FunctionLikeDeclaration) {
         if (!functionIsExempt(node)) {
-            this.addFailureAt(node.getStart(), "function".length, Rule.FAILURE_STRING);
+            this.addFailureAtNode(this.getFunctionKeyword(node), Rule.FAILURE_STRING);
         }
+    }
+
+    private getFunctionKeyword(node: ts.FunctionLikeDeclaration): ts.Node {
+        let functionKeyword: ts.Node|undefined = undefined;
+        for (const child of node.getChildren(this.getSourceFile())) {
+            if (child.kind === ts.SyntaxKind.FunctionKeyword) {
+                functionKeyword = child;
+                break;
+            }
+        }
+        return functionKeyword!;
     }
 }
 

--- a/test/rules/only-arrow-functions/allow-named-functions/test.js.lint
+++ b/test/rules/only-arrow-functions/allow-named-functions/test.js.lint
@@ -2,4 +2,6 @@ const x = function() {}
           ~~~~~~~~      [0]
 const y = function y() {}
 
+function z() {}
+
 [0]: non-arrow functions are forbidden

--- a/test/rules/only-arrow-functions/allow-named-functions/test.ts.lint
+++ b/test/rules/only-arrow-functions/allow-named-functions/test.ts.lint
@@ -2,4 +2,6 @@ const x = function() {}
           ~~~~~~~~      [0]
 const y = function y() {}
 
+function z() {}
+
 [0]: non-arrow functions are forbidden

--- a/test/rules/only-arrow-functions/default/test.ts.lint
+++ b/test/rules/only-arrow-functions/default/test.ts.lint
@@ -26,4 +26,10 @@ let generator = function*() {}
 function hasThisParameter(this) {}
 let hasThisParameter = function(this) {}
 
+export function exported() {}
+       ~~~~~~~~ [0]
+
+async function asyncFunction() {}
+      ~~~~~~~~ [0]
+
 [0]: non-arrow functions are forbidden


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

* Allow function declarations with `allow-named-functions`
  * you could argue, that one could simply use `allow-declarations`, but function declarations are also _named_
  * maybe this commit could just be replaced with a documentation update, as I was not expecting the current behaviour by reading the docs
* fix error location for `async` or `export`ed functions
* cache lookup of options

#### Is there anything you'd like reviewers to focus on?

~~The ci failure will go away when #1960 get's merged and this branch is rebased~~ ... and it's gone
