### PR TITLE
file-header fix for single-line comments

### DIFF
--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -46,7 +46,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 class FileHeaderWalker extends Lint.RuleWalker {
     // match a single line or multi line comment with leading whitespace
     // the wildcard dot does not match new lines - we can use [\s\S] instead
-    private commentRegexp: RegExp = /^\s*(\/\/(.*?)|\/\*([\s\S]*?)\*\/)/;
+    private commentRegexp: RegExp = /^\s*(\/\/(.*)|\/\*([\s\S]*?)\*\/)/;
     private headerRegexp: RegExp;
 
     public setRegexp(headerRegexp: RegExp) {

--- a/test/rules/file-header/bad-single-line/test.js.lint
+++ b/test/rules/file-header/bad-single-line/test.js.lint
@@ -1,7 +1,5 @@
-/*
+// Bad header 1
 ~nil [missing file header]
- * Bad header 1
- */
 
 export class A {
     x = 1;

--- a/test/rules/file-header/bad-single-line/test.ts.lint
+++ b/test/rules/file-header/bad-single-line/test.ts.lint
@@ -1,12 +1,10 @@
-/*
+// Bad header 1
 ~nil [missing file header]
- * Bad header 1
- */
 
 export class A {
-    x = 1;
+    public x = 1;
 
-    B() {
+    public B() {
         return 2;
     }
 }

--- a/test/rules/file-header/bad-single-line/tslint.json
+++ b/test/rules/file-header/bad-single-line/tslint.json
@@ -1,0 +1,8 @@
+{
+    "rules": {
+        "file-header": [true, "Good header \\d"]
+    },
+    "jsRules": {
+        "file-header": [true, "Good header \\d"]
+    }
+}

--- a/test/rules/file-header/empty-file/test.js.lint
+++ b/test/rules/file-header/empty-file/test.js.lint
@@ -1,1 +1,2 @@
-// empty.
+
+~nil [missing file header]

--- a/test/rules/file-header/empty-file/test.ts.lint
+++ b/test/rules/file-header/empty-file/test.ts.lint
@@ -1,1 +1,2 @@
-// empty.
+
+~nil [missing file header]

--- a/test/rules/file-header/good-single-line/test.js.lint
+++ b/test/rules/file-header/good-single-line/test.js.lint
@@ -1,0 +1,9 @@
+// Good header 4
+
+export class A {
+    x = 1;
+
+    B() {
+        return 2;
+    }
+}

--- a/test/rules/file-header/good-single-line/test.ts.lint
+++ b/test/rules/file-header/good-single-line/test.ts.lint
@@ -1,0 +1,9 @@
+// Good header 4
+
+export class A {
+    public x = 1;
+
+    public B() {
+        return 2;
+    }
+}

--- a/test/rules/file-header/good-single-line/tslint.json
+++ b/test/rules/file-header/good-single-line/tslint.json
@@ -1,0 +1,8 @@
+{
+    "rules": {
+        "file-header": [true, "Good header \\d"]
+    },
+    "jsRules": {
+        "file-header": [true, "Good header \\d"]
+    }
+}


### PR DESCRIPTION
The file-header rule was not correctly parsing single-line comments. Therefore the regex was not working. That is now fixed.

#### PR checklist

- [x] Addresses an existing issue: #2319
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
I fixed the `commentRegexp` so that it will correctly parse single-line comments. It was an easy fix. I simply removed a `?`.

#### Is there anything you'd like reviewers to focus on?

Please make sure I made the correct decision with the tests inside the `empty` directory.

#### CHANGELOG.md entry:

Fixed the file-header rule so that it correctly handles single-line coments.

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
