### PR TITLE
Add ignore-properties to no-inferrable-types

### DIFF
--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -20,6 +20,12 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 
 const OPTION_IGNORE_PARMS = "ignore-params";
+const OPTION_IGNORE_PROPERTIES = "ignore-properties";
+
+interface IOptions {
+    ignoreParameters: boolean;
+    ignoreProperties: boolean;
+}
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -28,20 +34,26 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.",
         rationale: "Explicit types where they can be easily infered by the compiler make code more verbose.",
         optionsDescription: Lint.Utils.dedent`
-            One argument may be optionally provided:
+            Two argument may be optionally provided:
 
             * \`${OPTION_IGNORE_PARMS}\` allows specifying an inferrable type annotation for function params.
-            This can be useful when combining with the \`typedef\` rule.`,
+            This can be useful when combining with the \`typedef\` rule.
+            * \`${OPTION_IGNORE_PROPERTIES}\` allows specifying an inferrable type annotation for class properties.`,
         options: {
             type: "array",
             items: {
                 type: "string",
-                enum: [OPTION_IGNORE_PARMS],
+                enum: [OPTION_IGNORE_PARMS, OPTION_IGNORE_PROPERTIES],
             },
             minLength: 0,
-            maxLength: 1,
+            maxLength: 2,
         },
-        optionExamples: ["true", `[true, "${OPTION_IGNORE_PARMS}"]`],
+        hasFix: true,
+        optionExamples: [
+            "true",
+            `[true, "${OPTION_IGNORE_PARMS}"]`,
+            `[true, "${OPTION_IGNORE_PARMS}", "${OPTION_IGNORE_PROPERTIES}"]`,
+        ],
         type: "typescript",
         typescriptOnly: true,
     };
@@ -52,29 +64,37 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoInferrableTypesWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new NoInferrableTypesWalker(sourceFile, this.ruleName, {
+            ignoreParameters: this.ruleArguments.indexOf(OPTION_IGNORE_PARMS) !== -1,
+            ignoreProperties: this.ruleArguments.indexOf(OPTION_IGNORE_PROPERTIES) !== -1,
+        }));
     }
 }
 
-class NoInferrableTypesWalker extends Lint.RuleWalker {
-    public visitVariableDeclaration(node: ts.VariableDeclaration) {
-        this.checkDeclaration(node);
-        super.visitVariableDeclaration(node);
+class NoInferrableTypesWalker extends Lint.AbstractWalker<IOptions> {
+    public walk(sourceFile: ts.SourceFile) {
+        const cb = (node: ts.Node): void => {
+            switch (node.kind) {
+                case ts.SyntaxKind.Parameter:
+                    if (!this.options.ignoreParameters) {
+                        this.checkDeclaration(node as ts.ParameterDeclaration);
+                    }
+                    break;
+                case ts.SyntaxKind.PropertyDeclaration:
+                    if (this.options.ignoreProperties) {
+                        break;
+                    }
+                    /* falls through*/
+                case ts.SyntaxKind.VariableDeclaration:
+                    this.checkDeclaration(node as ts.VariableLikeDeclaration);
+                default:
+            }
+            return ts.forEachChild(node, cb);
+        };
+        return ts.forEachChild(sourceFile, cb);
     }
 
-    public visitParameterDeclaration(node: ts.ParameterDeclaration) {
-        if (!this.hasOption(OPTION_IGNORE_PARMS)) {
-            this.checkDeclaration(node);
-        }
-        super.visitParameterDeclaration(node);
-    }
-
-    public visitPropertyDeclaration(node: ts.PropertyDeclaration) {
-        this.checkDeclaration(node);
-        super.visitPropertyDeclaration(node);
-    }
-
-    private checkDeclaration(node: ts.ParameterDeclaration | ts.VariableDeclaration | ts.PropertyDeclaration) {
+    private checkDeclaration(node: ts.VariableLikeDeclaration) {
         if (node.type != null && node.initializer != null) {
             let failure: string | null = null;
 
@@ -105,7 +125,10 @@ class NoInferrableTypesWalker extends Lint.RuleWalker {
             }
 
             if (failure != null) {
-                this.addFailureAtNode(node.type, Rule.FAILURE_STRING_FACTORY(failure));
+                this.addFailureAtNode(node.type,
+                                      Rule.FAILURE_STRING_FACTORY(failure),
+                                      this.createFix(Lint.Replacement.deleteFromTo(node.name.end, node.type.end)),
+                );
             }
         }
     }

--- a/test/rules/no-inferrable-types/default/test.ts.fix
+++ b/test/rules/no-inferrable-types/default/test.ts.fix
@@ -1,0 +1,31 @@
+// errors, inferrable type is declared
+let x = 7;
+let y = false;
+let z = "foo";
+class C {
+    x = 1;
+}
+
+// errors, types are inferrable
+function foo (a = 5, b = true, c = "bah") { }
+
+class Foo {
+    bar = 0;
+    baz = true,
+    bas = "moar";
+}
+
+// not errors, inferrable type is not declared
+let _x = 7;
+let _y = false;
+let _z = "foo";
+
+// not error, type is not inferrable
+let weird: any = 123;
+
+// not errors, inferrable type is not declared
+function bar(a = 5, b = true, c = "bah") { }
+
+// not errors, types are not inferrable
+function baz(a: any = 5, b: any = true, c: any = "bah") { }
+

--- a/test/rules/no-inferrable-types/default/test.ts.lint
+++ b/test/rules/no-inferrable-types/default/test.ts.lint
@@ -16,6 +16,15 @@ function foo (a: number = 5, b: boolean = true, c: string = "bah") { }
                                 ~~~~~~~                                [boolean]
                                                    ~~~~~~              [string]
 
+class Foo {
+    bar: number = 0;
+         ~~~~~~          [number]
+    baz: boolean = true,
+         ~~~~~~~         [boolean]
+    bas: string = "moar";
+         ~~~~~~          [string]
+}
+
 // not errors, inferrable type is not declared
 let _x = 7;
 let _y = false;

--- a/test/rules/no-inferrable-types/ignore-params/test.ts.fix
+++ b/test/rules/no-inferrable-types/ignore-params/test.ts.fix
@@ -1,0 +1,32 @@
+// errors, inferrable type is declared
+let x = 7;
+let y = false;
+let z = "foo";
+
+// not errors, we are skipping params
+function foo (a: number = 5, b: boolean = true, c: string = "bah") { }
+
+class TestClass {
+   doSomething(a: number = 5, b: boolean = true, c: string = "bah") {}
+}
+
+class Foo {
+    bar = 0;
+    baz = true,
+    bas = "moar";
+}
+
+// not errors, inferrable type is not declared
+let _x = 7;
+let _y = false;
+let _z = "foo";
+
+// not error, type is not inferrable
+let weird: any = 123;
+
+// not errors, inferrable type is not declared
+function bar(a = 5, b = true, c = "bah") { }
+
+// not errors, types are not inferrable
+function baz(a: any = 5, b: any = true, c: any = "bah") { }
+

--- a/test/rules/no-inferrable-types/ignore-properties/test.ts.fix
+++ b/test/rules/no-inferrable-types/ignore-properties/test.ts.fix
@@ -1,0 +1,31 @@
+// errors, inferrable type is declared
+let x = 7;
+let y = false;
+let z = "foo";
+class C {
+    x: number = 1;
+}
+
+// errors, types are inferrable
+function foo (a = 5, b = true, c = "bah") { }
+
+class Foo {
+    bar: number = 0;
+    baz: boolean = true,
+    bas: string = "moar";
+}
+
+// not errors, inferrable type is not declared
+let _x = 7;
+let _y = false;
+let _z = "foo";
+
+// not error, type is not inferrable
+let weird: any = 123;
+
+// not errors, inferrable type is not declared
+function bar(a = 5, b = true, c = "bah") { }
+
+// not errors, types are not inferrable
+function baz(a: any = 5, b: any = true, c: any = "bah") { }
+

--- a/test/rules/no-inferrable-types/ignore-properties/test.ts.lint
+++ b/test/rules/no-inferrable-types/ignore-properties/test.ts.lint
@@ -5,21 +5,20 @@ let y: boolean = false;
        ~~~~~~~          [boolean]
 let z: string = "foo";
        ~~~~~~           [string]
-
-// not errors, we are skipping params
-function foo (a: number = 5, b: boolean = true, c: string = "bah") { }
-
-class TestClass {
-   doSomething(a: number = 5, b: boolean = true, c: string = "bah") {}
+class C {
+    x: number = 1;
 }
+
+// errors, types are inferrable
+function foo (a: number = 5, b: boolean = true, c: string = "bah") { }
+                 ~~~~~~                                                [number]
+                                ~~~~~~~                                [boolean]
+                                                   ~~~~~~              [string]
 
 class Foo {
     bar: number = 0;
-         ~~~~~~          [number]
     baz: boolean = true,
-         ~~~~~~~         [boolean]
     bas: string = "moar";
-         ~~~~~~          [string]
 }
 
 // not errors, inferrable type is not declared

--- a/test/rules/no-inferrable-types/ignore-properties/tslint.json
+++ b/test/rules/no-inferrable-types/ignore-properties/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-inferrable-types": [true, "ignore-properties"]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2158
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### What changes did you make?

[new-fixer] automatically remove inferrable type annotations
[new-rule-option] added `ignore-properties` option to `no-inferrable-types`
Minor Refactoring to use the new `AbstractWalker`

#### Is there anything you'd like reviewers to focus on?

Not sure about the option name. `Parameters` is abbreviated to `params`. Maybe I should do the same for `properties` -> `props`?
