### PR TITLE
Set node engine version to 4.1.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - nodejs_version: "4.2"
+  - nodejs_version: "4.1.2"
   - nodejs_version: "5.7"
   - nodejs_version: "6.1"
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 dependencies:
   pre:
     - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
-    - case $CIRCLE_NODE_INDEX in 0) nvm use 4.2.0 ;; 1) nvm use 5.7 ;; [2-3]) nvm use 6.1 ;; esac
+    - case $CIRCLE_NODE_INDEX in 0) nvm use 4.1.2 ;; 1) nvm use 5.7 ;; [2-3]) nvm use 6.1 ;; esac
 test:
   override:
     - case $CIRCLE_NODE_INDEX in [0-2]) npm run verify ;; 3) npm run clean && npm run compile && npm i typescript@2.0.10 && npm run test ;; esac:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 dependencies:
   pre:
     - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
-    - case $CIRCLE_NODE_INDEX in 0) nvm use 4.2 ;; 1) nvm use 5.7 ;; [2-3]) nvm use 6.1 ;; esac
+    - case $CIRCLE_NODE_INDEX in 0) nvm use 4.2.0 ;; 1) nvm use 5.7 ;; [2-3]) nvm use 6.1 ;; esac
 test:
   override:
     - case $CIRCLE_NODE_INDEX in [0-2]) npm run verify ;; 3) npm run clean && npm run compile && npm i typescript@2.0.10 && npm run test ;; esac:

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.2.6"
+    "node": ">=4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.2.0"
+    "node": ">=4.1.2"
   }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2140
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

Set the node engine version to `4.1.2` since tslint works with that version, too and reverse the breaking change made with `tslint@4.4.0`.