### PR TITLE
Update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,18 +6,19 @@
 	"editor.insertSpaces": true,
 
 	// Controls after how many characters the editor will wrap to the next line. Setting this to 0 turns on viewport width wrapping
-	"editor.wrappingColumn": 140,
+	"editor.wordWrap": "bounded",
+	"editor.wordWrapColumn": 140,
 
 	// The folders to exclude when doing a full text search in the workspace.
-	"search.excludeFolders": [
-		".git",
-		".tscache",
-		"bower_components",
-                "bin",
-		"build",
-                "lib",
-		"node_modules"
-	],
+	"files.exclude": {
+		".git": true,
+		".tscache": true,
+		"bower_components": true,
+                "bin": true,
+		"build": true,
+                "lib": true,
+		"node_modules": true
+	},
 
 	// Always use project's provided typescript compiler version
 	"typescript.tsdk": "node_modules/typescript/lib"


### PR DESCRIPTION
`"editor.wrappingColumn"` is deprecated in the insiders build.
`"search.excludeFolders"` isn't recognized at all. `"files.exclude"` seems to work.