### PR TITLE
Add new object/array-destructuring options to typedef rule

### DIFF
--- a/test/rules/typedef/all/test.ts.lint
+++ b/test/rules/typedef/all/test.ts.lint
@@ -102,5 +102,5 @@ const { paramA, paramB }: { paramA: string, paramB: number } = { paramA: "test",
 const [ paramA, paramB ] = [15, 'test'];
                         ~    [expected array-destructuring: '[ paramA, paramB ]' to have a typedef]
 
-const [ paramA3, paramB3 ]: { number: string, paramB1: string } = [15, 'test'];
+const [ paramA3, paramB3 ]: [ number, string ] = [15, 'test'];
 

--- a/test/rules/typedef/all/test.ts.lint
+++ b/test/rules/typedef/all/test.ts.lint
@@ -92,3 +92,15 @@ class A {
               ~ [expected member-variable-declaration: 'foo' to have a typedef]
     private bar: number;
 }
+
+
+const { paramA, paramB } = { paramA: "test", paramB: 15 };
+                        ~    [expected object-destructuring: '{ paramA, paramB }' to have a typedef]
+
+const { paramA, paramB }: { paramA: string, paramB: number } = { paramA: "test", paramB: 15 };
+
+const [ paramA, paramB ] = [15, 'test'];
+                        ~    [expected array-destructuring: '[ paramA, paramB ]' to have a typedef]
+
+const [ paramA3, paramB3 ]: { number: string, paramB1: string } = [15, 'test'];
+

--- a/test/rules/typedef/all/tslint.json
+++ b/test/rules/typedef/all/tslint.json
@@ -7,7 +7,9 @@
          "arrow-parameter",
          "variable-declaration",
          "property-declaration",
-         "member-variable-declaration"
+         "member-variable-declaration",
+         "object-destructuring",
+         "array-destructuring"
       ]
    }
 }

--- a/test/rules/typedef/array-destructuring/test.ts.lint
+++ b/test/rules/typedef/array-destructuring/test.ts.lint
@@ -1,0 +1,4 @@
+const [ paramA, paramB ] = [15, 'test'];
+                        ~    [expected array-destructuring: '[ paramA, paramB ]' to have a typedef]
+
+const [ paramA3, paramB3 ]: { number: string, paramB1: string } = [15, 'test'];

--- a/test/rules/typedef/array-destructuring/tslint.json
+++ b/test/rules/typedef/array-destructuring/tslint.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+      "typedef": [true,
+         "array-destructuring"
+      ]
+   }
+}

--- a/test/rules/typedef/none/test.ts.lint
+++ b/test/rules/typedef/none/test.ts.lint
@@ -82,6 +82,6 @@ const [ paramA, paramB ] = [ 'test', 15 ];
 
 const { paramA, paramB } = { paramA: "test", paramB: 15 };
 
-const [ paramA, paramB ]: { paramA: string, paramB: number } = [ 'test', 15 ];
+const [ paramA3, paramB3 ]: [ number, string ] = [15, 'test'];
 
 const { paramA, paramB }: { paramA: string, paramB: number } = { paramA: "test", paramB: 15 };

--- a/test/rules/typedef/none/test.ts.lint
+++ b/test/rules/typedef/none/test.ts.lint
@@ -77,3 +77,11 @@ try {
 for (let i of [1, 2, 3]) {
 
 }
+
+const [ paramA, paramB ] = [ 'test', 15 ];
+
+const { paramA, paramB } = { paramA: "test", paramB: 15 };
+
+const [ paramA, paramB ]: { paramA: string, paramB: number } = [ 'test', 15 ];
+
+const { paramA, paramB }: { paramA: string, paramB: number } = { paramA: "test", paramB: 15 };

--- a/test/rules/typedef/object-destructuring/test.ts.lint
+++ b/test/rules/typedef/object-destructuring/test.ts.lint
@@ -1,0 +1,7 @@
+
+
+const { paramA, paramB } = { paramA: "test", paramB: 15 };
+                        ~    [expected object-destructuring: '{ paramA, paramB }' to have a typedef]
+
+
+const { paramA, paramB }: { paramA: string, paramB: number } = { paramA: "test", paramB: 15 };

--- a/test/rules/typedef/object-destructuring/tslint.json
+++ b/test/rules/typedef/object-destructuring/tslint.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+      "typedef": [true,
+         "object-destructuring"
+      ]
+   }
+}

--- a/test/rules/typedef/variable-declaration/test.ts.lint
+++ b/test/rules/typedef/variable-declaration/test.ts.lint
@@ -1,0 +1,6 @@
+var NoTypeObjectLiteralWithPropertyGetter = { }
+                                         ~    [expected variable-declaration: 'NoTypeObjectLiteralWithPropertyGetter' to have a typedef]
+
+
+const { paramA, paramB } = { paramA: "test", paramB: 15 };
+const [ paramA, paramB ] = [15, 'test'];

--- a/test/rules/typedef/variable-declaration/tslint.json
+++ b/test/rules/typedef/variable-declaration/tslint.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+      "typedef": [true,
+         "variable-declaration"
+      ]
+   }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1039
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### What changes did you make?
This PR adds support for opting in to `object-destructuring` and `array-destructuring` in **typedef** rule.  

Current `variable-declaration` option, if on, will fail if:
```
const [ paramA, paramB ] = [15, 'test'];
```

With this PR it wont, `variable-declaration` only fails on simple non-binding declarations.

Tests samples:
```
const { paramA, paramB } = { paramA: "test", paramB: 15 };
                        ~    [expected object-destructuring: '{ paramA, paramB }' to have a typedef]

const { paramA, paramB }: { paramA: string, paramB: number } = { paramA: "test", paramB: 15 };

const [ paramA, paramB ] = [15, 'test'];
                        ~    [expected array-destructuring: '[ paramA, paramB ]' to have a typedef]

const [ paramA3, paramB3 ]: { number: string, paramB1: string } = [15, 'test'];
```
#### Is there anything you'd like reviewers to focus on?
`variable-declaration` now has it's own test  directory.

