### PR TITLE
Add `no-import-side-effect` rule

### DIFF
--- a/src/rules/noImportSideEffectRule.ts
+++ b/src/rules/noImportSideEffectRule.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "tslint";
+
+const OPTION_IGNORE_MODULE = "ignore-module";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static metadata: Lint.IRuleMetadata = {
+        description: "Avoid import statements with side-effect.",
+        optionExamples: ["true", `[true, { "${OPTION_IGNORE_MODULE}": "(\\.html|\\.css)$" }]`],
+        options: {
+            items: {
+                properties: {
+                    "ignore-module": {
+                        type: "string",
+                    },
+                },
+                type: "object",
+            },
+            maxLength: 1,
+            minLength: 0,
+            type: "array",
+        },
+        optionsDescription: Lint.Utils.dedent`
+            One argument may be optionally provided:
+
+            * \`${OPTION_IGNORE_MODULE}\` allows to specify a regex and ignore modules which it matches.`,
+        rationale: "Imports with side effects may have behavior which is hard for static verification.",
+        ruleName: "no-import-side-effect",
+        type: "typescript",
+        typescriptOnly: false,
+    };
+    public static FAILURE_STRING = "import with explicit side-effect";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoImportSideEffectWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NoImportSideEffectWalker extends Lint.SkippableTokenAwareRuleWalker {
+    private scanner: ts.Scanner;
+    private ignorePattern: RegExp | null;
+
+    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+        super(sourceFile, options);
+        const patternConfig = this.getOptions().pop();
+        this.ignorePattern = patternConfig ? new RegExp(patternConfig[OPTION_IGNORE_MODULE]) : null;
+        this.scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, sourceFile.text);
+    }
+
+    public visitImportDeclaration(node: ts.ImportDeclaration) {
+        const importClause = node.importClause;
+        if (importClause === undefined) {
+            const specifier = node.moduleSpecifier.getText();
+            if (this.ignorePattern === null || !this.ignorePattern.test(specifier.substring(1, specifier.length - 1))) {
+                this.addFailureAtNode(node, Rule.FAILURE_STRING);
+            }
+        }
+        super.visitImportDeclaration(node);
+    }
+}

--- a/test/rules/no-import-side-effect/default/test.js.lint
+++ b/test/rules/no-import-side-effect/default/test.js.lint
@@ -1,0 +1,21 @@
+// valid cases
+import {Injectable, Component, Directive} from '@angular/core';
+import {Inject} from '@angular/core';
+import {Observable} from 'rxjs/Observable';
+import {Observable as Obs} from 'rxjs/Observable';
+import * as _ from 'underscore';
+import DefaultExport from 'module-with-default';
+
+// invalid cases
+import './allow-side-effect';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import './styles.css';
+~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'rxjs/add/observable/of';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'rxjs/add/operator/mapTo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'random-side-effect';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+
+[0]: import with explicit side-effect

--- a/test/rules/no-import-side-effect/default/test.ts.lint
+++ b/test/rules/no-import-side-effect/default/test.ts.lint
@@ -1,0 +1,21 @@
+// valid cases
+import {Injectable, Component, Directive} from '@angular/core';
+import {Inject} from '@angular/core';
+import {Observable} from 'rxjs/Observable';
+import {Observable as Obs} from 'rxjs/Observable';
+import * as _ from 'underscore';
+import DefaultExport from 'module-with-default';
+
+// invalid cases
+import './allow-side-effect';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import './styles.css';
+~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'rxjs/add/observable/of';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'rxjs/add/operator/mapTo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'random-side-effect';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+
+[0]: import with explicit side-effect

--- a/test/rules/no-import-side-effect/default/tslint.json
+++ b/test/rules/no-import-side-effect/default/tslint.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "no-import-side-effect": [true]
+  },
+  "jsRules": {
+    "no-import-side-effect": [true]
+  },
+  "linterOptions": {
+    "typeCheck": false
+  }
+}

--- a/test/rules/no-import-side-effect/ignore-module/test.js.lint
+++ b/test/rules/no-import-side-effect/ignore-module/test.js.lint
@@ -1,0 +1,18 @@
+// valid cases
+import {Injectable, Component, Directive} from '@angular/core';
+import {Observable} from 'rxjs/Observable';
+import {Observable as Obs} from 'rxjs/Observable';
+import * as _ from 'underscore';
+import DefaultExport from 'module-with-default';
+import './allow-side-effect';
+import './styles.css';
+
+// invalid cases
+import 'rxjs/add/observable/of';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'rxjs/add/operator/mapTo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'random-side-effect';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+
+[0]: import with explicit side-effect

--- a/test/rules/no-import-side-effect/ignore-module/test.ts.lint
+++ b/test/rules/no-import-side-effect/ignore-module/test.ts.lint
@@ -1,0 +1,18 @@
+// valid cases
+import {Injectable, Component, Directive} from '@angular/core';
+import {Observable} from 'rxjs/Observable';
+import {Observable as Obs} from 'rxjs/Observable';
+import * as _ from 'underscore';
+import DefaultExport from 'module-with-default';
+import './allow-side-effect';
+import './styles.css';
+
+// invalid cases
+import 'rxjs/add/observable/of';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'rxjs/add/operator/mapTo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+import 'random-side-effect';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+
+[0]: import with explicit side-effect

--- a/test/rules/no-import-side-effect/ignore-module/tslint.json
+++ b/test/rules/no-import-side-effect/ignore-module/tslint.json
@@ -1,0 +1,21 @@
+{
+  "rules": {
+    "no-import-side-effect": [
+      true,
+      {
+        "ignore-module": "(allow-side-effect|\\.css)$"
+      }
+    ]
+  },
+  "jsRules": {
+    "no-import-side-effect": [
+      true,
+      {
+        "ignore-module": "(allow-side-effect|\\.css)$"
+      }
+    ]
+  },
+  "linterOptions": {
+    "typeCheck": false
+  }
+}


### PR DESCRIPTION
Fix #2116

#### PR checklist

- [x] Addresses an existing issue: #2116, related to https://github.com/angular/angular-cli/issues/3904
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### What changes did you make?

Introduced a rule which warns when used imports with side-effects. For more details here https://github.com/palantir/tslint/issues/2116.

#### Is there anything you'd like reviewers to focus on?

Have I added the required documentation.
