### PR TITLE
`use-isnan` should only apply to comparison operators

### DIFF
--- a/src/rules/useIsnanRule.ts
+++ b/src/rules/useIsnanRule.ts
@@ -56,13 +56,13 @@ class UseIsnanRuleWalker extends Lint.RuleWalker {
     }
 
     private isComparisonOperator(operator: ts.BinaryOperator) {
-        return (operator == ts.SyntaxKind.LessThanToken
-            || operator == ts.SyntaxKind.GreaterThanToken
-            || operator == ts.SyntaxKind.LessThanEqualsToken
-            || operator == ts.SyntaxKind.GreaterThanEqualsToken
-            || operator == ts.SyntaxKind.EqualsEqualsToken
-            || operator == ts.SyntaxKind.ExclamationEqualsToken
-            || operator == ts.SyntaxKind.EqualsEqualsEqualsToken
-            || operator == ts.SyntaxKind.ExclamationEqualsEqualsToken);
+        return (operator === ts.SyntaxKind.LessThanToken
+            || operator === ts.SyntaxKind.GreaterThanToken
+            || operator === ts.SyntaxKind.LessThanEqualsToken
+            || operator === ts.SyntaxKind.GreaterThanEqualsToken
+            || operator === ts.SyntaxKind.EqualsEqualsToken
+            || operator === ts.SyntaxKind.ExclamationEqualsToken
+            || operator === ts.SyntaxKind.EqualsEqualsEqualsToken
+            || operator === ts.SyntaxKind.ExclamationEqualsEqualsToken);
     }
 }

--- a/src/rules/useIsnanRule.ts
+++ b/src/rules/useIsnanRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class UseIsnanRuleWalker extends Lint.RuleWalker {
     protected visitBinaryExpression(node: ts.BinaryExpression): void {
         if ((this.isExpressionNaN(node.left) || this.isExpressionNaN(node.right))
-                && node.operatorToken.kind !== ts.SyntaxKind.EqualsToken) {
+                && this.isComparisonOperator(node.operatorToken.kind)) {
             this.addFailureAtNode(node, Rule.FAILURE_STRING + node.getText());
         }
         super.visitBinaryExpression(node);
@@ -53,5 +53,16 @@ class UseIsnanRuleWalker extends Lint.RuleWalker {
 
     private isExpressionNaN(node: ts.Node) {
         return node.kind === ts.SyntaxKind.Identifier && node.getText() === "NaN";
+    }
+
+    private isComparisonOperator(operator: ts.BinaryOperator) {
+        return (operator == ts.SyntaxKind.LessThanToken
+            || operator == ts.SyntaxKind.GreaterThanToken
+            || operator == ts.SyntaxKind.LessThanEqualsToken
+            || operator == ts.SyntaxKind.GreaterThanEqualsToken
+            || operator == ts.SyntaxKind.EqualsEqualsToken
+            || operator == ts.SyntaxKind.ExclamationEqualsToken
+            || operator == ts.SyntaxKind.EqualsEqualsEqualsToken
+            || operator == ts.SyntaxKind.ExclamationEqualsEqualsToken);
     }
 }

--- a/test/rules/use-isnan/test.ts.lint
+++ b/test/rules/use-isnan/test.ts.lint
@@ -39,6 +39,10 @@ x = x >> NaN;
 x = NaN >>> x;
 x = x & NaN;
 
+// no violation for other operators
+if (x instanceof NaN) { }
+if (NaN in x) { }
+
 // do not use equality operators to compare for NaN
 if (foo == NaN) {  }
     ~~~~~~~~~~         [Found an invalid comparison for NaN: foo == NaN]

--- a/test/rules/use-isnan/test.ts.lint
+++ b/test/rules/use-isnan/test.ts.lint
@@ -9,6 +9,35 @@ if (isNaN(something)) { }
 // no violation for assignments
 let x = 0;
 x = NaN;
+x += NaN;
+x -= NaN;
+x /= NaN;
+x *= NaN;
+x %= NaN;
+x **= NaN;
+x <<= NaN;
+x >>= NaN;
+x >>>= NaN;
+x &= NaN;
+x ^= NaN;
+x |= NaN;
+
+// no violation for arithmetic operators
+x = x + NaN;
+x = NaN - x;
+x = x / NaN;
+x = NaN * x;
+x = x % NaN;
+x = NaN ** x;
+
+// no violation for bitwise operators
+x = x & NaN;
+x = NaN | x;
+x = x ^ NaN;
+x = NaN << x;
+x = x >> NaN;
+x = NaN >>> x;
+x = x & NaN;
 
 // do not use equality operators to compare for NaN
 if (foo == NaN) {  }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2255
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

The `use-isnan` rule was warning about all binary operators except for the simple assignment operator `=`.  This was problematic because `x || NaN` is a reasonable thing to do.  This change ensures that it only applies to comparison operators.  Instead of checking for the assignment exception, the rule now checks against a complete list of comparison operators.

#### Is there anything you'd like reviewers to focus on?

Most binary operators would be silly to use with a literal `NaN`.  I'm not sure whether it would have been better to just add more exceptions (specifically for `||` and `&&`).  The technique in this PR has the risk that if a new comparison operator is later added to the language (e.g. `<=>`) then the rule will need to be updated.  But it seemed better to me to limit the scope of the rule completely.

#### CHANGELOG.md entry:

[bugfix] `use-isnan` now applies only to comparison operators