### PR TITLE
no-floating-promises: Fix metadata

### DIFF
--- a/src/rules/noFloatingPromisesRule.ts
+++ b/src/rules/noFloatingPromisesRule.ts
@@ -37,7 +37,8 @@ export class Rule extends Lint.Rules.TypedRule {
         optionExamples: ["true", `[true, "JQueryPromise"]`],
         rationale: "Unhandled Promises can cause unexpected behavior, such as resolving at unexpected times.",
         type: "functionality",
-        typescriptOnly: false,
+        typescriptOnly: true,
+        requiresTypeInfo: true,
     };
     /* tslint:enable:object-literal-sort-keys */
 


### PR DESCRIPTION
This rule uses the type checker.
Re: https://github.com/palantir/tslint/pull/1972#issuecomment-275384846
