### PR TITLE
Preserve newlines and tabs when autofixing quote marks

### DIFF
--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -82,11 +82,10 @@ class QuotemarkWalker extends Lint.RuleWalker {
 
     public visitStringLiteral(node: ts.StringLiteral) {
         const expectedQuoteMark = node.parent!.kind === ts.SyntaxKind.JsxAttribute ? this.jsxQuoteMark : this.quoteMark;
-        const actualQuoteMark = node.getText()[0];
+        const text = node.getText();
+        const actualQuoteMark = text[0];
         if (actualQuoteMark !== expectedQuoteMark && !(this.avoidEscape && node.text.includes(expectedQuoteMark))) {
-            let escapedText = node.text.replace(new RegExp(expectedQuoteMark, "g"), `\\${expectedQuoteMark}`);
-            // replace newlines and tabs with their escaped versions
-            escapedText = escapedText.replace(new RegExp("\n", "g"), "\\n").replace(new RegExp("\t", "g"), "\\t");
+            const escapedText = text.slice(1, -1).replace(new RegExp(expectedQuoteMark, "g"), `\\${expectedQuoteMark}`);
             const newText = expectedQuoteMark + escapedText + expectedQuoteMark;
             this.addFailureAtNode(node, Rule.FAILURE_STRING(actualQuoteMark, expectedQuoteMark),
                 this.createFix(this.createReplacement(node.getStart(), node.getWidth(), newText)));

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -84,7 +84,9 @@ class QuotemarkWalker extends Lint.RuleWalker {
         const expectedQuoteMark = node.parent!.kind === ts.SyntaxKind.JsxAttribute ? this.jsxQuoteMark : this.quoteMark;
         const actualQuoteMark = node.getText()[0];
         if (actualQuoteMark !== expectedQuoteMark && !(this.avoidEscape && node.text.includes(expectedQuoteMark))) {
-            const escapedText = node.text.replace(new RegExp(expectedQuoteMark, "g"), `\\${expectedQuoteMark}`);
+            let escapedText = node.text.replace(new RegExp(expectedQuoteMark, "g"), `\\${expectedQuoteMark}`);
+            // replace newlines and tabs with their escaped versions
+            escapedText = escapedText.replace(new RegExp("\n", "g"), "\\n").replace(new RegExp("\t", "g"), "\\t");
             const newText = expectedQuoteMark + escapedText + expectedQuoteMark;
             this.addFailureAtNode(node, Rule.FAILURE_STRING(actualQuoteMark, expectedQuoteMark),
                 this.createFix(this.createReplacement(node.getStart(), node.getWidth(), newText)));

--- a/test/rules/quotemark/double-avoid-escape/test.js.lint
+++ b/test/rules/quotemark/double-avoid-escape/test.js.lint
@@ -1,5 +1,7 @@
 var single = 'single';
              ~~~~~~~~  [' should be "]
-    var doublee = "married";
+    var double = "married";
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [' should be "]

--- a/test/rules/quotemark/double-avoid-escape/test.ts.fix
+++ b/test/rules/quotemark/double-avoid-escape/test.ts.fix
@@ -1,4 +1,5 @@
 var single = "single";
-    var doublee = "married";
+    var double = "married";
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinSingle = "tab\tNewline\nWithinSingle";

--- a/test/rules/quotemark/double-avoid-escape/test.ts.lint
+++ b/test/rules/quotemark/double-avoid-escape/test.ts.lint
@@ -1,5 +1,7 @@
 var single = 'single';
              ~~~~~~~~  [' should be "]
-    var doublee = "married";
+    var double = "married";
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [' should be "]

--- a/test/rules/quotemark/double/test.js.lint
+++ b/test/rules/quotemark/double/test.js.lint
@@ -1,6 +1,8 @@
 var single = 'single';
              ~~~~~~~~  [' should be "]
-    var doublee = "married";
+    var double = "married";
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
                          ~~~~~~~~~~~~~~~~~~~~~~  [' should be "]
+var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [' should be "]

--- a/test/rules/quotemark/double/test.ts.fix
+++ b/test/rules/quotemark/double/test.ts.fix
@@ -1,4 +1,5 @@
 var single = "single";
-    var doublee = "married";
+    var double = "married";
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = "\"doubleWithinSingle\"";
+var tabNewlineWithinSingle = "tab\tNewline\nWithinSingle";

--- a/test/rules/quotemark/double/test.ts.lint
+++ b/test/rules/quotemark/double/test.ts.lint
@@ -1,6 +1,8 @@
 var single = 'single';
              ~~~~~~~~  [' should be "]
-    var doublee = "married";
+    var double = "married";
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
                          ~~~~~~~~~~~~~~~~~~~~~~  [' should be "]
+var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [' should be "]

--- a/test/rules/quotemark/jsx-double/test.tsx.fix
+++ b/test/rules/quotemark/jsx-double/test.tsx.fix
@@ -1,4 +1,4 @@
 import * as React from 'react';
 
 export const a = (
-    <div className="class" id="id" data-a={'a' + 'b'}></div>
+    <div className="class" id="id" data-a={'a' + 'b' + 'c\td\ne'}></div>

--- a/test/rules/quotemark/jsx-double/test.tsx.lint
+++ b/test/rules/quotemark/jsx-double/test.tsx.lint
@@ -2,6 +2,7 @@ import * as React from "react";
                        ~~~~~~~  [" should be ']
 
 export const a = (
-    <div className="class" id='id' data-a={'a' + "b"}></div>
-                              ~~~~                           [' should be "]
-                                                 ~~~         [" should be ']
+    <div className="class" id='id' data-a={'a' + "b" + "c\td\ne"}></div>
+                              ~~~~                                          [' should be "]
+                                                 ~~~                        [" should be ']
+                                                       ~~~~~~~~~            [" should be ']

--- a/test/rules/quotemark/jsx-single/test.tsx.fix
+++ b/test/rules/quotemark/jsx-single/test.tsx.fix
@@ -1,4 +1,4 @@
 import * as React from "react";
 
 export const a = (
-    <div className='class' id='id' data-a={"a" + "b"}></div>
+    <div className='class' id='id' data-a={"a" + "b" + "c\td\ne"}></div>

--- a/test/rules/quotemark/jsx-single/test.tsx.lint
+++ b/test/rules/quotemark/jsx-single/test.tsx.lint
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export const a = (
-    <div className="class" id='id' data-a={'a' + "b"}></div>
-                   ~~~~~~~                                   [" should be ']
-                                           ~~~               [' should be "]
+    <div className="class" id='id' data-a={'a' + "b" + 'c\td\ne'}></div>
+                   ~~~~~~~                                                  [" should be ']
+                                           ~~~                              [' should be "]
+                                                       ~~~~~~~~~            [' should be "]

--- a/test/rules/quotemark/single-avoid-escape/test.js.lint
+++ b/test/rules/quotemark/single-avoid-escape/test.js.lint
@@ -1,5 +1,7 @@
 var single = 'single';
-    var doublee = "married";
-                  ~~~~~~~~~  [" should be ']
+    var double = "married";
+                 ~~~~~~~~~  [" should be ']
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinDouble = "tab\tNewline\nWithinDouble";
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [" should be ']

--- a/test/rules/quotemark/single-avoid-escape/test.ts.fix
+++ b/test/rules/quotemark/single-avoid-escape/test.ts.fix
@@ -1,4 +1,5 @@
 var single = 'single';
-    var doublee = 'married';
+    var double = 'married';
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinDouble = 'tab\tNewline\nWithinDouble';

--- a/test/rules/quotemark/single-avoid-escape/test.ts.lint
+++ b/test/rules/quotemark/single-avoid-escape/test.ts.lint
@@ -1,5 +1,7 @@
 var single = 'single';
-    var doublee = "married";
-                  ~~~~~~~~~  [" should be ']
+    var double = "married";
+                 ~~~~~~~~~  [" should be ']
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinDouble = "tab\tNewline\nWithinDouble";
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [" should be ']

--- a/test/rules/quotemark/single/test.js.lint
+++ b/test/rules/quotemark/single/test.js.lint
@@ -1,6 +1,8 @@
 var single = 'single';
-    var doublee = "married";
-                  ~~~~~~~~~  [" should be ']
+    var double = "married";
+                 ~~~~~~~~~  [" should be ']
 var singleWithinDouble = "'singleWithinDouble'";
                          ~~~~~~~~~~~~~~~~~~~~~~  [" should be ']
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinDouble = "tab\tNewline\nWithinDouble";
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [" should be ']

--- a/test/rules/quotemark/single/test.ts.fix
+++ b/test/rules/quotemark/single/test.ts.fix
@@ -1,4 +1,5 @@
 var single = 'single';
-    var doublee = 'married';
+    var double = 'married';
 var singleWithinDouble = '\'singleWithinDouble\'';
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinDouble = 'tab\tNewline\nWithinDouble';

--- a/test/rules/quotemark/single/test.ts.lint
+++ b/test/rules/quotemark/single/test.ts.lint
@@ -1,6 +1,8 @@
 var single = 'single';
-    var doublee = "married";
-                  ~~~~~~~~~  [" should be ']
+    var double = "married";
+                 ~~~~~~~~~  [" should be ']
 var singleWithinDouble = "'singleWithinDouble'";
                          ~~~~~~~~~~~~~~~~~~~~~~  [" should be ']
 var doubleWithinSingle = '"doubleWithinSingle"';
+var tabNewlineWithinDouble = "tab\tNewline\nWithinDouble";
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [" should be ']


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2202
- [x] New feature, bugfix, or enhancement
- [x] Includes tests
- [x] Documentation update

#### What changes did you make?

Simple change in quotemarkRule::visitStringLiteral. Search the escaped text for \n and \t and replace with escaped versions. Also added a string containing tab/newline to the test cases for the quotemark rule.

#### Is there anything you'd like reviewers to focus on?
First PR to this project, so I'm sorry if I missed something obvious