### PR TITLE
Performance improvements pt. 1

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -54,11 +54,16 @@ export function createCompilerOptions(): ts.CompilerOptions {
 }
 
 export function doesIntersect(failure: RuleFailure, disabledIntervals: IDisabledInterval[]) {
-    return disabledIntervals.some((interval) => {
-        const maxStart = Math.max(interval.startPosition, failure.getStartPosition().getPosition());
-        const minEnd = Math.min(interval.endPosition, failure.getEndPosition().getPosition());
-        return maxStart <= minEnd;
-    });
+    const failureStart = failure.getStartPosition().getPosition();
+    const failureEnd = failure.getEndPosition().getPosition();
+    for (const interval of disabledIntervals) {
+        const maxStart = Math.max(interval.startPosition, failureStart);
+        const minEnd = Math.min(interval.endPosition, failureEnd);
+        if (maxStart <= minEnd) {
+            return true;
+        }
+    }
+    return false;
 }
 
 export function scanAllTokens(scanner: ts.Scanner, callback: (s: ts.Scanner) => void) {
@@ -81,9 +86,12 @@ export function hasModifier(modifiers: ts.ModifiersArray | undefined, ...modifie
         return false;
     }
 
-    return modifiers.some((m) => {
-        return modifierKinds.some((k) => m.kind === k);
-    });
+    for (const modifier of modifiers) {
+        if (modifierKinds.indexOf(modifier.kind) !== -1) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -54,16 +54,11 @@ export function createCompilerOptions(): ts.CompilerOptions {
 }
 
 export function doesIntersect(failure: RuleFailure, disabledIntervals: IDisabledInterval[]) {
-    const failureStart = failure.getStartPosition().getPosition();
-    const failureEnd = failure.getEndPosition().getPosition();
-    for (const interval of disabledIntervals) {
-        const maxStart = Math.max(interval.startPosition, failureStart);
-        const minEnd = Math.min(interval.endPosition, failureEnd);
-        if (maxStart <= minEnd) {
-            return true;
-        }
-    }
-    return false;
+    return disabledIntervals.some((interval) => {
+        const maxStart = Math.max(interval.startPosition, failure.getStartPosition().getPosition());
+        const minEnd = Math.min(interval.endPosition, failure.getEndPosition().getPosition());
+        return maxStart <= minEnd;
+    });
 }
 
 export function scanAllTokens(scanner: ts.Scanner, callback: (s: ts.Scanner) => void) {
@@ -86,12 +81,9 @@ export function hasModifier(modifiers: ts.ModifiersArray | undefined, ...modifie
         return false;
     }
 
-    for (const modifier of modifiers) {
-        if (modifierKinds.indexOf(modifier.kind) !== -1) {
-            return true;
-        }
-    }
-    return false;
+    return modifiers.some((m) => {
+        return modifierKinds.some((k) => m.kind === k);
+    });
 }
 
 /**

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -117,22 +117,17 @@ export function getBindingElementVariableDeclaration(node: ts.BindingElement): t
     return <ts.VariableDeclaration> currentParent;
 }
 
-/** Shim of Array.find */
-function find<T>(a: T[], predicate: (value: T) => boolean): T | undefined {
-    for (const value of a) {
-        if (predicate(value)) {
-            return value;
-        }
-    }
-    return undefined;
-}
-
 /**
  * Finds a child of a given node with a given kind.
  * Note: This uses `node.getChildren()`, which does extra parsing work to include tokens.
  */
-export function childOfKind(node: ts.Node, kind: ts.SyntaxKind): ts.Node | undefined {
-    return find(node.getChildren(), (child) => child.kind === kind);
+export function childOfKind(node: ts.Node, kind: ts.SyntaxKind, sourceFile?: ts.SourceFile): ts.Node | undefined {
+    for (const child of node.getChildren(sourceFile)) {
+        if (child.kind === kind) {
+            return child;
+        }
+    }
+    return undefined;
 }
 
 /**

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -99,12 +99,14 @@ class AlignWalker extends Lint.RuleWalker {
             return;
         }
 
-        let prevPos = this.getLineAndCharacterOfPosition(nodes[0].getStart());
+        const sourceFile = this.getSourceFile();
+
+        let prevPos = this.getLineAndCharacterOfPosition(nodes[0].getStart(sourceFile));
         const alignToColumn = prevPos.character;
 
         // skip first node in list
         for (let node of nodes.slice(1)) {
-            const curPos = this.getLineAndCharacterOfPosition(node.getStart());
+            const curPos = this.getLineAndCharacterOfPosition(node.getStart(sourceFile));
             if (curPos.line !== prevPos.line && curPos.character !== alignToColumn) {
                 this.addFailureAtNode(node, kind + Rule.FAILURE_STRING_SUFFIX);
                 break;

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -61,17 +61,19 @@ class ArrowParensWalker extends Lint.RuleWalker {
         if (node.parameters.length === 1 && node.typeParameters === undefined) {
             const parameter = node.parameters[0];
 
-            let openParen = node.getFirstToken();
+            const sourceFile = this.getSourceFile();
+
+            let openParen = node.getFirstToken(sourceFile);
             let openParenIndex = 0;
             if (openParen.kind === ts.SyntaxKind.AsyncKeyword) {
-                openParen = node.getChildAt(1);
+                openParen = node.getChildAt(1, sourceFile);
                 openParenIndex = 1;
             }
 
             const hasParens = openParen.kind === ts.SyntaxKind.OpenParenToken;
             if (!hasParens && !this.avoidOnSingleParameter) {
                 const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                    this.appendText(parameter.getStart(), "("),
+                    this.appendText(parameter.getStart(sourceFile), "("),
                     this.appendText(parameter.getEnd(), ")"),
                 ]);
                 this.addFailureAtNode(parameter, Rule.FAILURE_STRING_MISSING, fix);
@@ -79,8 +81,8 @@ class ArrowParensWalker extends Lint.RuleWalker {
                 // Skip over the parameter to get the closing parenthesis
                 const closeParen = node.getChildAt(openParenIndex + 2);
                 const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                    this.deleteText(openParen.getStart(), 1),
-                    this.deleteText(closeParen.getStart(), 1),
+                    this.deleteText(openParen.getStart(sourceFile), 1),
+                    this.deleteText(closeParen.getStart(sourceFile), 1),
                 ]);
                 this.addFailureAtNode(parameter, Rule.FAILURE_STRING_EXISTS, fix);
             }

--- a/src/rules/banRule.ts
+++ b/src/rules/banRule.ts
@@ -80,22 +80,23 @@ export class BanFunctionWalker extends Lint.RuleWalker {
     }
 
     private checkForObjectMethodBan(expression: ts.LeftHandSideExpression) {
+        const sourceFile = this.getSourceFile();
         if (expression.kind === ts.SyntaxKind.PropertyAccessExpression
-            && expression.getChildCount() >= 3) {
+            && expression.getChildCount(sourceFile) >= 3) {
 
-            const firstToken = expression.getFirstToken();
-            const firstChild = expression.getChildAt(0);
-            const secondChild = expression.getChildAt(1);
-            const thirdChild = expression.getChildAt(2);
+            const firstToken = expression.getFirstToken(sourceFile);
+            const firstChild = expression.getChildAt(0, sourceFile);
+            const secondChild = expression.getChildAt(1, sourceFile);
+            const thirdChild = expression.getChildAt(2, sourceFile);
 
-            const rightSideExpression = thirdChild.getFullText();
+            const rightSideExpression = thirdChild.getFullText(sourceFile);
 
             let leftSideExpression: string;
 
-            if (firstChild.getChildCount() > 0) {
-                leftSideExpression = firstChild.getLastToken().getText();
+            if (firstChild.getChildCount(sourceFile) > 0) {
+                leftSideExpression = firstChild.getLastToken(sourceFile).getText(sourceFile);
             } else {
-                leftSideExpression = firstToken.getText();
+                leftSideExpression = firstToken.getText(sourceFile);
             }
 
             if (secondChild.kind === ts.SyntaxKind.DotToken) {

--- a/src/rules/callableTypesRule.ts
+++ b/src/rules/callableTypesRule.ts
@@ -66,9 +66,9 @@ class Walker extends Lint.RuleWalker {
                 return;
             }
 
-            const suggestion = renderSuggestion(call);
+            const suggestion = renderSuggestion(call, this.getSourceFile());
             if (node.kind === ts.SyntaxKind.InterfaceDeclaration) {
-                this.addFailureAtNode(node.name, Rule.failureStringForInterface(node.name.getText(), suggestion));
+                this.addFailureAtNode(node.name, Rule.failureStringForInterface(node.name.text, suggestion));
             } else {
                 this.addFailureAtNode(call, Rule.failureStringForTypeLiteral(suggestion));
             }
@@ -92,10 +92,10 @@ function noSupertype(heritageClauses: ts.NodeArray<ts.HeritageClause> | undefine
     return false;
 }
 
-function renderSuggestion(call: ts.CallSignatureDeclaration): string {
-    const typeParameters = call.typeParameters && call.typeParameters.map((p) => p.getText()).join(", ");
-    const parameters = call.parameters.map((p) => p.getText()).join(", ");
-    const returnType = call.type === undefined ? "void" : call.type.getText();
+function renderSuggestion(call: ts.CallSignatureDeclaration, sourceFile: ts.SourceFile): string {
+    const typeParameters = call.typeParameters && call.typeParameters.map((p) => p.getText(sourceFile)).join(", ");
+    const parameters = call.parameters.map((p) => p.getText(sourceFile)).join(", ");
+    const returnType = call.type === undefined ? "void" : call.type.getText(sourceFile);
     let res = `(${parameters}) => ${returnType}`;
     if (typeParameters) {
         res = `<${typeParameters}>${res}`;

--- a/src/rules/classNameRule.ts
+++ b/src/rules/classNameRule.ts
@@ -43,9 +43,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NameWalker extends Lint.RuleWalker {
     public visitClassDeclaration(node: ts.ClassDeclaration) {
         // classes declared as default exports will be unnamed
-        if (node.name != null) {
-            const className = node.name.getText();
-            if (!this.isPascalCased(className)) {
+        if (node.name !== undefined) {
+            if (!this.isPascalCased(node.name.text)) {
                 this.addFailureAtNode(node.name, Rule.FAILURE_STRING);
             }
         }
@@ -54,8 +53,7 @@ class NameWalker extends Lint.RuleWalker {
     }
 
     public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
-        const interfaceName = node.name.getText();
-        if (!this.isPascalCased(interfaceName)) {
+        if (!this.isPascalCased(node.name.text)) {
             this.addFailureAtNode(node.name, Rule.FAILURE_STRING);
         }
 

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -111,8 +111,9 @@ export class CompletedDocsWalker extends Lint.ProgramAwareRuleWalker {
     }
 
     private addDocumentationFailure(node: ts.Declaration, nodeToCheck: string): void {
-        const start = node.getStart();
-        const width = node.getText().split(/\r|\n/g)[0].length;
+        const sourceFile = this.getSourceFile();
+        const start = node.getStart(sourceFile);
+        const width = node.getText(sourceFile).split(/\r|\n/)[0].length;
         const description = nodeToCheck[0].toUpperCase() + nodeToCheck.substring(1) + Rule.FAILURE_STRING_EXIST;
 
         this.addFailureAt(start, width, description);

--- a/src/rules/curlyRule.ts
+++ b/src/rules/curlyRule.ts
@@ -80,16 +80,17 @@ class CurlyWalker extends Lint.RuleWalker {
 
     public visitIfStatement(node: ts.IfStatement) {
         if (!isStatementBraced(node.thenStatement)) {
-            this.addFailureFromStartToEnd(node.getStart(), node.thenStatement.getEnd(), Rule.IF_FAILURE_STRING);
+            this.addFailureFromStartToEnd(node.getStart(this.getSourceFile()), node.thenStatement.getEnd(), Rule.IF_FAILURE_STRING);
         }
 
         if (node.elseStatement != null
                 && node.elseStatement.kind !== ts.SyntaxKind.IfStatement
                 && !isStatementBraced(node.elseStatement)) {
 
+            const sourceFile = this.getSourceFile();
             // find the else keyword to place the error appropriately
-            const elseKeywordNode = Lint.childOfKind(node, ts.SyntaxKind.ElseKeyword, this.getSourceFile())!;
-            this.addFailureFromStartToEnd(elseKeywordNode.getStart(), node.elseStatement.getEnd(), Rule.ELSE_FAILURE_STRING);
+            const elseKeywordNode = Lint.childOfKind(node, ts.SyntaxKind.ElseKeyword, sourceFile)!;
+            this.addFailureFromStartToEnd(elseKeywordNode.getStart(sourceFile), node.elseStatement.getEnd(), Rule.ELSE_FAILURE_STRING);
         }
 
         super.visitIfStatement(node);

--- a/src/rules/curlyRule.ts
+++ b/src/rules/curlyRule.ts
@@ -88,7 +88,7 @@ class CurlyWalker extends Lint.RuleWalker {
                 && !isStatementBraced(node.elseStatement)) {
 
             // find the else keyword to place the error appropriately
-            const elseKeywordNode = Lint.childOfKind(node, ts.SyntaxKind.ElseKeyword)!;
+            const elseKeywordNode = Lint.childOfKind(node, ts.SyntaxKind.ElseKeyword, this.getSourceFile())!;
             this.addFailureFromStartToEnd(elseKeywordNode.getStart(), node.elseStatement.getEnd(), Rule.ELSE_FAILURE_STRING);
         }
 

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -118,7 +118,7 @@ export class MemberAccessWalker extends Lint.RuleWalker {
             } else if (node.kind === ts.SyntaxKind.Constructor) {
                 memberType = "class constructor";
                 publicOnly = true;
-                end = Lint.childOfKind(node, ts.SyntaxKind.ConstructorKeyword)!.getEnd();
+                end = Lint.childOfKind(node, ts.SyntaxKind.ConstructorKeyword, this.getSourceFile())!.getEnd();
             } else if (node.kind === ts.SyntaxKind.GetAccessor) {
                 memberType = "get property accessor";
                 end = (node as ts.AccessorDeclaration).name.getEnd();
@@ -135,7 +135,7 @@ export class MemberAccessWalker extends Lint.RuleWalker {
                 memberName = (node.name as ts.Identifier).text;
             }
             const failureString = Rule.FAILURE_STRING_FACTORY(memberType, memberName, publicOnly);
-            this.addFailureFromStartToEnd(node.getStart(), end, failureString);
+            this.addFailureFromStartToEnd(node.getStart(this.getSourceFile()), end, failureString);
         }
     }
 }

--- a/src/rules/noConstructRule.ts
+++ b/src/rules/noConstructRule.ts
@@ -56,7 +56,7 @@ class NoConstructWalker extends Lint.RuleWalker {
             const identifier = <ts.Identifier> node.expression;
             const constructorName = identifier.text;
             if (NoConstructWalker.FORBIDDEN_CONSTRUCTORS.indexOf(constructorName) !== -1) {
-                this.addFailureAt(node.getStart(), identifier.getEnd() - node.getStart(), Rule.FAILURE_STRING);
+                this.addFailureFromStartToEnd(node.getStart(this.getSourceFile()), identifier.getEnd(), Rule.FAILURE_STRING);
             }
         }
         super.visitNewExpression(node);

--- a/src/rules/noDebuggerRule.ts
+++ b/src/rules/noDebuggerRule.ts
@@ -42,8 +42,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoDebuggerWalker extends Lint.RuleWalker {
     public visitDebuggerStatement(node: ts.Statement) {
-        const debuggerKeywordNode = node.getChildAt(0);
-        this.addFailureAtNode(debuggerKeywordNode, Rule.FAILURE_STRING);
+        this.addFailureAt(node.getStart(this.getSourceFile()), "debugger".length, Rule.FAILURE_STRING);
         super.visitDebuggerStatement(node);
    }
 }

--- a/src/rules/noDefaultExportRule.ts
+++ b/src/rules/noDefaultExportRule.ts
@@ -46,7 +46,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoDefaultExportWalker extends Lint.RuleWalker {
     public visitExportAssignment(node: ts.ExportAssignment) {
-        const exportMember = node.getChildAt(1);
+        const exportMember = node.getChildAt(1, this.getSourceFile());
         if (exportMember != null && exportMember.kind === ts.SyntaxKind.DefaultKeyword) {
             this.addFailureAtNode(exportMember, Rule.FAILURE_STRING);
         }

--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -78,7 +78,7 @@ class OneLineWalker extends Lint.RuleWalker {
         const elseStatement = node.elseStatement;
         if (elseStatement != null) {
             // find the else keyword
-            const elseKeyword = Lint.childOfKind(node, ts.SyntaxKind.ElseKeyword)!;
+            const elseKeyword = Lint.childOfKind(node, ts.SyntaxKind.ElseKeyword, this.getSourceFile())!;
             if (elseStatement.kind === ts.SyntaxKind.Block) {
                 const elseOpeningBrace = elseStatement.getChildAt(0);
                 this.handleOpeningBrace(elseKeyword, elseOpeningBrace);
@@ -96,7 +96,7 @@ class OneLineWalker extends Lint.RuleWalker {
     }
 
     public visitCatchClause(node: ts.CatchClause) {
-        const catchClosingParen = Lint.childOfKind(node, ts.SyntaxKind.CloseParenToken);
+        const catchClosingParen = Lint.childOfKind(node, ts.SyntaxKind.CloseParenToken, this.getSourceFile());
         const catchOpeningBrace = node.block.getChildAt(0);
         this.handleOpeningBrace(catchClosingParen, catchOpeningBrace);
         super.visitCatchClause(node);
@@ -105,7 +105,7 @@ class OneLineWalker extends Lint.RuleWalker {
     public visitTryStatement(node: ts.TryStatement) {
         const catchClause = node.catchClause;
         const finallyBlock = node.finallyBlock;
-        const finallyKeyword = Lint.childOfKind(node, ts.SyntaxKind.FinallyKeyword);
+        const finallyKeyword = Lint.childOfKind(node, ts.SyntaxKind.FinallyKeyword, this.getSourceFile());
 
         // "visit" try block
         const tryKeyword = node.getChildAt(0);
@@ -172,7 +172,7 @@ class OneLineWalker extends Lint.RuleWalker {
     public visitVariableDeclaration(node: ts.VariableDeclaration) {
         const initializer = node.initializer;
         if (initializer != null && initializer.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-            const equalsToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsToken);
+            const equalsToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsToken, this.getSourceFile());
             const openBraceToken = initializer.getChildAt(0);
             this.handleOpeningBrace(equalsToken, openBraceToken);
         }
@@ -201,7 +201,7 @@ class OneLineWalker extends Lint.RuleWalker {
 
     public visitEnumDeclaration(node: ts.EnumDeclaration) {
         const nameNode = node.name;
-        const openBraceToken = Lint.childOfKind(node, ts.SyntaxKind.OpenBraceToken)!;
+        const openBraceToken = Lint.childOfKind(node, ts.SyntaxKind.OpenBraceToken, this.getSourceFile())!;
         this.handleOpeningBrace(nameNode, openBraceToken);
         super.visitEnumDeclaration(node);
     }
@@ -241,7 +241,7 @@ class OneLineWalker extends Lint.RuleWalker {
     public visitArrowFunction(node: ts.FunctionLikeDeclaration) {
         const body = node.body;
         if (body != null && body.kind === ts.SyntaxKind.Block) {
-            const arrowToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsGreaterThanToken);
+            const arrowToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsGreaterThanToken, this.getSourceFile());
             const openBraceToken = body.getChildAt(0);
             this.handleOpeningBrace(arrowToken, openBraceToken);
         }
@@ -255,7 +255,7 @@ class OneLineWalker extends Lint.RuleWalker {
             if (node.type != null) {
                 this.handleOpeningBrace(node.type, openBraceToken);
             } else {
-                const closeParenToken = Lint.childOfKind(node, ts.SyntaxKind.CloseParenToken);
+                const closeParenToken = Lint.childOfKind(node, ts.SyntaxKind.CloseParenToken, this.getSourceFile());
                 this.handleOpeningBrace(closeParenToken, openBraceToken);
             }
         }
@@ -263,7 +263,7 @@ class OneLineWalker extends Lint.RuleWalker {
 
     private handleClassLikeDeclaration(node: ts.ClassDeclaration | ts.InterfaceDeclaration) {
         let lastNodeOfDeclaration: ts.Node | undefined = node.name;
-        const openBraceToken = Lint.childOfKind(node, ts.SyntaxKind.OpenBraceToken)!;
+        const openBraceToken = Lint.childOfKind(node, ts.SyntaxKind.OpenBraceToken, this.getSourceFile())!;
 
         if (node.heritageClauses != null) {
             lastNodeOfDeclaration = node.heritageClauses[node.heritageClauses.length - 1];

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -165,7 +165,7 @@ class SemicolonWalker extends Lint.RuleWalker {
 
     private checkSemicolonAt(node: ts.Node, override?: "never") {
         const sourceFile = this.getSourceFile();
-        const hasSemicolon = Lint.childOfKind(node, ts.SyntaxKind.SemicolonToken) !== undefined;
+        const hasSemicolon = Lint.childOfKind(node, ts.SyntaxKind.SemicolonToken, sourceFile) !== undefined;
         const position = node.getStart(sourceFile) + node.getWidth(sourceFile);
         const never = override === "never" || this.hasOption(OPTION_NEVER);
         // Backwards compatible with plain {"semicolon": true}

--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -69,10 +69,11 @@ class FunctionWalker extends Lint.RuleWalker {
     }
 
     protected visitArrowFunction(node: ts.FunctionLikeDeclaration): void {
+        const sourceFile = this.getSourceFile();
         const option = this.getOption("asyncArrow");
-        const syntaxList = Lint.childOfKind(node, ts.SyntaxKind.SyntaxList)!;
+        const syntaxList = Lint.childOfKind(node, ts.SyntaxKind.SyntaxList, sourceFile)!;
         const isAsyncArrow = syntaxList.getStart() === node.getStart() && syntaxList.getText() === "async";
-        const openParen = isAsyncArrow ? Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken) : undefined;
+        const openParen = isAsyncArrow ? Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken, sourceFile) : undefined;
         this.evaluateRuleAt(openParen, option);
 
         super.visitArrowFunction(node);
@@ -80,7 +81,7 @@ class FunctionWalker extends Lint.RuleWalker {
 
     protected visitConstructorDeclaration(node: ts.ConstructorDeclaration): void {
         const option = this.getOption("constructor");
-        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken);
+        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken, this.getSourceFile());
         this.evaluateRuleAt(openParen, option);
 
         super.visitConstructorDeclaration(node);
@@ -158,17 +159,18 @@ class FunctionWalker extends Lint.RuleWalker {
     }
 
     private visitFunction(node: ts.Node): void {
-        const identifier = Lint.childOfKind(node, ts.SyntaxKind.Identifier);
+        const sourceFile = this.getSourceFile();
+        const identifier = Lint.childOfKind(node, ts.SyntaxKind.Identifier, sourceFile);
         const hasIdentifier = identifier !== undefined && (identifier.getEnd() !== identifier.getStart());
         const optionName = hasIdentifier ? "named" : "anonymous";
         const option = this.getOption(optionName);
-        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken);
+        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken, sourceFile);
         this.evaluateRuleAt(openParen, option);
     }
 
     private visitMethod(node: ts.Node): void {
         const option = this.getOption("method");
-        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken);
+        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken, this.getSourceFile());
         this.evaluateRuleAt(openParen, option);
     }
 

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -176,23 +176,24 @@ class TrailingCommaWalker extends Lint.RuleWalker {
 
     public visitTypeLiteral(node: ts.TypeLiteralNode) {
         this.lintNode(node);
+        const sourceFile = this.getSourceFile();
         // object type literals need to be inspected separately because they
         // have a different syntax list wrapper token, and they can be semicolon delimited
-        const children = node.getChildren();
+        const children = node.getChildren(sourceFile);
         for (let i = 0; i < children.length - 2; i++) {
             if (children[i].kind === ts.SyntaxKind.OpenBraceToken &&
                 children[i + 1].kind === ts.SyntaxKind.SyntaxList &&
                 children[i + 2].kind === ts.SyntaxKind.CloseBraceToken) {
-                const grandChildren = children[i + 1].getChildren();
+                const grandChildren = children[i + 1].getChildren(sourceFile);
                 // the AST is different from the grammar spec. The semicolons are included as tokens as part of *Signature,
                 // as opposed to optionals alongside it. So instead of children[i + 1] having
                 // [ PropertySignature, Semicolon, PropertySignature, Semicolon ], the AST is
                 // [ PropertySignature, PropertySignature], where the Semicolons are under PropertySignature
                 const hasSemicolon = grandChildren.some((grandChild) =>
-                    Lint.childOfKind(grandChild, ts.SyntaxKind.SemicolonToken) !== undefined);
+                    Lint.childOfKind(grandChild, ts.SyntaxKind.SemicolonToken, sourceFile) !== undefined);
 
                 if (!hasSemicolon) {
-                    const endLineOfClosingElement = this.getSourceFile().getLineAndCharacterOfPosition(children[i + 2].getEnd()).line;
+                    const endLineOfClosingElement = sourceFile.getLineAndCharacterOfPosition(children[i + 2].getEnd()).line;
                     this.lintChildNodeWithIndex(children[i + 1], grandChildren.length - 1, endLineOfClosingElement);
                 }
             }

--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -89,11 +89,6 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class TypedefWhitespaceWalker extends Lint.RuleWalker {
-    private static getColonPosition(node: ts.Node) {
-        const colon = Lint.childOfKind(node, ts.SyntaxKind.ColonToken);
-        return colon && colon.getStart();
-    }
-
     public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
         this.checkSpace("call-signature", node, node.type);
         super.visitFunctionDeclaration(node);
@@ -151,7 +146,7 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
 
     public checkSpace(option: string, node: ts.Node, typeNode: ts.TypeNode | ts.StringLiteral | undefined) {
         if (this.hasOption(option) && typeNode != null) {
-            const colonPosition = TypedefWhitespaceWalker.getColonPosition(node);
+            const colonPosition = this.getColonPosition(node);
 
             if (colonPosition !== undefined) {
                 const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.getText());
@@ -164,6 +159,12 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
 
     public hasOption(option: string) {
         return this.hasLeftOption(option) || this.hasRightOption(option);
+    }
+
+    private getColonPosition(node: ts.Node) {
+        const sourceFile = this.getSourceFile();
+        const colon = Lint.childOfKind(node, ts.SyntaxKind.ColonToken, sourceFile);
+        return colon && colon.getStart(sourceFile);
     }
 
     private hasLeftOption(option: string) {

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -243,7 +243,7 @@ class WhitespaceWalker extends Lint.SkippableTokenAwareRuleWalker {
             return;
         }
 
-        const equalsGreaterThanToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsGreaterThanToken);
+        const equalsGreaterThanToken = Lint.childOfKind(node, ts.SyntaxKind.EqualsGreaterThanToken, this.getSourceFile());
         // condition so we don't crash if the arrow is somehow missing
         if (equalsGreaterThanToken === undefined) {
             return;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] ~~New feature, bugfix, or~~ enhancement
  - [ ] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

This is a first attempt to improve performance of core rules. It's basically #1747 ... search for `\.get((Full)?Text|Start|(LeadingTrivia)?Width|(First|Last)Token|Child(ren|Count))\(\)|\.getChildAt\(\d+\)` and pass SourceFile as parameter.

To keep the diff somewhat small, I chose to submit the changes in chunks as I progress. So here we go from `alignRule` until `noDefaultExportRule`.

Of course this is only the low hanging fruit. When I find the time, I will look at the rules in more detail.