### PR TITLE
New Rule: newline-before-return

### DIFF
--- a/src/rules/newlineBeforeReturnRule.ts
+++ b/src/rules/newlineBeforeReturnRule.ts
@@ -16,7 +16,6 @@
  */
 
 import * as ts from "typescript";
-
 import * as Lint from "../index";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -67,17 +66,12 @@ class NewlineBeforeReturnWalker extends Lint.RuleWalker {
         }
         const lc = this.getLineAndCharacterOfPosition(start);
 
-        this.validateBlankLine(lc.line);
-    }
+        const prev = parent.statements[index - 1];
+        const prevLine = this.getLineAndCharacterOfPosition(prev.getEnd()).line;
 
-    private validateBlankLine(line: number) {
-        const source = this.getSourceFile();
-        const position = source.getPositionOfLineAndCharacter(line - 1, 0);
-        const end = source.getPositionOfLineAndCharacter(line, 0) - 1;
-        const all = source.getText().substr(position, end - position);
-
-        if (all.search(/\S/) !== -1) {
-            this.addFailureFromStartToEnd(position, position, Rule.FAILURE_STRING_FACTORY());
+        if (prevLine >= lc.line - 1) {
+            // Previous statement is on the same or previous line
+            this.addFailureFromStartToEnd(start, start, Rule.FAILURE_STRING_FACTORY());
         }
     }
 }

--- a/src/rules/newlineBeforeReturnRule.ts
+++ b/src/rules/newlineBeforeReturnRule.ts
@@ -76,7 +76,7 @@ class NewlineBeforeReturnWalker extends Lint.RuleWalker {
     private validateBlankLine(line: number) {
         const source = this.getSourceFile();
         const position = source.getPositionOfLineAndCharacter(line - 1, 0);
-        const end = source.getLineEndOfPosition(position);
+        const end = source.getPositionOfLineAndCharacter(line, 0) - 1;
         const all = source.getText().substr(position, end - position);
         const trimmed = all.replace(/\s+/, "");
 

--- a/src/rules/newlineBeforeReturnRule.ts
+++ b/src/rules/newlineBeforeReturnRule.ts
@@ -49,7 +49,7 @@ class NewlineBeforeReturnWalker extends Lint.RuleWalker {
         super.visitReturnStatement(node);
 
         const parent = node.parent!;
-        if (!NewlineBeforeReturnWalker.isBlockLike(parent)) {
+        if (!isBlockLike(parent)) {
             // `node` is the only statement within this "block scope". No need to do any further validation.
             return;
         }
@@ -81,8 +81,8 @@ class NewlineBeforeReturnWalker extends Lint.RuleWalker {
             this.addFailureFromStartToEnd(position, position, Rule.FAILURE_STRING_FACTORY());
         }
     }
+}
 
-    private static isBlockLike(node: ts.Node): node is ts.BlockLike {
-        return "statements" in node;
-    }
+function isBlockLike(node: ts.Node): node is ts.BlockLike {
+    return "statements" in node;
 }

--- a/src/rules/newlineBeforeReturnRule.ts
+++ b/src/rules/newlineBeforeReturnRule.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2013 Palantir Technologies, Inc.
+ * Copyright 2017 Palantir Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "newline-before-return",
         description: "Enforces blank line before return when not the only line in the block.",
         rationale: "Helps maintain a readable style in your codebase.",
-        optionsDescription: Lint.Utils.dedent`
-            TSLint implementation of http://eslint.org/docs/rules/newline-before-return.`,
+        optionsDescription: "Not configurable.",
         options: {},
         optionExamples: ["true"],
         type: "style",

--- a/src/rules/newlineBeforeReturnRule.ts
+++ b/src/rules/newlineBeforeReturnRule.ts
@@ -68,9 +68,9 @@ class NewlineBeforeReturnWalker extends Lint.RuleWalker {
     private getIndex(node: ts.Node) {
         const children = node.parent ? node.parent.getChildren() : [];
         // For some reason instances are not the same and indexOf doesn't work with given node directly
-        const child = children.filter((child: ts.Node) => child.pos === node.pos && child.end === node.end)[0];
+        const foundChild = children.filter((child: ts.Node) => child.pos === node.pos && child.end === node.end)[0];
 
-        return children.indexOf(child);
+        return children.indexOf(foundChild);
     }
 
     private validateBlankLine(line: number) {
@@ -78,9 +78,9 @@ class NewlineBeforeReturnWalker extends Lint.RuleWalker {
         const position = source.getPositionOfLineAndCharacter(line - 1, 0);
         const end = source.getLineEndOfPosition(position);
         const all = source.getText().substr(position, end - position);
-        const trimmed = all.replace(/\s+/, '');
+        const trimmed = all.replace(/\s+/, "");
 
-        if (trimmed !== '') {
+        if (trimmed !== "") {
             this.addFailureFromStartToEnd(position, position, Rule.FAILURE_STRING_FACTORY());
         }
     }

--- a/src/rules/newlineBeforeReturnRule.ts
+++ b/src/rules/newlineBeforeReturnRule.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "newline-before-return",
+        description: "Enforces blank line before return when not the only line in the block.",
+        rationale: "Helps maintain a readable style in your codebase.",
+        optionsDescription: Lint.Utils.dedent`
+            TSLint implementation of http://eslint.org/docs/rules/newline-before-return.`,
+        options: {},
+        optionExamples: ["true"],
+        type: "style",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING_FACTORY() {
+        return "Missing blank line before return";
+    };
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NewlineBeforeReturnWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NewlineBeforeReturnWalker extends Lint.RuleWalker {
+
+    public visitReturnStatement(node: ts.ReturnStatement) {
+        super.visitReturnStatement(node);
+
+        let start = node.getStart();
+        const comments = ts.getLeadingCommentRanges(node.getSourceFile().text, node.getFullStart());
+        if (comments) {
+            // In case the return statement is preceded by a comment, we use comments start as the starting position
+            start = comments[0].pos;
+        }
+        const lc = this.getLineAndCharacterOfPosition(start);
+        const index = this.getIndex(node);
+        const prev = index > -1 && node.parent ? node.parent.getChildAt(index - 1) : undefined;
+        // In case previous token was either
+        if (prev && ([ts.SyntaxKind.OpenBraceToken, ts.SyntaxKind.CloseParenToken].indexOf(prev.kind) !== -1)) {
+            return;
+        }
+
+        this.validateBlankLine(lc.line);
+    }
+
+    private getIndex(node: ts.Node) {
+        const children = node.parent ? node.parent.getChildren() : [];
+        // For some reason instances are not the same and indexOf doesn't work with given node directly
+        const child = children.filter((child: ts.Node) => child.pos === node.pos && child.end === node.end)[0];
+
+        return children.indexOf(child);
+    }
+
+    private validateBlankLine(line: number) {
+        const source = this.getSourceFile();
+        const position = source.getPositionOfLineAndCharacter(line - 1, 0);
+        const end = source.getLineEndOfPosition(position);
+        const all = source.getText().substr(position, end - position);
+        const trimmed = all.replace(/\s+/, '');
+
+        if (trimmed !== '') {
+            this.addFailureFromStartToEnd(position, position, Rule.FAILURE_STRING_FACTORY());
+        }
+    }
+}

--- a/test/rules/newline-before-return/default/test.ts.lint
+++ b/test/rules/newline-before-return/default/test.ts.lint
@@ -2,15 +2,15 @@ function foo(bar) {
     if (!bar) {
         return;
     }
-~nil  [0]
     return bar;
+    ~nil  [0]
 }
 
 function foo(bar) {
     if (!bar) {
         var statement = '';
-~nil  [0]
         return statement;
+        ~nil  [0]
     }
 
     return bar;
@@ -20,8 +20,8 @@ function foo(bar) {
     if (!bar) {
         return;
     }
-~nil  [0]
     /* multi-line
+    ~nil  [0]
     comment */
     return bar;
 }
@@ -29,8 +29,13 @@ function foo(bar) {
 var fn = () => null;
 function foo() {
     fn();
-~nil  [0]
     return;
+    ~nil  [0]
+}
+
+function foo(fn) {
+    fn(); return;
+          ~nil [0]
 }
 
 function foo() {

--- a/test/rules/newline-before-return/default/test.ts.lint
+++ b/test/rules/newline-before-return/default/test.ts.lint
@@ -1,0 +1,85 @@
+function foo(bar) {
+    if (!bar) {
+        return;
+    }
+~nil  [0]
+    return bar;
+}
+
+function foo(bar) {
+    if (!bar) {
+        var statement = '';
+~nil  [0]
+        return statement;
+    }
+
+    return bar;
+}
+
+function foo(bar) {
+    if (!bar) {
+        return;
+    }
+~nil  [0]
+    /* multi-line
+    comment */
+    return bar;
+}
+
+var fn = () => null;
+function foo() {
+    fn();
+~nil  [0]
+    return;
+}
+
+function foo() {
+    return;
+}
+
+function foo() {
+
+    return;
+}
+
+function foo(bar) {
+    if (!bar) return;
+}
+
+function foo(bar) {
+    let someCall;
+    if (!bar) return;
+}
+
+function foo(bar) {
+    if (!bar) { return };
+}
+
+function foo(bar) {
+    if (!bar) {
+        return;
+    }
+}
+
+function foo(bar) {
+    if (!bar) {
+        return;
+    }
+
+    return bar;
+}
+
+function foo(bar) {
+    if (!bar) {
+
+        return;
+    }
+}
+
+function foo() {
+
+    // comment
+    return;
+}
+
+[0]: Missing blank line before return

--- a/test/rules/newline-before-return/default/test.tsx.lint
+++ b/test/rules/newline-before-return/default/test.tsx.lint
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 <div>{ [].map((child: any) => {
     let i = 0;
-~nil  [0]
     return <span />;
+    ~nil  [0]
 }) }</div>
 
 <div>{ [].map((child: any) => {

--- a/test/rules/newline-before-return/default/test.tsx.lint
+++ b/test/rules/newline-before-return/default/test.tsx.lint
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+<div>{ [].map((child: any) => {
+    let i = 0;
+~nil  [0]
+    return <span />;
+}) }</div>
+
+<div>{ [].map((child: any) => {
+    return <span />;
+}) }</div>
+
+<div>{ [].map((child: any) =>
+    <span />;
+) }</div>
+
+
+[0]: Missing blank line before return

--- a/test/rules/newline-before-return/default/tslint.json
+++ b/test/rules/newline-before-return/default/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "newline-before-return": true
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue:
- [x] New feature, bugfix, or enhancement
- [x] Includes tests
- [ ] Documentation update

#### What changes did you make?

A new rule to force blank lines before return. Based on http://eslint.org/docs/rules/newline-before-return

#### Is there anything you'd like reviewers to focus on?

Making sure all test cases are covered. I took the base file from eslint and added a few cases.
