### PR TITLE
object-literal-key-quotes: No need to quote a float if its .toString() is the same.

### DIFF
--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -155,9 +155,8 @@ function quotesAreInconsistent(properties: ts.ObjectLiteralElementLike[]): boole
 }
 
 function propertyNeedsQuotes(property: string): boolean {
-    return !(IDENTIFIER_NAME_REGEX.test(property) || NUMBER_REGEX.test(property) && Number(property).toString() === property);
+    return !IDENTIFIER_NAME_REGEX.test(property) && Number(property).toString() !== property;
 }
 
 // This is simplistic. See https://mothereff.in/js-properties for the gorey details.
 const IDENTIFIER_NAME_REGEX = /^(?:[\$A-Z_a-z])+$/;
-const NUMBER_REGEX = /^[0-9]+$/;

--- a/test/rules/object-literal-key-quotes/as-needed/test.ts.fix
+++ b/test/rules/object-literal-key-quotes/as-needed/test.ts.fix
@@ -9,6 +9,7 @@ const o = {
   1e4: "something",
   .123: "float",
   123: 'numbers do not need quotes', // failure
+  1.23: null,
   '010': 'but this one does.',
   '.123': 'as does this one',
   fn() { return },

--- a/test/rules/object-literal-key-quotes/as-needed/test.ts.lint
+++ b/test/rules/object-literal-key-quotes/as-needed/test.ts.lint
@@ -12,6 +12,7 @@ const o = {
   .123: "float",
   '123': 'numbers do not need quotes', // failure
   ~~~~~  [Unnecessarily quoted property '123' found.]
+  1.23: null,
   '010': 'but this one does.',
   '.123': 'as does this one',
   fn() { return },


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### What changes did you make?

A property `{ "1.23": null }` does not need quotes since `{ 1.23: null }` is the same object. But the values `{ ".123": null }` and `{ .123: null }` differ. Try it out: `node -p '({ 1.23: null })'`.