### PR TITLE
Restore old behaviour of text wrap in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,10 @@
     // Controls if the editor will insert spaces for tabs. If set to auto, the value will be guessed based on the opened file.
     "editor.insertSpaces": true,
 
-    // Controls after how many characters the editor will wrap to the next line. Setting this to 0 turns on viewport width wrapping
-    "editor.wordWrap": "bounded",
+    // Controls after how many characters the editor will wrap to the next line.
+    "editor.wordWrap": "wordWrapColumn",
     "editor.wordWrapColumn": 140,
+    "editor.wrappingIndent": "none",
 
     // The folders to exclude when doing a full text search in the workspace.
     "files.exclude": {


### PR DESCRIPTION
#### Overview of change:

#2250 changed how vscode wrapped long lines. After that change lines were wrapped at the end of the viewport. This PR restores the old behaviour of wrapping at the specified column.

I also added `wrappingIndent: none`. Wrapped lines will begin in column 0, which makes it easier to distinguish from regular indented lines.

#### CHANGELOG.md entry:
[no-log]
