### PR TITLE
New Rule: no-enum-boolean-expressions

### DIFF
--- a/src/rules/noEnumBooleanExpressionsRule.ts
+++ b/src/rules/noEnumBooleanExpressionsRule.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../index";
+import * as utils from "../language/utils";
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-enum-boolean-expressions",
+        description: "Disallow Enum type in boolean expressions.",
+        descriptionDetails: Lint.Utils.dedent `
+        Usage of \`&&\` or \`||\` operators should not be with Enum type and expressions
+         in \`do-while\`, \`for\`, \`if\`, and \`while\` statements should not be of Enum type.`,
+        rationale: Lint.Utils.dedent `
+        Usage of Enum type in boolean expressions is often confusing especially because the first member of an Enum type is given a default value of 0.`,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "functionality",
+        typescriptOnly: true,
+        requiresTypeInfo: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static BINARY_EXPRESSION_ERROR = "Operands for the && or || operator should not be of Enum type";
+    public static UNARY_EXPRESSION_ERROR = "Operand for the ! operator should not be of Enum type";
+    public static STATEMENT_ERROR = "statement condition cannot be an Enum expression";
+    public static CONDITIONAL_EXPRESSION_ERROR = "Condition cannot be an Enum expression";
+
+    public applyWithProgram(srcFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
+        return this.applyWithWalker(new StrictBooleanExpressionsRule(srcFile, this.getOptions(), langSvc.getProgram()));
+    }
+}
+
+type StatementType = ts.IfStatement|ts.DoStatement|ts.WhileStatement;
+
+class StrictBooleanExpressionsRule extends Lint.ProgramAwareRuleWalker {
+    private checker: ts.TypeChecker;
+
+    constructor(srcFile: ts.SourceFile, lintOptions: Lint.IOptions, program: ts.Program) {
+        super(srcFile, lintOptions, program);
+        this.checker = this.getTypeChecker();
+    }
+
+    public visitBinaryExpression(node: ts.BinaryExpression) {
+        const isAndAndBinaryOperator = node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken;
+        const isOrOrBinaryOperator = node.operatorToken.kind === ts.SyntaxKind.BarBarToken;
+        if (isAndAndBinaryOperator || isOrOrBinaryOperator) {
+            const lhsExpression = node.left;
+            const lhsType = this.checker.getTypeAtLocation(lhsExpression);
+            const rhsExpression = node.right;
+            const rhsType = this.checker.getTypeAtLocation(rhsExpression);
+            if (this.isEnumType(lhsType)) {
+                if (lhsExpression.kind !== ts.SyntaxKind.BinaryExpression) {
+                    this.addFailureAtNode(lhsExpression, Rule.BINARY_EXPRESSION_ERROR);
+                } else {
+                    this.visitBinaryExpression(lhsExpression as ts.BinaryExpression);
+                }
+            }
+            if (this.isEnumType(rhsType)) {
+                if (rhsExpression.kind !== ts.SyntaxKind.BinaryExpression) {
+                    this.addFailureAtNode(rhsExpression, Rule.BINARY_EXPRESSION_ERROR);
+                } else {
+                    this.visitBinaryExpression(rhsExpression as ts.BinaryExpression);
+                }
+            }
+        }
+        super.visitBinaryExpression(node);
+    }
+
+    public visitPrefixUnaryExpression(node: ts.PrefixUnaryExpression) {
+        const isExclamationOperator = node.operator === ts.SyntaxKind.ExclamationToken;
+        if (isExclamationOperator) {
+            const expr = node.operand;
+            const expType = this.checker.getTypeAtLocation(expr);
+            if (this.isEnumType(expType)) {
+                this.addFailureAtNode(node, Rule.UNARY_EXPRESSION_ERROR);
+            }
+        }
+        super.visitPrefixUnaryExpression(node);
+    }
+
+    public visitIfStatement(node: ts.IfStatement) {
+        this.checkStatement(node);
+        super.visitIfStatement(node);
+    }
+
+    public visitWhileStatement(node: ts.WhileStatement) {
+        this.checkStatement(node);
+        super.visitWhileStatement(node);
+    }
+
+    public visitDoStatement(node: ts.DoStatement) {
+        this.checkStatement(node);
+        super.visitDoStatement(node);
+    }
+
+    public visitConditionalExpression(node: ts.ConditionalExpression) {
+        const cexp = node.condition;
+        const expType = this.checker.getTypeAtLocation(cexp);
+        if (this.isEnumType(expType)) {
+            this.addFailureAtNode(cexp, Rule.CONDITIONAL_EXPRESSION_ERROR);
+        }
+        super.visitConditionalExpression(node);
+    }
+
+    public visitForStatement(node: ts.ForStatement) {
+        const forCondition = node.condition;
+        if (forCondition !== undefined) {
+            const expType = this.checker.getTypeAtLocation(forCondition);
+            if (this.isEnumType(expType)) {
+                this.addFailureAtNode(forCondition, `For ${Rule.STATEMENT_ERROR}`);
+            }
+        }
+        super.visitForStatement(node);
+    }
+
+    private checkStatement(node: StatementType) {
+        const bexp = node.expression;
+        const expType = this.checker.getTypeAtLocation(bexp);
+        if (this.isEnumType(expType)) {
+            this.addFailureAtNode(bexp, `${failureTextForKind(node.kind)} ${Rule.STATEMENT_ERROR}`);
+        }
+    }
+
+    private isEnumType(btype: ts.Type): boolean {
+        return utils.isTypeFlagSet(btype, ts.TypeFlags.EnumLike);
+    }
+}
+
+function failureTextForKind(kind: ts.SyntaxKind) {
+    switch (kind) {
+        case ts.SyntaxKind.IfStatement:
+            return "If";
+        case ts.SyntaxKind.DoStatement:
+            return "Do-While";
+        case ts.SyntaxKind.WhileStatement:
+            return "While";
+        default:
+            throw new Error("Unknown Syntax Kind");
+    }
+}

--- a/src/rules/noEnumBooleanExpressionsRule.ts
+++ b/src/rules/noEnumBooleanExpressionsRule.ts
@@ -28,7 +28,8 @@ export class Rule extends Lint.Rules.TypedRule {
         Usage of \`&&\` or \`||\` operators should not be with Enum type and expressions
          in \`do-while\`, \`for\`, \`if\`, and \`while\` statements should not be of Enum type.`,
         rationale: Lint.Utils.dedent `
-        Usage of Enum type in boolean expressions is often confusing especially because the first member of an Enum type is given a default value of 0.`,
+        Usage of Enum type in boolean expressions is often confusing especially because
+         the first member of an Enum type is given a default value of 0.`,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: ["true"],

--- a/test/rules/no-enum-boolean-expressions/test.ts.lint
+++ b/test/rules/no-enum-boolean-expressions/test.ts.lint
@@ -10,6 +10,7 @@ let strType = "string";
 let objType = new Object();
 let classType = new C();
 let enumType = MyEnum.A;
+let numFromEnumType = MyEnum.A | MyEnum.B;
 let boolFn = () => { return true; };
 let strFn = () => { return strType; };
 let numFn = () => { return numType; };
@@ -58,6 +59,9 @@ classType ? strType : undefined;
 bwrapType ? 1 : 0;
 boolFn() ? numType : strType;
 boolType ? strType : undefined;
+enumType !== undefined ? enumType : MyEnum.B;
+enumType & MyEnum.A ? 1 : 0;
+numFromEnumType & MyEnum.A ? 1 : 0;
 
 /*** PrefixUnary Expressions ***/
 /*** Invalid ***/
@@ -74,10 +78,12 @@ boolType ? strType : undefined;
 !!boolFn();
 !boolExpr;
 !!boolType;
+!(enumType & MyEnum.A);
+!(numFromEnumType & MyEnum.A);
 
 /*** If Statement ***/
 /*** Invalid ***/
-if (MyEnum.A) { /* statements */ }
+if (enumType) { /* statements */ }
     ~~~~~~~~                       [If statement condition cannot be an Enum expression]
 
 /*** Valid ***/
@@ -90,10 +96,12 @@ if (classType) { /* statements */ }
 if (boolFn()) { /* statements */ }
 if (boolExpr) { /* statements */ }
 if (boolType) { /* statements */ }
+if (enumType & MyEnum.A) { /* statements */ }
+if (numFromEnumType & MyEnum.A) { /* statements */ }
 
 /*** While Statement ***/
 /*** Invalid ***/
-while (MyEnum.A) { /* statements */ }
+while (enumType) { /* statements */ }
        ~~~~~~~~                       [While statement condition cannot be an Enum expression]
 
 /*** Valid ***/
@@ -106,10 +114,12 @@ while (classType) { /* statements */ }
 while (boolFn()) { /* statements */ }
 while (boolExpr) { /* statements */ }
 while (boolType) { /* statements */ }
+while (enumType & MyEnum.A) { /* statements */ }
+while (numFromEnumType & MyEnum.A) { /* statements */ }
 
 /*** Do Statement ***/
 /*** Invalid ***/
-do { /* statements */ } while (MyEnum.A);
+do { /* statements */ } while (enumType);
                                ~~~~~~~~  [Do-While statement condition cannot be an Enum expression]
 
 /*** Valid ***/
@@ -122,6 +132,8 @@ do { /* statements */ } while (classType);
 do { /* statements */ } while (boolFn());
 do { /* statements */ } while (boolExpr);
 do { /* statements */ } while (boolType);
+do { /* statements */ } while (enumType & MyEnum.A);
+do { /* statements */ } while (numFromEnumType & MyEnum.A);
 
 /*** For Statement ***/
 /*** Valid ***/

--- a/test/rules/no-enum-boolean-expressions/test.ts.lint
+++ b/test/rules/no-enum-boolean-expressions/test.ts.lint
@@ -1,0 +1,129 @@
+class C { }
+enum MyEnum {
+	A, B, C
+}
+let anyType: {};
+let boolType: boolean;
+let bwrapType: Boolean;
+let numType = 9;
+let strType = "string";
+let objType = new Object();
+let classType = new C();
+let enumType = MyEnum.A;
+let boolFn = () => { return true; };
+let strFn = () => { return strType; };
+let numFn = () => { return numType; };
+let boolExpr = (strType !== undefined);
+
+/*** Binary Expressions ***/
+/*** Invalid Boolean Expressions ***/
+boolType && objType && enumType;
+                       ~~~~~~~~  [Operands for the && or || operator should not be of Enum type]
+objType || boolType || enumType;
+                       ~~~~~~~~  [Operands for the && or || operator should not be of Enum type]
+
+/*** Valid Boolean Expressions ***/
+classType && boolType;
+anyType && boolType;
+numType && boolType;
+boolType && strType;
+bwrapType && boolType;
+
+boolType || classType;
+boolType || anyType;
+boolType || numType;
+strType || boolType;
+bwrapType || boolType;
+boolExpr && strType;
+numType || boolExpr;
+numType && boolExpr || strType;
+bwrapType || boolExpr && bwrapType;
+boolType && boolType;
+boolExpr || boolType;
+(numType > 0) && boolFn();
+(strType !== "bool") && boolExpr;
+(numType > 0) && (strType !== "bool");
+(strType !== undefined) || (numType < 0);
+
+/*** ConditionalExpression ***/
+/*** Invalid ***/
+enumType ? 0 : 1;
+~~~~~~~~          [Condition cannot be an Enum expression]
+
+/*** Valid ***/
+strType ? strType : numType;
+numType ? numType : numFn();
+objType ? objType : boolExpr;
+classType ? strType : undefined;
+bwrapType ? 1 : 0;
+boolFn() ? numType : strType;
+boolType ? strType : undefined;
+
+/*** PrefixUnary Expressions ***/
+/*** Invalid ***/
+!enumType;
+~~~~~~~~~  [Operand for the ! operator should not be of Enum type]
+
+/*** Valid ***/
+!!numType;
+!strType;
+!objType;
+!!classType;
+!bwrapType;
+!!undefined;
+!!boolFn();
+!boolExpr;
+!!boolType;
+
+/*** If Statement ***/
+/*** Invalid ***/
+if (MyEnum.A) { /* statements */ }
+    ~~~~~~~~                       [If statement condition cannot be an Enum expression]
+
+/*** Valid ***/
+if (numType) { /* statements */ }
+if (objType) { /* statements */ }
+if (strType) { /* statements */ }
+if (bwrapType) { /* statements */ }
+if (strFn()) { /* statements */ }
+if (classType) { /* statements */ }
+if (boolFn()) { /* statements */ }
+if (boolExpr) { /* statements */ }
+if (boolType) { /* statements */ }
+
+/*** While Statement ***/
+/*** Invalid ***/
+while (MyEnum.A) { /* statements */ }
+       ~~~~~~~~                       [While statement condition cannot be an Enum expression]
+
+/*** Valid ***/
+while (numType) { /* statements */ }
+while (objType) { /* statements */ }
+while (strType) { /* statements */ }
+while (strFn()) { /* statements */ }
+while (bwrapType) { /* statements */ }
+while (classType) { /* statements */ }
+while (boolFn()) { /* statements */ }
+while (boolExpr) { /* statements */ }
+while (boolType) { /* statements */ }
+
+/*** Do Statement ***/
+/*** Invalid ***/
+do { /* statements */ } while (MyEnum.A);
+                               ~~~~~~~~  [Do-While statement condition cannot be an Enum expression]
+
+/*** Valid ***/
+do { /* statements */ } while (numType);
+do { /* statements */ } while (objType);
+do { /* statements */ } while (strType);
+do { /* statements */ } while (bwrapType);
+do { /* statements */ } while (strFn());
+do { /* statements */ } while (classType);
+do { /* statements */ } while (boolFn());
+do { /* statements */ } while (boolExpr);
+do { /* statements */ } while (boolType);
+
+/*** For Statement ***/
+/*** Valid ***/
+for (let j = 0; j; j++) { /* statements */ }
+for (let j = 0; j > numType; j++) { /* statements */ }

--- a/test/rules/no-enum-boolean-expressions/tslint.json
+++ b/test/rules/no-enum-boolean-expressions/tslint.json
@@ -1,0 +1,8 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "no-enum-boolean-expressions": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1555
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### What changes did you make?

A new rule ` no-enum-boolean-expressions`, which disallows the use of Enum in boolean expressions.

I tried to make it an option of [strict-boolean-expressions](https://palantir.github.io/tslint/rules/strict-boolean-expressions/), but it wasn't straight forward because [strict-boolean-expressions](https://palantir.github.io/tslint/rules/strict-boolean-expressions/) assumes strictNullChecks TypeScript option. For example, Enum types are always truthy with that assumption. So, I made a new rule from strictBooleanExpressionsRule.ts (as of 6dcf3f06e9d79de1437b238dc89d2822964f4b02).

#### Is there anything you'd like reviewers to focus on?

As mentioned above, please note that the diff from strictBooleanExpressionsRule.ts (as of 6dcf3f06e9d79de1437b238dc89d2822964f4b02) is small.
