### PR TITLE
Normalized spaces to tabs in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,9 +13,9 @@
 		".git",
 		".tscache",
 		"bower_components",
-                "bin",
+		"bin",
 		"build",
-                "lib",
+		"lib",
 		"node_modules"
 	],
 


### PR DESCRIPTION
I was shamelessly copy & pasting TSLint's settings for another project and noticed the discrepancy...
