### PR TITLE
Fix arrow-parens with return type annotation

### DIFF
--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -25,3 +25,6 @@ var f = ab => {};
 // invalid case
 var a = a => {};
 const invalidAsync = async param => {};
+
+// parens required when return type annotation is present
+const fn = (param): void => {};

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -28,4 +28,7 @@ var a = (a) => {};
 const invalidAsync = async (param) => {};
                             ~~~~~ [0]
 
+// parens required when return type annotation is present
+const fn = (param): void => {};
+
 [0]: Parentheses are prohibited around the parameter in this single parameter arrow function


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2237
- [x] bugfix
  - [x] Includes tests

#### Overview of change:

Fixes: #2237

#### CHANGELOG.md entry:

[bugfix] `arrow-parens` with option `ban-single-arg-parens` now correctly handles functions with return type annotation
