### PR TITLE
Simplify scanning with skippable tokens

### DIFF
--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -60,18 +60,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
-class CommentWalker extends Lint.SkippableTokenAwareRuleWalker {
+class CommentWalker extends Lint.RuleWalker {
     public visitSourceFile(node: ts.SourceFile) {
-        super.visitSourceFile(node);
-        Lint.scanAllTokens(ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text), (scanner: ts.Scanner) => {
-            const skip = this.getSkipEndFromStart(scanner.getStartPos());
-            if (skip !== undefined) {
-                // tokens to skip are places where the scanner gets confused about what the token is, without the proper context
-                // (specifically, regex, identifiers, and templates). So skip those tokens.
-                scanner.setTextPos(skip);
-                return;
-            }
-
+        const scan = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text);
+        Lint.scanAllTokensWithSkip(scan, Lint.getSkippableTokens(node), (scanner: ts.Scanner) => {
             if (scanner.getToken() === ts.SyntaxKind.SingleLineCommentTrivia) {
                 const commentText = scanner.getTokenText();
                 const startPosition = scanner.getTokenPos() + 2;

--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -50,16 +50,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class JsdocWalker extends Lint.SkippableTokenAwareRuleWalker {
     public visitSourceFile(node: ts.SourceFile) {
-        super.visitSourceFile(node);
-        Lint.scanAllTokens(ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text), (scanner: ts.Scanner) => {
-            const skip = this.getSkipEndFromStart(scanner.getStartPos());
-            if (skip !== undefined) {
-                // tokens to skip are places where the scanner gets confused about what the token is, without the proper context
-                // (specifically, regex, identifiers, and templates). So skip those tokens.
-                scanner.setTextPos(skip);
-                return;
-            }
-
+        const scan = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text);
+        Lint.scanAllTokensWithSkip(scan, Lint.getSkippableTokens(node), (scanner: ts.Scanner) => {
             if (scanner.getToken() === ts.SyntaxKind.MultiLineCommentTrivia) {
                 const commentText = scanner.getTokenText();
                 const startPosition = scanner.getTokenPos();


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, ~~bugfix, or~~ enhancement
  - [ ] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

`SkippableTokenAwareRuleWalker` is totally overkill to just find the start and end position of identifiers, regex literals and template expressions.
I added the utility function `getSkippableTokens` to do exactly the same without the walker overhead. This function also takes advantage of proper tail calls if implemented in the vm.

Also the code for skipping tokens while scanning was copied to 5 different classes. I added a new function `scanAllTokensWithSkip` (name is for discussion) to address 4 of them.

#### Performance

I turns out that the overall performance gain for the 4 walkers is around 50%.
I profiled linting of `tslint` sources. Total time was 14s. Before this change each of `EnableDisableRuleWalker`, `CommentFormatRule`, `JsdocFormatRule` and `NoTrailingWhitespaceRule` accounted for around 260ms (~1.85% of total).
With this change each execution time reduces to under 120ms (~0.85% of total).

#### Is there anything you'd like reviewers to focus on?

`whitespaceRule` actually needs the walker to do its thing, so I left it untouched. Using `utils.getSkippableTokens` would walk the AST a second time. The slowdown is almost not measurable, but there is no real benefit either. Also the skipping logic here is different, as it needs to add failures before skipping.
