### PR TITLE
Fix error location for typedef rule (#968)

### DIFF
--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -87,7 +87,7 @@ class TypedefWalker extends Lint.RuleWalker {
             && node.parent.kind !== ts.SyntaxKind.CallExpression
             && !isTypedPropertyDeclaration(node.parent)) {
 
-            this.checkTypeAnnotation("arrow-call-signature", location, node.type, node.name);
+            this.checkTypeAnnotation("arrow-call-signature", node.getStart(), node.type, node.name);
         }
         super.visitArrowFunction(node);
     }
@@ -148,7 +148,7 @@ class TypedefWalker extends Lint.RuleWalker {
             }
 
             if (optionName !== null) {
-                this.checkTypeAnnotation(optionName, node.getEnd(), node.type as ts.TypeNode, node.name);
+                this.checkTypeAnnotation(optionName, node.getStart(), node.type as ts.TypeNode, node.name);
             }
         }
         super.visitParameterDeclaration(node);
@@ -174,14 +174,14 @@ class TypedefWalker extends Lint.RuleWalker {
         const performCheck = !(node.initializer != null && node.initializer.kind === ts.SyntaxKind.ArrowFunction && node.type == null);
 
         if (performCheck) {
-            this.checkTypeAnnotation(optionName, node.name.getEnd(), node.type, node.name);
+            this.checkTypeAnnotation(optionName, node.name.getStart(), node.type, node.name);
         }
         super.visitPropertyDeclaration(node);
     }
 
     public visitPropertySignature(node: ts.PropertyDeclaration) {
         const optionName = "property-declaration";
-        this.checkTypeAnnotation(optionName, node.name.getEnd(), node.type, node.name);
+        this.checkTypeAnnotation(optionName, node.name.getStart(), node.type, node.name);
         super.visitPropertySignature(node);
     }
 
@@ -211,8 +211,7 @@ class TypedefWalker extends Lint.RuleWalker {
                     rule = "variable-declaration";
                     break;
             }
-
-            this.checkTypeAnnotation(rule, node.name.getEnd(), node.type, node.name);
+            this.checkTypeAnnotation(rule, node.name.getStart(), node.type, node.name);
         }
         super.visitVariableDeclaration(node);
     }
@@ -221,7 +220,11 @@ class TypedefWalker extends Lint.RuleWalker {
         const location = (node.parameters != null) ? node.parameters.end : null;
         // set accessors can't have a return type.
         if (location != null && node.kind !== ts.SyntaxKind.SetAccessor && node.kind !== ts.SyntaxKind.ArrowFunction) {
-            this.checkTypeAnnotation("call-signature", location, node.type, node.name);
+            let errorLocation = node.getStart();
+            if (node.name !== undefined){
+                errorLocation = node.name.getStart();
+            }
+            this.checkTypeAnnotation("call-signature", errorLocation, node.type, node.name);
         }
     }
 

--- a/test/rules/typedef/all/test.ts.lint
+++ b/test/rules/typedef/all/test.ts.lint
@@ -4,67 +4,67 @@ try {
 }
 
 var NoTypeObjectLiteralWithPropertyGetter = {
-                                         ~    [expected variable-declaration: 'NoTypeObjectLiteralWithPropertyGetter' to have a typedef]
+    ~    [expected variable-declaration: 'NoTypeObjectLiteralWithPropertyGetter' to have a typedef]
     Prop: "some property",
 
     get PropDef() {
-                ~   [expected call-signature: 'PropDef' to have a typedef]
+        ~   [expected call-signature: 'PropDef' to have a typedef]
         return this.Prop;
     },
 
     methodDef() {
-              ~   [expected call-signature: 'methodDef' to have a typedef]
+    ~   [expected call-signature: 'methodDef' to have a typedef]
         return 'untyped';
     },
 
     anotherMethodDef: function() {
-                               ~   [expected call-signature to have a typedef]
+                      ~   [expected call-signature to have a typedef]
         return 'also untyped';
     },
 
     arrowMethodDef: () => {
-                     ~      [expected arrow-call-signature to have a typedef]
+                    ~      [expected arrow-call-signature to have a typedef]
         return 'also untyped';
     }
 };
 
 interface NoTypeInterface {
     Prop;
-        ~ [expected property-declaration: 'Prop' to have a typedef]
+    ~ [expected property-declaration: 'Prop' to have a typedef]
     PropWithType: string;
 }
 
 var NoTypesFn = function (
-             ~             [expected variable-declaration: 'NoTypesFn' to have a typedef]
+    ~             [expected variable-declaration: 'NoTypesFn' to have a typedef]
+                ~   [expected call-signature to have a typedef]
     a,
-     ~ [expected parameter: 'a' to have a typedef]
+    ~ [expected parameter: 'a' to have a typedef]
     b) {
-     ~   [expected call-signature to have a typedef]
-     ~   [expected parameter: 'b' to have a typedef]
+    ~   [expected parameter: 'b' to have a typedef]
     var c = a + b,
-         ~         [expected variable-declaration: 'c' to have a typedef]
+        ~         [expected variable-declaration: 'c' to have a typedef]
         d = a - b;
-         ~         [expected variable-declaration: 'd' to have a typedef]
+        ~         [expected variable-declaration: 'd' to have a typedef]
 
 class TsLint {
     helloWorld() {
-               ~   [expected call-signature: 'helloWorld' to have a typedef]
+    ~   [expected call-signature: 'helloWorld' to have a typedef]
         return 'Hello World';
     };
 
     regularMemberWithType: string = this.getValue();
 
     regularMemberWithoutType = this.getValue();
-                            ~    [expected member-variable-declaration: 'regularMemberWithoutType' to have a typedef]
+    ~    [expected member-variable-declaration: 'regularMemberWithoutType' to have a typedef]
 
     arrowHelloWorld = () => {
-                       ~      [expected arrow-call-signature to have a typedef]
+                      ~      [expected arrow-call-signature to have a typedef]
         return this.helloWorld();
     };
 
     arrowHelloWorldWithArgsNoTypedef = (arg1) => {
-                                            ~      [expected member-variable-declaration: 'arg1' to have a typedef]
-                                            ~      [expected arrow-call-signature to have a typedef]
+                                        ~      [expected member-variable-declaration: 'arg1' to have a typedef]
+                                       ~      [expected arrow-call-signature to have a typedef]
         return this.helloWorld();
     };
 
@@ -79,28 +79,28 @@ class TsLint {
 
 setTimeout(() => {}, 1000);
 setTimeout(function() {}, 1000);
-                    ~            [expected call-signature to have a typedef]
+           ~            [expected call-signature to have a typedef]
 
 someFunc(n => n+1);
-          ~        [expected arrow-parameter: 'n' to have a typedef]
+         ~        [expected arrow-parameter: 'n' to have a typedef]
 someFunc(n => {});
-          ~        [expected arrow-parameter: 'n' to have a typedef]
+         ~        [expected arrow-parameter: 'n' to have a typedef]
 
 class A {
     // property w/o an initializer
     public foo;
-              ~ [expected member-variable-declaration: 'foo' to have a typedef]
+           ~ [expected member-variable-declaration: 'foo' to have a typedef]
     private bar: number;
 }
 
 
 const { paramA, paramB } = { paramA: "test", paramB: 15 };
-                        ~    [expected object-destructuring: '{ paramA, paramB }' to have a typedef]
+      ~    [expected object-destructuring: '{ paramA, paramB }' to have a typedef]
 
 const { paramA, paramB }: { paramA: string, paramB: number } = { paramA: "test", paramB: 15 };
 
 const [ paramA, paramB ] = [15, 'test'];
-                        ~    [expected array-destructuring: '[ paramA, paramB ]' to have a typedef]
+      ~    [expected array-destructuring: '[ paramA, paramB ]' to have a typedef]
 
 const [ paramA3, paramB3 ]: [ number, string ] = [15, 'test'];
 

--- a/test/rules/typedef/array-destructuring/test.ts.lint
+++ b/test/rules/typedef/array-destructuring/test.ts.lint
@@ -1,4 +1,4 @@
 const [ paramA, paramB ] = [15, 'test'];
-                        ~    [expected array-destructuring: '[ paramA, paramB ]' to have a typedef]
+      ~    [expected array-destructuring: '[ paramA, paramB ]' to have a typedef]
 
 const [ paramA3, paramB3 ]: { number: string, paramB1: string } = [15, 'test'];

--- a/test/rules/typedef/arrow-call-signature/test.ts.lint
+++ b/test/rules/typedef/arrow-call-signature/test.ts.lint
@@ -6,7 +6,7 @@ class TsLint {
     };
 
     arrowHelloWorld = () => {
-                       ~      [expected arrow-call-signature to have a typedef]
+                      ~      [expected arrow-call-signature to have a typedef]
         return this.helloWorld();
     };
 }
@@ -14,7 +14,7 @@ class TsLint {
 var obj = {
     foge: function() {},
     bar: () => {}
-          ~       [expected arrow-call-signature to have a typedef]
+         ~       [expected arrow-call-signature to have a typedef]
 }
 
 setTimeout(() => {}, 1000);

--- a/test/rules/typedef/arrow-parameter/test.ts.lint
+++ b/test/rules/typedef/arrow-parameter/test.ts.lint
@@ -1,5 +1,5 @@
 var NoTypesFn = function (a, b) {}
 
 var NoTypesArrowFn = (a, b) => {}
-                       ~ [expected arrow-parameter: 'a' to have a typedef]
-                          ~ [expected arrow-parameter: 'b' to have a typedef]
+                      ~ [expected arrow-parameter: 'a' to have a typedef]
+                         ~ [expected arrow-parameter: 'b' to have a typedef]

--- a/test/rules/typedef/call-signature/test.ts.lint
+++ b/test/rules/typedef/call-signature/test.ts.lint
@@ -1,9 +1,9 @@
 function foge() {}
-              ~    [expected call-signature: 'foge' to have a typedef]
+         ~    [expected call-signature: 'foge' to have a typedef]
 
 class TsLint {
     helloWorld() {
-               ~   [expected call-signature: 'helloWorld' to have a typedef]
+    ~   [expected call-signature: 'helloWorld' to have a typedef]
         return 'Hello World';
     };
 
@@ -14,13 +14,13 @@ class TsLint {
 
 var obj = {
     foge: function() {},
-                   ~     [expected call-signature to have a typedef]
+          ~     [expected call-signature to have a typedef]
     bar: () => {}
 }
 
 setTimeout(() => {}, 1000);
 setTimeout(function() {}, 1000);
-                    ~            [expected call-signature to have a typedef]
+           ~            [expected call-signature to have a typedef]
 
 someFunc(n => n+1);
 someFunc(n => {});

--- a/test/rules/typedef/member-variable-declaration/test.ts.lint
+++ b/test/rules/typedef/member-variable-declaration/test.ts.lint
@@ -12,5 +12,5 @@ class TypesInFunctionWithReturnMemberArrowFn {
 
 class NoTypesMemberArrowFn {
   fn = (param) => {}
-             ~       [expected member-variable-declaration: 'param' to have a typedef]
+        ~       [expected member-variable-declaration: 'param' to have a typedef]
 }

--- a/test/rules/typedef/object-destructuring/test.ts.lint
+++ b/test/rules/typedef/object-destructuring/test.ts.lint
@@ -1,7 +1,7 @@
 
 
 const { paramA, paramB } = { paramA: "test", paramB: 15 };
-                        ~    [expected object-destructuring: '{ paramA, paramB }' to have a typedef]
+      ~    [expected object-destructuring: '{ paramA, paramB }' to have a typedef]
 
 
 const { paramA, paramB }: { paramA: string, paramB: number } = { paramA: "test", paramB: 15 };

--- a/test/rules/typedef/parameter/test.ts.lint
+++ b/test/rules/typedef/parameter/test.ts.lint
@@ -1,6 +1,6 @@
 var NoTypesFn = function (a, b) {
-                           ~ [expected parameter: 'a' to have a typedef]
-                              ~ [expected parameter: 'b' to have a typedef]
+                          ~ [expected parameter: 'a' to have a typedef]
+                             ~ [expected parameter: 'b' to have a typedef]
 }
 
 var NoTypesArrowFn = (a, b) => {}

--- a/test/rules/typedef/variable-declaration/test.ts.lint
+++ b/test/rules/typedef/variable-declaration/test.ts.lint
@@ -1,5 +1,5 @@
 var NoTypeObjectLiteralWithPropertyGetter = { }
-                                         ~    [expected variable-declaration: 'NoTypeObjectLiteralWithPropertyGetter' to have a typedef]
+    ~    [expected variable-declaration: 'NoTypeObjectLiteralWithPropertyGetter' to have a typedef]
 
 
 const { paramA, paramB } = { paramA: "test", paramB: 15 };


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #968
- [x] New feature, bugfix, or enhancement
- [x] Includes tests
- [ ] Documentation update - N/A

#### What changes did you make?

I modified the typedef rule so that error location is adjusted, and updated the tests accordingly.

#### Is there anything you'd like reviewers to focus on?

I have chosen to modify as well the behaviour for the arrow operator and the function calls, in an attempt to be homogeneous. I think you should have a close look at this behaviour change in particular. Feel free to reject the PR if behaviour is not correct, I'll patch it.
Please note that this is my first contribution to open source, so any comment is welcome !
