### PR TITLE
`object-literal-key-quotes` flags negative number as not needing quotes

### DIFF
--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -155,7 +155,7 @@ function quotesAreInconsistent(properties: ts.ObjectLiteralElementLike[]): boole
 }
 
 function propertyNeedsQuotes(property: string): boolean {
-    return !IDENTIFIER_NAME_REGEX.test(property) && Number(property).toString() !== property;
+    return !IDENTIFIER_NAME_REGEX.test(property) && (Number(property).toString() !== property || property.startsWith("-"));
 }
 
 // This is simplistic. See https://mothereff.in/js-properties for the gorey details.

--- a/test/rules/object-literal-key-quotes/as-needed/test.ts.fix
+++ b/test/rules/object-literal-key-quotes/as-needed/test.ts.fix
@@ -12,6 +12,7 @@ const o = {
   1.23: null,
   '010': 'but this one does.',
   '.123': 'as does this one',
+  '-1': 'and this one',
   fn() { return },
   true: 0,
   "0x0": 0,

--- a/test/rules/object-literal-key-quotes/as-needed/test.ts.lint
+++ b/test/rules/object-literal-key-quotes/as-needed/test.ts.lint
@@ -15,6 +15,7 @@ const o = {
   1.23: null,
   '010': 'but this one does.',
   '.123': 'as does this one',
+  '-1': 'and this one',
   fn() { return },
   true: 0,
   "0x0": 0,


### PR DESCRIPTION
fixes #2260 