### PR TITLE
Unified-signatures: When there are more than 2 overloads, include the line number of the other overload to be unified

### DIFF
--- a/test/rules/unified-signatures/test.d.ts.lint
+++ b/test/rules/unified-signatures/test.d.ts.lint
@@ -1,8 +1,14 @@
 interface I {
+    // For 3 or more overloads, mentions the line.
+    a0(): void;
+    a0(x: string): string;
+    a0(x: number): void;
+       ~~~~~~~~~ [This overload and the one on line 3 can be combined into one signature with an optional parameter.]
+
     // Error for extra parameter.
-    a(): void;
-    a(x: number): void;
-      ~~~~~~~~~ [0]
+    a1(): void;
+    a1(x: number): void;
+       ~~~~~~~~~ [0]
 
     // No error for arity difference greater than 1.
     a2(): void;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Improved the error message to indicate which is the other failing overload. This has led to some confusion (https://github.com/palantir/tslint/issues/2016#issuecomment-283059245).
