### PR TITLE
Disable `no-invalid-this` in tslint:latest

### DIFF
--- a/src/configs/latest.ts
+++ b/src/configs/latest.ts
@@ -18,7 +18,7 @@
 // tslint:disable object-literal-sort-keys
 export const rules = {
     // added in v3.x
-    "no-invalid-this": true,
+    "no-invalid-this": false,
     "no-angle-bracket-type-assertion": true,
 
     // added in v4.1


### PR DESCRIPTION
Rule shows false positive in callbacks defined outside of a class and assigned methods (https://github.com/palantir/tslint/issues/1544)

Also, `--noImplicitThis` takes care of the problem the rule addresses