### PR TITLE
Bugfix no-inferrable-types with readonly property

### DIFF
--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { hasAccessModifier, hasModifier } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -76,12 +77,16 @@ class NoInferrableTypesWalker extends Lint.AbstractWalker<IOptions> {
         const cb = (node: ts.Node): void => {
             switch (node.kind) {
                 case ts.SyntaxKind.Parameter:
-                    if (!this.options.ignoreParameters) {
+                    if (!this.options.ignoreParameters &&
+                        !hasModifier(node.modifiers, ts.SyntaxKind.ReadonlyKeyword) &&
+                        // "ignore-properties" also works for parameter properties
+                        (!this.options.ignoreProperties || !hasAccessModifier(node as ts.ParameterDeclaration))) {
                         this.checkDeclaration(node as ts.ParameterDeclaration);
                     }
                     break;
                 case ts.SyntaxKind.PropertyDeclaration:
-                    if (this.options.ignoreProperties) {
+                    if (this.options.ignoreProperties ||
+                        hasModifier(node.modifiers, ts.SyntaxKind.ReadonlyKeyword)) {
                         break;
                     }
                     /* falls through*/

--- a/test/rules/no-inferrable-types/default/test.ts.fix
+++ b/test/rules/no-inferrable-types/default/test.ts.fix
@@ -13,6 +13,8 @@ class Foo {
     bar = 0;
     baz = true,
     bas = "moar";
+    readonly foo: boolean = false;
+    constructor(readonly foobar: string = "test", public barfoo = 1) {}
 }
 
 // not errors, inferrable type is not declared

--- a/test/rules/no-inferrable-types/default/test.ts.lint
+++ b/test/rules/no-inferrable-types/default/test.ts.lint
@@ -23,6 +23,9 @@ class Foo {
          ~~~~~~~         [boolean]
     bas: string = "moar";
          ~~~~~~          [string]
+    readonly foo: boolean = false;
+    constructor(readonly foobar: string = "test", public barfoo: number = 1) {}
+                                                                 ~~~~~~ [number]
 }
 
 // not errors, inferrable type is not declared

--- a/test/rules/no-inferrable-types/ignore-params/test.ts.fix
+++ b/test/rules/no-inferrable-types/ignore-params/test.ts.fix
@@ -14,6 +14,8 @@ class Foo {
     bar = 0;
     baz = true,
     bas = "moar";
+    readonly foo: boolean = false;
+    constructor(readonly foobar: string = "test", public barfoo: number = 1) {}
 }
 
 // not errors, inferrable type is not declared

--- a/test/rules/no-inferrable-types/ignore-params/test.ts.lint
+++ b/test/rules/no-inferrable-types/ignore-params/test.ts.lint
@@ -20,6 +20,8 @@ class Foo {
          ~~~~~~~         [boolean]
     bas: string = "moar";
          ~~~~~~          [string]
+    readonly foo: boolean = false;
+    constructor(readonly foobar: string = "test", public barfoo: number = 1) {}
 }
 
 // not errors, inferrable type is not declared

--- a/test/rules/no-inferrable-types/ignore-properties/test.ts.fix
+++ b/test/rules/no-inferrable-types/ignore-properties/test.ts.fix
@@ -13,6 +13,8 @@ class Foo {
     bar: number = 0;
     baz: boolean = true,
     bas: string = "moar";
+    readonly foo: boolean = false;
+    constructor(readonly foobar: string = "test", public barfoo: number = 1) {}
 }
 
 // not errors, inferrable type is not declared

--- a/test/rules/no-inferrable-types/ignore-properties/test.ts.lint
+++ b/test/rules/no-inferrable-types/ignore-properties/test.ts.lint
@@ -19,6 +19,8 @@ class Foo {
     bar: number = 0;
     baz: boolean = true,
     bas: string = "moar";
+    readonly foo: boolean = false;
+    constructor(readonly foobar: string = "test", public barfoo: number = 1) {}
 }
 
 // not errors, inferrable type is not declared


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2306 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Overview of change:

[bugfix] `no-inferrable-types` don't warn for inferrable type on readonly property
Fixes: #2306
[enhancement] `ignore-properties` option of `no-inferrable-types` now also ignores parameter properties