### PR TITLE
Added only-throw-errors rule

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -193,6 +193,34 @@ export function isObjectFlagSet(objectType: ts.ObjectType, flagToCheck: ts.Objec
 }
 
 /**
+ * @returns true if type is or extends from a class of the given name
+ */
+export function isTypeOfClassName(type: ts.Type, className: string): boolean {
+    if (isTypeClassName(type, className)) {
+        return true;
+    }
+
+    const baseTypes = type.getBaseTypes();
+
+    if (baseTypes) {
+        for (const baseType of type.getBaseTypes()) {
+            if (isTypeClassName(baseType, className)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @returns true if type is a class of the given name
+ */
+export function isTypeClassName(type: ts.Type, className: string): boolean {
+    return !!(type.symbol && type.symbol.name === className);
+}
+
+/**
  * @returns true if decl is a nested module declaration, i.e. represents a segment of a dotted module path.
  */
 export function isNestedModuleDeclaration(decl: ts.ModuleDeclaration) {

--- a/src/rules/onlyThrowErrorsRule.ts
+++ b/src/rules/onlyThrowErrorsRule.ts
@@ -18,7 +18,7 @@
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { isTypeOfClassName } from "../language/utils";
+import { isTypeFlagSet, isTypeOfClassName } from "../language/utils";
 
 export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -49,7 +49,7 @@ class OnlyThrowErrorsWalker extends Lint.ProgramAwareRuleWalker {
         const expression = node.expression;
         const type = this.getTypeChecker().getTypeAtLocation(expression);
 
-        if (type && !this.symbolIsError(type)) {
+        if (type && !isTypeFlagSet(type, ts.TypeFlags.Any) && !this.symbolIsError(type)) {
             this.addFailure(this.createFailure(expression.getStart(), expression.getWidth(), Rule.FAILURE_STRING));
         }
 

--- a/src/rules/onlyThrowErrorsRule.ts
+++ b/src/rules/onlyThrowErrorsRule.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+import { isTypeOfClassName } from "../language/utils";
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "only-throw-errors",
+        description: "Requires that only instances of Error or its subclass be thrown.",
+        descriptionDetails: Lint.Utils.dedent`
+            It is considered good practice to only throw the Error object itself or an
+            object using the Error object as base objects for user-defined exceptions.`,
+        hasFix: true,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "functionality",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Only Error instances may be thrown";
+
+    public applyWithProgram(sourceFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
+        return this.applyWithWalker(new OnlyThrowErrorsWalker(sourceFile, this.getOptions(), langSvc.getProgram()));
+    }
+}
+
+class OnlyThrowErrorsWalker extends Lint.ProgramAwareRuleWalker {
+    public visitThrowStatement(node: ts.ThrowStatement) {
+        const expression = node.expression;
+        const type = this.getTypeChecker().getTypeAtLocation(expression);
+
+        if (type && this.symbolIsError(type)) {
+            this.addFailure(this.createFailure(expression.getStart(), expression.getWidth(), Rule.FAILURE_STRING));
+        }
+
+        super.visitThrowStatement(node);
+    }
+
+     private symbolIsError(type: ts.Type) {
+         return isTypeOfClassName(type, "Error");
+     }
+}

--- a/src/rules/onlyThrowErrorsRule.ts
+++ b/src/rules/onlyThrowErrorsRule.ts
@@ -49,7 +49,7 @@ class OnlyThrowErrorsWalker extends Lint.ProgramAwareRuleWalker {
         const expression = node.expression;
         const type = this.getTypeChecker().getTypeAtLocation(expression);
 
-        if (type && this.symbolIsError(type)) {
+        if (type && !this.symbolIsError(type)) {
             this.addFailure(this.createFailure(expression.getStart(), expression.getWidth(), Rule.FAILURE_STRING));
         }
 

--- a/test/rules/only-throw-errors/test.js.lint
+++ b/test/rules/only-throw-errors/test.js.lint
@@ -44,10 +44,4 @@ throw foo("error");
 throw new String("error");
       ~~~~~~~~~~~~~~~~~~~    [0]
 
-const foo = {
-    bar: "error"
-};
-throw foo.bar;
-      ~~~~~~~    [0]
-
 [0]: Only Error instances may be thrown

--- a/test/rules/only-throw-errors/test.js.lint
+++ b/test/rules/only-throw-errors/test.js.lint
@@ -10,30 +10,30 @@ throw undefined;
 throw null;
       ~~~~    [0]
 
-var err = new Error();
-throw "an " + err;
-      ~~~~~~~~~~~    [0]
+const a = new Error();
+throw "an " + a;
+      ~~~~~~~~~    [0]
 
-var err = new Error();
-throw `${err}`
-      ~~~~~~~~    [0]
+const b = new Error();
+throw `${b}`
+      ~~~~~~    [0]
 
 throw new Error();
 
 throw new Error("error");
 
-var e = new Error("error");
-throw e;
+const c = new Error("error");
+throw c;
 
 try {
     throw new Error("error");
-} catch (e) {
-    throw e;
+} catch (d) {
+    throw d;
 }
 
-var err = "error";
-throw err;
-      ~~~    [0]
+const e = "error";
+throw e;
+      ~    [0]
 
 function foo(bar) {
     console.log(bar);
@@ -44,7 +44,7 @@ throw foo("error");
 throw new String("error");
       ~~~~~~~~~~~~~~~~~~~    [0]
 
-var foo = {
+const foo = {
     bar: "error"
 };
 throw foo.bar;

--- a/test/rules/only-throw-errors/test.js.lint
+++ b/test/rules/only-throw-errors/test.js.lint
@@ -1,0 +1,53 @@
+throw "error";
+      ~~~~~~~    [0]
+
+throw 0;
+      ~    [0]
+
+throw undefined;
+      ~~~~~~~~~    [0]
+
+throw null;
+      ~~~~    [0]
+
+var err = new Error();
+throw "an " + err;
+      ~~~~~~~~~~~    [0]
+
+var err = new Error();
+throw `${err}`
+      ~~~~~~~~    [0]
+
+throw new Error();
+
+throw new Error("error");
+
+var e = new Error("error");
+throw e;
+
+try {
+    throw new Error("error");
+} catch (e) {
+    throw e;
+}
+
+var err = "error";
+throw err;
+      ~~~    [0]
+
+function foo(bar) {
+    console.log(bar);
+}
+throw foo("error");
+      ~~~~~~~~~~~~    [0]
+
+throw new String("error");
+      ~~~~~~~~~~~~~~~~~~~    [0]
+
+var foo = {
+    bar: "error"
+};
+throw foo.bar;
+      ~~~~~~~    [0]
+
+[0]: Only Error instances may be thrown

--- a/test/rules/only-throw-errors/test.ts.lint
+++ b/test/rules/only-throw-errors/test.ts.lint
@@ -44,10 +44,4 @@ throw foo("error");
 throw new String("error");
       ~~~~~~~~~~~~~~~~~~~    [0]
 
-const foo = {
-    bar: "error"
-};
-throw foo.bar;
-      ~~~~~~~    [0]
-
 [0]: Only Error instances may be thrown

--- a/test/rules/only-throw-errors/test.ts.lint
+++ b/test/rules/only-throw-errors/test.ts.lint
@@ -1,0 +1,53 @@
+throw "error";
+      ~~~~~~~    [0]
+
+throw 0;
+      ~    [0]
+
+throw undefined;
+      ~~~~~~~~~    [0]
+
+throw null;
+      ~~~~    [0]
+
+const a = new Error();
+throw "an " + a;
+      ~~~~~~~~~    [0]
+
+const b = new Error();
+throw `${b}`
+      ~~~~~~    [0]
+
+throw new Error();
+
+throw new Error("error");
+
+const c = new Error("error");
+throw c;
+
+try {
+    throw new Error("error");
+} catch (d) {
+    throw d;
+}
+
+const e = "error";
+throw e;
+      ~    [0]
+
+function foo(bar) {
+    console.log(bar);
+}
+throw foo("error");
+      ~~~~~~~~~~~~    [0]
+
+throw new String("error");
+      ~~~~~~~~~~~~~~~~~~~    [0]
+
+const foo = {
+    bar: "error"
+};
+throw foo.bar;
+      ~~~~~~~    [0]
+
+[0]: Only Error instances may be thrown

--- a/test/rules/only-throw-errors/tslint.json
+++ b/test/rules/only-throw-errors/tslint.json
@@ -1,0 +1,11 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "only-throw-errors": true
+  },
+  "jsRules": {
+    "only-throw-errors": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1465
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update
- [x] Enable CircleCI for your fork (https://circleci.com/add-projects) *(I think)*

#### What changes did you make?

If something is being thrown whose type is known, its type and base
types must contain the `"Error"` class.

#### Is there anything you'd like reviewers to focus on?

Not feeling great about what I named the `utils` functions.
