### PR TITLE
Fix no-trailing-whitespace for comments and EOF

### DIFF
--- a/test/rules/no-trailing-whitespace/test.js.fix
+++ b/test/rules/no-trailing-whitespace/test.js.fix
@@ -1,0 +1,10 @@
+class Clazz {
+    public funcxion() {
+        console.log("test")   ;
+    }
+
+
+    private foobar() {
+    }
+}
+

--- a/test/rules/no-trailing-whitespace/test.ts.fix
+++ b/test/rules/no-trailing-whitespace/test.ts.fix
@@ -1,0 +1,20 @@
+class Clazz {
+    public funcxion() {
+        console.log("test")   ;
+    }
+
+
+    private foobar() {
+    }
+}
+// single line comment without trailing whitespace
+// single line comment with trailing whitespace
+ /* single line multiline comment */
+/* whitespace after comment */
+/* first line has trailing whitespace
+   second line is ok
+   last line is not checked         */
+/*
+ */
+
+// following line checks for trailing whitespace before EOF

--- a/test/rules/no-trailing-whitespace/test.ts.lint
+++ b/test/rules/no-trailing-whitespace/test.ts.lint
@@ -1,16 +1,30 @@
 class Clazz {
     public funcxion() {    
-                       ~~~~ [0]
+                       ~~~~ [trailing whitespace]
         console.log("test")   ;    
-                               ~~~~ [0]
+                               ~~~~ [trailing whitespace]
     }
     
-~~~~ [0]
+~~~~ [trailing whitespace]
     
-~~~~ [0]
+~~~~ [trailing whitespace]
     private foobar() {
     }
 }    
- ~~~~ [0]
+ ~~~~ [trailing whitespace]
+// single line comment without trailing whitespace
+// single line comment with trailing whitespace   
+                                               ~~~ [trailing whitespace]
+ /* single line multiline comment */
+/* whitespace after comment */ 
+                              ~ [trailing whitespace]
+/* first line has trailing whitespace  
+                                     ~~ [trailing whitespace]
+   second line is ok
+   last line is not checked         */
+/*
+ */
 
-[0]: trailing whitespace
+// following line checks for trailing whitespace before EOF
+   
+~~~ [trailing whitespace]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2049 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Detect trailing whitespace in comments.
Detect trailing whitespace before EOF.
Add fixer.

#### Is there anything you'd like reviewers to focus on?

(optional)
