### PR TITLE
Changed --test to take multiple directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,11 @@ tslint accepts the following command-line options:
     option is set.
 
 --test:
-    Runs tslint on the specified directory and checks if tslint's output matches
-    the expected output in .lint files. Automatically loads the tslint.json file in the
-    specified directory as the configuration file for the tests. See the
-    full tslint documentation for more details on how this can be used to test custom rules.
+    Runs tslint on matched directories and checks if tslint outputs
+    match the expected output in .lint files. Automatically loads the
+    tslint.json files in the directories as the configuration file for
+    the tests. See the full tslint documentation for more details on how
+    this can be used to test custom rules.
 
 --project:
     The location of a tsconfig.json file that will be used to determine which

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -27,7 +27,7 @@ import {
 } from "./configuration";
 import { FatalError } from "./error";
 import * as Linter from "./linter";
-import { consoleTestResultHandler, runTest } from "./test";
+import { consoleTestResultsHandler, runTests } from "./test";
 import { updateNotifierCheck } from "./updateNotifier";
 
 export interface IRunnerOptions {
@@ -130,8 +130,8 @@ export class Runner {
         }
 
         if (this.options.test) {
-            const results = runTest(this.options.test, this.options.rulesDirectory);
-            const didAllTestsPass = consoleTestResultHandler(results);
+            const results = runTests(this.options.test, this.options.rulesDirectory);
+            const didAllTestsPass = consoleTestResultsHandler(results);
             onComplete(didAllTestsPass ? 0 : 1);
             return;
         }

--- a/src/test.ts
+++ b/src/test.ts
@@ -44,6 +44,11 @@ export interface TestResult {
     };
 }
 
+export function runTests(pattern: string, rulesDirectory?: string | string[]): TestResult[] {
+    return glob.sync(`${pattern}/tslint.json`)
+        .map((directory: string): TestResult => runTest(path.dirname(directory), rulesDirectory));
+}
+
 export function runTest(testDirectory: string, rulesDirectory?: string | string[]): TestResult {
     const filesToLint = glob.sync(path.join(testDirectory, `**/*${MARKUP_FILE_EXTENSION}`));
     const tslintConfig = Linter.findConfiguration(path.join(testDirectory, "tslint.json"), "").results;
@@ -157,6 +162,18 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
     }
 
     return results;
+}
+
+export function consoleTestResultsHandler(testResults: TestResult[]): boolean {
+    let didAllTestsPass = true;
+
+    for (const testResult of testResults) {
+        if (!consoleTestResultHandler(testResult)) {
+            didAllTestsPass = false;
+        }
+    }
+
+    return didAllTestsPass;
 }
 
 export function consoleTestResultHandler(testResult: TestResult): boolean {

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -180,10 +180,11 @@ tslint accepts the following commandline options:
         option is set.
 
     --test:
-        Runs tslint on the specified directory and checks if tslint's output matches
-        the expected output in .lint files. Automatically loads the tslint.json file in the
-        specified directory as the configuration file for the tests. See the
-        full tslint documentation for more details on how this can be used to test custom rules.
+        Runs tslint on matched directories and checks if tslint outputs
+        match the expected output in .lint files. Automatically loads the
+        tslint.json files in the directories as the configuration file for
+        the tests. See the full tslint documentation for more details on how
+        this can be used to test custom rules.
 
     --project:
         The location of a tsconfig.json file that will be used to determine which


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2064
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### What changes did you make?

Used an extra `glob.sync` to allow for wildcards / general glob patterns from `--test`.

#### Is there anything you'd like reviewers to focus on?

A couple of issues I think should be addressed before merge:
- [ ] No tests added. I didn't see much coverage for `runTest` other than the CLI's general exit code testing. I can add exit similar testing for `runTests`, but is there a more direct testing method you'd like instead?
- [ ] Can part of `ruleTestRunner.ts` be replaced with `runTests`?