### PR TITLE
member-ordering: Add 'alphabetize' option

### DIFF
--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -251,7 +251,7 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
                     }
 
                     const curName = nameString(member.name);
-                    if (prevName !== undefined && curName < prevName) {
+                    if (prevName !== undefined && caseInsensitiveLess(curName, prevName)) {
                         this.addFailureAtNode(member.name,
                             Rule.FAILURE_STRING_ALPHABETIZE(this.findLowerName(members, rank, curName), curName));
                     } else {
@@ -272,7 +272,7 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
                 continue;
             }
             const name = nameString(member.name);
-            if (name > targetName) {
+            if (caseInsensitiveLess(targetName, name)) {
                 return name;
             }
         }
@@ -302,6 +302,10 @@ export class MemberOrderingWalker extends Lint.RuleWalker {
     private rankName(rank: Rank): string {
         return this.opts.order[rank].name;
     }
+}
+
+function caseInsensitiveLess(a: string, b: string) {
+    return a.toLowerCase() < b.toLowerCase();
 }
 
 function memberKindForConstructor(access: Access): MemberKind {

--- a/test/rules/member-ordering/alphabetize/test.ts.lint
+++ b/test/rules/member-ordering/alphabetize/test.ts.lint
@@ -14,7 +14,8 @@ class X {
 
     foo() {}
     "goo"() {}
-    hoo() {}
+    Hoo() {}
+    ioo() {}
     bar() {}
     ~~~ ['bar' should come alphabetically before 'foo']
 

--- a/test/rules/member-ordering/alphabetize/test.ts.lint
+++ b/test/rules/member-ordering/alphabetize/test.ts.lint
@@ -1,0 +1,24 @@
+class X {
+    // Different categories have alphabetization together.
+    bar: number;
+    foo: string;
+
+    [Symbol.iterator]() {}
+    // No ordering among computed properties
+    [Symbol.alpherator]() {}
+
+    0() {}
+    2() {}
+    1() {}
+    ~ ['1' should come alphabetically before '2']
+
+    foo() {}
+    "goo"() {}
+    hoo() {}
+    bar() {}
+    ~~~ ['bar' should come alphabetically before 'foo']
+
+    // Computed properties must go at the beginning.
+    [Symbol.zeterator]() {}
+    ~~~~~~~~~~~~~~~~~~ [Computed property should come alphabetically before '0']
+}

--- a/test/rules/member-ordering/alphabetize/tslint.json
+++ b/test/rules/member-ordering/alphabetize/tslint.json
@@ -1,0 +1,8 @@
+{
+    "rules": {
+        "member-ordering": [true, {
+            "order": "fields-first",
+            "alphabetize": true
+        }]
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #973
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### What changes did you make?

Added the 'alphabetize' option to member-ordering, which enforces alphabetical ordering within each category.

#### Is there anything you'd like reviewers to focus on?

This uses `<` for string comparison. I think `.localeCompare` would be troublesome if people in different locales want linting to succeed on all of their machines.