### PR TITLE
Rewrite and fix EnableDisableRulesWalker

### DIFF
--- a/docs/usage/rule-flags/index.md
+++ b/docs/usage/rule-flags/index.md
@@ -15,7 +15,7 @@ You can enable/disable TSLint or a subset of rules within a file with the follow
 * `// tslint:disable-next-line:rule1 rule2 rule3...` - Disables the listed rules for the next line
 * etc.
 
-Rules flags enable or disable rules as they are parsed. Disabling an already disabled rule or enabling an already enabled rule has no effect.
+Rules flags enable or disable rules as they are parsed. Disabling an already disabled rule or enabling an already enabled rule has no effect. Enabling a rule that is not present or disabled in `tslint.json` has also no effect.
 
 For example, imagine the directive `/* tslint:disable */` on the first line of a file, `/* tslint:enable:ban class-name */` on the 10th line and `/* tslint:enable */` on the 20th. No rules will be checked between the 1st and 10th lines, only the `ban` and `class-name` rules will be checked between the 10th and 20th, and all rules will be checked for the remainder of the file.
 

--- a/src/enableDisableRules.ts
+++ b/src/enableDisableRules.ts
@@ -86,28 +86,20 @@ export class EnableDisableRulesWalker {
     }
 
     private handleComment(commentText: string, pos: TokenPosition) {
-        const match = /^\s*tslint:/.exec(commentText);
-        if (match !== null) {
-            // remove everything up to the colon from text
-            commentText = commentText.substr(match[0].length);
-            this.handlePossibleTslintSwitch(commentText, pos);
-        }
-    }
-
-    private handlePossibleTslintSwitch(commentText: string, pos: TokenPosition) {
-        // regex is: start of string followed by either "enable" or "disable"
+        // regex is: start of string followed by any amount of whitespace
+        // followed by tslint and colon
+        // followed by either "enable" or "disable"
         // followed optionally by -line or -next-line
         // followed by either colon, whitespace or end of string
-        const enableOrDisableMatch = /^(enable|disable)(?:-(line|next-line))?(:|\s|$)/.exec(commentText);
-
-        if (enableOrDisableMatch !== null) {
+        const match = /^\s*tslint:(enable|disable)(?:-(line|next-line))?(:|\s|$)/.exec(commentText);
+        if (match !== null) {
             // remove everything matched by the previous regex to get only the specified rules
             // split at whitespaces
             // filter empty items coming from whitespaces at start, at end or empty list
-            let rulesList = commentText.substr(enableOrDisableMatch[0].length)
+            let rulesList = commentText.substr(match[0].length)
                                        .split(/\s+/)
                                        .filter((rule) => !!rule);
-            if (rulesList.length === 0 && enableOrDisableMatch[3] === ":") {
+            if (rulesList.length === 0 && match[3] === ":") {
                 // nothing to do here: an explicit separator was specified but no rules to switch
                 return;
             }
@@ -118,7 +110,7 @@ export class EnableDisableRulesWalker {
                 rulesList = this.enabledRules;
             }
 
-            this.handleTslintLineSwitch(rulesList, enableOrDisableMatch[1] === "enable", enableOrDisableMatch[2], pos);
+            this.handleTslintLineSwitch(rulesList, match[1] === "enable", match[2], pos);
         }
     }
 

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -180,13 +180,7 @@ class Linter {
         const configurationRules = isJs ? configuration.jsRules : configuration.rules;
 
         // walk the code first to find all the intervals where rules are disabled
-        const rulesWalker = new EnableDisableRulesWalker(sourceFile, {
-            disabledIntervals: [],
-            ruleArguments: [],
-            ruleName: "",
-        }, configurationRules);
-        rulesWalker.walk(sourceFile);
-        const enableDisableRuleMap = rulesWalker.enableDisableRuleMap;
+        const enableDisableRuleMap = new EnableDisableRulesWalker(sourceFile, configurationRules).getEnableDisableRuleMap();
 
         const rulesDirectories = arrayify(this.options.rulesDirectory)
             .concat(arrayify(configuration.rulesDirectory));

--- a/test/rules/_integration/enable-disable/test.ts.lint
+++ b/test/rules/_integration/enable-disable/test.ts.lint
@@ -115,3 +115,14 @@ var AAAaA = 'test'; //tslint:disable
             ~~~~~~ [' should be "]
 var AAAaA = 'test'
 
+// ensure that "all" switches all rules
+var AAAaA = 'test'; //tslint:enable-line all
+    ~~~~~          [variable name must be in camelcase or uppercase]
+            ~~~~~~ [' should be "]
+                      ~~~~~~~~~~~~~~~~~~~~~~ [comment must start with a space]
+
+// ensure that "all" switches all rules even if others are in the list
+var AAAaA = 'test'; //tslint:enable-line quotemark all
+    ~~~~~          [variable name must be in camelcase or uppercase]
+            ~~~~~~ [' should be "]
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [comment must start with a space]

--- a/test/rules/_integration/enable-disable/test.ts.lint
+++ b/test/rules/_integration/enable-disable/test.ts.lint
@@ -65,11 +65,11 @@ var AAAaA = 'test'
 /* tslint:disable:quotemark */
 var s = 'xxx';
 
-//Test case for issue #1624
+// Test case for issue #1624
 // tslint:disable:quotemark variable-name
 var AAAaA = 'test' // tslint:disable-line:quotemark
 // tslint:disable-next-line:variable-name
-var AAAaA = 'test' //previously `quotemark` rule was enabled after previous line
+var AAAaA = 'test' // previously `quotemark` rule was enabled after previous line
 
 var AAAaA = 'test' // previously both `quotemark` and `variable-name` rules were enabled after previous lines
 
@@ -80,3 +80,38 @@ var AAAaA = 'test' // ensure that disable-line rule correctly handles previous `
 
 // tslint:enable:no-var-keyword
 var AAAaA = 'test' // ensure that disabled in config rule isn't enabled
+
+/* tslint:enable-next-line: */
+var AAAaA = 'test' // ensure that nothing is enabled with explicit separator and empty list of rules
+
+/* tslint:enable-next-line quotemark*/
+var AAAaA = 'test' // ensure that comment end is handled correctly with implicit separator
+            ~~~~~~                                 [' should be "]
+
+/* tslint:enable-next-line:quotemark*/
+var AAAaA = 'test' // ensure that comment end is handled correctly with explicit separator
+            ~~~~~~                                 [' should be "]
+
+// ensure that line switches switch the whole line
+var AAAaA = 'test'; /* tslint:enable-line quotemark */ var AAAaA = 'test'
+            ~~~~~~                                 [' should be "]
+                                                                   ~~~~~~ [' should be "]
+var AAAaA = 'test' // line should not be affected
+
+// ensure that next-line switch only switches next line
+var AAAaA = 'test'; /*tslint:enable-next-line*/ var AAAaA = 'test'
+var AAAaA = 'test'
+    ~~~~~          [variable name must be in camelcase or uppercase]
+            ~~~~~~ [' should be "]
+var AAAaA = 'test'
+var AAAaA = 'test'; //tslint:enable-next-line
+
+
+// ensure that enable/disable switch switches at start of comment
+var AAAaA = 'test'; //tslint:enable
+                      ~~~~~~~~~~~~~ [comment must start with a space]
+var AAAaA = 'test'; //tslint:disable
+    ~~~~~          [variable name must be in camelcase or uppercase]
+            ~~~~~~ [' should be "]
+var AAAaA = 'test'
+

--- a/test/rules/_integration/enable-disable/tslint.json
+++ b/test/rules/_integration/enable-disable/tslint.json
@@ -2,6 +2,10 @@
   "rules": {
     "quotemark": [true, "double"],
     "variable-name": true,
-    "no-var-keyword": false
+    "no-var-keyword": false,
+    "comment-format": [
+      true,
+      "check-space"
+    ]
   }
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

* Add minor clarification to line switches documentation.
* Split up methods into maintainable chunks of code
* Fix bugs to make behaviour as described in the docs:
  * `enable-line` and `disable-line` switched from the start of the line only to the end of the comment. That is correct for single line comments, but multiline comments can be followed by other statements.
  * `enable-next-line` and `disable-next-line` switched from the start of the comment instead of the start of the next line.
  * handling of multiline comment end
    * `/*tslint:disable foo bar*/` removed `bar*/` resulting in swiching only `foo`
    * `/*tslint:disable foo*/` removed `foo*/` resulting in switching **all rules**
    * `/*tslint:disable:foo*/` tried to switch rule `foo*/`, which does not exist -> nothing changed
* add tests for everything stated above

#### Is there anything you'd like reviewers to focus on?

Don't know if this is a breaking change, because it used to be this way for a while, although not documented.

Furthermore this changes the API of `EnableDisableRulesWalker` which is no longer a subclass of `RuleWalker`. This class is exported by the package, so it *could* be used by others. Don't know if care or if we even want to support this, because technically every `Rule` could be used from outside the project.
If we consider this an implementation detail, we should remove the export in `index.ts` for the next major version. This should also be done for all other "internal" functions and classes.
