### PR TITLE
noInferrableTypes: check property declarations.

### DIFF
--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -69,7 +69,12 @@ class NoInferrableTypesWalker extends Lint.RuleWalker {
         super.visitParameterDeclaration(node);
     }
 
-    private checkDeclaration(node: ts.ParameterDeclaration | ts.VariableDeclaration) {
+    public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
+        this.checkDeclaration(node);
+        super.visitPropertyDeclaration(node);
+    }
+
+    private checkDeclaration(node: ts.ParameterDeclaration | ts.VariableDeclaration | ts.PropertyDeclaration) {
         if (node.type != null && node.initializer != null) {
             let failure: string | null = null;
 

--- a/test/rules/no-inferrable-types/default/test.ts.lint
+++ b/test/rules/no-inferrable-types/default/test.ts.lint
@@ -5,6 +5,10 @@ let y: boolean = false;
        ~~~~~~~          [boolean]
 let z: string = "foo";
        ~~~~~~           [string]
+class C {
+    x: number = 1;
+       ~~~~~~           [number]
+}
 
 // errors, types are inferrable
 function foo (a: number = 5, b: boolean = true, c: string = "bah") { }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### What changes did you make?

Currently, the noInferrableTypes check only runs on variables and parameters, not on property declarations:

```ts
class X {
  f: string = 'string'; // not checked :-(
}
```

#### Is there anything you'd like reviewers to focus on?

Compilation and tests fail on my local machine for unrelated reasons, let's hope CircleCI can run this?
