### PR TITLE
Improve the UI for the rules documentation

### DIFF
--- a/docs/_includes/rule_list.html
+++ b/docs/_includes/rule_list.html
@@ -1,6 +1,21 @@
-<ul>
+<ul class="rules-list">
  {% assign rules = site.data.rules | where: "type",include.ruleType | sort: "name" %}
  {% for rule in rules %}
-  <li><a href="{{rule.ruleName}}">{{rule.ruleName}}</a> - {{rule.description | markdownify | remove:"<p>" | remove: "</p>"}}</li>
+  <li>
+      <a href="{{rule.ruleName}}">
+        <div class="rule-features">
+            {% if rule.typescriptOnly %}
+                <span class="feature feature-sm feature-ts-only" title="This rule cannot be run against JavaScript files">TS Only</span>
+            {% endif %}
+            {% if rule.hasFix %}
+                <span class="feature feature-sm feature-fixer" title="This rule has the ability to auto-fix violations">Has Fixer</span>
+            {% endif %}
+            {% if rule.requiresTypeInfo %}
+                <span class="feature feature-sm feature-requires-type-info" title="This rule requires type information to run">Requires Type Info</span>
+            {% endif %}
+        </div>
+        <strong>{{rule.ruleName}}</strong> - {{rule.description | markdownify | remove:"<p>" | remove: "</p>"}}
+      </a>
+  </li>
  {% endfor %}
 </ul>

--- a/docs/_layouts/rule.html
+++ b/docs/_layouts/rule.html
@@ -9,11 +9,21 @@ layout: page
    <h5>Rationale</h5>
    {{page.rationale | markdownify}}
 {% endif %}
-{% if page.requiresTypeInfo %}
-   <strong>Note:</strong>
-   <a href="https://github.com/palantir/tslint#type-checking">This rule requires type info to run</a>
-{% endif %}
 
+{% if page.typescriptOnly or page.hasFix or page.requiresTypeInfo %}
+   <h5>Notes: </h5>
+    <div class="rule-features">
+        {% if page.typescriptOnly %}
+            <span class="feature feature-ts-only" title="This rule cannot be run against JavaScript files">TS Only</span>
+        {% endif %}
+        {% if page.hasFix %}
+            <span class="feature feature-fixer" title="This rule has the ability to auto-fix violations">Has Fixer</span>
+        {% endif %}
+        {% if page.requiresTypeInfo %}
+            <a class="feature feature-requires-type-info" href="https://github.com/palantir/tslint#type-checking" title="This rule requires type information to run. Click to learn more.">Requires Type Info</a>
+        {% endif %}
+    </div>
+{% endif %}
 
 <h3>Config</h3>
 {{page.optionsDescription | markdownify}}

--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -101,6 +101,7 @@ figcaption {
  }
 
  .rule-features {
+     //This is the container for a list of feature badges
     display: -webkit-box;
     display: -moz-box;
     display: -ms-flexbox;
@@ -109,6 +110,7 @@ figcaption {
  }
 
  .feature {
+     //This is the setup for the a feature badge
     display: inline-block;
     margin-right: 2px;
     padding: 2px 4px;
@@ -122,16 +124,19 @@ figcaption {
     cursor: help;
 
     &:before {
+        //This is the setup for the icon that appears inside the badge
         display: inline-block;
         margin-right: 2px;
     }
 
     &.feature-sm {
+        //This class is added to make the feature badge smaller.  This is used on the rules list
         padding: 1px 3px;
         font-size: 75%;
     }
 
     &.feature-ts-only {
+        //This feature badge is added to rules that are "TypeScript Only"
         background-color: #FCF8E3;
         border-color: #FAF2CC;
         color: #8A6D3B;
@@ -142,6 +147,7 @@ figcaption {
     }
 
     &.feature-fixer {
+        //This feature badge is added to rules that have an auto-fixer
         background-color: #DFF0D8;
         border-color: #D0E9C6;
         color: #3C763D;
@@ -152,6 +158,7 @@ figcaption {
     }
 
     &.feature-requires-type-info {
+        //This feature badge is added to rules that require type information
         background-color: #F2DEDE;
         border-color: #EBCCCC;
         color: #A94442;
@@ -162,12 +169,7 @@ figcaption {
             border-radius: 50%;
             background: #0078D7;
             color: #FFF;
-        }
-
-        &.feature-sm {
-            &:before {
-                width: 1em;
-            }
+            width: 1em;
         }
     }
  }

--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -132,32 +132,43 @@ figcaption {
     }
 
     &.feature-ts-only {
-        background-color: #fcf8e3;
-        border-color: #faf2cc;
-        color: #8a6d3b;
+        background-color: #FCF8E3;
+        border-color: #FAF2CC;
+        color: #8A6D3B;
 
         &:before {
-            content: "\1F4C4"; //page facing up icon
+            content: "\1F4C4"; //"page facing up" icon - http://www.fileformat.info/info/unicode/char/1F4C4/index.htm
         }
     }
 
     &.feature-fixer {
-        background-color: #dff0d8;
-        border-color: #d0e9c6;
-        color: #3c763d;
+        background-color: #DFF0D8;
+        border-color: #D0E9C6;
+        color: #3C763D;
         
         &:before {
-            content: "\1f527"; //wrench icon
+            content: "\1f527"; //"wrench" icon - http://www.fileformat.info/info/unicode/char/1f527/index.htm
         }
     }
 
     &.feature-requires-type-info {
-        background-color: #f2dede;
-        border-color: #ebcccc;
-        color: #a94442;
+        background-color: #F2DEDE;
+        border-color: #EBCCCC;
+        color: #A94442;
 
         &:before {
-            content: "\1F6C8"; //information-circle icon
+            content: "\2139"; //"information source" icon - http://www.fileformat.info/info/unicode/char/2139/index.htm
+            //Surround it with a blue circle
+            border-radius: 50%;
+            padding: 0 6px;
+            background: #0078D7;
+            color: #FFF;
+        }
+
+        &.feature-sm {
+            &:before {
+                padding: 0 5px;
+            }
         }
     }
  }

--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -91,7 +91,7 @@ figcaption {
             border-left: 3px solid transparent;
             text-decoration: none;
             padding: .75rem;
-            
+
             &:hover {
                 background-color: rgba(0, 0, 0,.075);
                 border-left-color: #159957;
@@ -145,7 +145,7 @@ figcaption {
         background-color: #DFF0D8;
         border-color: #D0E9C6;
         color: #3C763D;
-        
+
         &:before {
             content: "\1f527"; //"wrench" icon - http://www.fileformat.info/info/unicode/char/1f527/index.htm
         }
@@ -160,14 +160,13 @@ figcaption {
             content: "\2139"; //"information source" icon - http://www.fileformat.info/info/unicode/char/2139/index.htm
             //Surround it with a blue circle
             border-radius: 50%;
-            padding: 0 6px;
             background: #0078D7;
             color: #FFF;
         }
 
         &.feature-sm {
             &:before {
-                padding: 0 5px;
+                width: 1em;
             }
         }
     }

--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -70,3 +70,94 @@ figcaption {
         }
     }
 }
+
+
+/**
+ * Rules & Feature Badges
+ */
+ .rules-list {
+    list-style: none;
+    margin: 0 !important; //need to override the `main-content ul` selector
+
+    > li {
+        &:nth-child(odd) {
+            a {
+                background-color: rgba(0, 0, 0, .03);
+            }
+        }
+
+        a {
+            display: block;
+            border-left: 3px solid transparent;
+            text-decoration: none;
+            padding: .75rem;
+            
+            &:hover {
+                background-color: rgba(0, 0, 0,.075);
+                border-left-color: #159957;
+            }
+        }
+    }
+ }
+
+ .rule-features {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+ }
+
+ .feature {
+    display: inline-block;
+    margin-right: 2px;
+    padding: 2px 4px;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border: 1px solid transparent;
+    border-radius: .25rem;
+    cursor: help;
+
+    &:before {
+        display: inline-block;
+        margin-right: 2px;
+    }
+
+    &.feature-sm {
+        padding: 1px 3px;
+        font-size: 75%;
+    }
+
+    &.feature-ts-only {
+        background-color: #fcf8e3;
+        border-color: #faf2cc;
+        color: #8a6d3b;
+
+        &:before {
+            content: "\1F4C4"; //page facing up icon
+        }
+    }
+
+    &.feature-fixer {
+        background-color: #dff0d8;
+        border-color: #d0e9c6;
+        color: #3c763d;
+        
+        &:before {
+            content: "\1f527"; //wrench icon
+        }
+    }
+
+    &.feature-requires-type-info {
+        background-color: #f2dede;
+        border-color: #ebcccc;
+        color: #a94442;
+
+        &:before {
+            content: "\1F6C8"; //information-circle icon
+        }
+    }
+ }

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -140,8 +140,8 @@ export class Rule extends Lint.Rules.TypedRule {
         ruleName: "completed-docs",
         description: "Enforces documentation for important items be filled out.",
         optionsDescription: Lint.Utils.dedent`
-             \`true\` to enable for ["${ARGUMENT_CLASSES}", "${ARGUMENT_FUNCTIONS}", "${ARGUMENT_METHODS}", "${ARGUMENT_PROPERTIES}"],
-             or an array with each item in one of two formats:
+            \`true\` to enable for ["${ARGUMENT_CLASSES}", "${ARGUMENT_FUNCTIONS}", "${ARGUMENT_METHODS}", "${ARGUMENT_PROPERTIES}"],
+            or an array with each item in one of two formats:
 
             * \`string\` to enable for that type
             * \`object\` keying types to when their documentation is required:


### PR DESCRIPTION
### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] enhancement
  - [ ] Includes tests
- [x] Documentation update

### Overview of change:
This PR make some UI changes to the the list of rules, and the individual rule detail pages.

- The rules on the rules list page are now clickable, not just the rule name
- Alternating background colors + hover colors
- "feature" badges for each rule in the list, and larger versions on the actual rule details page
  - yellow badge with document icon when `typescriptOnly` is true
  - green badge with wrench icon when `hasFix` is true
  - red badge with info icon when `requiresTypeInfo` is true

**Here's what the changes look like!**
![tslint-docs](https://cloud.githubusercontent.com/assets/463685/23415403/14119c96-fdad-11e6-878f-32c816f95f94.gif)


Eventually it would be really nice to have some interactive rule filters on that page.  To be able to filter the rules list down to only show the rules that require type info, or could be auto-fixed would be awesome!  I wanted to keep this PR minimal & focused though.