### PR TITLE
completed-docs: Handle undefined symbol

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -392,7 +392,12 @@ class CompletedDocsWalker extends Lint.ProgramAwareRuleWalker {
             return;
         }
 
-        const comments = this.getTypeChecker().getSymbolAtLocation(node.name).getDocumentationComment();
+        const symbol = this.getTypeChecker().getSymbolAtLocation(node.name);
+        if (!symbol) {
+            return;
+        }
+
+        const comments = symbol.getDocumentationComment();
         this.checkComments(node, nodeType, comments);
     }
 

--- a/test/rules/completed-docs/defaults/test.ts.lint
+++ b/test/rules/completed-docs/defaults/test.ts.lint
@@ -5,6 +5,10 @@ export class Aaa {
 
     public ccc() { }
     ~~~~~~~~~~~~~~~~       [Documentation must exist for public methods.]
+
+    // TODO: TypeScript API doesn't give us a symbol for this, so we must ignore it.
+    // https://github.com/Microsoft/TypeScript/issues/14257
+    [Symbol.iterator]() {}
 }
 
 export enum Ddd { }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### What changes did you make?

Handled an undefined `symbol` returned by the type checker.
Ref: Microsoft/TypeScript#14257