### PR TITLE
Fail build if CircleCI parallelism < 4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ general:
       - gh-pages
 dependencies:
   pre:
+    - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
     - case $CIRCLE_NODE_INDEX in 0) nvm use 4.2 ;; 1) nvm use 5.7 ;; [2-3]) nvm use 6.1 ;; esac
 test:
   override:

--- a/scripts/assertMinCircleNodes.js
+++ b/scripts/assertMinCircleNodes.js
@@ -1,0 +1,8 @@
+var requiredNodes = 4;
+var nodes = parseInt(process.argv[2], 10);
+if (requiredNodes != null && requiredNodes > nodes) {
+    console.error("ERROR: You must run CircleCI with 4 parallel nodes");
+    console.error("    This ensures that different environments are tested for TSLint compatibility");
+    console.error("    https://circleci.com/gh/<YOUR ACCOUNT>/tslint/edit#parallel-builds");
+    process.exit(1);
+}


### PR DESCRIPTION
We run using 4 nodes so that each node can test a different environment. Since forks default to 1 node, we don't get full coverage from PRs unless parallelism is set to 4 or more

Environments:
- node 4.2
- node 5.7
- node 6.1
- TypeScript 2.0.10