### PR TITLE
Allow empty interfaces with 2 or more parents

### DIFF
--- a/src/rules/noEmptyInterfaceRule.ts
+++ b/src/rules/noEmptyInterfaceRule.ts
@@ -42,9 +42,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class Walker extends Lint.RuleWalker {
     public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
-        if (node.members.length === 0) {
+        if (node.members.length === 0 &&
+            (node.heritageClauses === undefined ||
+             node.heritageClauses[0].types === undefined ||
+             // allow interfaces that extend 2 or more interfaces
+             node.heritageClauses[0].types!.length < 2)) {
             this.addFailureAtNode(node.name, node.heritageClauses ? Rule.FAILURE_STRING_FOR_EXTENDS : Rule.FAILURE_STRING);
         }
-        super.visitInterfaceDeclaration(node);
     }
 }

--- a/test/rules/no-empty-interface/test.ts.lint
+++ b/test/rules/no-empty-interface/test.ts.lint
@@ -5,3 +5,8 @@ interface J extends I { }
           ~               [An interface declaring no members is equivalent to its supertype.]
 
 interface K { x: number; }
+
+interface L extends J, K {} // extending more than one interface is ok, as it can be used instead of intersection types
+
+interface M extends {} // don't crash on empty extends list
+          ~               [An interface declaring no members is equivalent to its supertype.]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2065
- [x] bugfix
  - [x] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects)

#### What changes did you make?

Allow empty interfaces with 2 or more parents as they can be used like intersection types.
