### PR TITLE
Add no-string-jsx rule

### DIFF
--- a/src/rules/noStringJsx.ts
+++ b/src/rules/noStringJsx.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-string-jsx",
+        description: "Makes sure there is no string literal in JSX statements. Enforces use of a translation method.",
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "maintainability",
+        typescriptOnly: false,
+        hasFix: false,
+    };
+
+    public static ERROR_MESSAGE = "No string literal in JSX. Use a translation function.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoStringJSXWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NoStringJSXWalker extends Lint.RuleWalker {
+    public visitJsxElement(node: ts.JsxElement) {
+        for (const child of node.children) {
+            if (child.kind === ts.SyntaxKind.JsxText) {
+                this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.ERROR_MESSAGE));
+            }
+        }
+    }
+
+    public visitJsxExpression(node: ts.JsxExpression) {
+        if (node.expression && node.expression.kind === ts.SyntaxKind.StringLiteral) {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.ERROR_MESSAGE));
+        }
+    }
+}

--- a/test/rules/no-string-jsx/test.tsx.lint
+++ b/test/rules/no-string-jsx/test.tsx.lint
@@ -1,0 +1,9 @@
+const foo = <div>Hello world!</div>
+                 ~~~~~~~~~~~~         [0]
+
+const bar = <div>{'Hello world!'}</div>
+                   ~~~~~~~~~~~~       [0]
+
+const baz = <div>{translate('hello-world')}</div>
+
+[0]: No string literal in JSX. Use a translation function.

--- a/test/rules/no-string-jsx/tslint.json
+++ b/test/rules/no-string-jsx/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-string-jsx": true
+  },
+  "jsRules": {
+    "no-string-jsx": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### What changes did you make?

Adds no-string-jsx rule for projects that use translation functions to enforce use of those functions 
