### PR TITLE
Bugfix prefer-function-over-method for overloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "glob": "^7.1.1",
     "optimist": "~0.6.0",
     "resolve": "^1.1.7",
-    "tsutils": "^1.1.0"
+    "tsutils": "^1.2.2"
   },
   "peerDependencies": {
     "typescript": ">=2.0.0 || >=2.0.0-dev || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev"

--- a/test/rules/prefer-function-over-method/default/test.ts.lint
+++ b/test/rules/prefer-function-over-method/default/test.ts.lint
@@ -42,6 +42,17 @@ class C {
 
     [Symbol.iterator]() {}
     ~~~~~~~~~~~~~~~~~ [0]
+
+    thisType(foo: this): this {
+    ~~~~~~~~ [0]
+        return foo;
+    }
+
+    overload(): void;
+    overload(foo): void;
+    overload(foo?): void {
+        return this;
+    }
 }
 
 abstract class C2 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,13 +896,13 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
-semver@~5.0.1:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@~5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
+
+semver@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
 shell-quote@^1.6.1:
   version "1.6.1"
@@ -1038,6 +1038,10 @@ tslint@latest:
 tsutils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.1.0.tgz#94e0c267624eeb1b63561ba8ec0bcff71b4e2872"
+
+tsutils@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.2.2.tgz#7e165c601367b9f89200b97ff47d9e38d1a6e4c8"
 
 type-detect@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2305 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

[bugfix] exclude overload signatures from `prefer-function-over-method`
This would have also fixed #2305
Refactor the rule to use AbstractWalker and simplify the algorithm.
