### PR TITLE
Un-deprecate noUnusedVariable.

### DIFF
--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -31,8 +31,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-unused-variable",
-        deprecationMessage: "Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.",
-        description: "Disallows unused imports, variables, functions and private class members.",
+        description: Lint.Utils.dedent`Disallows unused imports, variables, functions and
+            private class members. Similar to tsc's --noUnusedParameters and --noUnusedLocals
+            options, but does not interrupt code compilation.`,
         hasFix: true,
         optionsDescription: Lint.Utils.dedent`
             Three optional arguments may be optionally provided:


### PR DESCRIPTION
As discussed in feedback on  #1481 and #1617, for many users `--noUnusedParameters` and `--noUnusedLocals` do not work as a replacement for `noUnusedVariable`. This change de-deprecates the rule and documents the alternative compiler flags (and why they might not work for users) in the description.

Fixes #1617.

This is a proposal, please discuss and feel free to reject :-)

#### PR checklist

- [x] Addresses an existing issue: #1617