### PR TITLE
Add support to fix `align` rule

### DIFF
--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -106,8 +106,14 @@ class AlignWalker extends Lint.RuleWalker {
         for (const node of nodes.slice(1)) {
             const curPos = this.getLineAndCharacterOfPosition(node.getStart());
             if (curPos.line !== prevPos.line && curPos.character !== alignToColumn) {
-                this.addFailureAtNode(node, kind + Rule.FAILURE_STRING_SUFFIX);
-                break;
+                const diff = alignToColumn - curPos.character;
+                let fix;
+                if (0 < diff) {
+                    fix = this.createFix(this.appendText(node.getStart(), " ".repeat(diff)));
+                } else {
+                    fix = this.createFix(this.deleteText(node.getStart() + diff, -diff));
+                }
+                this.addFailureAtNode(node, kind + Rule.FAILURE_STRING_SUFFIX, fix);
             }
             prevPos = curPos;
         }

--- a/test/rules/align/arguments/test.ts.fix
+++ b/test/rules/align/arguments/test.ts.fix
@@ -1,0 +1,149 @@
+function invalidParametersAlignment1(a: number,
+b: number) {
+    var i = 0;
+}
+
+function invalidParametersAlignment2(a: number, b: number,
+c: number) {
+    var i = 0;
+}
+
+function invalidParametersAlignment3(a: number,
+                             b: number,
+                           c: number) {
+    var i = 0;
+}
+
+class C1 {
+    invalidParametersAlignment(a: number,
+                           b: number)
+    {
+    }
+}
+
+class InvalidAlignmentInConstructor {
+    constructor(a: number,
+                                 str: string)
+    {
+    }
+}
+
+var invalidParametersAlignment4 = function(xxx: foo,
+                              yyy: bar) { return true; }
+
+function validParametersAlignment1(a: number, b: number) {
+    var i = 0;
+}
+
+function validParametersAlignment2(a: number, b: number,
+                                   c: number) {
+    var i = 0;
+}
+
+function validParametersAlignment3(a: number,
+                                   b: number,
+                                   c: number) {
+    var i = 0;
+}
+
+function validParametersAlignment4(
+      a: number,
+      b: number,
+      c: number) {
+    var i = 0;
+}
+
+var validParametersAlignment6 = function(xxx: foo,
+                                         yyy: bar) { return true; }
+
+///////
+
+function invalidArgumentsAlignment1()
+{
+    f(10,
+      'abcd', 0);
+}
+
+function invalidArgumentsAlignment2()
+{
+    f(10,
+      'abcd',
+      0);
+
+}
+
+class Foo {
+    constructor(a: number,
+                str: string)
+    {
+    }
+}
+
+var invalidConstructorArgsAlignment = new foo(10,
+                                              "abcd");
+
+function validArgumentsAlignment1()
+{
+    f(101, 'xyz', 'abc');
+}
+
+function validArgumentsAlignment2()
+{
+    f(1,
+      2,
+      3,
+      4);
+}
+
+function validArgumentsAlignment3()
+{
+    f(
+        1,
+        2,
+        3,
+        4);
+}
+
+function validArgumentsAlignment3()
+{
+    f(1, 2,
+      3, 4);
+}
+
+////////
+
+function invalidStatementsAlignment1()
+{
+    var i = 0;
+    var j = 0;
+     var k = 1;
+}
+
+function invalidStatementsAlignment1()
+{
+    var i = 0;
+    {
+        var j = 0;
+       var k = 1;
+    }
+}
+
+function validStatementsAlignment1()
+{
+    var i = 0;
+    var j = 0;
+    var k = 1;
+}
+
+function validStatementsAlignment2()
+{
+    var i = 0;
+    {
+        var j = 0;
+        var k = 1;
+    }
+}
+
+function shouldntCrash() {
+  let f = new Foo;
+}

--- a/test/rules/align/parameters/test.js.lint
+++ b/test/rules/align/parameters/test.js.lint
@@ -14,6 +14,7 @@ function invalidParametersAlignment3(a,
                              b,
                              ~  [parameters are not aligned]
                            c) {
+                           ~  [parameters are not aligned]
     var i = 0;
 }
 

--- a/test/rules/align/parameters/test.ts.fix
+++ b/test/rules/align/parameters/test.ts.fix
@@ -1,0 +1,32 @@
+function invalidParametersAlignment1(a: number,
+                                     b: number) {
+    var i = 0;
+}
+
+function invalidParametersAlignment2(a: number, b: number,
+                                     c: number) {
+    var i = 0;
+}
+
+function invalidParametersAlignment3(a: number,
+                                     b: number,
+                                     c: number) {
+    var i = 0;
+}
+
+class C1 {
+    invalidParametersAlignment(a: number,
+                               b: number)
+    {
+    }
+}
+
+class InvalidAlignmentInConstructor {
+    constructor(a: number,
+                str: string)
+    {
+    }
+}
+
+var invalidParametersAlignment4 = function(xxx: foo,
+                                           yyy: bar) { return true; }

--- a/test/rules/align/parameters/test.ts.lint
+++ b/test/rules/align/parameters/test.ts.lint
@@ -14,6 +14,7 @@ function invalidParametersAlignment3(a: number,
                              b: number,
                              ~~~~~~~~~  [parameters are not aligned]
                            c: number) {
+                           ~~~~~~~~~  [parameters are not aligned]
     var i = 0;
 }
 

--- a/test/rules/align/statements/test.ts.fix
+++ b/test/rules/align/statements/test.ts.fix
@@ -1,0 +1,149 @@
+function invalidParametersAlignment1(a: number,
+b: number) {
+    var i = 0;
+}
+
+function invalidParametersAlignment2(a: number, b: number,
+c: number) {
+    var i = 0;
+}
+
+function invalidParametersAlignment3(a: number,
+                             b: number,
+                           c: number) {
+    var i = 0;
+}
+
+class C1 {
+    invalidParametersAlignment(a: number,
+                           b: number)
+    {
+    }
+}
+
+class InvalidAlignmentInConstructor {
+    constructor(a: number,
+                                 str: string)
+    {
+    }
+}
+
+var invalidParametersAlignment4 = function(xxx: foo,
+                              yyy: bar) { return true; }
+
+function validParametersAlignment1(a: number, b: number) {
+    var i = 0;
+}
+
+function validParametersAlignment2(a: number, b: number,
+                                   c: number) {
+    var i = 0;
+}
+
+function validParametersAlignment3(a: number,
+                                   b: number,
+                                   c: number) {
+    var i = 0;
+}
+
+function validParametersAlignment4(
+      a: number,
+      b: number,
+      c: number) {
+    var i = 0;
+}
+
+var validParametersAlignment6 = function(xxx: foo,
+                                         yyy: bar) { return true; }
+
+
+///////
+
+function invalidArgumentsAlignment1()
+{
+    f(10,
+    'abcd', 0);
+}
+
+function invalidArgumentsAlignment2()
+{
+    f(10,
+      'abcd',
+        0);
+}
+
+class Foo {
+    constructor(a: number,
+                str: string)
+    {
+    }
+}
+
+var invalidConstructorArgsAlignment = new foo(10,
+             "abcd");
+
+function validArgumentsAlignment1()
+{
+    f(101, 'xyz', 'abc');
+}
+
+function validArgumentsAlignment2()
+{
+    f(1,
+      2,
+      3,
+      4);
+}
+
+function validArgumentsAlignment3()
+{
+    f(
+        1,
+        2,
+        3,
+        4);
+}
+
+function validArgumentsAlignment3()
+{
+    f(1, 2,
+      3, 4);
+}
+
+////////
+
+function invalidStatementsAlignment1()
+{
+    var i = 0;
+    var j = 0;
+    var k = 1;
+}
+
+function invalidStatementsAlignment1()
+{
+    var i = 0;
+    {
+        var j = 0;
+        var k = 1;
+    }
+}
+
+function validStatementsAlignment1()
+{
+    var i = 0;
+    var j = 0;
+    var k = 1;
+}
+
+function validStatementsAlignment2()
+{
+    var i = 0;
+    {
+        var j = 0;
+        var k = 1;
+    }
+}
+
+function shouldntCrash() {
+  let f = new Foo;
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### What changes did you make?

Add an ability to auto-fix for `align` rule.

#### Is there anything you'd like reviewers to focus on?

Now `AlignWalker.checkAlignment` doesn't support early break since to get an ability to auto-fix.