### PR TITLE
only-arrow-functions: Allow functions that use 'this' somewhere in the body

### DIFF
--- a/test/rules/only-arrow-functions/default/test.ts.lint
+++ b/test/rules/only-arrow-functions/default/test.ts.lint
@@ -26,6 +26,17 @@ let generator = function*() {}
 function hasThisParameter(this) {}
 let hasThisParameter = function(this) {}
 
+let usesThis = function() { this; }
+
+let notUsesThis = function() {
+                  ~~~~~~~~ [0]
+    function f() { this; }
+}
+let notUsesThis2 = function() {
+                   ~~~~~~~~ [0]
+    return class { method() { this; } }
+}
+
 export function exported() {}
        ~~~~~~~~ [0]
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### What changes did you make?

Changed `only-arrow-functions` to allow a non-arrow function if `this` appears somewhere in its body. These cannot be converted to arrow functions.
There is already an exception for `this` as an explicit parameter, but often it comes from a contextual type, as in:

```ts
function f(g: (this: number) => void) { g.call(0); }
f(function() { console.log(this) });
```
