### PR TITLE
Add `no-unnecessary-callback-wrapper` rule

### DIFF
--- a/src/rules/noUnnecessaryCallbackWrapperRule.ts
+++ b/src/rules/noUnnecessaryCallbackWrapperRule.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isArrowFunction, isCallExpression, isIdentifier, isSpreadElement } from "tsutils";
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-unnecessary-callback-wrapper",
+        description: Lint.Utils.dedent`
+            Replaces \`x => f(x)\` with just \`f\`.
+            To catch more cases, enable \`only-arrow-functions\` and \`arrow-return-shorthand\` too.`,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: ["true"],
+        type: "style",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING(cbText: string): string {
+        return `No need to wrap '${cbText}' in another function. Just use it directly.`;
+    }
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, cb);
+    function cb(node: ts.Node): void {
+        const fn = detectRedundantCallback(node);
+        if (fn) {
+            const fix = ctx.createFix(
+                Lint.Replacement.deleteFromTo(node.getStart(), fn.getStart()),
+                Lint.Replacement.deleteFromTo(fn.getEnd(), node.getEnd()));
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING(fn.getText()), fix);
+        } else {
+            return ts.forEachChild(node, cb);
+        }
+    }
+
+}
+
+// Returns the `f` in `x => f(x)`.
+function detectRedundantCallback(node: ts.Node): ts.Expression | undefined {
+    if (!isArrowFunction(node)) {
+        return undefined;
+    }
+
+    const { body, parameters } = node;
+    if (!isCallExpression(body)) {
+        return undefined;
+    }
+
+    const { arguments: args, expression } = body;
+
+    if (expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+        // Allow `x => obj.f(x)`
+        return undefined;
+    }
+
+    const argumentsSameAsParameters = parameters.length === args.length && parameters.every(({dotDotDotToken, name}, i) => {
+        let arg = args[i];
+        if (dotDotDotToken) {
+            // Use SpreadElementExpression for ts2.0 compatibility
+            if (!(isSpreadElement(arg) || arg.kind === (ts.SyntaxKind as any).SpreadElementExpression)) {
+                return false;
+            }
+            arg = (arg as ts.SpreadElement).expression;
+        }
+
+        return isIdentifier(name) && isIdentifier(arg) && name.text === arg.text;
+    });
+
+    return argumentsSameAsParameters ? expression : undefined;
+}

--- a/test/rules/no-unnecessary-callback-wrapper/test.js.lint
+++ b/test/rules/no-unnecessary-callback-wrapper/test.js.lint
@@ -1,0 +1,2 @@
+x => f(x);
+~~~~~~~~~ [No need to wrap 'f' in another function. Just use it directly.]

--- a/test/rules/no-unnecessary-callback-wrapper/test.ts.fix
+++ b/test/rules/no-unnecessary-callback-wrapper/test.ts.fix
@@ -1,0 +1,19 @@
+f;
+
+f;
+
+(x, y) => f(x, y, 0);
+(x, y) => f(y, x);
+
+f;
+
+(x, ...y) => f(x, y);
+
+f;
+
+// Not catching this case (obj.f may need a 'this' binding)
+(x) => obj.f(x);
+
+// Not bothering to catch this case.
+({ x, y }) => f({ x, y });
+

--- a/test/rules/no-unnecessary-callback-wrapper/test.ts.lint
+++ b/test/rules/no-unnecessary-callback-wrapper/test.ts.lint
@@ -1,0 +1,24 @@
+x => f(x);
+~~~~~~~~~ [0]
+
+(x, y) => f(x, y);
+~~~~~~~~~~~~~~~~~ [0]
+
+(x, y) => f(x, y, 0);
+(x, y) => f(y, x);
+
+(x, y) => f<T>(x, y);
+~~~~~~~~~~~~~~~~~~~~ [0]
+
+(x, ...y) => f(x, y);
+
+(...args) => f(...args);
+~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+// Not catching this case (obj.f may need a 'this' binding)
+(x) => obj.f(x);
+
+// Not bothering to catch this case.
+({ x, y }) => f({ x, y });
+
+[0]: No need to wrap 'f' in another function. Just use it directly.

--- a/test/rules/no-unnecessary-callback-wrapper/tslint.json
+++ b/test/rules/no-unnecessary-callback-wrapper/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-unnecessary-callback-wrapper": true
+  },
+  "jsRules": {
+    "no-unnecessary-callback-wrapper": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### Overview of change:

Added the `no-redundant-callback` rule, which warns on `x => f(x)` (prefer just `f`).

#### CHANGELOG.md entry:

[new-rule] `no-unnecessary-callback-wrapper`
