### PR TITLE
Clean up quotemarkRule.ts

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -139,22 +139,44 @@
     "ruleName": "comment-format",
     "description": "Enforces formatting rules for single-line comments.",
     "rationale": "Helps maintain a consistent, readable style in your codebase.",
-    "optionsDescription": "\nThree arguments may be optionally provided:\n\n* `\"check-space\"` requires that all single-line comments must begin with a space, as in `// comment`\n    * note that comments starting with `///` are also allowed, for things such as `///<reference>`\n* `\"check-lowercase\"` requires that the first non-whitespace character of a comment must be lowercase, if applicable.\n* `\"check-uppercase\"` requires that the first non-whitespace character of a comment must be uppercase, if applicable.",
+    "optionsDescription": "\nThree arguments may be optionally provided:\n\n* `\"check-space\"` requires that all single-line comments must begin with a space, as in `// comment`\n    * note that comments starting with `///` are also allowed, for things such as `///<reference>`\n* `\"check-lowercase\"` requires that the first non-whitespace character of a comment must be lowercase, if applicable.\n* `\"check-uppercase\"` requires that the first non-whitespace character of a comment must be uppercase, if applicable.\n\nExceptions to `\"check-lowercase\"` or `\"check-uppercase\"` can be managed with object that may be passed as last argument.\n\nOne of two options can be provided in this object:\n    \n    * `\"ignoreWords\"`  - array of strings - words that will be ignored at the beginning of the comment.\n    * `\"ignorePattern\"` - string - RegExp pattern that will be ignored at the beginning of the comment.\n",
     "options": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": [
-          "check-space",
-          "check-lowercase",
-          "check-uppercase"
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "check-space",
+              "check-lowercase",
+              "check-uppercase"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ignoreWords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "ignorePattern": {
+                "type": "string"
+              }
+            },
+            "minProperties": 1,
+            "maxProperties": 1
+          }
         ]
       },
       "minLength": 1,
-      "maxLength": 3
+      "maxLength": 4
     },
     "optionExamples": [
-      "[true, \"check-space\", \"check-lowercase\"]"
+      "[true, \"check-space\", \"check-uppercase\"]",
+      "[true, \"check-lowercase\", {\"ignoreWords\": [\"TODO\", \"HACK\"]}]",
+      "[true, \"check-lowercase\", {\"ignorePattern\": \"STD\\w{2,3}\\b\"}]"
     ],
     "type": "style",
     "typescriptOnly": false

--- a/docs/rules/comment-format/index.html
+++ b/docs/rules/comment-format/index.html
@@ -2,7 +2,7 @@
 ruleName: comment-format
 description: Enforces formatting rules for single-line comments.
 rationale: 'Helps maintain a consistent, readable style in your codebase.'
-optionsDescription: |-
+optionsDescription: |
 
   Three arguments may be optionally provided:
 
@@ -10,18 +10,38 @@ optionsDescription: |-
       * note that comments starting with `///` are also allowed, for things such as `///<reference>`
   * `"check-lowercase"` requires that the first non-whitespace character of a comment must be lowercase, if applicable.
   * `"check-uppercase"` requires that the first non-whitespace character of a comment must be uppercase, if applicable.
+
+  Exceptions to `"check-lowercase"` or `"check-uppercase"` can be managed with object that may be passed as last argument.
+
+  One of two options can be provided in this object:
+      
+      * `"ignoreWords"`  - array of strings - words that will be ignored at the beginning of the comment.
+      * `"ignorePattern"` - string - RegExp pattern that will be ignored at the beginning of the comment.
 options:
   type: array
   items:
-    type: string
-    enum:
-      - check-space
-      - check-lowercase
-      - check-uppercase
+    anyOf:
+      - type: string
+        enum:
+          - check-space
+          - check-lowercase
+          - check-uppercase
+      - type: object
+        properties:
+          ignoreWords:
+            type: array
+            items:
+              type: string
+          ignorePattern:
+            type: string
+        minProperties: 1
+        maxProperties: 1
   minLength: 1
-  maxLength: 3
+  maxLength: 4
 optionExamples:
-  - '[true, "check-space", "check-lowercase"]'
+  - '[true, "check-space", "check-uppercase"]'
+  - '[true, "check-lowercase", {"ignoreWords": ["TODO", "HACK"]}]'
+  - '[true, "check-lowercase", {"ignorePattern": "STD\w{2,3}\b"}]'
 type: style
 typescriptOnly: false
 layout: rule
@@ -30,14 +50,34 @@ optionsJSON: |-
   {
     "type": "array",
     "items": {
-      "type": "string",
-      "enum": [
-        "check-space",
-        "check-lowercase",
-        "check-uppercase"
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "check-space",
+            "check-lowercase",
+            "check-uppercase"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ignoreWords": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignorePattern": {
+              "type": "string"
+            }
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        }
       ]
     },
     "minLength": 1,
-    "maxLength": 3
+    "maxLength": 4
   }
 ---


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update
- [X] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Cleaned up `quotemarkRule.ts`.

#### Is there anything you'd like reviewers to focus on?

`isEnabled()` is still ugly. We need a solution that allows us to declaratively describe the options and get back the parsed options, without calling `hasOptions` over and over again.