### PR TITLE
Wordsmith the error message for no-inferrable-types a bit

### DIFF
--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -48,7 +48,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING_FACTORY = (type: string) => {
-        return `LHS type (${type}) inferred by RHS expression, remove type annotation`;
+        return `Type ${type} trivially inferred from a ${type} literal, remove type annotation`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/test/rules/no-inferrable-types/default/test.ts.lint
+++ b/test/rules/no-inferrable-types/default/test.ts.lint
@@ -26,6 +26,6 @@ function bar(a = 5, b = true, c = "bah") { }
 // not errors, types are not inferrable
 function baz(a: any = 5, b: any = true, c: any = "bah") { }
 
-[number]: LHS type (number) inferred by RHS expression, remove type annotation
-[boolean]: LHS type (boolean) inferred by RHS expression, remove type annotation
-[string]: LHS type (string) inferred by RHS expression, remove type annotation
+[number]: Type number trivially inferred from a number literal, remove type annotation
+[boolean]: Type boolean trivially inferred from a boolean literal, remove type annotation
+[string]: Type string trivially inferred from a string literal, remove type annotation

--- a/test/rules/no-inferrable-types/ignore-params/test.ts.lint
+++ b/test/rules/no-inferrable-types/ignore-params/test.ts.lint
@@ -27,6 +27,6 @@ function bar(a = 5, b = true, c = "bah") { }
 // not errors, types are not inferrable
 function baz(a: any = 5, b: any = true, c: any = "bah") { }
 
-[number]: LHS type (number) inferred by RHS expression, remove type annotation
-[boolean]: LHS type (boolean) inferred by RHS expression, remove type annotation
-[string]: LHS type (string) inferred by RHS expression, remove type annotation
+[number]: Type number trivially inferred from a number literal, remove type annotation
+[boolean]: Type boolean trivially inferred from a boolean literal, remove type annotation
+[string]: Type string trivially inferred from a string literal, remove type annotation


### PR DESCRIPTION
In particular, call out that only trivially inferred types of literals
should be left out, not every type that's inferrable.

#### PR checklist

- [x] Documentation update

#### What changes did you make?

Wordsmith the error message for no-inferrable-types to make it easier to understand for users why this is considered lint, and when they should use types that could be inferred.