### PR TITLE
Add fixers for no-any and object-literal-shortand (properties only)

### DIFF
--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -24,6 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-any",
         description: "Diallows usages of `any` as a type declaration.",
+        hasFix: true,
         rationale: "Using `any` as a type declaration nullifies the compile-time benefits of the type system.",
         optionsDescription: "Not configurable.",
         options: null,
@@ -42,7 +43,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoAnyWalker extends Lint.RuleWalker {
     public visitAnyKeyword(node: ts.Node) {
-        this.addFailureAtNode(node, Rule.FAILURE_STRING);
+        const fix = this.createFix(
+            this.createReplacement(node.getStart(), node.getWidth(), "{}"),
+        );
+        this.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
         super.visitAnyKeyword(node);
     }
 }

--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -23,6 +23,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "object-literal-shorthand",
         description: "Enforces use of ES6 object literal shorthand when possible.",
+        hasFix: true,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: ["true"],
@@ -49,7 +50,12 @@ class ObjectLiteralShorthandWalker extends Lint.RuleWalker {
         if (name.kind === ts.SyntaxKind.Identifier &&
             value.kind === ts.SyntaxKind.Identifier &&
             name.getText() === value.getText()) {
-                this.addFailureAtNode(node, Rule.LONGHAND_PROPERTY);
+                // Delete from name start up to value to include the ':'.
+                const lengthToValueStart = value.getStart() - name.getStart();
+                const fix = this.createFix(
+                    this.deleteText(name.getStart(), lengthToValueStart),
+                );
+                this.addFailureAtNode(node, Rule.LONGHAND_PROPERTY, fix);
         }
 
         if (value.kind === ts.SyntaxKind.FunctionExpression) {

--- a/test/rules/no-any/test.ts.fix
+++ b/test/rules/no-any/test.ts.fix
@@ -1,0 +1,11 @@
+var x: {}; // error
+
+function foo(a: {}) : {} { // 2 errors
+    return;
+}
+
+let a: {} = 2, // error
+    b: {} = 4; // error
+
+let {a: c, b: d}: {c: {}, d: number} = {c: 99, d: 100};  // error
+

--- a/test/rules/object-literal-shorthand/test.ts.fix
+++ b/test/rules/object-literal-shorthand/test.ts.fix
@@ -1,0 +1,37 @@
+const bad = {
+  w: function() {},
+  x: function *() {},
+  [y]: function() {},
+  z
+};
+
+const good = {
+  w() {},
+  *x() {},
+  [y]() {},
+  z
+};
+
+const arrows = {
+  x: (y) => y  // this is OK.
+};
+
+const namedFunctions = {
+  x: function y() {}  // named function expressions are also OK.
+};
+
+const quotes = {
+  "foo-bar": function() {},
+  "foo-bar"() {}
+};
+
+const extraCases = {
+  x,
+  a: 123,
+  b: "hello",
+  c: 'c',
+  ["a" + "nested"]: {
+    x
+  }
+};
+


### PR DESCRIPTION
#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### What changes did you make?

Add fixers for no-any and objectLiteralShorthand (for keys).

For object literals with functions, it's sadly pretty tricky to find the opening `(` token, so for now those will have to live without a fix.
