### PR TITLE
Introduce alternative to SkippableTokenAwareRuleWalker and scanAllTokens

### DIFF
--- a/src/enableDisableRules.ts
+++ b/src/enableDisableRules.ts
@@ -19,11 +19,11 @@ import * as ts from "typescript";
 
 import {AbstractRule} from "./language/rule/abstractRule";
 import {IOptions} from "./language/rule/rule";
-import {scanAllTokens} from "./language/utils";
-import {SkippableTokenAwareRuleWalker} from "./language/walker/skippableTokenAwareRuleWalker";
+import {forEachComment, TokenPosition} from "./language/utils";
+import {RuleWalker} from "./language/walker/ruleWalker";
 import {IEnableDisablePosition} from "./ruleLoader";
 
-export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
+export class EnableDisableRulesWalker extends RuleWalker {
     public enableDisableRuleMap: {[rulename: string]: IEnableDisablePosition[]} = {};
 
     constructor(sourceFile: ts.SourceFile, options: IOptions, rules: {[name: string]: any}) {
@@ -42,25 +42,8 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
     }
 
     public visitSourceFile(node: ts.SourceFile) {
-        super.visitSourceFile(node);
-        const scan = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, node.text);
-
-        scanAllTokens(scan, (scanner: ts.Scanner) => {
-            const startPos = scanner.getStartPos();
-            const skip = this.getSkipEndFromStart(startPos);
-            if (skip !== undefined) {
-                // tokens to skip are places where the scanner gets confused about what the token is, without the proper context
-                // (specifically, regex, identifiers, and templates). So skip those tokens.
-                scanner.setTextPos(skip);
-                return;
-            }
-
-            if (scanner.getToken() === ts.SyntaxKind.MultiLineCommentTrivia ||
-                scanner.getToken() === ts.SyntaxKind.SingleLineCommentTrivia) {
-                const commentText = scanner.getTokenText();
-                const startPosition = scanner.getTokenPos();
-                this.handlePossibleTslintSwitch(commentText, startPosition, node, scanner);
-            }
+        forEachComment(node, (fullText, _kind, pos) => {
+            return this.handlePossibleTslintSwitch(fullText.substring(pos.tokenStart, pos.end), node, pos);
         });
     }
 
@@ -97,7 +80,7 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
         return ruleStateMap[ruleStateMap.length - 1].isEnabled;
     }
 
-    private handlePossibleTslintSwitch(commentText: string, startingPosition: number, node: ts.SourceFile, scanner: ts.Scanner) {
+    private handlePossibleTslintSwitch(commentText: string, node: ts.SourceFile, pos: TokenPosition) {
         // regex is: start of string followed by "/*" or "//" followed by any amount of whitespace followed by "tslint:"
         if (commentText.match(/^(\/\*|\/\/)\s*tslint:/)) {
             const commentTextParts = commentText.split(":");
@@ -150,18 +133,18 @@ export class EnableDisableRulesWalker extends SkippableTokenAwareRuleWalker {
 
                     if (isCurrentLine) {
                         // start at the beginning of the current line
-                        start = this.getStartOfLinePosition(node, startingPosition);
+                        start = this.getStartOfLinePosition(node, pos.tokenStart);
                         // end at the beginning of the next line
-                        end = scanner.getTextPos() + 1;
+                        end = pos.end + 1;
                     } else if (isNextLine) {
                         // start at the current position
-                        start = startingPosition;
+                        start = pos.tokenStart;
                         // end at the beginning of the line following the next line
-                        end = this.getStartOfLinePosition(node, startingPosition, 2);
+                        end = this.getStartOfLinePosition(node, pos.tokenStart, 2);
                     } else {
                         // disable rule for the rest of the file
                         // start at the current position, but skip end position
-                        start = startingPosition;
+                        start = pos.tokenStart;
                         end = undefined;
                     }
 

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -247,7 +247,8 @@ export interface TokenPosition {
     /** The end of the token */
     end: number;
 }
-export type ForEachCallback = (fullText: string, kind: ts.SyntaxKind, pos: TokenPosition) => void;
+export type ForEachTokenCallback = (fullText: string, kind: ts.SyntaxKind, pos: TokenPosition, parent: ts.Node) => void;
+export type ForEachCommentCallback = (fullText: string, kind: ts.SyntaxKind, pos: TokenPosition) => void;
 export type FilterCallback = (node: ts.Node) => boolean;
 
 /**
@@ -256,16 +257,16 @@ export type FilterCallback = (node: ts.Node) => boolean;
  * @description JsDoc comments are treated like regular comments and only visited if `skipTrivia` === false.
  * 
  * @param node The node whose tokens should be visited
- * @param skipTrivia If set to false all trivia owned by `node` or its children is included
+ * @param skipTrivia If set to false all trivia preceeding `node` or any of its children is included
  * @param cb Is called for every token of `node`. It gets the full text of the SourceFile and the position of the token within that text.
  * @param filter If provided, will be called for every Node and Token found. If it returns false `cb` will not be called for this subtree.
  */
-export function forEachToken(node: ts.Node, skipTrivia: boolean, cb: ForEachCallback, filter?: FilterCallback) {
+export function forEachToken(node: ts.Node, skipTrivia: boolean, cb: ForEachTokenCallback, filter?: FilterCallback) {
     // this function will most likely be called with SourceFile anyways, so there is no need for an additional parameter
     const sourceFile = node.getSourceFile();
     const fullText = sourceFile.text;
-    const scanner = skipTrivia ? undefined : ts.createScanner(sourceFile.languageVersion, false, sourceFile.languageVariant, fullText);
     const iterateFn = filter === undefined ? iterateChildren : iterateWithFilter;
+    const handleTrivia = skipTrivia ? undefined : createTriviaHandler(sourceFile, cb);
 
     iterateFn(node);
 
@@ -294,47 +295,113 @@ export function forEachToken(node: ts.Node, skipTrivia: boolean, cb: ForEachCall
         const tokenStart = token.getStart(sourceFile);
         if (!skipTrivia && tokenStart !== token.pos) {
             // we only have to handle trivia before each token, because there is nothing after EndOfFileToken
-            handleTrivia(token.pos, tokenStart);
+            handleTrivia!(token.pos, tokenStart, token);
         }
-        return cb(fullText, token.kind, {tokenStart, fullStart: token.pos, end: token.end});
+        return cb(fullText, token.kind, {tokenStart, fullStart: token.pos, end: token.end}, token.parent!);
     }
+}
 
+function createTriviaHandler(sourceFile: ts.SourceFile, cb: ForEachTokenCallback) {
+    const fullText = sourceFile.text;
+    const scanner = ts.createScanner(sourceFile.languageVersion, false, sourceFile.languageVariant, fullText);
     /** 
      * Scan the specified range to get all trivia tokens.
      * This includes trailing trivia of the last token and the leading trivia of the current token
      */
-    function handleTrivia(start: number, end: number) {
-        scanner!.setTextPos(start);
+    function handleTrivia(start: number, end: number, token: ts.Node) {
+        const parent = token.parent!;
+        // prevent false positives by not scanning inside JsxText
+        if (!canHaveLeadingTrivia(token.kind, parent)) {
+            return;
+        }
+        scanner.setTextPos(start);
         let position: number;
         // we only get here if start !== end, so we can scan at least one time
         do {
-            const kind = scanner!.scan();
-            position = scanner!.getTextPos();
-            cb(fullText, kind, {tokenStart: scanner!.getTokenPos(), end: position, fullStart: start});
+            const kind = scanner.scan();
+            position = scanner.getTextPos();
+            cb(fullText, kind, {tokenStart: scanner.getTokenPos(), end: position, fullStart: start}, parent);
         } while (position < end);
     }
+
+    return handleTrivia;
 }
 
-// TODO whitespaceRule template expression
-
 /** Iterate over all comments owned by `node` or its children */
-export function forEachComment(node: ts.Node, cb: ForEachCallback) {
-    // get all tokens and skip trivia. comment ranges between tokens are parsed without the need of a scanner
-    return forEachToken(node, true, (fullText, _kind, pos) => {
-        // Comments before the first token (pos.fullStart === 0) are all considered leading comments, so no need for special treatment
-        ts.forEachLeadingCommentRange(fullText, pos.fullStart, commentCallback);
-        ts.forEachTrailingCommentRange(fullText, pos.end, commentCallback);
+export function forEachComment(node: ts.Node, cb: ForEachCommentCallback) {
+    /* Visit all tokens and skip trivia.
+       Comment ranges between tokens are parsed without the need of a scanner.
+       forEachToken also does intentionally not pay attention to the correct comment ownership of nodes as it always
+       scans all trivia before each token, which could include trailing comments of the previous token.
+       Comment onwership is done right in this function*/
+    return forEachToken(node, true, (fullText, tokenKind, pos, parent) => {
+        // don't search for comments inside JsxText
+        if (canHaveLeadingTrivia(tokenKind, parent)) {
+            // Comments before the first token (pos.fullStart === 0) are all considered leading comments, so no need for special treatment
+            ts.forEachLeadingCommentRange(fullText, pos.fullStart, commentCallback);
+        }
+        if (canHaveTrailingTrivia(tokenKind, parent)) {
+            ts.forEachTrailingCommentRange(fullText, pos.end, commentCallback);
+        }
         function commentCallback(tokenStart: number, end: number, kind: ts.SyntaxKind) {
             cb(fullText, kind, {tokenStart, end, fullStart: pos.fullStart});
         }
     });
 }
 
+/** Exclude leading positions that would lead to scanning for trivia inside JsxText */
+function canHaveLeadingTrivia(tokenKind: ts.SyntaxKind, parent: ts.Node): boolean {
+    if (tokenKind === ts.SyntaxKind.JsxText) {
+        return false; // there is no trivia before JsxText
+    }
+    if (tokenKind === ts.SyntaxKind.OpenBraceToken) {
+        // before a JsxExpression inside a JsxElement's body can only be other JsxChild, but no trivia
+        return parent.kind !== ts.SyntaxKind.JsxExpression || parent.parent!.kind !== ts.SyntaxKind.JsxElement;
+    }
+    if (tokenKind === ts.SyntaxKind.LessThanToken) {
+        if (parent.kind === ts.SyntaxKind.JsxClosingElement) {
+            return false; // would be inside the element body
+        }
+        if (parent.kind === ts.SyntaxKind.JsxOpeningElement || parent.kind === ts.SyntaxKind.JsxSelfClosingElement) {
+            // there can only be leading trivia if we are at the end of the top level element
+            return parent.parent!.parent!.kind !== ts.SyntaxKind.JsxElement;
+        }
+    }
+    return true;
+}
+
+/** Exclude trailing positions that would lead to scanning for trivia inside JsxText */
+function canHaveTrailingTrivia(tokenKind: ts.SyntaxKind, parent: ts.Node): boolean {
+    if (tokenKind === ts.SyntaxKind.JsxText) {
+        return false; // there is no trivia after JsxText
+    }
+    if (tokenKind === ts.SyntaxKind.CloseBraceToken) {
+        // after a JsxExpression inside a JsxElement's body can only be other JsxChild, but no trivia
+        return parent.kind !== ts.SyntaxKind.JsxExpression || parent.parent!.kind !== ts.SyntaxKind.JsxElement;
+    }
+    if (tokenKind === ts.SyntaxKind.GreaterThanToken) {
+        if (parent.kind === ts.SyntaxKind.JsxOpeningElement) {
+            return false; // would be inside the element
+        }
+        if (parent.kind === ts.SyntaxKind.JsxClosingElement || parent.kind === ts.SyntaxKind.JsxSelfClosingElement) {
+            // there can only be trailing trivia if we are at the end of the top level element
+            return parent.parent!.parent!.kind !== ts.SyntaxKind.JsxElement;
+        }
+    }
+    return true;
+}
+
 function hasCommentCallback() {
     return true;
 }
 
-/** Checks if there are any comments between `position` and the next non-tivia token */
+/** 
+ * Checks if there are any comments between `position` and the next non-tivia token
+ * 
+ * @param text The text to scan
+ * @param position The position inside `text` where to start scanning. Make sure that this is a valid start position.
+ *                 This value is typically obtained from `node.getFullStart()` or `node.getEnd()`
+ */
 export function hasCommentAfterPosition(text: string, position: number): boolean {
     return ts.forEachTrailingCommentRange(text, position, hasCommentCallback) ||
            ts.forEachLeadingCommentRange(text, position, hasCommentCallback) ||

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -391,19 +391,16 @@ function canHaveTrailingTrivia(tokenKind: ts.SyntaxKind, parent: ts.Node): boole
     return true;
 }
 
-function hasCommentCallback() {
-    return true;
-}
-
 /** 
- * Checks if there are any comments between `position` and the next non-tivia token
+ * Checks if there are any comments between `position` and the next non-trivia token
  * 
  * @param text The text to scan
  * @param position The position inside `text` where to start scanning. Make sure that this is a valid start position.
  *                 This value is typically obtained from `node.getFullStart()` or `node.getEnd()`
  */
 export function hasCommentAfterPosition(text: string, position: number): boolean {
-    return ts.forEachTrailingCommentRange(text, position, hasCommentCallback) ||
-           ts.forEachLeadingCommentRange(text, position, hasCommentCallback) ||
+    const cb = () => true;
+    return ts.forEachTrailingCommentRange(text, position, cb) ||
+           ts.forEachLeadingCommentRange(text, position, cb) ||
            false; // return boolean instead of undefined if no comment is found
 }

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -35,7 +35,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Enforces whitespace style conventions.",
         rationale: "Helps maintain a readable, consistent style in your codebase.",
         optionsDescription: Lint.Utils.dedent`
-            Seven arguments may be optionally provided:
+            Eight arguments may be optionally provided:
 
             * \`"check-branch"\` checks branching statements (\`if\`/\`else\`/\`for\`/\`while\`) are followed by whitespace.
             * \`"check-decl"\`checks that variable declarations have whitespace around the equals token.

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -80,7 +80,7 @@ class WhitespaceWalker extends Lint.RuleWalker {
         super.visitSourceFile(node);
 
         let prevTokenShouldBeFollowedByWhitespace = false;
-        Lint.forEachToken(node, false, (_text, tokenKind, pos) => {
+        Lint.forEachToken(node, false, (_text, tokenKind, pos, parent) => {
             if (tokenKind === ts.SyntaxKind.WhitespaceTrivia || tokenKind === ts.SyntaxKind.NewLineTrivia) {
                 prevTokenShouldBeFollowedByWhitespace = false;
                 return;
@@ -107,7 +107,7 @@ class WhitespaceWalker extends Lint.RuleWalker {
                     }
                     break;
                 case ts.SyntaxKind.EqualsToken:
-                    if (this.hasOption(OPTION_DECL)) {
+                    if (this.hasOption(OPTION_DECL) && parent.kind !== ts.SyntaxKind.JsxAttribute) {
                         prevTokenShouldBeFollowedByWhitespace = true;
                     }
                     break;
@@ -126,10 +126,6 @@ class WhitespaceWalker extends Lint.RuleWalker {
                 default:
                     break;
             }
-        },
-        (n) => {
-            // don't apply the whitespace rules to JSX specific syntax
-            return n.kind !== ts.SyntaxKind.JsxElement && n.kind !== ts.SyntaxKind.JsxSelfClosingElement;
         });
     }
 

--- a/test/rules/_integration/enable-disable/test.tsx.lint
+++ b/test/rules/_integration/enable-disable/test.tsx.lint
@@ -19,3 +19,16 @@ const span = (
         text
     </span>
 );
+
+const span = (
+    <span>
+        {x + 'works with text'} // tslint:disable-line
+        works with text
+    </span>
+);
+
+const span = (
+    <span>
+        {x + 'failing test case'} // tslint:disable-line
+    </span>
+);

--- a/test/rules/_integration/enable-disable/test.tsx.lint
+++ b/test/rules/_integration/enable-disable/test.tsx.lint
@@ -1,0 +1,21 @@
+const span = (
+    <span>
+        without this text test fails
+        /* tslint:disable */
+        {
+            x + 'test'
+                ~~~~~~ [' should be "]
+        }
+        text
+    </span>
+);
+
+const span = (
+    <span>
+        without this text test fails
+        // tslint:disable-next-line
+        {x + 'test'}
+             ~~~~~~ [' should be "]
+        text
+    </span>
+);

--- a/test/rules/_integration/enable-disable/test.tsx.lint
+++ b/test/rules/_integration/enable-disable/test.tsx.lint
@@ -1,6 +1,5 @@
 const span = (
     <span>
-        without this text test fails
         /* tslint:disable */
         {
             x + 'test'
@@ -12,7 +11,6 @@ const span = (
 
 const span = (
     <span>
-        without this text test fails
         // tslint:disable-next-line
         {x + 'test'}
              ~~~~~~ [' should be "]
@@ -22,13 +20,50 @@ const span = (
 
 const span = (
     <span>
-        {x + 'works with text'} // tslint:disable-line
+        {x + 'comment is ignored with text'} // tslint:disable-line
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [' should be "]
         works with text
     </span>
 );
 
 const span = (
     <span>
-        {x + 'failing test case'} // tslint:disable-line
+        {x + 'comment is ignored without text'} // tslint:disable-line
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [' should be "]
+    </span>
+);
+
+const span = (
+    <span>
+    /* tslint:disable */ <span>{x + 'ignores comments before element if not root'}</span>
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [' should be "]
+    </span>
+);
+
+const span = (
+    <span>
+        <span>{x + 'ignores comments after element if not root'}</span> /* tslint:disable-line */
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [' should be "]
+    </span>
+);
+
+const span = (
+    <span> /* tslint:disable-next-line */
+        <span>{x + 'ignores trailing comments of root element'}</span>
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [' should be "]
+    </span>
+);
+
+const span = (
+    <span>
+        {<span>{x + 'works for comments inside JsxExpression'}</span> /* tslint:disable-line */}
+    </span>
+);
+
+const span = (
+    <span>
+        {/* tslint:disable-next-line */}
+        {x + 'works for comment-only expressions'}
+        text
     </span>
 );

--- a/test/rules/_integration/react/test.tsx.lint
+++ b/test/rules/_integration/react/test.tsx.lint
@@ -25,7 +25,13 @@ export class FooComponent extends React.Component<IFooProps, IFooState> {
 
     public render() {
         return (
-            <div onClick={() => this.onClick()}>
+            <div onClick={() => this.onClick()} class={true===false?"foo":"bar"}>
+                                                           ~                      [missing whitespace]
+                                                              ~                   [missing whitespace]
+                                                                   ~              [missing whitespace]
+                                                                    ~             [missing whitespace]
+                                                                         ~        [missing whitespace]
+                                                                          ~       [missing whitespace]
                 {this.state.bar.map((s) => <span>{s}</span>)}
                 <BazComponent someProp={123} anotherProp={456} />
             </div>

--- a/test/rules/comment-format/lower/test.tsx.lint
+++ b/test/rules/comment-format/lower/test.tsx.lint
@@ -1,0 +1,12 @@
+const a = (
+    <a href="https://github.com/">
+        https://github.com/ {
+            //invalid comment
+              ~~~~~~~~~~~~~~~ [space]
+            content
+        },	text
+    </a>
+);
+
+
+[space]: comment must start with a space

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -53,6 +53,12 @@ var test = `
   <div class="repeat"
 `;
 
+var withinTemplateExpression = `${name === "something" ? "foo" : "bar"}`;
+var withinTemplateExpression = `${name === "something" ? "foo" : "bar"}`;
+
+var objectInsideTemplateExpression = `${({foo: "bar"}).foo}`;
+var objectInsideTemplateExpression = `${({foo: "bar"}).foo}`;
+
 import { importA } from "libA";
 import { importB } from "libB";
 import {importC} from "libC";

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -88,6 +88,19 @@ var test = `
   <div class="repeat"
 `;
 
+var withinTemplateExpression = `${name==="something"?"foo":"bar"}`;
+                                      ~                             [missing whitespace]
+                                         ~                          [missing whitespace]
+                                                    ~               [missing whitespace]
+                                                     ~              [missing whitespace]
+                                                          ~         [missing whitespace]
+                                                           ~        [missing whitespace]
+var withinTemplateExpression = `${name === "something" ? "foo" : "bar"}`;
+
+var objectInsideTemplateExpression = `${({foo:"bar"}).foo}`;
+                                              ~                     [missing whitespace]
+var objectInsideTemplateExpression = `${({foo: "bar"}).foo}`;
+
 import { importA } from "libA";
 import { importB }from "libB";
                   ~            [missing whitespace]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2007
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Scanning the whole source file is very fragile, because the grammar is not context free. You had to skip certain ranges, that were known to cause trouble. For example regex literals or template expressions.
This approach is prone to errors, as it didn't cover all cases and has to adopt new grammar as the language adds it.

The new function hands the scanning and parsing off to the parser and only iterates over the tokens of all AST nodes. Skipping ranges is no longer necessary.

This fixes #2007 and replaces #2009 (I took 2 commits from that PR to include the contained tests)

For more information please refer to the description of each individual commit.

#### Is there anything you'd like reviewers to focus on?

This is a rather big PR. I could split it into several smaller ones if you want.

`WhitespaceRule` used to skip `TemplateExpression`, `JsxElement` and `JsxSelfClosingElement`. That's no longer necessary.
That means not all whitespace errors were found with the previous implementation. Now we find all errors, even inside `JsxExpression` and `TemplateExpression`.
If you think this is a breaking change, I would fall back to skipping the aforementioned nodes for now and submit a separate PR to include them for the next major version.


I'm currently investigating what the performance impact of this change is. I'll keep you posted.