### PR TITLE
Add a rule to ban specified types from being used in type annotations or type assertions.

### DIFF
--- a/src/rules/banTypesRule.ts
+++ b/src/rules/banTypesRule.ts
@@ -24,8 +24,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "ban-types",
         description: Lint.Utils.dedent`
-        Bans specific global types from being used. Does not ban the
-        corresponding runtime objects from being used.`,
+            Bans specific global types from being used. Does not ban the
+            corresponding runtime objects from being used.`,
         options: {
             type: "list",
             listType: {
@@ -36,8 +36,8 @@ export class Rule extends Lint.Rules.AbstractRule {
             },
         },
         optionsDescription: Lint.Utils.dedent`
-        A list of \`["type", "optional explanation here"]\`, which bans
-        \`type\``,
+            A list of \`["regex", "optional explanation here"]\`, which bans
+            types that match \`regex\``,
         optionExamples: [`[true, ["Object", "Use {} instead."], ["String"]]`],
         type: "typescript",
         typescriptOnly: true,
@@ -65,7 +65,8 @@ class BanTypeWalker extends Lint.RuleWalker {
     public visitTypeReference(node: ts.TypeReferenceNode) {
         const typeName = node.typeName.getText();
         const ban =
-            this.bans.find(([bannedType]) => typeName === bannedType) as string[];
+            this.bans.find(([bannedType]) =>
+                typeName.match(`^${bannedType}$`) != null) as string[];
         if (ban) {
             this.addFailure(this.createFailure(
                 node.getStart(), node.getWidth(),

--- a/src/rules/banTypesRule.ts
+++ b/src/rules/banTypesRule.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "ban-types",
+        description: Lint.Utils.dedent`
+        Bans specific global types from being used. Does not ban the
+        corresponding runtime objects from being used.`,
+        options: {
+            type: "list",
+            listType: {
+                type: "array",
+                items: { type: "string" },
+                minLength: 1,
+                maxLength: 2,
+            },
+        },
+        optionsDescription: Lint.Utils.dedent`
+        A list of \`["type", "optional explanation here"]\`, which bans
+        \`type\``,
+        optionExamples: [`[true, ["Object", "Use {} instead."], ["String"]]`],
+        type: "typescript",
+        typescriptOnly: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING_FACTORY(typeName: string, messageAddition?: string) {
+        return `Don't use '${typeName}' as a type.` +
+            (messageAddition ? " " + messageAddition : "");
+    }
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(
+            new BanTypeWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class BanTypeWalker extends Lint.RuleWalker {
+    private bans: string[][];
+    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+        super(sourceFile, options);
+        this.bans = options.ruleArguments!;
+    }
+
+    public visitTypeReference(node: ts.TypeReferenceNode) {
+        const typeName = node.typeName.getText();
+        const ban =
+            this.bans.find(([bannedType]) => typeName === bannedType) as string[];
+        if (ban) {
+            this.addFailure(this.createFailure(
+                node.getStart(), node.getWidth(),
+                Rule.FAILURE_STRING_FACTORY(typeName, ban[1])));
+        }
+        super.visitTypeReference(node);
+    }
+}

--- a/src/rules/banTypesRule.ts
+++ b/src/rules/banTypesRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "ban-types",
         description: Lint.Utils.dedent`
-            Bans specific global types from being used. Does not ban the
+            Bans specific types from being used. Does not ban the
             corresponding runtime objects from being used.`,
         options: {
             type: "list",

--- a/test/rules/ban-types/test.ts.lint
+++ b/test/rules/ban-types/test.ts.lint
@@ -1,0 +1,16 @@
+let a: Object;
+       ~~~~~~  [Don't use 'Object' as a type.]
+let b: {c: String};
+           ~~~~~~   [Don't use 'String' as a type. Use 'string' instead.]
+function foo(a: String) {}
+                ~~~~~~     [Don't use 'String' as a type. Use 'string' instead.]
+'a' as String;
+       ~~~~~~  [Don't use 'String' as a type. Use 'string' instead.]
+
+// no warning for separately scoped types
+let c: foo.String;
+
+// no warning for actual uses.
+let d = Object();
+let e = Object.create(null);
+let f = String(false);

--- a/test/rules/ban-types/test.ts.lint
+++ b/test/rules/ban-types/test.ts.lint
@@ -6,11 +6,15 @@ function foo(a: String) {}
                 ~~~~~~     [Don't use 'String' as a type. Use 'string' instead.]
 'a' as String;
        ~~~~~~  [Don't use 'String' as a type. Use 'string' instead.]
+let c: F;
+       ~ [Don't use 'F' as a type.]
+let d: Foooooo;
+       ~~~~~~~ [Don't use 'Foooooo' as a type.]
 
 // no warning for separately scoped types
-let c: foo.String;
+let e: foo.String;
 
 // no warning for actual uses.
-let d = Object();
-let e = Object.create(null);
-let f = String(false);
+let f = Object();
+let g = Object.create(null);
+let h = String(false);

--- a/test/rules/ban-types/tslint.json
+++ b/test/rules/ban-types/tslint.json
@@ -3,7 +3,8 @@
     "ban-types": [
       true,
       ["String", "Use 'string' instead."],
-      ["Object"]
+      ["Object"],
+      ["Fo*"]
     ]
   }
 }

--- a/test/rules/ban-types/tslint.json
+++ b/test/rules/ban-types/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "ban-types": [
+      true,
+      ["String", "Use 'string' instead."],
+      ["Object"]
+    ]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### What changes did you make?

I added a new rule, `ban-types`, that allows a list of specified global types to be banned from use, similar to the existing `ban` rule for functions.
