### PR TITLE
Show time taken for each rule test if > 100ms

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -42,6 +42,7 @@ export interface TestResult {
             markupFromMarkup: string;
         },
     };
+    timeMs?: number;
 }
 
 export function runTests(pattern: string, rulesDirectory?: string | string[]): TestResult[] {
@@ -74,6 +75,7 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
     const results: TestResult = { directory: testDirectory, results: {} };
 
     for (const fileToLint of filesToLint) {
+        const startTime = new Date().getTime();
         const fileBasename = path.basename(fileToLint, MARKUP_FILE_EXTENSION);
         const fileCompileName = fileBasename.replace(/\.lint$/, "");
         const fileText = fs.readFileSync(fileToLint, "utf8");
@@ -162,6 +164,7 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
             markupFromLinter: parse.createMarkupFromErrors(fileTextWithoutMarkup, errorsFromMarkup),
             markupFromMarkup: parse.createMarkupFromErrors(fileTextWithoutMarkup, errorsFromLinter),
         };
+        results.timeMs = new Date().getTime() - startTime;
     }
 
     return results;
@@ -193,7 +196,8 @@ export function consoleTestResultHandler(testResult: TestResult): boolean {
 
         /* tslint:disable:no-console */
         if (didMarkupTestPass && didFixesTestPass) {
-            console.log(colors.green(" Passed"));
+            const slowness = testResult.timeMs > 100 ? colors.red(` (${testResult.timeMs} ms)`) : "";
+            console.log(colors.green(` Passed`) + slowness);
         } else {
             console.log(colors.red(" Failed!"));
             didAllTestsPass = false;


### PR DESCRIPTION
Some rules are running very slowly, this PR adds timing to the rules so we're aware (though there might not be much we can do about it)

|rule|time
|-|-|
|await-promise| 769 ms
|completed-docs/functions| 603 ms
|no-boolean-literal-compare| 492 ms
|no-floating-promises/promises| 509 ms
|no-for-in-array| 502 ms
|no-inferred-empty-object-type| 497 ms
|no-unbound-method| 505 ms
|no-unnecessary-qualifier| 793 ms
|no-unsafe-any| 508 ms
|no-unused-variable/type-checked| 505 ms
|no-void-expression| 570 ms