### PR TITLE
Improve error messages for no-any and object-literal-shorthand.

### DIFF
--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -34,7 +34,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Type declaration of 'any' is forbidden (use the empty type '{}'?)";
+    public static FAILURE_STRING = "Type declaration of 'any' loses type-safety. " +
+        "Consider replacing it with a more precise type, the empty type ('{}'), " +
+        "or suppress this occurrence.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new NoAnyWalker(sourceFile, this.getOptions()));

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -34,7 +34,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Type declaration of 'any' is forbidden";
+    public static FAILURE_STRING = "Type declaration of 'any' is forbidden (use the empty type '{}'?)";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new NoAnyWalker(sourceFile, this.getOptions()));

--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -32,8 +32,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static LONGHAND_PROPERTY = "Expected property shorthand in object literal ('{foo, bar}').";
-    public static LONGHAND_METHOD = "Expected method shorthand in object literal ('{foo() {...}}').";
+    public static LONGHAND_PROPERTY = "Expected property shorthand in object literal ";
+    public static LONGHAND_METHOD = "Expected method shorthand in object literal ";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const objectLiteralShorthandWalker = new ObjectLiteralShorthandWalker(sourceFile, this.getOptions());
@@ -55,7 +55,7 @@ class ObjectLiteralShorthandWalker extends Lint.RuleWalker {
                 const fix = this.createFix(
                     this.deleteText(name.getStart(), lengthToValueStart),
                 );
-                this.addFailureAtNode(node, Rule.LONGHAND_PROPERTY, fix);
+                this.addFailureAtNode(node, Rule.LONGHAND_PROPERTY + `('{${name.getText()}}').`, fix);
         }
 
         if (value.kind === ts.SyntaxKind.FunctionExpression) {
@@ -63,8 +63,8 @@ class ObjectLiteralShorthandWalker extends Lint.RuleWalker {
             if (fnNode.name) {
                 return;  // named function expressions are OK.
             }
-
-            this.addFailureAtNode(node, Rule.LONGHAND_METHOD);
+            const star = fnNode.asteriskToken ? fnNode.asteriskToken.getText() : "";
+            this.addFailureAtNode(node, Rule.LONGHAND_METHOD + `('{${name.getText()}${star}() {...}}').`);
         }
 
         super.visitPropertyAssignment(node);

--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -32,8 +32,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static LONGHAND_PROPERTY = "Expected property shorthand in object literal.";
-    public static LONGHAND_METHOD = "Expected method shorthand in object literal.";
+    public static LONGHAND_PROPERTY = "Expected property shorthand in object literal ('{foo, bar}').";
+    public static LONGHAND_METHOD = "Expected method shorthand in object literal ('{foo() {...}}').";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const objectLiteralShorthandWalker = new ObjectLiteralShorthandWalker(sourceFile, this.getOptions());

--- a/test/rules/no-any/test.ts.lint
+++ b/test/rules/no-any/test.ts.lint
@@ -15,4 +15,4 @@ let a: any = 2, // error
 let {a: c, b: d}: {c: any, d: number} = {c: 99, d: 100};  // error
                       ~~~                                          [0]
 
-[0]: Type declaration of 'any' is forbidden
+[0]: Type declaration of 'any' is forbidden (use the empty type '{}'?)

--- a/test/rules/no-any/test.ts.lint
+++ b/test/rules/no-any/test.ts.lint
@@ -15,4 +15,4 @@ let a: any = 2, // error
 let {a: c, b: d}: {c: any, d: number} = {c: 99, d: 100};  // error
                       ~~~                                          [0]
 
-[0]: Type declaration of 'any' is forbidden (use the empty type '{}'?)
+[0]: Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type, the empty type ('{}'), or suppress this occurrence.

--- a/test/rules/object-literal-shorthand/test.js.lint
+++ b/test/rules/object-literal-shorthand/test.js.lint
@@ -42,5 +42,5 @@ const extraCases = {
 };
 
 
-[property]: Expected property shorthand in object literal.
-[method]: Expected method shorthand in object literal.
+[property]: Expected property shorthand in object literal ('{foo, bar}').
+[method]: Expected method shorthand in object literal ('{foo() {...}}').

--- a/test/rules/object-literal-shorthand/test.js.lint
+++ b/test/rules/object-literal-shorthand/test.js.lint
@@ -1,12 +1,12 @@
 const bad = {
   w: function() {},
-  ~~~~~~~~~~~~~~~~  [method]
+  ~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{w() {...}}').]
   x: function *() {},
-  ~~~~~~~~~~~~~~~~~~  [method]
+  ~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{x*() {...}}').]
   [y]: function() {},
-  ~~~~~~~~~~~~~~~~~~  [method]
+  ~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{[y]() {...}}').]
   z: z
-  ~~~~  [property]
+  ~~~~  [Expected property shorthand in object literal ('{z}').]
 };
 
 const good = {
@@ -26,7 +26,7 @@ const namedFunctions = {
 
 const quotes = {
   "foo-bar": function() {},
-  ~~~~~~~~~~~~~~~~~~~~~~~~  [method]
+  ~~~~~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{"foo-bar"() {...}}').]
   "foo-bar"() {}
 };
 
@@ -37,10 +37,7 @@ const extraCases = {
   c: 'c',
   ["a" + "nested"]: {
     x: x
-    ~~~~  [property]
+    ~~~~  [Expected property shorthand in object literal ('{x}').]
   }
 };
 
-
-[property]: Expected property shorthand in object literal ('{foo, bar}').
-[method]: Expected method shorthand in object literal ('{foo() {...}}').

--- a/test/rules/object-literal-shorthand/test.ts.lint
+++ b/test/rules/object-literal-shorthand/test.ts.lint
@@ -42,5 +42,5 @@ const extraCases = {
 };
 
 
-[property]: Expected property shorthand in object literal.
-[method]: Expected method shorthand in object literal.
+[property]: Expected property shorthand in object literal ('{foo, bar}').
+[method]: Expected method shorthand in object literal ('{foo() {...}}').

--- a/test/rules/object-literal-shorthand/test.ts.lint
+++ b/test/rules/object-literal-shorthand/test.ts.lint
@@ -1,12 +1,12 @@
 const bad = {
   w: function() {},
-  ~~~~~~~~~~~~~~~~  [method]
+  ~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{w() {...}}').]
   x: function *() {},
-  ~~~~~~~~~~~~~~~~~~  [method]
+  ~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{x*() {...}}').]
   [y]: function() {},
-  ~~~~~~~~~~~~~~~~~~  [method]
+  ~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{[y]() {...}}').]
   z: z
-  ~~~~  [property]
+  ~~~~  [Expected property shorthand in object literal ('{z}').]
 };
 
 const good = {
@@ -26,7 +26,7 @@ const namedFunctions = {
 
 const quotes = {
   "foo-bar": function() {},
-  ~~~~~~~~~~~~~~~~~~~~~~~~  [method]
+  ~~~~~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{"foo-bar"() {...}}').]
   "foo-bar"() {}
 };
 
@@ -37,7 +37,7 @@ const extraCases = {
   c: 'c',
   ["a" + "nested"]: {
     x: x
-    ~~~~  [property]
+    ~~~~  [Expected property shorthand in object literal ('{x}').]
   }
 };
 


### PR DESCRIPTION
Users often use `any` when they could equally well use `{}`, because
they are not aware of the empty type.

Users also often don't know what object shorthand is - giving them a
hint as to what syntax is expected makes it easier to fix the lint
warning.

#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### What changes did you make?

Improve error messages for no-any and object-literal-shorthand.