### PR TITLE
Add `prefer-method-signature` rule

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -1281,6 +1281,17 @@
     "typescriptOnly": false
   },
   {
+    "ruleName": "prefer-method-signature",
+    "description": "Prefer `foo(): void` over `foo: () => void`.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "style",
+    "typescriptOnly": false
+  },
+  {
     "ruleName": "promise-function-async",
     "description": "Requires any function or method that returns a promise to be marked async.",
     "rationale": "\nEnsures that each function is only capable of 1) returning a rejected promise, or 2)\nthrowing an Error object. In contrast, non-`async` `Promise`-returning functions\nare technically capable of either. This practice removes a requirement for consuming\ncode to handle both cases.\n        ",

--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -1282,7 +1282,8 @@
   },
   {
     "ruleName": "prefer-method-signature",
-    "description": "Prefer `foo(): void` over `foo: () => void`.",
+    "description": "Prefer `foo(): void` over `foo: () => void` in interfaces and types.",
+    "hasFix": true,
     "optionsDescription": "Not configurable.",
     "options": null,
     "optionExamples": [

--- a/docs/rules/prefer-method-signature/index.html
+++ b/docs/rules/prefer-method-signature/index.html
@@ -1,0 +1,13 @@
+---
+ruleName: prefer-method-signature
+description: 'Prefer `foo(): void` over `foo: () => void`.'
+optionsDescription: Not configurable.
+options: null
+optionExamples:
+  - 'true'
+type: style
+typescriptOnly: false
+layout: rule
+title: 'Rule: prefer-method-signature'
+optionsJSON: 'null'
+---

--- a/docs/rules/prefer-method-signature/index.html
+++ b/docs/rules/prefer-method-signature/index.html
@@ -1,6 +1,7 @@
 ---
 ruleName: prefer-method-signature
-description: 'Prefer `foo(): void` over `foo: () => void`.'
+description: 'Prefer `foo(): void` over `foo: () => void` in interfaces and types.'
+hasFix: true
 optionsDescription: Not configurable.
 options: null
 optionExamples:

--- a/src/rules/preferMethodSignatureRule.ts
+++ b/src/rules/preferMethodSignatureRule.ts
@@ -23,7 +23,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "prefer-method-signature",
-        description: "Prefer `foo(): void` over `foo: () => void`.",
+        description: "Prefer `foo(): void` over `foo: () => void` in interfaces and types.",
+        hasFix: true,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: ["true"],

--- a/src/rules/preferMethodSignatureRule.ts
+++ b/src/rules/preferMethodSignatureRule.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "prefer-method-signature",
+        description: "Prefer `foo(): void` over `foo: () => void`.",
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "style",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Use a method signature instead of a property signature of function type.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+    }
+}
+
+class Walker extends Lint.RuleWalker {
+    public visitPropertySignature(node: ts.PropertyDeclaration) {
+        const { type } = node;
+        if (type !== undefined && type.kind === ts.SyntaxKind.FunctionType) {
+            this.addFailureAtNode(node.name, Rule.FAILURE_STRING, this.createMethodSignatureFix(node, type as ts.FunctionTypeNode));
+        }
+
+        super.visitPropertySignature(node);
+    }
+
+    private createMethodSignatureFix(node: ts.PropertyDeclaration, type: ts.FunctionTypeNode): Lint.Fix | undefined {
+        return type.type && this.createFix(
+            this.deleteFromTo(Lint.childOfKind(node, ts.SyntaxKind.ColonToken)!.getStart(), type.getStart()),
+            this.deleteFromTo(Lint.childOfKind(type, ts.SyntaxKind.EqualsGreaterThanToken)!.getStart(), type.type.getStart()),
+            this.appendText(Lint.childOfKind(type, ts.SyntaxKind.CloseParenToken)!.end, ":"));
+    }
+}

--- a/test/rules/prefer-method-signature/test.ts.fix
+++ b/test/rules/prefer-method-signature/test.ts.fix
@@ -1,0 +1,14 @@
+interface I {
+    foo(): void;
+    bar<T>(): T;
+}
+
+type T = {
+    foo?(): void;
+}
+
+class C {
+    // OK in class
+    foo: () => void;
+}
+

--- a/test/rules/prefer-method-signature/test.ts.lint
+++ b/test/rules/prefer-method-signature/test.ts.lint
@@ -1,0 +1,18 @@
+interface I {
+    foo: () => void;
+    ~~~ [0]
+    bar: <T>() => T;
+    ~~~ [0]
+}
+
+type T = {
+    foo?: () => void;
+    ~~~ [0]
+}
+
+class C {
+    // OK in class
+    foo: () => void;
+}
+
+[0]: Use a method signature instead of a property signature of function type.

--- a/test/rules/prefer-method-signature/tslint.json
+++ b/test/rules/prefer-method-signature/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "prefer-method-signature": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update
- [X] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Added the `prefer-method-signature` rule, which recommends to use `foo(): void` over `foo: () => void`.

It looks like these will be semantically equivalent in TS2.2. (And were in 2.0.) https://github.com/Microsoft/TypeScript/issues/13148#issuecomment-270204165