### PR TITLE
Support dev versions of typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "update-notifier": "^2.0.0"
   },
   "peerDependencies": {
-    "typescript": ">=2.0.0"
+    "typescript": ">=2.0.0 || >=2.0.0-dev || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev"
   },
   "devDependencies": {
     "@types/babel-code-frame": "^6.20.0",


### PR DESCRIPTION
This would help us to use the latest `tslint` alongside an install of `typescript@next`. (Microsoft/TypeScript#14391). CC @vladima.
Previously there was a `next` tag of `tslint` but it doesn't seem to have been updated in a while, and I don't think it's necessary if we can just do this?

If this is accepted, I will also make the same PR to `tsutils`.