### PR TITLE
Simplify RuleWalker.prototype.createFix

### DIFF
--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -109,7 +109,7 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
         return this.ruleName;
     }
 
-    public createFix(replacements: Replacement[]): Fix {
+    public createFix(...replacements: Replacement[]): Fix {
         return new Fix(this.ruleName, replacements);
     }
 }

--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -64,11 +64,11 @@ class ArrayTypeWalker extends Lint.RuleWalker {
             // Add a space if the type is preceded by 'as' and the node has no leading whitespace
             const space = !parens && node.parent!.kind === ts.SyntaxKind.AsExpression &&
                 node.getStart() === node.getFullStart() ? " " : "";
-            const fix = new Lint.Fix(Rule.metadata.ruleName, [
+            const fix = this.createFix(
                 this.createReplacement(typeName.getStart(), parens, space + "Array<"),
                 // Delete the square brackets and replace with an angle bracket
                 this.createReplacement(typeName.getEnd() - parens, node.getEnd() - typeName.getEnd() + parens, ">"),
-            ]);
+            );
             this.addFailureAtNode(node, failureString, fix);
         }
 
@@ -82,9 +82,7 @@ class ArrayTypeWalker extends Lint.RuleWalker {
             const typeArgs = node.typeArguments;
             if (!typeArgs || typeArgs.length === 0) {
                 // Create an 'any' array
-                const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                    this.createReplacement(node.getStart(), node.getWidth(), "any[]"),
-                ]);
+                const fix = this.createFix(this.createReplacement(node.getStart(), node.getWidth(), "any[]"));
                 this.addFailureAtNode(node, failureString, fix);
             } else if (typeArgs && typeArgs.length === 1 && (!this.hasOption(OPTION_ARRAY_SIMPLE) || this.isSimpleType(typeArgs[0]))) {
                 const type = typeArgs[0];
@@ -92,12 +90,12 @@ class ArrayTypeWalker extends Lint.RuleWalker {
                 const typeEnd = type.getEnd();
                 const parens = type.kind === ts.SyntaxKind.UnionType ||
                     type.kind === ts.SyntaxKind.FunctionType || type.kind === ts.SyntaxKind.IntersectionType;
-                const fix = new Lint.Fix(Rule.metadata.ruleName, [
+                const fix = this.createFix(
                     // Delete Array and the first angle bracket
                     this.createReplacement(node.getStart(), typeStart - node.getStart(), parens ? "(" : ""),
                     // Delete the last angle bracket and replace with square brackets
                     this.createReplacement(typeEnd, node.getEnd() - typeEnd, (parens ? ")" : "") + "[]"),
-                ]);
+                );
                 this.addFailureAtNode(node, failureString, fix);
             }
         }

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -70,18 +70,18 @@ class ArrowParensWalker extends Lint.RuleWalker {
 
             const hasParens = openParen.kind === ts.SyntaxKind.OpenParenToken;
             if (!hasParens && !this.avoidOnSingleParameter) {
-                const fix = new Lint.Fix(Rule.metadata.ruleName, [
+                const fix = this.createFix(
                     this.appendText(parameter.getStart(), "("),
                     this.appendText(parameter.getEnd(), ")"),
-                ]);
+                );
                 this.addFailureAtNode(parameter, Rule.FAILURE_STRING_MISSING, fix);
             } else if (hasParens && this.avoidOnSingleParameter && isSimpleParameter(parameter)) {
                 // Skip over the parameter to get the closing parenthesis
                 const closeParen = node.getChildAt(openParenIndex + 2);
-                const fix = new Lint.Fix(Rule.metadata.ruleName, [
+                const fix = this.createFix(
                     this.deleteText(openParen.getStart(), 1),
                     this.deleteText(closeParen.getStart(), 1),
-                ]);
+                );
                 this.addFailureAtNode(parameter, Rule.FAILURE_STRING_EXISTS, fix);
             }
         }

--- a/src/rules/noAngleBracketTypeAssertionRule.ts
+++ b/src/rules/noAngleBracketTypeAssertionRule.ts
@@ -46,12 +46,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoAngleBracketTypeAssertionWalker extends Lint.RuleWalker {
     public visitTypeAssertionExpression(node: ts.TypeAssertion) {
         const { expression, type } = node;
-        const fix = new Lint.Fix(Rule.metadata.ruleName, [
+        const fix = this.createFix(
             // add 'as' syntax at end
             this.createReplacement(node.getEnd(), 0, ` as ${type.getText()}`),
             // delete the angle bracket assertion
             this.createReplacement(node.getStart(), expression.getStart() - node.getStart(), ""),
-        ]);
+        );
         this.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
         super.visitTypeAssertionExpression(node);
     }

--- a/src/rules/noStringThrowRule.ts
+++ b/src/rules/noStringThrowRule.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import * as Lint from "tslint";
 import * as ts from "typescript";
+import * as Lint from "../index";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -43,12 +43,9 @@ class Walker extends Lint.RuleWalker {
     public visitThrowStatement(node: ts.ThrowStatement) {
         const {expression} = node;
         if (this.stringConcatRecursive(expression)) {
-            const fix = new Lint.Fix(
-                    Rule.metadata.ruleName,
-                    [new Lint.Replacement(
-                            expression.getStart(),
-                            expression.getEnd() - expression.getStart(),
-                            `new Error(${expression.getText()})`)]);
+            const fix = this.createFix(this.createReplacement(expression.getStart(),
+                                                              expression.getEnd() - expression.getStart(),
+                                                              `new Error(${expression.getText()})`));
             this.addFailure(this.createFailure(
                     node.getStart(), node.getWidth(), Rule.FAILURE_STRING, fix));
         }

--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -45,7 +45,7 @@ class NoVarKeywordWalker extends Lint.RuleWalker {
     public visitVariableStatement(node: ts.VariableStatement) {
         if (!Lint.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
                 && !Lint.isBlockScopedVariable(node)) {
-            this.addFailureAt(node.declarationList.getStart(), "var".length, Rule.FAILURE_STRING, this.fix(node.declarationList));
+            this.reportFailure(node.declarationList);
         }
 
         super.visitVariableStatement(node);
@@ -69,12 +69,14 @@ class NoVarKeywordWalker extends Lint.RuleWalker {
     private handleInitializerNode(node: ts.VariableDeclarationList | ts.Expression | undefined) {
         if (node && node.kind === ts.SyntaxKind.VariableDeclarationList &&
                 !(Lint.isNodeFlagSet(node, ts.NodeFlags.Let) || Lint.isNodeFlagSet(node, ts.NodeFlags.Const))) {
-            this.addFailureAt(node.getStart(), "var".length, Rule.FAILURE_STRING, this.fix(node));
+            this.reportFailure(node);
         }
     }
 
-    private fix = (node: ts.Node) => new Lint.Fix(Rule.metadata.ruleName, [
-        this.deleteText(node.getStart(), "var".length),
-        this.appendText(node.getStart(), "let"),
-    ]);
+    private reportFailure(node: ts.Node) {
+        const nodeStart = node.getStart(this.getSourceFile());
+        this.addFailureAt(nodeStart, "var".length, Rule.FAILURE_STRING, this.createFix(
+            this.createReplacement(nodeStart, "var".length, "let"),
+        ));
+    }
 }

--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -121,7 +121,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
     private allMustHaveQuotes(properties: ts.ObjectLiteralElementLike[]) {
         for (const { name } of properties) {
             if (name !== undefined && name.kind !== ts.SyntaxKind.StringLiteral && name.kind !== ts.SyntaxKind.ComputedPropertyName) {
-                const fix = this.fix(this.appendText(name.getStart(), '"'), this.appendText(name.getEnd(), '"'));
+                const fix = this.createFix(this.appendText(name.getStart(), '"'), this.appendText(name.getEnd(), '"'));
                 this.addFailureAtNode(name, Rule.UNQUOTED_PROPERTY(name.getText()), fix);
             }
         }
@@ -130,14 +130,10 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
     private noneMayHaveQuotes(properties: ts.ObjectLiteralElementLike[], noneNeedQuotes?: boolean) {
         for (const { name } of properties) {
             if (name !== undefined && name.kind === ts.SyntaxKind.StringLiteral && (noneNeedQuotes || !propertyNeedsQuotes(name.text))) {
-                const fix = this.fix(this.deleteText(name.getStart(), 1), this.deleteText(name.getEnd() - 1, 1));
+                const fix = this.createFix(this.deleteText(name.getStart(), 1), this.deleteText(name.getEnd() - 1, 1));
                 this.addFailureAtNode(name, Rule.UNNEEDED_QUOTES(name.text), fix);
             }
         }
-    }
-
-    private fix(...replacements: Lint.Replacement[]) {
-        return new Lint.Fix(Rule.metadata.ruleName, replacements);
     }
 }
 

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -176,7 +176,7 @@ class OrderedImportsWalker extends Lint.RuleWalker {
         this.currentImportsBlock.addImportDeclaration(this.getSourceFile(), node, source);
 
         if (previousSource && compare(source, previousSource) === -1) {
-            this.lastFix = new Lint.Fix(Rule.metadata.ruleName, []);
+            this.lastFix = this.createFix();
             this.addFailureAtNode(node, Rule.IMPORT_SOURCES_UNORDERED, this.lastFix);
         }
 
@@ -201,7 +201,7 @@ class OrderedImportsWalker extends Lint.RuleWalker {
                 this.currentImportsBlock.replaceNamedImports(start, length, sortedDeclarations[i]);
             }
 
-            this.lastFix = new Lint.Fix(Rule.metadata.ruleName, []);
+            this.lastFix = this.createFix();
             this.addFailureFromStartToEnd(a.getStart(), b.getEnd(), Rule.NAMED_IMPORTS_UNORDERED, this.lastFix);
         }
 

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -117,8 +117,7 @@ class PreferConstWalker extends Lint.BlockScopeAwareRuleWalker<{}, ScopeInfo> {
             let fix: Lint.Fix | undefined;
             if (!usage.reassignedSibling && !seenLetStatements[usage.letStatement.getStart().toString()]) {
                 // only fix if all variables in the `let` statement can use `const`
-                const replacement = new Lint.Replacement(usage.letStatement.getStart(), "let".length, "const");
-                fix = new Lint.Fix(Rule.metadata.ruleName, [replacement]);
+                fix = this.createFix(this.createReplacement(usage.letStatement.getStart(), "let".length, "const"));
                 seenLetStatements[usage.letStatement.getStart().toString()] = true;
             }
             this.addFailureAtNode(usage.identifier, Rule.FAILURE_STRING_FACTORY(usage.identifier.text), fix);

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -121,7 +121,7 @@ class QuotemarkWalker extends Lint.RuleWalker {
                     + text.slice(1, -1).replace(new RegExp(expectedQuoteMark, "g"), `\\${expectedQuoteMark}`)
                     + expectedQuoteMark;
 
-                const fix = new Lint.Fix(Rule.metadata.ruleName, [ new Lint.Replacement(position, width, newText) ]);
+                const fix = this.createFix(this.createReplacement(position, width, newText));
                 this.addFailureAt(position, width, failureMessage, fix);
             }
         }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -176,15 +176,11 @@ class SemicolonWalker extends Lint.RuleWalker {
             const lastChild = children[children.length - 1];
             if (node.parent!.kind === ts.SyntaxKind.InterfaceDeclaration && lastChild.kind === ts.SyntaxKind.CommaToken) {
                 const failureStart = lastChild.getStart(sourceFile);
-                const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                    this.createReplacement(failureStart, lastChild.getWidth(sourceFile), ";"),
-                ]);
+                const fix = this.createFix(this.createReplacement(failureStart, lastChild.getWidth(sourceFile), ";"));
                 this.addFailureAt(failureStart, 0, Rule.FAILURE_STRING_COMMA, fix);
             } else {
                 const failureStart = Math.min(position, this.getLimit());
-                const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                    this.appendText(failureStart, ";"),
-                ]);
+                const fix = this.createFix(this.appendText(failureStart, ";"));
                 this.addFailureAt(failureStart, 0, Rule.FAILURE_STRING_MISSING, fix);
             }
         } else if (never && hasSemicolon) {
@@ -199,9 +195,7 @@ class SemicolonWalker extends Lint.RuleWalker {
             if (tokenKind !== ts.SyntaxKind.OpenParenToken && tokenKind !== ts.SyntaxKind.OpenBracketToken
                     && tokenKind !== ts.SyntaxKind.PlusToken && tokenKind !== ts.SyntaxKind.MinusToken) {
                 const failureStart = Math.min(position - 1, this.getLimit());
-                const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                    this.deleteText(failureStart, 1),
-                ]);
+                const fix = this.createFix(this.deleteText(failureStart, 1));
                 this.addFailureAt(failureStart, 1, Rule.FAILURE_STRING_UNNECESSARY, fix);
             }
         }

--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -190,16 +190,12 @@ class FunctionWalker extends Lint.RuleWalker {
     }
 
     private createInvalidWhitespaceFailure(pos: number): Lint.RuleFailure {
-        const fix = new Lint.Fix(Rule.metadata.ruleName, [
-            this.deleteText(pos, 1),
-        ]);
+        const fix = this.createFix(this.deleteText(pos, 1));
         return this.createFailure(pos, 1, Rule.INVALID_WHITESPACE_ERROR, fix);
     }
 
     private createMissingWhitespaceFailure(pos: number): Lint.RuleFailure {
-        const fix = new Lint.Fix(Rule.metadata.ruleName, [
-            this.appendText(pos, " "),
-        ]);
+        const fix = this.createFix(this.appendText(pos, " "));
         return this.createFailure(pos, 1, Rule.MISSING_WHITESPACE_ERROR, fix);
     }
 }

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -243,15 +243,11 @@ class TrailingCommaWalker extends Lint.RuleWalker {
 
                 if (hasTrailingComma && option === "never") {
                     const failureStart = lastGrandChild.getStart();
-                    const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                        this.deleteText(failureStart, 1),
-                    ]);
+                    const fix = this.createFix(this.deleteText(failureStart, 1));
                     this.addFailureAt(failureStart, 1, Rule.FAILURE_STRING_NEVER, fix);
                 } else if (!hasTrailingComma && option === "always") {
                     const failureStart = lastGrandChild.getEnd();
-                    const fix = new Lint.Fix(Rule.metadata.ruleName, [
-                        this.appendText(failureStart, ","),
-                    ]);
+                    const fix = this.createFix(this.appendText(failureStart, ","));
                     this.addFailureAt(failureStart - 1, 1, Rule.FAILURE_STRING_ALWAYS, fix);
                 }
             }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] ~~New feature, bugfix, or~~ enhancement
  - [ ] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Simplify the usage of `RuleWalker.prototype.createFix` to use rest parameter instead of passing an array explicitly. Most of the time only one replacement is needed and it is really awkward to need to wrap it in brackets.
This method is not yet part of any release so it's not a breaking change.
