### PR TITLE
Added an abstract OptionallyTypedRule

### DIFF
--- a/src/language/rule/optionallyTypedRule.ts
+++ b/src/language/rule/optionallyTypedRule.ts
@@ -20,12 +20,7 @@ import * as ts from "typescript";
 import {AbstractRule} from "./abstractRule";
 import {ITypedRule, RuleFailure} from "./rule";
 
-export abstract class TypedRule extends AbstractRule implements ITypedRule {
-
-    public apply(): RuleFailure[] {
-        // if no program is given to the linter, throw an error
-        throw new Error(`The '${this.ruleName}' rule requires type checking`);
-    }
+export abstract class OptionallyTypedRule extends AbstractRule implements ITypedRule {
 
     public abstract applyWithProgram(sourceFile: ts.SourceFile, languageService: ts.LanguageService): RuleFailure[];
 }

--- a/src/language/rule/optionallyTypedRule.ts
+++ b/src/language/rule/optionallyTypedRule.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2016 Palantir Technologies, Inc.
+ * Copyright 2017 Palantir Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -107,6 +107,10 @@ export interface IRule {
     applyWithWalker(walker: IWalker): RuleFailure[];
 }
 
+export interface ITypedRule extends IRule {
+    applyWithProgram(sourceFile: ts.SourceFile, languageService: ts.LanguageService): RuleFailure[];
+}
+
 export interface IRuleFailureJson {
     endPosition: IRuleFailurePositionJson;
     failure: string;
@@ -121,6 +125,10 @@ export interface IRuleFailurePositionJson {
     character: number;
     line: number;
     position: number;
+}
+
+export function isTypedRule(rule: IRule): rule is ITypedRule {
+    return "applyWithProgram" in rule;
 }
 
 export class Replacement {

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -35,8 +35,7 @@ import { findFormatter } from "./formatterLoader";
 import { ILinterOptions, LintResult } from "./index";
 import { IFormatter } from "./language/formatter/formatter";
 import { createLanguageService, wrapProgram } from "./language/languageServiceHost";
-import { Fix, IRule, RuleFailure, RuleSeverity } from "./language/rule/rule";
-import { TypedRule } from "./language/rule/typedRule";
+import { Fix, IRule, isTypedRule, RuleFailure, RuleSeverity } from "./language/rule/rule";
 import * as utils from "./language/utils";
 import { loadRules } from "./ruleLoader";
 import { arrayify, dedent } from "./utils";
@@ -179,7 +178,7 @@ class Linter {
     private applyRule(rule: IRule, sourceFile: ts.SourceFile) {
         let ruleFailures: RuleFailure[] = [];
         try {
-            if (TypedRule.isTypedRule(rule) && this.program) {
+            if (this.program && isTypedRule(rule)) {
                 ruleFailures = rule.applyWithProgram(sourceFile, this.languageService);
             } else {
                 ruleFailures = rule.apply(sourceFile, this.languageService);


### PR DESCRIPTION
Like `AbstractRule`, it provides abstract `apply*` members that must be
implemented.

*(errata: switched the order of checks in `linter.ts` because it felt
quicker having a property check before the function call)*

Also moved `isTypedRule` logic to a separate function, as it's no longer
unique to the `TypedRule` class. An alternative I'd considered but
rejected would be to make a member `isTyped(): this is IRule` on
`IRule`, but that would require classes not inheriting from
`AbstractRule` to also define their own `isTyped()`.

Resolves #2091.