### PR TITLE
Add JSX text nodes into skip list of walker (fixes #2007)

### DIFF
--- a/src/language/walker/skippableTokenAwareRuleWalker.ts
+++ b/src/language/walker/skippableTokenAwareRuleWalker.ts
@@ -37,6 +37,11 @@ export class SkippableTokenAwareRuleWalker extends RuleWalker {
         super.visitTemplateExpression(node);
     }
 
+    protected visitJsxText(node: ts.JsxText) {
+        this.addTokenToSkipFromNode(node);
+        super.visitJsxText(node);
+    }
+
     protected addTokenToSkipFromNode(node: ts.Node) {
         const start = node.getStart();
         const end = node.getEnd();

--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -206,6 +206,10 @@ export class SyntaxWalker {
         this.walkChildren(node);
     }
 
+    protected visitJsxText(node: ts.JsxText) {
+        this.walkChildren(node);
+    }
+
     protected visitLabeledStatement(node: ts.LabeledStatement) {
         this.walkChildren(node);
     }
@@ -526,6 +530,10 @@ export class SyntaxWalker {
 
             case ts.SyntaxKind.JsxSpreadAttribute:
                 this.visitJsxSpreadAttribute(node as ts.JsxSpreadAttribute);
+                break;
+
+            case ts.SyntaxKind.JsxText:
+                this.visitJsxText(node as ts.JsxText);
                 break;
 
             case ts.SyntaxKind.LabeledStatement:

--- a/src/rules/noTrailingWhitespaceRule.ts
+++ b/src/rules/noTrailingWhitespaceRule.ts
@@ -41,6 +41,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class NoTrailingWhitespaceWalker extends Lint.SkippableTokenAwareRuleWalker {
+    // prevents skipping of JsxText nodes
+    protected visitJsxText(node: ts.JsxText) {
+        this.walkChildren(node);
+    }
+
     public visitSourceFile(node: ts.SourceFile) {
         super.visitSourceFile(node);
         let lastSeenWasWhitespace = false;

--- a/test/rules/_integration/enable-disable/test.tsx.lint
+++ b/test/rules/_integration/enable-disable/test.tsx.lint
@@ -19,3 +19,16 @@ const span = (
         text
     </span>
 );
+
+const span = (
+    <span>
+        {x + 'works with text'} // tslint:disable-line
+        works with text
+    </span>
+);
+
+const span = (
+    <span>
+        {x + 'failing test case'} // tslint:disable-line
+    </span>
+);

--- a/test/rules/_integration/enable-disable/test.tsx.lint
+++ b/test/rules/_integration/enable-disable/test.tsx.lint
@@ -27,6 +27,7 @@ const span = (
     </span>
 );
 
+// false negative test case
 const span = (
     <span>
         {x + 'failing test case'} // tslint:disable-line

--- a/test/rules/_integration/enable-disable/test.tsx.lint
+++ b/test/rules/_integration/enable-disable/test.tsx.lint
@@ -1,0 +1,21 @@
+const span = (
+    <span>
+        without this text test fails
+        /* tslint:disable */
+        {
+            x + 'test'
+                ~~~~~~ [' should be "]
+        }
+        text
+    </span>
+);
+
+const span = (
+    <span>
+        without this text test fails
+        // tslint:disable-next-line
+        {x + 'test'}
+             ~~~~~~ [' should be "]
+        text
+    </span>
+);

--- a/test/rules/comment-format/lower/test.tsx.lint
+++ b/test/rules/comment-format/lower/test.tsx.lint
@@ -1,0 +1,12 @@
+const a = (
+    <a href="https://github.com/">
+        https://github.com/ {
+            //invalid comment
+              ~~~~~~~~~~~~~~~ [space]
+            content
+        },	text
+    </a>
+);
+
+
+[space]: comment must start with a space

--- a/test/rules/no-trailing-whitespace/test.tsx.lint
+++ b/test/rules/no-trailing-whitespace/test.tsx.lint
@@ -1,0 +1,33 @@
+class Clazz {
+    public funcxion() {    
+                       ~~~~ [0]
+        console.log("test")   ;    
+                               ~~~~ [0]
+    }
+    
+~~~~ [0]
+    
+~~~~ [0]
+    private foobar() {
+    }
+}    
+ ~~~~ [0]
+
+const span = (    
+              ~~~~ [0]
+    <span>    
+          ~~~~ [0]
+        without this text test fails    
+                                    ~~~~ [0]
+        
+~~~~~~~~ [0]
+        {x + 'test'}    
+                    ~~~~ [0]
+        text    
+            ~~~~ [0]
+    </span>    
+           ~~~~ [0]
+);  
+  ~~ [0]
+
+[0]: trailing whitespace


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2007
- [x] ~New feature,~ bugfix, ~or enhancement~
  - [x] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

This PR adds `JsxText` nodes into skip map in `SkippableTokenAwareRuleWalker`.

#### Is there anything you'd like reviewers to focus on?

1. This change should definitely skip `JsxText` nodes in `EnableDisableRulesWalker`, `CommentWalker` and `JsdocWalker`, but I'm unsure about `WhitespaceWalker` and `NoTrailingWhitespaceWalker`.

2. If `JsxText` node consist of whitespace and "comment" it isn't added to skip map since `getStart()` and `getEnd()` return same value. See [test case](https://github.com/palantir/tslint/pull/2009/files#diff-a6ab2cec0ac51f38a677150e1b954946R32)