### PR TITLE
Rewrite eoflineRule

### DIFF
--- a/src/rules/eoflineRule.ts
+++ b/src/rules/eoflineRule.ts
@@ -35,20 +35,14 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "file should end with a newline";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        if (sourceFile.text === "") {
-            // if the file is empty, it "ends with a newline", so don't return a failure
+        const length = sourceFile.text.length;
+        if (length === 0 || // if the file is empty, it "ends with a newline", so don't return a failure
+            sourceFile.text[length - 1] === "\n") {
             return [];
         }
 
-        const eofToken = sourceFile.endOfFileToken;
-        const eofTokenFullText = eofToken.getFullText();
-        if (eofTokenFullText.length === 0 || eofTokenFullText.charAt(eofTokenFullText.length - 1) !== "\n") {
-            const start = eofToken.getStart();
-            return [
-                new Lint.RuleFailure(sourceFile, start, start, Rule.FAILURE_STRING, this.getOptions().ruleName),
-            ];
-        }
-
-        return [];
+        return this.filterFailures([
+            new Lint.RuleFailure(sourceFile, length, length, Rule.FAILURE_STRING, this.getOptions().ruleName),
+        ]);
     }
 }

--- a/test/rules/eofline/comment/test.js.lint
+++ b/test/rules/eofline/comment/test.js.lint
@@ -1,0 +1,3 @@
+let foo = bar;
+// some comment in last line
+                            ~nil [file should end with a newline]

--- a/test/rules/eofline/comment/test.ts.lint
+++ b/test/rules/eofline/comment/test.ts.lint
@@ -1,0 +1,3 @@
+let foo = bar;
+// some comment in last line
+                            ~nil [file should end with a newline]

--- a/test/rules/eofline/comment/tslint.json
+++ b/test/rules/eofline/comment/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "eofline": true
+  },
+  "jsRules": {
+    "eofline": true
+  }
+}

--- a/test/rules/eofline/disabled/test.js.lint
+++ b/test/rules/eofline/disabled/test.js.lint
@@ -1,0 +1,2 @@
+let bar = baz;
+let foo = bar; // tslint:disable-line: eofline

--- a/test/rules/eofline/disabled/test.ts.lint
+++ b/test/rules/eofline/disabled/test.ts.lint
@@ -1,0 +1,2 @@
+let bar = baz;
+let foo = bar; // tslint:disable-line: eofline

--- a/test/rules/eofline/disabled/tslint.json
+++ b/test/rules/eofline/disabled/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "eofline": true
+  },
+  "jsRules": {
+    "eofline": true
+  }
+}

--- a/test/rules/eofline/empty/tslint.json
+++ b/test/rules/eofline/empty/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "eofline": true
+  },
+  "jsRules": {
+    "eofline": true
+  }
+}

--- a/test/rules/eofline/invalid/test.js.lint
+++ b/test/rules/eofline/invalid/test.js.lint
@@ -1,0 +1,2 @@
+let foo = bar;
+              ~nil [file should end with a newline]

--- a/test/rules/eofline/invalid/test.ts.lint
+++ b/test/rules/eofline/invalid/test.ts.lint
@@ -1,0 +1,2 @@
+let foo = bar;
+              ~nil [file should end with a newline]

--- a/test/rules/eofline/invalid/tslint.json
+++ b/test/rules/eofline/invalid/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "eofline": true
+  },
+  "jsRules": {
+    "eofline": true
+  }
+}

--- a/test/rules/eofline/only-whitespace/test.js.lint
+++ b/test/rules/eofline/only-whitespace/test.js.lint
@@ -1,0 +1,3 @@
+
+    
+    ~nil [file should end with a newline]

--- a/test/rules/eofline/only-whitespace/test.ts.lint
+++ b/test/rules/eofline/only-whitespace/test.ts.lint
@@ -1,0 +1,3 @@
+
+    
+    ~nil [file should end with a newline]

--- a/test/rules/eofline/only-whitespace/tslint.json
+++ b/test/rules/eofline/only-whitespace/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "eofline": true
+  },
+  "jsRules": {
+    "eofline": true
+  }
+}

--- a/test/rules/eofline/valid/test.js.lint
+++ b/test/rules/eofline/valid/test.js.lint
@@ -1,0 +1,1 @@
+let foo = bar;

--- a/test/rules/eofline/valid/test.ts.lint
+++ b/test/rules/eofline/valid/test.ts.lint
@@ -1,0 +1,1 @@
+let foo = bar;

--- a/test/rules/eofline/valid/tslint.json
+++ b/test/rules/eofline/valid/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "eofline": true
+  },
+  "jsRules": {
+    "eofline": true
+  }
+}

--- a/test/rules/eofline/whitespace/test.js.lint
+++ b/test/rules/eofline/whitespace/test.js.lint
@@ -1,0 +1,2 @@
+let foo = bar;    
+                  ~nil [file should end with a newline]

--- a/test/rules/eofline/whitespace/test.ts.lint
+++ b/test/rules/eofline/whitespace/test.ts.lint
@@ -1,0 +1,2 @@
+let foo = bar;    
+                  ~nil [file should end with a newline]

--- a/test/rules/eofline/whitespace/tslint.json
+++ b/test/rules/eofline/whitespace/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "eofline": true
+  },
+  "jsRules": {
+    "eofline": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Add tests.
Allow disabling the rule.
Use SourceFile's text instead of EndOfFileToken.

#### Is there anything you'd like reviewers to focus on?

I'd like to get feedback, if checking for `\n` is a problem on systems where only `\r` is used (macOS?).

The original code was also checking for `\n`, but only if the line before EOF contained only comments or whitespace.
