### PR TITLE
Fix document bug in strict-boolean-expressions and the contributing doc

### DIFF
--- a/docs/develop/contributing/index.md
+++ b/docs/develop/contributing/index.md
@@ -41,4 +41,4 @@ The current debug configurations are:
 - Debug CLI: Used to debug TSLint using command line arguments. Modify the `args` array in `.vscode/launch.json` to add arguments.
 - Debug Mocha Tests: Runs non-rule tests
 - Debug Rule Tests: Runs rule tests (under `test/rules`)
-- Deubg Document Generation: Debug the `scripts/buildDocs.ts` script.
+- Debug Document Generation: Debug the `scripts/buildDocs.ts` script.

--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -51,8 +51,8 @@ export class Rule extends Lint.Rules.TypedRule {
               - It does *not* allow unions containing 'number'.
               - It does *not* allow enums or number literal types.
             * '${OPTION_ALLOW_MIX} allow multiple of the above to appear together.
-              - For example, 'string | number' or 'RegExp | null | undefined' would normally not be allowed.
-              - A type like '"foo" | "bar" | undefined' is always allowed, because it has only one way to be false.`,
+              - For example, \`string | number\` or \`RegExp | null | undefined\` would normally not be allowed.
+              - A type like \`"foo" | "bar" | undefined\` is always allowed, because it has only one way to be false.`,
         options: {
             type: "array",
             items: {

--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -34,23 +34,24 @@ export class Rule extends Lint.Rules.TypedRule {
             Restricts the types allowed in boolean expressions. By default only booleans are allowed.
 
             The following nodes are checked:
-            * Arguments to the '!', '&&', and '||' operators
-            * The condition in a conditional expression ('cond ? x : y')
-            * Conditions for 'if', 'for', 'while', and 'do-while' statements.`,
+
+            * Arguments to the \`!\`, \`&&\`, and \`||\` operators
+            * The condition in a conditional expression (\`cond ? x : y\`)
+            * Conditions for \`if\`, \`for\`, \`while\`, and \`do-while\` statements.`,
         optionsDescription: Lint.Utils.dedent`
             These options may be provided:
 
-            * '${OPTION_ALLOW_NULL_UNION} allows union types containing 'null'.
-              - It does *not* allow 'null' itself.
-            * '${OPTION_ALLOW_UNDEFINED_UNION} allows union types containing 'undefined'.
-              - It does *not* allow 'undefined' itself.
-            * '${OPTION_ALLOW_STRING} allows strings.
-              - It does *not* allow unions containing 'string'.
+            * \`${OPTION_ALLOW_NULL_UNION}\` allows union types containing \`null\`.
+              - It does *not* allow \`null\` itself.
+            * \`${OPTION_ALLOW_UNDEFINED_UNION}\` allows union types containing \`undefined\`.
+              - It does *not* allow \`undefined\` itself.
+            * \`${OPTION_ALLOW_STRING}\` allows strings.
+              - It does *not* allow unions containing \`string\`.
               - It does *not* allow string literal types.
-            * '${OPTION_ALLOW_NUMBER} allows numbers.
-              - It does *not* allow unions containing 'number'.
+            * \`${OPTION_ALLOW_NUMBER}\` allows numbers.
+              - It does *not* allow unions containing \`number\`.
               - It does *not* allow enums or number literal types.
-            * '${OPTION_ALLOW_MIX} allow multiple of the above to appear together.
+            * \`${OPTION_ALLOW_MIX}\` allow multiple of the above to appear together.
               - For example, \`string | number\` or \`RegExp | null | undefined\` would normally not be allowed.
               - A type like \`"foo" | "bar" | undefined\` is always allowed, because it has only one way to be false.`,
         options: {


### PR DESCRIPTION
This change is just for fixing simple document bugs.
1. strict-boolean-expressions
"|" (bitwise OR operator) is interpreted as table. (See https://palantir.github.io/tslint/rules/strict-boolean-expressions )
2. Typo in the contributing document
