### PR TITLE
Extend cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Options:
 -h, --help            display detailed help
 -i, --init            generate a tslint.json config file in the current working directory
 -o, --out             output file
---project             tsconfig.json file
+-p, --project         tsconfig.json file
 -r, --rules-dir       rules directory
 -s, --formatters-dir  formatters directory
 -t, --format          output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist)  [default: "prose"]
@@ -200,7 +200,7 @@ tslint accepts the following command-line options:
     the tests. See the full tslint documentation for more details on how
     this can be used to test custom rules.
 
---project:
+-p, --project:
     The location of a tsconfig.json file that will be used to determine which
     files will be linted.
 

--- a/docs/usage/cli/index.md
+++ b/docs/usage/cli/index.md
@@ -36,7 +36,7 @@ Options:
 -h, --help            display detailed help
 -i, --init            generate a tslint.json config file in the current working directory
 -o, --out             output file
---project             tsconfig.json file
+-p, --project         tsconfig.json file
 -r, --rules-dir       rules directory
 -s, --formatters-dir  formatters directory
 -t, --format          output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)  [default: "prose"]
@@ -115,7 +115,7 @@ tslint accepts the following command-line options:
     specified directory as the configuration file for the tests. See the
     full tslint documentation for more details on how this can be used to test custom rules.
 
---project:
+-p, --project:
     The location of a tsconfig.json file that will be used to determine which
     files will be linted.
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -112,35 +112,30 @@ export class Runner {
     public run(onComplete: (status: number) => void) {
         if (this.options.version) {
             this.outputStream.write(Linter.VERSION + "\n");
-            onComplete(0);
-            return;
+            return onComplete(0);
         }
 
         if (this.options.init) {
             if (fs.existsSync(CONFIG_FILENAME)) {
                 console.error(`Cannot generate ${CONFIG_FILENAME}: file already exists`);
-                onComplete(1);
-                return;
+                return onComplete(1);
             }
 
             const tslintJSON = JSON.stringify(DEFAULT_CONFIG, undefined, "    ");
             fs.writeFileSync(CONFIG_FILENAME, tslintJSON);
-            onComplete(0);
-            return;
+            return onComplete(0);
         }
 
         if (this.options.test) {
-            const results = runTests(this.options.test, this.options.rulesDirectory);
+            const results = runTests((this.options.files || []).map(Runner.trimSingleQuotes), this.options.rulesDirectory);
             const didAllTestsPass = consoleTestResultsHandler(results);
-            onComplete(didAllTestsPass ? 0 : 1);
-            return;
+            return onComplete(didAllTestsPass ? 0 : 1);
         }
 
         // when provided, it should point to an existing location
         if (this.options.config && !fs.existsSync(this.options.config)) {
             console.error("Invalid option for configuration: " + this.options.config);
-            onComplete(1);
-            return;
+            return onComplete(1);
         }
 
         // if both files and tsconfig are present, use files
@@ -150,8 +145,7 @@ export class Runner {
         if (this.options.project != null) {
             if (!fs.existsSync(this.options.project)) {
                 console.error("Invalid option for project: " + this.options.project);
-                onComplete(1);
-                return;
+                return onComplete(1);
             }
             program = Linter.createProgram(this.options.project, path.dirname(this.options.project));
             if (files.length === 0) {
@@ -171,12 +165,16 @@ export class Runner {
                         message += " " + ts.flattenDiagnosticMessageText(diag.messageText, "\n");
                         return message;
                     });
-                    throw new Error(messages.join("\n"));
+                    console.error(messages.join("\n"));
+                    return onComplete(this.options.force ? 0 : 1);
                 }
             } else {
                 // if not type checking, we don't need to pass in a program object
                 program = undefined;
             }
+        } else if (this.options.typeCheck) {
+            console.error("--project must be specified in order to enable type checking.");
+            return onComplete(1);
         }
 
         let ignorePatterns: string[] = [];
@@ -197,7 +195,7 @@ export class Runner {
         } catch (error) {
             if (error.name === FatalError.NAME) {
                 console.error(error.message);
-                onComplete(1);
+                return onComplete(1);
             }
             // rethrow unhandled error
             throw error;
@@ -215,26 +213,26 @@ export class Runner {
 
         let lastFolder: string | undefined;
         let configFile: IConfigurationFile | undefined;
+        const buffer = Buffer.allocUnsafe(256);
         for (const file of files) {
             if (!fs.existsSync(file)) {
                 console.error(`Unable to open file: ${file}`);
-                onComplete(1);
-                return;
+                return onComplete(1);
             }
 
-            const buffer = new Buffer(256);
             buffer.fill(0);
             const fd = fs.openSync(file, "r");
             try {
                 fs.readSync(fd, buffer, 0, 256, 0);
-                if (buffer.readInt8(0) === 0x47 && buffer.readInt8(188) === 0x47) {
+                if (buffer.readInt8(0, true) === 0x47 && buffer.readInt8(188, true) === 0x47) {
                     // MPEG transport streams use the '.ts' file extension. They use 0x47 as the frame
                     // separator, repeating every 188 bytes. It is unlikely to find that pattern in
                     // TypeScript source, so tslint ignores files with the specific pattern.
                     console.warn(`${file}: ignoring MPEG transport stream`);
-                    return;
+                    fs.closeSync(fd);
+                    continue;
                 }
-            } finally {
+            } catch (e) {
                 fs.closeSync(fd);
             }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -228,10 +228,9 @@ export class Runner {
                     // separator, repeating every 188 bytes. It is unlikely to find that pattern in
                     // TypeScript source, so tslint ignores files with the specific pattern.
                     console.warn(`${file}: ignoring MPEG transport stream`);
-                    fs.closeSync(fd);
                     continue;
                 }
-            } catch (e) {
+            } finally {
                 fs.closeSync(fd);
             }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -213,14 +213,13 @@ export class Runner {
 
         let lastFolder: string | undefined;
         let configFile: IConfigurationFile | undefined;
-        const buffer = Buffer.allocUnsafe(256);
         for (const file of files) {
             if (!fs.existsSync(file)) {
                 console.error(`Unable to open file: ${file}`);
                 return onComplete(1);
             }
 
-            buffer.fill(0);
+            const buffer = new Buffer(256);
             const fd = fs.openSync(file, "r");
             try {
                 fs.readSync(fd, buffer, 0, 256, 0);

--- a/src/test.ts
+++ b/src/test.ts
@@ -44,9 +44,12 @@ export interface TestResult {
     };
 }
 
-export function runTests(pattern: string, rulesDirectory?: string | string[]): TestResult[] {
-    return glob.sync(`${pattern}/tslint.json`)
-        .map((directory: string): TestResult => runTest(path.dirname(directory), rulesDirectory));
+export function runTests(patterns: string[], rulesDirectory?: string | string[]): TestResult[] {
+    const files: string[] = [];
+    for (const pattern of patterns) {
+        files.push(...glob.sync(`${pattern}/tslint.json`));
+    }
+    return files.map((directory: string): TestResult => runTest(path.dirname(directory), rulesDirectory));
 }
 
 export function runTest(testDirectory: string, rulesDirectory?: string | string[]): TestResult {

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -70,7 +70,8 @@ const processed = optimist
             describe: "output file",
             type: "string",
         },
-        "project": {
+        "p": {
+            alias: "project",
             describe: "tsconfig.json file",
             type: "string",
         },
@@ -92,7 +93,7 @@ const processed = optimist
         },
         "test": {
             describe: "test that tslint produces the correct output for the specified directory",
-            type: "string",
+            type: "boolean",
         },
         "type-check": {
             describe: "enable type checking when linting a project",
@@ -186,7 +187,7 @@ tslint accepts the following commandline options:
         the tests. See the full tslint documentation for more details on how
         this can be used to test custom rules.
 
-    --project:
+    -p, --project:
         The location of a tsconfig.json file that will be used to determine which
         files will be linted.
 
@@ -213,7 +214,7 @@ const options: IRunnerOptions = {
     formattersDirectory: argv.s,
     init: argv.init,
     out: argv.out,
-    project: argv.project,
+    project: argv.p,
     rulesDirectory: argv.r,
     test: argv.test,
     typeCheck: argv["type-check"],

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -210,6 +210,15 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
                 done();
             });
         });
+
+        it("can be used with multiple paths", (done) => {
+            // pass a failing test as second path to make sure it gets executed
+            execCli(["--test", "test/files/custom-rule-rule-test", "test/files/incorrect-fixes-test"], (err) => {
+                assert.isNotNull(err, "process should exit with error");
+                assert.strictEqual(err.code, 1, "error code should be 1");
+                done();
+            });
+        });
     });
 
     describe("tsconfig.json", () => {
@@ -230,11 +239,21 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
         });
 
         it("exits with code 0 if `tsconfig.json` is passed but it includes no ts files", (done) => {
-            execCli(["-c", "test/files/tsconfig-no-ts-files/tslint.json", "--project", "test/files/tsconfig-no-ts-files/tsconfig.json"],
+            execCli(["-c", "test/files/tsconfig-no-ts-files/tslint.json", "-p", "test/files/tsconfig-no-ts-files/tsconfig.json"],
                 (err) => {
                     assert.isNull(err, "process should exit without an error");
                     done();
                 });
+        });
+    });
+
+    describe("--type-check", () => {
+        it("exits with code 1 if --project is not passed", (done) => {
+            execCli(["--type-check"], (err) => {
+                assert.isNotNull(err, "process should exit with error");
+                assert.strictEqual(err.code, 2, "error code should be 2");
+                done();
+            });
         });
     });
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2087
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
[bugfix] exit with 0 on type check errors when `--force` is specified
Fixes: #2087
[bugfix] `--test` now correctly strips single quotes from patterns on windows
[enhancement] `--test` can handle multiple paths at once
^useful when shell expands globs
[enhancement] added `-p` as shorthand for `--project` to be consistent with `tsc`
Kind of fixes: #2291
[enhancement] print error when `--type-check` is used without `--project`
[enhancement] don't print stack trace on type check error