### PR TITLE
Don't publish yarn.lock in dist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@
 appveyor.yml
 circle.yml
 tslint.json
+yarn.lock
 /build/
 /docs/
 /scripts/


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #2231
- [ ] Enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### What changes did you make?

Add `yarn.lock` to .npmignore, per https://twitter.com/gabro27/status/786825544998481920

