### PR TITLE
Fix README to correctly show example of using tslint as library

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,26 +215,21 @@ tslint accepts the following command-line options:
 #### Library
 
 ```js
-import { Linter } from "tslint";
+import { Linter, Configuration } from "tslint";
 import * as fs from "fs";
 
-const fileName = "Specify file name";
-const configuration = {
-    rules: {
-        "variable-name": true,
-        "quotemark": [true, "double"]
-    }
-};
+const fileName = "Specify input file name";
+const configurationFilename = "Specify configuration file name";
 const options = {
     formatter: "json",
-    configuration: configuration,
     rulesDirectory: "customRules/",
     formattersDirectory: "customFormatters/"
 };
 
 const fileContents = fs.readFileSync(fileName, "utf8");
-const linter = new Linter(fileName, fileContents, options);
-const result = linter.lint();
+const linter = new Linter(options);
+const configLoad = Configuration.findConfiguration(configurationFilename, filename);
+const result = linter.lint(fileName, fileContents, configLoad.results);
 ```
 
 #### Type Checking
@@ -314,10 +309,10 @@ TSLint ships with a set of core rules that can be configured. However, users are
 
 Let us take the example of how to write a new rule to forbid all import statements (you know, *for science*). Let us name the rule file `noImportsRule.ts`. Rules are referenced in `tslint.json` with their kebab-cased identifer, so `"no-imports": true` would configure the rule.
 
-__Important conventions__: 
+__Important conventions__:
 * Rule identifiers are always kebab-cased.
 * Rule files are always camel-cased (`camelCasedRule.ts`).
-* Rule files *must* contain the suffix `Rule`. 
+* Rule files *must* contain the suffix `Rule`.
 * The exported class must always be named `Rule` and extend from `Lint.Rules.AbstractRule`.
 
 Now, let us first write the rule in TypeScript:


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2011
- [x] Documentation update

#### What changes did you make?

Updated the README example of using tslint as library. It basically explicitly calls `findConfiguration` before calling `lint` API so that `extends` key is resolved correctly.

#### Is there anything you'd like reviewers to focus on?

(optional)

cc: @adidahiya 