### PR TITLE
Change color for visited links

### DIFF
--- a/_sass/_cayman.scss
+++ b/_sass/_cayman.scss
@@ -39,6 +39,10 @@ a {
   &:hover {
     text-decoration: underline;
   }
+
+  &:visited {
+	color: $link-visited-color;
+  }
 }
 
 h1 { font-size: 2.5rem; }

--- a/css/main.scss
+++ b/css/main.scss
@@ -12,9 +12,10 @@ $base-font-size:   16px;
 $small-font-size:  $base-font-size * 0.875;
 $base-line-height: 1.5;
 
-$text-color:       #606c71;
-$link-color:       #1e6bb8;
-$heading-color:    #159957;
+$heading-color:        #159957;
+$text-color:           #606c71;
+$link-color:           #1e6bb8;
+$link-visited-color:   #7d0ce8;
 
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import


### PR DESCRIPTION
This makes it easier, when reviewing rules doc, to see which rules you've seen and which ones you haven't (which is what I ran into). I calculated a color for visited links based on the normal link color using [the Adobe colors tool](https://color.adobe.com/create/color-wheel/?base=2&rule=Analogous&selected=1&name=My%20Color%20Theme&mode=rgb&rgbvalues=0.11764705882352941,0.4196078431372549,0.7215686274509804,0.48953863636362566,0.04550000000000004,0.91,1,0,0,0.91,0.5224758680556909,0.04550000000000004,1,0.9457325268814998,0.050000000000000044&swatchOrder=0,1,2,3,4).