### PR TITLE
Add `no-unbound-method` rule

### DIFF
--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-unbound-method",
+        description: "Warns when a method is used as outside of a method call.",
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "functionality",
+        typescriptOnly: true,
+        requiresTypeInfo: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "'this' may be unbound when a method is used as a property without being invoked.";
+
+    public applyWithProgram(srcFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
+        return this.applyWithWalker(new Walker(srcFile, this.getOptions(), langSvc.getProgram()));
+    }
+}
+
+class Walker extends Lint.ProgramAwareRuleWalker {
+    public visitPropertyAccessExpression(node: ts.PropertyAccessExpression) {
+        if (!isInCall(node)) {
+            const symbol = this.getTypeChecker().getSymbolAtLocation(node);
+            const declaration = symbol && symbol.valueDeclaration;
+            if (declaration && isMethod(declaration)) {
+                this.addFailureAtNode(node, Rule.FAILURE_STRING);
+            }
+        }
+        super.visitPropertyAccessExpression(node);
+    }
+}
+
+function isMethod(node: ts.Node): boolean {
+    switch (node.kind) {
+        case ts.SyntaxKind.MethodDeclaration:
+        case ts.SyntaxKind.MethodSignature:
+            return true;
+        default:
+            return false;
+    }
+}
+
+function isInCall(node: ts.Node): boolean {
+    const parent = node.parent!;
+    switch (parent.kind) {
+        case ts.SyntaxKind.CallExpression:
+            return (parent as ts.CallExpression).expression === node;
+        case ts.SyntaxKind.TaggedTemplateExpression:
+            return (parent as ts.TaggedTemplateExpression).tag === node;
+        default:
+            return false;
+    }
+}

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -32,7 +32,7 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "'this' may be unbound when a method is used as a property without being invoked.";
+    public static FAILURE_STRING = "Avoid referencing unbound methods which may cause unintentional scoping of 'this'.";
 
     public applyWithProgram(srcFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
         return this.applyWithWalker(new Walker(srcFile, this.getOptions(), langSvc.getProgram()));

--- a/test/rules/no-unbound-method/test.ts.lint
+++ b/test/rules/no-unbound-method/test.ts.lint
@@ -25,4 +25,4 @@ i.foo;
 ~~~~~ [0]
 i.bar;
 
-[0]: 'this' may be unbound when a method is used as a property without being invoked.
+[0]: Avoid referencing unbound methods which may cause unintentional scoping of 'this'.

--- a/test/rules/no-unbound-method/test.ts.lint
+++ b/test/rules/no-unbound-method/test.ts.lint
@@ -1,0 +1,28 @@
+class C {
+    method(x: number) {}
+    property: () => void;
+    template(strs: TemplateStringsArray, x: any) {}
+}
+
+const c = new C();
+[0].forEach(c.method);
+            ~~~~~~~~ [0]
+[0].forEach(x => c.method(x));
+[0].forEach(c.property);
+
+c.template;
+~~~~~~~~~~ [0]
+c.template`foo${0}`;
+String.raw`${c.template}`;
+             ~~~~~~~~~~ [0]
+
+interface I {
+    foo(): void;
+    bar: () => void;
+}
+declare var i: I;
+i.foo;
+~~~~~ [0]
+i.bar;
+
+[0]: 'this' may be unbound when a method is used as a property without being invoked.

--- a/test/rules/no-unbound-method/tslint.json
+++ b/test/rules/no-unbound-method/tslint.json
@@ -1,0 +1,8 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "no-unbound-method": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #259
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### What changes did you make?

Added the `no-unbound-method` rule, which forbids the use of `x.foo` where `foo` is a method on a class or interface, but allows `y => x.foo(y)`.
