### PR TITLE
[New Rule] Adds support for enforcing JSDoc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,15 +9,15 @@
 	"editor.wrappingColumn": 140,
 
 	// The folders to exclude when doing a full text search in the workspace.
-	"search.excludeFolders": [
-		".git",
-		".tscache",
-		"bower_components",
-                "bin",
-		"build",
-                "lib",
-		"node_modules"
-	],
+	"search.exclude": {
+		".git": true,
+		".tscache": true,
+		"node_modules": true,
+		"bower_components": true,
+		"bin": true,
+		"lib" : true,
+		"build": true
+	},
 
 	// Always use project's provided typescript compiler version
 	"typescript.tsdk": "node_modules/typescript/lib"

--- a/src/rules/requireJsdocRule.ts
+++ b/src/rules/requireJsdocRule.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "require-jsdoc",
+        description: "Require JSDoc comments.",
+        hasFix: false,
+        optionsDescription: Lint.Utils.dedent`
+            Ensure your project is documented. Defaults to only show errors 
+            on undocumented classes or functions which are exported.
+
+            You can opt out of checking for a specific set of declarations in
+            the options.
+            `,
+        options: {
+            type: "object",
+            properties: {
+                exportedOnly: {
+                    type: "boolean",
+                },
+                functionDeclaration: {
+                    type: "boolean",
+                },
+                classDeclaration: {
+                    type: "boolean",
+                },
+                methodDefinition: {
+                    type: "boolean",
+                },
+            },
+            additionalProperties: false,
+        },
+        optionExamples: ['[true, {"exportedOnly": false, "classDeclaration": false}]',
+                         '[true, {"exportedOnly": false, "classDeclaration": false, functionDeclaration: false, methodDefinition: false}]'],
+
+        type: "style",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Missing JSDoc comment.";
+
+    public applyWithProgram(sourceFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
+        const noForInArrayWalker = new RequireJSDocWalker(sourceFile, this.getOptions(), langSvc.getProgram());
+        return this.applyWithWalker(noForInArrayWalker);
+    }
+}
+
+class RequireJSDocWalker extends Lint.ProgramAwareRuleWalker {
+    public visitClassDeclaration(node: ts.ClassDeclaration) {
+        const settings = this.getRequireJSDocOptions();
+        if (settings.classDeclaration) {
+            this.checkJSDoc(node);
+        }
+        super.visitClassDeclaration(node);
+    }
+
+    public visitFunctionExpression(node: ts.FunctionExpression) {
+        const settings = this.getRequireJSDocOptions();
+        if (settings.functionDeclaration) {
+            this.checkJSDoc(node);
+        }
+        super.visitFunctionExpression(node);
+    }
+
+    public visitFunctionDeclaration(node: ts.FunctionDeclaration) {
+        const settings = this.getRequireJSDocOptions();
+        if (settings.functionDeclaration) {
+            this.checkJSDoc(node);
+        }
+        super.visitFunctionDeclaration(node);
+    }
+
+    public visitMethodDeclaration(node: ts.MethodDeclaration) {
+        const settings = this.getRequireJSDocOptions();
+        if (settings.methodDefinition) {
+            this.checkJSDoc(node);
+        }
+        super.visitMethodDeclaration(node);
+    }
+
+    private getRequireJSDocOptions() {
+        const DEFAULT_OPTIONS = {
+            classDeclaration: true,
+            exportedOnly: true,
+            functionDeclaration: true,
+            methodDefinition: true,
+        };
+
+        const ruleOptions = this.getOptions();
+        return Object.assign(DEFAULT_OPTIONS, ruleOptions && ruleOptions[0]);
+    }
+
+    private checkJSDoc(node: ts.FunctionDeclaration | ts.FunctionExpression | ts.ClassDeclaration | ts.MethodDeclaration) {
+        if (node.name) {
+            const checker = this.getTypeChecker();
+            const symbol = checker.getSymbolAtLocation(node.name);
+            const hasDocs = symbol.getDocumentationComment().length > 0;
+
+            if (!hasDocs ) {
+                const settings = this.getRequireJSDocOptions();
+                // console.log(settings);
+                if (settings.exportedOnly && !this.isExportedNode(node)) {
+                    return;
+                }
+                this.addFailureAtNode(node.name, Rule.FAILURE_STRING);
+            }
+        }
+    }
+
+    private isExportedNode(node: ts.Node): boolean {
+        if (Lint.hasModifier(node.modifiers, ts.SyntaxKind.ExportKeyword)) { return true; }
+        if (!node.parent) { return false; }
+        return this.isExportedNode(node.parent);
+    }
+}

--- a/test/ruleTestRunner.ts
+++ b/test/ruleTestRunner.ts
@@ -25,7 +25,12 @@ console.log();
 console.log(colors.underline("Testing Lint Rules:"));
 /* tslint:enable:no-console */
 
-const testDirectories = glob.sync("test/rules/**/tslint.json").map(path.dirname);
+// Support running a subset of lint rules:
+// node ./build/test/ruleTestRunner.js "test/rules/require-jsdoc/*/tslint.json"
+
+const useCustomRuleGlob = process.argv.length === 3;
+const testGlob = useCustomRuleGlob ? process.argv[2] : "test/rules/**/tslint.json";
+const testDirectories = glob.sync(testGlob).map(path.dirname);
 
 for (const testDirectory of testDirectories) {
     const results = runTest(testDirectory);

--- a/test/rules/require-jsdoc/defaults/test.js.lint
+++ b/test/rules/require-jsdoc/defaults/test.js.lint
@@ -1,0 +1,7 @@
+class MyOKClass {
+
+}
+
+export class MyClass {
+             ~~~~~~~   [Missing JSDoc comment.]
+}

--- a/test/rules/require-jsdoc/defaults/test.ts.lint
+++ b/test/rules/require-jsdoc/defaults/test.ts.lint
@@ -1,0 +1,8 @@
+class MyOKClass {
+
+}
+
+export class MyClass {
+             ~~~~~~~   [Missing JSDoc comment.]
+}
+

--- a/test/rules/require-jsdoc/defaults/tslint.json
+++ b/test/rules/require-jsdoc/defaults/tslint.json
@@ -1,0 +1,11 @@
+{ 
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "require-jsdoc": true
+  },
+  "jsRules": {
+    "require-jsdoc": true
+  }
+}

--- a/test/rules/require-jsdoc/exports-only-classes-only/test.js.lint
+++ b/test/rules/require-jsdoc/exports-only-classes-only/test.js.lint
@@ -1,0 +1,7 @@
+class MyClass {
+      
+}
+
+export function myUndocumentedFunc() {
+
+} 

--- a/test/rules/require-jsdoc/exports-only-classes-only/test.ts.lint
+++ b/test/rules/require-jsdoc/exports-only-classes-only/test.ts.lint
@@ -1,0 +1,17 @@
+/** I am documented */
+export class Documented {
+      
+}
+
+export class Undocumented {
+             ~~~~~~~~~~~~   [Missing JSDoc comment.]
+}
+
+/** I am documented **/
+function iAmDocumented() {
+
+}
+
+function iAmUnDocumented() {
+
+}

--- a/test/rules/require-jsdoc/exports-only-classes-only/tslint.json
+++ b/test/rules/require-jsdoc/exports-only-classes-only/tslint.json
@@ -1,0 +1,11 @@
+{ 
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "require-jsdoc": [true, {"functionDeclaration": false, "methodDefinition": false}]
+  },
+  "jsRules": {
+    "require-jsdoc": [true, {"functionDeclaration": false, "methodDefinition": false}]
+  }
+}

--- a/test/rules/require-jsdoc/exports-only-false/test.js.lint
+++ b/test/rules/require-jsdoc/exports-only-false/test.js.lint
@@ -1,0 +1,17 @@
+/** I am documented */
+class Documented {
+      
+}
+
+class Undocumented {
+      ~~~~~~~~~~~~   [Missing JSDoc comment.]
+}
+
+/** I am documented **/
+function iAmDocumented() {
+
+}
+
+function iAmUnDocumented() {
+         ~~~~~~~~~~~~~~~     [Missing JSDoc comment.]
+}

--- a/test/rules/require-jsdoc/exports-only-false/test.ts.lint
+++ b/test/rules/require-jsdoc/exports-only-false/test.ts.lint
@@ -1,0 +1,17 @@
+/** I am documented */
+class Documented {
+      
+}
+
+class Undocumented {
+      ~~~~~~~~~~~~   [Missing JSDoc comment.]
+}
+
+/** I am documented **/
+function iAmDocumented() {
+
+}
+
+function iAmUnDocumented() {
+         ~~~~~~~~~~~~~~~     [Missing JSDoc comment.]
+}

--- a/test/rules/require-jsdoc/exports-only-false/tslint.json
+++ b/test/rules/require-jsdoc/exports-only-false/tslint.json
@@ -1,0 +1,11 @@
+{ 
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "require-jsdoc": [true, {"exportedOnly": false}]
+  },
+  "jsRules": {
+    "require-jsdoc": [true, {"exportedOnly": false}]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #623
- [x] New feature
  - [x] Includes tests
- [ ] Documentation update

#### What changes did you make?

Hey there, I had been wanting to add a [feature](https://github.com/eslint/eslint/pull/7867) to ESLint for a while, but we moved to TypeScript, and so I actually needed it in TSLint also. 

This is close to an exact port of the "require-jsdoc" port from ESLint, but with less rigid defaults. It will default to only raising errors to `export`ed classes/functions. You can make it apply to all functions though, too.

#### Is there anything you'd like reviewers to focus on?

- I've only done JavaScript for ~6 months TS for 1 month, there are things I've probably not taken into account.
- Should this take into account TS' private / public functions?
- Not sure what I have to do re:docs

--

Sidenotes:

* I updated the settings for VS Code - the JSON shape has changed, and it would show the JS files instead of just TS files in search
* I added a quick feature to the ruleTestRunner so you could run a subset of tests with ` node ./build/test/ruleTestRunner.js "test/rules/require-jsdoc/*/tslint.json"` - 30 seconds  was too long.