### PR TITLE
no-magic-numbers: Allow default parameter values to be number literals

### DIFF
--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -57,6 +57,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         [ts.SyntaxKind.VariableDeclarationList]: true,
         [ts.SyntaxKind.EnumMember]: true,
         [ts.SyntaxKind.PropertyDeclaration]: true,
+        [ts.SyntaxKind.Parameter]: true,
     };
 
     public static DEFAULT_ALLOWED = [ -1, 0, 1 ];

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -25,7 +25,6 @@ const EXECUTABLE_DIR = path.resolve(process.cwd(), "test", "executable");
 const EXECUTABLE_PATH = path.resolve(EXECUTABLE_DIR, "npm-like-executable");
 const TEMP_JSON_PATH = path.resolve(EXECUTABLE_DIR, "tslint.json");
 
-/* tslint:disable:only-arrow-functions */
 describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
     // tslint:disable:no-invalid-this
     this.slow(3000);    // the executable is JIT-ed each time it runs; avoid showing slowness warnings
@@ -289,7 +288,7 @@ function execCli(args: string[], options: cp.ExecFileOptions, cb: ExecFileCallba
 function execCli(args: string[], options: cp.ExecFileOptions | ExecFileCallback, cb?: ExecFileCallback): cp.ChildProcess {
     let filePath = EXECUTABLE_PATH;
 
-    // Specify extension for Windows executable to avoid ENOENT errors 
+    // Specify extension for Windows executable to avoid ENOENT errors
     if (os.platform() === "win32") {
         filePath += ".cmd";
     }

--- a/test/rules/no-magic-numbers/default/test.ts.lint
+++ b/test/rules/no-magic-numbers/default/test.ts.lint
@@ -22,7 +22,6 @@ class A {
     static test = 1337;
 
     constructor (private a = 1337) {
-                             ~~~~   ['magic numbers' are not allowed]
     }
 }
 


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1965
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update
- [X] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Allowed "magic" numbers to appear inside parameters.