### PR TITLE
Use tsutils package for utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "glob": "^7.1.1",
     "optimist": "~0.6.0",
     "resolve": "^1.1.7",
+    "tsutils": "^1.0.0",
     "update-notifier": "^2.0.0"
   },
   "peerDependencies": {
@@ -68,7 +69,7 @@
     "rimraf": "^2.5.4",
     "tslint": "latest",
     "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
-    "typescript": "2.1.4"
+    "typescript": "^2.1.6"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/src/rules/adjacentOverloadSignaturesRule.ts
+++ b/src/rules/adjacentOverloadSignaturesRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -114,32 +115,13 @@ interface Overload {
     name: string;
 }
 
-function isLiteralExpression(node: ts.Node): node is ts.LiteralExpression {
-    return node.kind === ts.SyntaxKind.StringLiteral || node.kind === ts.SyntaxKind.NumericLiteral;
-}
-
 export function getOverloadKey(node: ts.SignatureDeclaration): string | undefined {
     const o = getOverload(node);
     return o && o.key;
 }
 
 function getOverloadIfSignature(node: ts.TypeElement | ts.ClassElement): Overload | undefined {
-    return isSignatureDeclaration(node) ? getOverload(node) : undefined;
-}
-
-export function isSignatureDeclaration(node: ts.Node): node is ts.SignatureDeclaration {
-    switch (node.kind) {
-        case ts.SyntaxKind.ConstructSignature:
-        case ts.SyntaxKind.Constructor:
-        case ts.SyntaxKind.CallSignature:
-        case ts.SyntaxKind.CallSignature:
-        case ts.SyntaxKind.MethodSignature:
-        case ts.SyntaxKind.MethodDeclaration:
-        case ts.SyntaxKind.FunctionDeclaration:
-            return true;
-        default:
-            return false;
-    }
+    return utils.isSignatureDeclaration(node) ? getOverload(node) : undefined;
 }
 
 function getOverload(node: ts.SignatureDeclaration): Overload | undefined {
@@ -173,8 +155,8 @@ function getPropertyInfo(name: ts.PropertyName): { name: string, computed?: bool
             return { name: (name as ts.Identifier).text };
         case ts.SyntaxKind.ComputedPropertyName:
             const { expression } = (name as ts.ComputedPropertyName);
-            return isLiteralExpression(expression) ? { name: expression.text } : { name: expression.getText(), computed: true };
+            return utils.isLiteralExpression(expression) ? { name: expression.text } : { name: expression.getText(), computed: true };
         default:
-            return isLiteralExpression(name) ? { name: (name as ts.StringLiteral).text } : undefined;
+            return utils.isLiteralExpression(name) ? { name: (name as ts.StringLiteral).text } : undefined;
     }
 }

--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -117,10 +118,10 @@ class CommentWalker extends Lint.RuleWalker {
     }
 
     public visitSourceFile(node: ts.SourceFile) {
-        Lint.forEachComment(node, (fullText, kind, pos) => {
-            if (kind === ts.SyntaxKind.SingleLineCommentTrivia) {
-                const commentText = fullText.substring(pos.tokenStart, pos.end);
-                const startPosition = pos.tokenStart + 2;
+        utils.forEachComment(node, (fullText, comment) => {
+            if (comment.kind === ts.SyntaxKind.SingleLineCommentTrivia) {
+                const commentText = fullText.substring(comment.pos, comment.end);
+                const startPosition = comment.pos + 2;
                 const width = commentText.length - 2;
                 if (this.hasOption(OPTION_SPACE)) {
                     if (!startsWithSpace(commentText)) {

--- a/src/rules/importBlacklistRule.ts
+++ b/src/rules/importBlacklistRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -66,7 +67,7 @@ class ImportBlacklistWalker extends Lint.RuleWalker {
     }
 
     public visitImportEqualsDeclaration(node: ts.ImportEqualsDeclaration) {
-        if (isExternalModuleReference(node.moduleReference) &&
+        if (utils.isExternalModuleReference(node.moduleReference) &&
             node.moduleReference.expression !== undefined) {
             // If it's an import require and not an import alias
             this.checkForBannedImport(node.moduleReference.expression);
@@ -80,7 +81,7 @@ class ImportBlacklistWalker extends Lint.RuleWalker {
     }
 
     private checkForBannedImport(expression: ts.Expression) {
-        if (isStringLiteral(expression) && this.hasOption(expression.text)) {
+        if (utils.isTextualLiteral(expression) && this.hasOption(expression.text)) {
             this.addFailureFromStartToEnd(
                 expression.getStart(this.getSourceFile()) + 1,
                 expression.getEnd() - 1,
@@ -88,13 +89,4 @@ class ImportBlacklistWalker extends Lint.RuleWalker {
             );
         }
     }
-}
-
-function isStringLiteral(node: ts.Node): node is ts.LiteralExpression {
-    return node.kind === ts.SyntaxKind.StringLiteral ||
-        node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral;
-}
-
-function isExternalModuleReference(node: ts.ModuleReference): node is ts.ExternalModuleReference {
-    return node.kind === ts.SyntaxKind.ExternalModuleReference;
 }

--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -50,9 +51,9 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class JsdocWalker extends Lint.RuleWalker {
     public visitSourceFile(node: ts.SourceFile) {
-        Lint.forEachComment(node, (fullText, kind, pos) => {
-            if (kind === ts.SyntaxKind.MultiLineCommentTrivia) {
-                this.findFailuresForJsdocComment(fullText.substring(pos.tokenStart, pos.end), pos.tokenStart);
+        utils.forEachComment(node, (fullText, comment) => {
+            if (comment.kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+                this.findFailuresForJsdocComment(fullText.substring(comment.pos, comment.end), comment.pos);
             }
         });
     }

--- a/src/rules/newlineBeforeReturnRule.ts
+++ b/src/rules/newlineBeforeReturnRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -47,7 +48,7 @@ class NewlineBeforeReturnWalker extends Lint.RuleWalker {
         super.visitReturnStatement(node);
 
         const parent = node.parent!;
-        if (!isBlockLike(parent)) {
+        if (!utils.isBlockLike(parent)) {
             // `node` is the only statement within this "block scope". No need to do any further validation.
             return;
         }
@@ -74,8 +75,4 @@ class NewlineBeforeReturnWalker extends Lint.RuleWalker {
             this.addFailureFromStartToEnd(start, start, Rule.FAILURE_STRING_FACTORY());
         }
     }
-}
-
-function isBlockLike(node: ts.Node): node is ts.BlockLike {
-    return "statements" in node;
 }

--- a/src/rules/noUnnecessaryInitializerRule.ts
+++ b/src/rules/noUnnecessaryInitializerRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -45,7 +46,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class Walker extends Lint.RuleWalker {
     public visitVariableDeclaration(node: ts.VariableDeclaration) {
-        if (isBindingPattern(node.name)) {
+        if (utils.isBindingPattern(node.name)) {
             for (const elem of node.name.elements) {
                 if (elem.kind === ts.SyntaxKind.BindingElement) {
                     this.checkInitializer(elem);
@@ -114,8 +115,4 @@ function isUndefined(node: ts.Node | undefined): boolean {
     return node !== undefined &&
         node.kind === ts.SyntaxKind.Identifier &&
         (node as ts.Identifier).originalKeywordKind === ts.SyntaxKind.UndefinedKeyword;
-}
-
-function isBindingPattern(node: ts.Node): node is ts.ArrayBindingPattern | ts.ObjectBindingPattern {
-    return node.kind === ts.SyntaxKind.ArrayBindingPattern || node.kind === ts.SyntaxKind.ObjectBindingPattern;
 }

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -67,7 +68,7 @@ class Walker extends Lint.ProgramAwareRuleWalker {
                 break;
             case ts.SyntaxKind.PropertyAccessExpression:
                 const { expression, name } = node as ts.PropertyAccessExpression;
-                if (isEntityNameExpression(expression)) {
+                if (utils.isEntityNameExpression(expression)) {
                     this.visitNamespaceAccess(node, expression, name);
                     break;
                 }
@@ -124,11 +125,6 @@ class Walker extends Lint.ProgramAwareRuleWalker {
     private tryGetAliasedSymbol(symbol: ts.Symbol): ts.Symbol | undefined {
         return Lint.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias) ? this.getTypeChecker().getAliasedSymbol(symbol) : undefined;
     }
-}
-
-function isEntityNameExpression(expr: ts.Expression): expr is ts.EntityNameExpression {
-    return expr.kind === ts.SyntaxKind.Identifier ||
-        expr.kind === ts.SyntaxKind.PropertyAccessExpression && isEntityNameExpression((expr as ts.PropertyAccessExpression).expression);
 }
 
 // TODO: Should just be `===`. See https://github.com/palantir/tslint/issues/1969

--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -42,9 +42,12 @@ export class Rule extends Lint.Rules.TypedRule {
     }
 }
 
+// This is marked @internal, but we need it!
+const isExpression: (node: ts.Node) => node is ts.Expression = (ts as any).isExpression;
+
 class Walker extends Lint.ProgramAwareRuleWalker {
     public visitNode(node: ts.Node) {
-        if (ts.isExpression(node) && isAny(this.getType(node)) && !this.isAllowedLocation(node)) {
+        if (isExpression(node) && isAny(this.getType(node)) && !this.isAllowedLocation(node)) {
             this.addFailureAtNode(node, Rule.FAILURE_STRING);
         } else {
             super.visitNode(node);
@@ -110,9 +113,4 @@ class Walker extends Lint.ProgramAwareRuleWalker {
 
 function isAny(type: ts.Type | undefined): boolean {
     return type !== undefined && Lint.isTypeFlagSet(type, ts.TypeFlags.Any);
-}
-
-// This is marked @internal, but we need it!
-declare module "typescript" {
-    export function isExpression(node: ts.Node): node is ts.Expression;
 }

--- a/src/rules/noUnsafeFinallyRule.ts
+++ b/src/rules/noUnsafeFinallyRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -192,12 +193,8 @@ function isFinallyBlock(node: ts.Node): boolean {
 
     return parent !== undefined &&
         node.kind === ts.SyntaxKind.Block &&
-        isTryStatement(parent) &&
+        utils.isTryStatement(parent) &&
         parent.finallyBlock === node;
-}
-
-function isTryStatement(node: ts.Node): node is ts.TryStatement {
-    return node.kind === ts.SyntaxKind.TryStatement;
 }
 
 function isReturnsOrThrowsBoundary(scope: IFinallyScope) {

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -139,7 +140,7 @@ class TypedefWalker extends Lint.RuleWalker {
             let optionName: string | null = null;
             if (isArrowFunction && isTypedPropertyDeclaration(node.parent.parent)) {
                 // leave optionName as null and don't perform check
-            } else if (isArrowFunction && isPropertyDeclaration(node.parent.parent)) {
+            } else if (isArrowFunction && utils.isPropertyDeclaration(node.parent.parent)) {
                 optionName = "member-variable-declaration";
             } else if (isArrowFunction) {
                 optionName = "arrow-parameter";
@@ -259,10 +260,6 @@ function getName(name?: ts.Node, prefix?: string, suffix?: string): string {
     return ns ? `${prefix || ""}${ns}${suffix || ""}` : "";
 }
 
-function isPropertyDeclaration(node: ts.Node): node is ts.PropertyDeclaration {
-    return node.kind === ts.SyntaxKind.PropertyDeclaration;
-}
-
 function isTypedPropertyDeclaration(node: ts.Node): boolean {
-    return isPropertyDeclaration(node) && node.type != null;
+    return utils.isPropertyDeclaration(node) && node.type != null;
 }

--- a/src/rules/unifiedSignaturesRule.ts
+++ b/src/rules/unifiedSignaturesRule.ts
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
 import { arraysAreEqual, Equal } from "../utils";
 
-import { getOverloadKey, isSignatureDeclaration } from "./adjacentOverloadSignaturesRule";
+import { getOverloadKey } from "./adjacentOverloadSignaturesRule";
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -94,7 +95,7 @@ class Walker extends Lint.RuleWalker {
     private checkMembers(members: Array<ts.TypeElement | ts.ClassElement>, typeParameters?: ts.TypeParameterDeclaration[]) {
         this.checkOverloads(members, getOverloadName, typeParameters);
         function getOverloadName(member: ts.TypeElement | ts.ClassElement) {
-            if (!isSignatureDeclaration(member) || (member as ts.MethodDeclaration).body) {
+            if (!utils.isSignatureDeclaration(member) || (member as ts.MethodDeclaration).body) {
                 return undefined;
             }
             const key = getOverloadKey(member);

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -80,7 +81,7 @@ class WhitespaceWalker extends Lint.RuleWalker {
         super.visitSourceFile(node);
 
         let prevTokenShouldBeFollowedByWhitespace = false;
-        Lint.forEachToken(node, false, (_text, tokenKind, pos, parent) => {
+        utils.forEachTokenWithTrivia(node, (_text, tokenKind, range, parent) => {
             if (tokenKind === ts.SyntaxKind.WhitespaceTrivia ||
                 tokenKind === ts.SyntaxKind.NewLineTrivia ||
                 tokenKind === ts.SyntaxKind.EndOfFileToken) {
@@ -88,7 +89,7 @@ class WhitespaceWalker extends Lint.RuleWalker {
                 prevTokenShouldBeFollowedByWhitespace = false;
                 return;
             } else if (prevTokenShouldBeFollowedByWhitespace) {
-                this.addMissingWhitespaceErrorAt(pos.tokenStart);
+                this.addMissingWhitespaceErrorAt(range.pos);
                 prevTokenShouldBeFollowedByWhitespace = false;
             }
             // check for trailing space after the given tokens

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,6 +1130,10 @@ tslint@latest:
     resolve "^1.1.7"
     update-notifier "^1.0.2"
 
+tsutils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.0.0.tgz#a1f87d1092179987d13a1a8406deaec28ac3a0ad"
+
 type-detect@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
@@ -1138,9 +1142,9 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.4.tgz#b53b69fb841126acb1dd4b397d21daba87572251"
+typescript@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.6.tgz#40c7e6e9e5da7961b7718b55505f9cac9487a607"
 
 unique-string@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### PR checklist

- [x] Closes: #2180
- [x] enhancement

#### What changes did you make?

Use the package `tsutils` for typeguards and other utility functions.

> The idea was to create a separate project which maintains typeguards and AST utilities for everyone, not just tslint and custom rules packages. This way tslint core could remain just a runtime for rules instead of growing to a bulk of utility functions.
