### PR TITLE
`prefer-function-over-method` should ignore abstract methods

### DIFF
--- a/src/rules/preferFunctionOverMethodRule.ts
+++ b/src/rules/preferFunctionOverMethodRule.ts
@@ -99,7 +99,7 @@ class PreferFunctionOverMethodWalker extends Lint.RuleWalker {
     }
 
     private shouldWarnForModifiers(node: ts.MethodDeclaration): boolean {
-        if (Lint.hasModifier(node.modifiers, ts.SyntaxKind.StaticKeyword)) {
+        if (Lint.hasModifier(node.modifiers, ts.SyntaxKind.StaticKeyword, ts.SyntaxKind.AbstractKeyword)) {
             return false;
         }
         // TODO: Also return false if it's marked "override" (https://github.com/palantir/tslint/pull/2037)

--- a/test/rules/prefer-function-over-method/default/test.ts.lint
+++ b/test/rules/prefer-function-over-method/default/test.ts.lint
@@ -44,6 +44,10 @@ class C {
     ~~~~~~~~~~~~~~~~~ [0]
 }
 
+abstract class C2 {
+    abstract abstract(): void;
+}
+
 const o = {
     x() {}
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2305
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

The `prefer-function-over-method` rule was warning for abstract methods.  This change adds a test case for that, and resolves it.  The rule already checks for the `static` modifier, so it was simple enough to also check for the `abstract` modifier.

#### CHANGELOG.md entry:

[bugfix] `prefer-function-over-method` now ignores abstract methods
