### PR TITLE
Add `childOfKind` helper function

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -117,6 +117,24 @@ export function getBindingElementVariableDeclaration(node: ts.BindingElement): t
     return <ts.VariableDeclaration> currentParent;
 }
 
+/** Shim of Array.find */
+function find<T>(a: T[], predicate: (value: T) => boolean): T | undefined {
+    for (const value of a) {
+        if (predicate(value)) {
+            return value;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Finds a child of a given node with a given kind.
+ * Note: This uses `node.getChildren()`, which does extra parsing work to include tokens.
+ */
+export function childOfKind(node: ts.Node, kind: ts.SyntaxKind): ts.Node | undefined {
+    return find(node.getChildren(), (child) => child.kind === kind);
+}
+
 /**
  * @returns true if some ancestor of `node` satisfies `predicate`, including `node` itself.
  */

--- a/src/rules/curlyRule.ts
+++ b/src/rules/curlyRule.ts
@@ -88,8 +88,7 @@ class CurlyWalker extends Lint.RuleWalker {
                 && !isStatementBraced(node.elseStatement)) {
 
             // find the else keyword to place the error appropriately
-            const elseKeywordNode = node.getChildren().filter((child) => child.kind === ts.SyntaxKind.ElseKeyword)[0];
-
+            const elseKeywordNode = Lint.childOfKind(node, ts.SyntaxKind.ElseKeyword)!;
             this.addFailureFromStartToEnd(elseKeywordNode.getStart(), node.elseStatement.getEnd(), Rule.ELSE_FAILURE_STRING);
         }
 

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -45,8 +45,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_FACTORY = (memberType: string, memberName: string | null, publicOnly: boolean) => {
-        memberName = memberName == null ? "" : ` '${memberName}'`;
+    public static FAILURE_STRING_FACTORY = (memberType: string, memberName: string | undefined, publicOnly: boolean) => {
+        memberName = memberName === undefined ? "" : ` '${memberName}'`;
         if (publicOnly) {
             return `The ${memberType}${memberName} must be marked as 'public'`;
         }
@@ -124,12 +124,8 @@ export class MemberAccessWalker extends Lint.RuleWalker {
             }
 
             // look for the identifier and get its text
-            let memberName: string | null = null;
-            node.getChildren().forEach((n: ts.Node) => {
-                if (n.kind === ts.SyntaxKind.Identifier) {
-                    memberName = n.getText();
-                }
-            });
+            const member = Lint.childOfKind(node, ts.SyntaxKind.Identifier);
+            const memberName = member && member.getText();
             const failureString = Rule.FAILURE_STRING_FACTORY(memberType, memberName, publicOnly);
             this.addFailureAtNode(node, failureString);
         }

--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -78,7 +78,7 @@ class OneLineWalker extends Lint.RuleWalker {
         const elseStatement = node.elseStatement;
         if (elseStatement != null) {
             // find the else keyword
-            const elseKeyword = getFirstChildOfKind(node, ts.SyntaxKind.ElseKeyword);
+            const elseKeyword = Lint.childOfKind(node, ts.SyntaxKind.ElseKeyword)!;
             if (elseStatement.kind === ts.SyntaxKind.Block) {
                 const elseOpeningBrace = elseStatement.getChildAt(0);
                 this.handleOpeningBrace(elseKeyword, elseOpeningBrace);
@@ -96,7 +96,7 @@ class OneLineWalker extends Lint.RuleWalker {
     }
 
     public visitCatchClause(node: ts.CatchClause) {
-        const catchClosingParen = node.getChildren().filter((n) => n.kind === ts.SyntaxKind.CloseParenToken)[0];
+        const catchClosingParen = Lint.childOfKind(node, ts.SyntaxKind.CloseParenToken);
         const catchOpeningBrace = node.block.getChildAt(0);
         this.handleOpeningBrace(catchClosingParen, catchOpeningBrace);
         super.visitCatchClause(node);
@@ -105,7 +105,7 @@ class OneLineWalker extends Lint.RuleWalker {
     public visitTryStatement(node: ts.TryStatement) {
         const catchClause = node.catchClause;
         const finallyBlock = node.finallyBlock;
-        const finallyKeyword = node.getChildren().filter((n) => n.kind === ts.SyntaxKind.FinallyKeyword)[0];
+        const finallyKeyword = Lint.childOfKind(node, ts.SyntaxKind.FinallyKeyword);
 
         // "visit" try block
         const tryKeyword = node.getChildAt(0);
@@ -172,7 +172,7 @@ class OneLineWalker extends Lint.RuleWalker {
     public visitVariableDeclaration(node: ts.VariableDeclaration) {
         const initializer = node.initializer;
         if (initializer != null && initializer.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-            const equalsToken = node.getChildren().filter((n) => n.kind === ts.SyntaxKind.EqualsToken)[0];
+            const equalsToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsToken);
             const openBraceToken = initializer.getChildAt(0);
             this.handleOpeningBrace(equalsToken, openBraceToken);
         }
@@ -201,7 +201,7 @@ class OneLineWalker extends Lint.RuleWalker {
 
     public visitEnumDeclaration(node: ts.EnumDeclaration) {
         const nameNode = node.name;
-        const openBraceToken = getFirstChildOfKind(node, ts.SyntaxKind.OpenBraceToken);
+        const openBraceToken = Lint.childOfKind(node, ts.SyntaxKind.OpenBraceToken)!;
         this.handleOpeningBrace(nameNode, openBraceToken);
         super.visitEnumDeclaration(node);
     }
@@ -241,7 +241,7 @@ class OneLineWalker extends Lint.RuleWalker {
     public visitArrowFunction(node: ts.FunctionLikeDeclaration) {
         const body = node.body;
         if (body != null && body.kind === ts.SyntaxKind.Block) {
-            const arrowToken = getFirstChildOfKind(node, ts.SyntaxKind.EqualsGreaterThanToken);
+            const arrowToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsGreaterThanToken);
             const openBraceToken = body.getChildAt(0);
             this.handleOpeningBrace(arrowToken, openBraceToken);
         }
@@ -255,7 +255,7 @@ class OneLineWalker extends Lint.RuleWalker {
             if (node.type != null) {
                 this.handleOpeningBrace(node.type, openBraceToken);
             } else {
-                const closeParenToken = getFirstChildOfKind(node, ts.SyntaxKind.CloseParenToken);
+                const closeParenToken = Lint.childOfKind(node, ts.SyntaxKind.CloseParenToken);
                 this.handleOpeningBrace(closeParenToken, openBraceToken);
             }
         }
@@ -263,7 +263,7 @@ class OneLineWalker extends Lint.RuleWalker {
 
     private handleClassLikeDeclaration(node: ts.ClassDeclaration | ts.InterfaceDeclaration) {
         let lastNodeOfDeclaration: ts.Node | undefined = node.name;
-        const openBraceToken = getFirstChildOfKind(node, ts.SyntaxKind.OpenBraceToken);
+        const openBraceToken = Lint.childOfKind(node, ts.SyntaxKind.OpenBraceToken)!;
 
         if (node.heritageClauses != null) {
             lastNodeOfDeclaration = node.heritageClauses[node.heritageClauses.length - 1];
@@ -303,8 +303,4 @@ class OneLineWalker extends Lint.RuleWalker {
             this.addFailureAtNode(openBraceToken, failure);
         }
     }
-}
-
-function getFirstChildOfKind(node: ts.Node, kind: ts.SyntaxKind) {
-    return node.getChildren().filter((child) => child.kind === kind)[0];
 }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -164,8 +164,7 @@ class SemicolonWalker extends Lint.RuleWalker {
 
     private checkSemicolonAt(node: ts.Node, override?: "never") {
         const sourceFile = this.getSourceFile();
-        const children = node.getChildren(sourceFile);
-        const hasSemicolon = children.some((child) => child.kind === ts.SyntaxKind.SemicolonToken);
+        const hasSemicolon = Lint.childOfKind(node, ts.SyntaxKind.SemicolonToken) !== undefined;
         const position = node.getStart(sourceFile) + node.getWidth(sourceFile);
         const never = override === "never" || this.hasOption(OPTION_NEVER);
         // Backwards compatible with plain {"semicolon": true}

--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -70,9 +70,9 @@ class FunctionWalker extends Lint.RuleWalker {
 
     protected visitArrowFunction(node: ts.FunctionLikeDeclaration): void {
         const option = this.getOption("asyncArrow");
-        const syntaxList = this.getChildOfType(node, ts.SyntaxKind.SyntaxList);
+        const syntaxList = Lint.childOfKind(node, ts.SyntaxKind.SyntaxList)!;
         const isAsyncArrow = syntaxList.getStart() === node.getStart() && syntaxList.getText() === "async";
-        const openParen = isAsyncArrow ? this.getChildOfType(node, ts.SyntaxKind.OpenParenToken) : undefined;
+        const openParen = isAsyncArrow ? Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken) : undefined;
         this.evaluateRuleAt(openParen, option);
 
         super.visitArrowFunction(node);
@@ -80,7 +80,7 @@ class FunctionWalker extends Lint.RuleWalker {
 
     protected visitConstructorDeclaration(node: ts.ConstructorDeclaration): void {
         const option = this.getOption("constructor");
-        const openParen = this.getChildOfType(node, ts.SyntaxKind.OpenParenToken);
+        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken);
         this.evaluateRuleAt(openParen, option);
 
         super.visitConstructorDeclaration(node);
@@ -132,11 +132,6 @@ class FunctionWalker extends Lint.RuleWalker {
         return this.cachedOptions[optionName];
     }
 
-    private getChildOfType(node: ts.Node, kind: ts.SyntaxKind): ts.Node {
-        const filtered = node.getChildren().filter((child: ts.Node): boolean => child.kind === kind);
-        return filtered[0];
-    }
-
     private evaluateRuleAt(openParen?: ts.Node, option?: string): void {
         if (openParen === undefined || option === undefined) {
             return;
@@ -163,17 +158,17 @@ class FunctionWalker extends Lint.RuleWalker {
     }
 
     private visitFunction(node: ts.Node): void {
-        const identifier = this.getChildOfType(node, ts.SyntaxKind.Identifier);
+        const identifier = Lint.childOfKind(node, ts.SyntaxKind.Identifier);
         const hasIdentifier = identifier !== undefined && (identifier.getEnd() !== identifier.getStart());
         const optionName = hasIdentifier ? "named" : "anonymous";
         const option = this.getOption(optionName);
-        const openParen = this.getChildOfType(node, ts.SyntaxKind.OpenParenToken);
+        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken);
         this.evaluateRuleAt(openParen, option);
     }
 
     private visitMethod(node: ts.Node): void {
         const option = this.getOption("method");
-        const openParen = this.getChildOfType(node, ts.SyntaxKind.OpenParenToken);
+        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken);
         this.evaluateRuleAt(openParen, option);
     }
 

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -188,9 +188,8 @@ class TrailingCommaWalker extends Lint.RuleWalker {
                 // as opposed to optionals alongside it. So instead of children[i + 1] having
                 // [ PropertySignature, Semicolon, PropertySignature, Semicolon ], the AST is
                 // [ PropertySignature, PropertySignature], where the Semicolons are under PropertySignature
-                const hasSemicolon = grandChildren.some((grandChild) => {
-                    return grandChild.getChildren().some((ggc) => ggc.kind === ts.SyntaxKind.SemicolonToken);
-                });
+                const hasSemicolon = grandChildren.some((grandChild) =>
+                    Lint.childOfKind(grandChild, ts.SyntaxKind.SemicolonToken) !== undefined);
 
                 if (!hasSemicolon) {
                     const endLineOfClosingElement = this.getSourceFile().getLineAndCharacterOfPosition(children[i + 2].getEnd()).line;

--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -90,9 +90,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class TypedefWhitespaceWalker extends Lint.RuleWalker {
     private static getColonPosition(node: ts.Node) {
-        const colon = node.getChildren().filter((child) => child.kind === ts.SyntaxKind.ColonToken)[0];
-
-        return colon == null ? -1 : colon.getStart();
+        const colon = Lint.childOfKind(node, ts.SyntaxKind.ColonToken);
+        return colon && colon.getStart();
     }
 
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
@@ -154,7 +153,7 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
         if (this.hasOption(option) && typeNode != null) {
             const colonPosition = TypedefWhitespaceWalker.getColonPosition(node);
 
-            if (colonPosition != null) {
+            if (colonPosition !== undefined) {
                 const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.getText());
 
                 this.checkLeft(option, node, scanner, colonPosition);

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -239,24 +239,18 @@ class WhitespaceWalker extends Lint.SkippableTokenAwareRuleWalker {
     }
 
     private checkEqualsGreaterThanTokenInNode(node: ts.Node) {
-        let arrowChildNumber = -1;
-        node.getChildren().forEach((child, i) => {
-            if (child.kind === ts.SyntaxKind.EqualsGreaterThanToken) {
-                arrowChildNumber = i;
-            }
-        });
-
-        // condition so we don't crash if the arrow is somehow missing
-        if (arrowChildNumber !== -1) {
-            const equalsGreaterThanToken = node.getChildAt(arrowChildNumber);
-            if (this.hasOption(OPTION_OPERATOR)) {
-                let position = equalsGreaterThanToken.getFullStart();
-                this.checkForTrailingWhitespace(position);
-
-                position = equalsGreaterThanToken.getEnd();
-                this.checkForTrailingWhitespace(position);
-            }
+        if (!this.hasOption(OPTION_OPERATOR)) {
+            return;
         }
+
+        const equalsGreaterThanToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsGreaterThanToken);
+        // condition so we don't crash if the arrow is somehow missing
+        if (equalsGreaterThanToken === undefined) {
+            return;
+        }
+
+        this.checkForTrailingWhitespace(equalsGreaterThanToken.getFullStart());
+        this.checkForTrailingWhitespace(equalsGreaterThanToken.getEnd());
     }
 
     private checkForTrailingWhitespace(position: number) {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update
- [X] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Added a helper function for a common need.
Note that this function may be unperformant since it calls `getChildren`. But it's no worse than before. (At least it's better than `.filter(...)[0]`.)
