### PR TITLE
no-magic-numbers: Make condition lazy (don't call `.getText()` for every number literal in the file)

### DIFF
--- a/docs/_data/rules.json
+++ b/docs/_data/rules.json
@@ -1720,7 +1720,7 @@
     "ruleName": "whitespace",
     "description": "Enforces whitespace style conventions.",
     "rationale": "Helps maintain a readable, consistent style in your codebase.",
-    "optionsDescription": "\nSeven arguments may be optionally provided:\n\n* `\"check-branch\"` checks branching statements (`if`/`else`/`for`/`while`) are followed by whitespace.\n* `\"check-decl\"`checks that variable declarations have whitespace around the equals token.\n* `\"check-operator\"` checks for whitespace around operator tokens.\n* `\"check-module\"` checks for whitespace in import & export statements.\n* `\"check-separator\"` checks for whitespace after separator tokens (`,`/`;`).\n* `\"check-type\"` checks for whitespace before a variable type specification.\n* `\"check-typecast\"` checks for whitespace between a typecast and its target.",
+    "optionsDescription": "\nSeven arguments may be optionally provided:\n\n* `\"check-branch\"` checks branching statements (`if`/`else`/`for`/`while`) are followed by whitespace.\n* `\"check-decl\"`checks that variable declarations have whitespace around the equals token.\n* `\"check-operator\"` checks for whitespace around operator tokens.\n* `\"check-module\"` checks for whitespace in import & export statements.\n* `\"check-separator\"` checks for whitespace after separator tokens (`,`/`;`).\n* `\"check-type\"` checks for whitespace before a variable type specification.\n* `\"check-typecast\"` checks for whitespace between a typecast and its target.\n* `\"check-preblock\"` checks for whitespace before the opening brace of a block",
     "options": {
       "type": "array",
       "items": {
@@ -1732,7 +1732,8 @@
           "check-module",
           "check-separator",
           "check-type",
-          "check-typecast"
+          "check-typecast",
+          "check-preblock"
         ]
       },
       "minLength": 0,

--- a/docs/rules/whitespace/index.html
+++ b/docs/rules/whitespace/index.html
@@ -13,6 +13,7 @@ optionsDescription: |-
   * `"check-separator"` checks for whitespace after separator tokens (`,`/`;`).
   * `"check-type"` checks for whitespace before a variable type specification.
   * `"check-typecast"` checks for whitespace between a typecast and its target.
+  * `"check-preblock"` checks for whitespace before the opening brace of a block
 options:
   type: array
   items:
@@ -25,6 +26,7 @@ options:
       - check-separator
       - check-type
       - check-typecast
+      - check-preblock
   minLength: 0
   maxLength: 7
 optionExamples:
@@ -45,7 +47,8 @@ optionsJSON: |-
         "check-module",
         "check-separator",
         "check-type",
-        "check-typecast"
+        "check-typecast",
+        "check-preblock"
       ]
     },
     "minLength": 0,

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -1,5 +1,6 @@
 console.log(1337);
 console.log(-1337);
+console.log(- 1337);
 console.log(1337.7);
 console.log(1338);
             ~~~~                      ['magic numbers' are not allowed]


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update
- [X] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Changed to avoid calling `node.getText()` for every number literal.