### PR TITLE
Rewrite 'no-shadowed-variable'

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -174,7 +174,7 @@ function resolveConfigurationPath(filePath: string, relativeTo?: string) {
     } catch (err) {
         try {
             return require.resolve(filePath);
-        } catch (err) {
+        } catch (anotherErr) {
             throw new Error(`Invalid "extends" configuration value - could not require "${filePath}". ` +
                 "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +
                 "for the approximate method TSLint uses to find the referenced configuration file.");

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+// tslint:disable switch-default
+
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -33,122 +36,257 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_FACTORY = (name: string) => {
+    public static FAILURE_STRING(name: string): string {
         return `Shadowed variable: '${name}'`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoShadowedVariableWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new Walker(sourceFile, this.ruleName, undefined));
     }
 }
 
-class NoShadowedVariableWalker extends Lint.BlockScopeAwareRuleWalker<Set<string>, Set<string>> {
-    public createScope() {
-        return new Set();
+class Walker extends Lint.AbstractWalker<void> {
+    private curLevel = -1;
+    private scopes: ts.Node[] = [];
+    // Maps a variable name to the scope level (or levels) where it appears.
+    // (It only appears in multiple levels if there is shadowing.)
+    private nameToLevel = new Map<string, number | number[]>();
+    // Map from scope level to names added there. Used to remove variables after closing a scope.
+    private namesAddedToCurrentScope: string[][] = [];
+
+    public walk(sourceFile: ts.SourceFile): void {
+        this.visitChildrenInNewScope(sourceFile);
+        if (this.curLevel !== -1 || this.namesAddedToCurrentScope.length || this.nameToLevel.size) {
+            throw new Error("Did not properly close scopes.");
+        }
     }
 
-    public createBlockScope() {
-        return new Set();
+    private visit(node: ts.Node): void {
+        if (isSignatureLike(node)) {
+            this.handleSignatureLike(node);
+        } else if (isNonSignatureDeclaration(node)) {
+            this.handleNonSignatureDeclaration(node);
+        } else if (utils.isScopeBoundary(node)) {
+            this.visitChildrenInNewScope(node);
+        } else if (utils.isVariableDeclaration(node)) {
+            const isVar = !utils.isBlockScopedVariableDeclaration(node);
+            const lvl = isVar ? this.getNonBlockScopedLevel() : this.curLevel;
+            this.addBindingNameToScope(node.name, lvl, /*mergable*/false);
+            if (node.initializer) {
+                this.visitChildren(node.initializer);
+            }
+        } else {
+            this.visitChildren(node);
+        }
     }
 
-    public visitBindingElement(node: ts.BindingElement) {
-        const isSingleVariable = node.name.kind === ts.SyntaxKind.Identifier;
-        if (isSingleVariable) {
-            const name = node.name as ts.Identifier;
-            const variableDeclaration = Lint.getBindingElementVariableDeclaration(node);
-            const isBlockScopedVariable = variableDeclaration !== null && Lint.isBlockScopedVariable(variableDeclaration);
-            this.handleSingleVariableIdentifier(name, isBlockScopedVariable);
+    private visitChildren(node: ts.Node): void {
+        ts.forEachChild(node, (child) => this.visit(child));
+    }
+
+    private getNonBlockScopedLevel(): number {
+        for (let lvl = this.scopes.length - 1; lvl >= 0; lvl--) {
+            if (utils.isFunctionScopeBoundary(this.scopes[lvl])) {
+                return lvl;
+            }
+        }
+        return 0;
+    }
+
+    private handleSignatureLike(node: SignatureLike): void {
+        const addToScope = (name: ts.Identifier | undefined, isMergeable: boolean) => {
+            if (name) {
+                this.addIdentifierToScope(name, this.curLevel, isMergeable);
+            }
+        };
+
+        // For fn declaration, name goes in *outer* scope. For function expression, name goes in *inner* scope.
+        // Fn declaration may be merged with another overload. Fn expression should *not* merge with others in the same scope.
+        if (node.kind === ts.SyntaxKind.FunctionDeclaration) {
+            addToScope(node.name, /*isMergeable*/ true);
         }
 
-        super.visitBindingElement(node);
-    }
+        this.inNewScope(node, () => {
+            if (node.kind === ts.SyntaxKind.FunctionExpression) {
+                addToScope(node.name, /*isMergeable*/ false);
+            }
 
-    public visitCatchClause(node: ts.CatchClause) {
-        // don't visit the catch clause variable declaration, just visit the block
-        // the catch clause variable declaration has its own special scoping rules
-        this.visitBlock(node.block);
-    }
+            const { parameters, typeParameters } = node;
+            this.addTypeParametersToScope(typeParameters);
 
-    public visitCallSignature(_node: ts.SignatureDeclaration) {
-        // don't call super, we don't need to check parameter names in call signatures
-    }
+            for (const { name } of parameters) {
+                this.addBindingNameToScope(name, this.curLevel, /*mergable*/ false);
+            }
 
-    public visitFunctionType(_node: ts.FunctionOrConstructorTypeNode) {
-        // don't call super, we don't need to check names in function types
-    }
-
-    public visitConstructorType(_node: ts.FunctionOrConstructorTypeNode) {
-        // don't call super, we don't need to check names in constructor types
-    }
-
-    public visitIndexSignatureDeclaration(_node: ts.SignatureDeclaration) {
-        // don't call super, we don't want to walk index signatures
-    }
-
-    public visitMethodSignature(_node: ts.SignatureDeclaration) {
-        // don't call super, we don't want to walk method signatures either
-    }
-
-    public visitParameterDeclaration(node: ts.ParameterDeclaration) {
-        const isSingleParameter = node.name.kind === ts.SyntaxKind.Identifier;
-
-        if (isSingleParameter) {
-            this.handleSingleVariableIdentifier(node.name as ts.Identifier, false);
-        }
-
-        super.visitParameterDeclaration(node);
-    }
-
-    public visitTypeLiteral(_node: ts.TypeLiteralNode) {
-        // don't call super, we don't want to walk the inside of type nodes
-    }
-
-    public visitVariableDeclaration(node: ts.VariableDeclaration) {
-        const isSingleVariable = node.name.kind === ts.SyntaxKind.Identifier;
-
-        if (isSingleVariable) {
-            this.handleSingleVariableIdentifier(node.name as ts.Identifier, Lint.isBlockScopedVariable(node));
-        }
-
-        super.visitVariableDeclaration(node);
-    }
-
-    private handleSingleVariableIdentifier(variableIdentifier: ts.Identifier, isBlockScoped: boolean) {
-        const variableName = variableIdentifier.text;
-
-        if (this.isVarInCurrentScope(variableName) && !this.inCurrentBlockScope(variableName)) {
-            // shadowing if there's already a `var` of the same name in the scope AND
-            // it's not in the current block (handled by the 'no-duplicate-variable' rule)
-            this.addFailureOnIdentifier(variableIdentifier);
-        } else if (this.inPreviousBlockScope(variableName)) {
-            // shadowing if there is a `var`, `let`, 'const`, or parameter in a previous block scope
-            this.addFailureOnIdentifier(variableIdentifier);
-        }
-
-        if (!isBlockScoped) {
-            // `var` variables go on the scope
-            this.getCurrentScope().add(variableName);
-        }
-        // all variables go on block scope, including `var`
-        this.getCurrentBlockScope().add(variableName);
-    }
-
-    private isVarInCurrentScope(varName: string) {
-        return this.getCurrentScope().has(varName);
-    }
-
-    private inCurrentBlockScope(varName: string) {
-        return this.getCurrentBlockScope().has(varName);
-    }
-
-    private inPreviousBlockScope(varName: string) {
-        return this.getAllBlockScopes().some((scopeInfo) => {
-            return scopeInfo !== this.getCurrentBlockScope() && scopeInfo.has(varName);
+            switch (node.kind) {
+                case ts.SyntaxKind.MethodSignature:
+                case ts.SyntaxKind.ConstructSignature:
+                case ts.SyntaxKind.CallSignature:
+                    break;
+                default:
+                    if (node.body) {
+                        this.visitChildren(node.body);
+                    }
+            }
         });
     }
 
-    private addFailureOnIdentifier(ident: ts.Identifier) {
-        const failureString = Rule.FAILURE_STRING_FACTORY(ident.text);
-        this.addFailureAtNode(ident, failureString);
+    private handleNonSignatureDeclaration(node: NonSignatureDeclaration): void {
+        // Class expression is declared in its own scope, not outer scope.
+        if (node.kind !== ts.SyntaxKind.ClassExpression && node.name) {
+            this.addIdentifierToScope(node.name, this.curLevel, /*isMergeable*/ true);
+        }
+
+        switch (node.kind) {
+            case ts.SyntaxKind.InterfaceDeclaration:
+            case ts.SyntaxKind.ClassDeclaration:
+            case ts.SyntaxKind.ClassExpression:
+                this.inNewScope(node, () => {
+                    if (node.kind === ts.SyntaxKind.ClassExpression && node.name) {
+                        this.addIdentifierToScope(node.name, this.curLevel, /*isMergeable*/ false);
+                    }
+
+                    this.addTypeParametersToScope(node.typeParameters);
+                    for (const m of node.members) {
+                        this.visit(m);
+                    }
+                });
+                break;
+
+            case ts.SyntaxKind.ModuleDeclaration:
+                this.visitChildrenInNewScope(node.body);
+                break;
+
+            case ts.SyntaxKind.TypeAliasDeclaration:
+                this.inNewScope(node, () => {
+                    this.addTypeParametersToScope(node.typeParameters);
+                    this.visit(node.type);
+                });
+                break;
+        }
+    }
+
+    private inNewScope(node: ts.Node, action: () => void): void {
+        this.scopes.push(node);
+        this.curLevel++;
+        this.namesAddedToCurrentScope.push([]);
+
+        action();
+
+        this.scopes.pop();
+        this.curLevel--;
+        for (const name of this.namesAddedToCurrentScope.pop()!) {
+            this.nameToLevel.delete(name);
+        }
+    }
+
+    private visitChildrenInNewScope(node: ts.Node): void {
+        this.inNewScope(node, () => this.visitChildren(node));
+    }
+
+    private addTypeParametersToScope(params: ts.TypeParameterDeclaration[] | undefined): void {
+        if (params) {
+            for (const { name } of params) {
+                this.addBindingNameToScope(name, this.curLevel, /*isMergeable*/false);
+            }
+        }
+    }
+
+    private addBindingNameToScope(b: ts.BindingName, scopeLevel: number, isMergeable: boolean): void {
+        eachIdentifier(b, (id) => {
+            // Exempt "this" because shadowing it may be unavoidable. See #2214.
+            if (id.text !== "this") {
+                this.addIdentifierToScope(id, scopeLevel, isMergeable);
+            }
+        });
+    }
+
+    private addIdentifierToScope(id: ts.Identifier, level: number, isMergeable: boolean): void {
+        const name = id.text;
+        const oldLevel = this.nameToLevel.get(name);
+        if (oldLevel === undefined) {
+            // This name doesn't appear in lower scope, and this is the first time we've seen it in the current scope.
+            this.nameToLevel.set(name, level);
+            this.namesAddedToCurrentScope[level].push(name);
+            return;
+        }
+
+        if (isMergeable && level === (typeof oldLevel === "number" ? oldLevel : oldLevel[oldLevel.length - 1])) {
+            // This name appears another time in this same scope, and that's fine.
+            return;
+        }
+
+        // This name appears in a lower scope, or in the current scope and it's not mergeable.
+        // Since this is a failure, just pretend this doesn't exist.
+        this.addFailureAtNode(id, Rule.FAILURE_STRING(name));
+    }
+}
+
+function eachIdentifier(node: ts.BindingName, action: (id: ts.Identifier) => void): void {
+    switch (node.kind) {
+        case ts.SyntaxKind.Identifier:
+            action(node);
+            break;
+
+        case ts.SyntaxKind.ObjectBindingPattern:
+            for (const e of node.elements) {
+                eachIdentifier(e.name, action);
+            }
+            break;
+
+        case ts.SyntaxKind.ArrayBindingPattern:
+            for (const e of node.elements) {
+                if (e.kind !== ts.SyntaxKind.OmittedExpression) {
+                    eachIdentifier(e.name, action);
+                }
+            }
+            break;
+    }
+}
+
+type NonSignatureDeclaration =
+    | ts.NamespaceDeclaration
+    | ts.TypeAliasDeclaration
+    | ts.InterfaceDeclaration
+    | ts.ClassDeclaration
+    | ts.ClassExpression;
+function isNonSignatureDeclaration(node: ts.Node): node is NonSignatureDeclaration {
+    switch (node.kind) {
+        case ts.SyntaxKind.ModuleDeclaration: {
+            const { name } = node as ts.ModuleDeclaration;
+            return name.kind === ts.SyntaxKind.Identifier;
+        }
+        case ts.SyntaxKind.TypeAliasDeclaration:
+        case ts.SyntaxKind.InterfaceDeclaration:
+        case ts.SyntaxKind.ClassDeclaration:
+        case ts.SyntaxKind.ClassExpression:
+            return true;
+        default:
+            return false;
+    }
+}
+
+type SignatureLike =
+    | ts.FunctionDeclaration
+    | ts.FunctionExpression
+    | ts.ArrowFunction
+    | ts.MethodDeclaration
+    | ts.MethodSignature
+    | ts.ConstructSignatureDeclaration
+    | ts.ConstructorDeclaration
+    | ts.CallSignatureDeclaration;
+function isSignatureLike(node: ts.Node): node is SignatureLike {
+    switch (node.kind) {
+        case ts.SyntaxKind.FunctionDeclaration:
+        case ts.SyntaxKind.FunctionExpression:
+        case ts.SyntaxKind.ArrowFunction:
+        case ts.SyntaxKind.MethodDeclaration:
+        case ts.SyntaxKind.MethodSignature:
+        case ts.SyntaxKind.ConstructSignature:
+        case ts.SyntaxKind.Constructor:
+        case ts.SyntaxKind.CallSignature:
+            return true;
+        default:
+            return false;
     }
 }

--- a/test/rules/no-shadowed-variable/test.ts.lint
+++ b/test/rules/no-shadowed-variable/test.ts.lint
@@ -217,3 +217,38 @@ for (let i = 0; i < 3; i++) {
     let i = 34;
         ~       [Shadowed variable: 'i']
 }
+
+class C<C> {
+        ~ [C]
+    C<C>(C: C): C {
+      ~ [C]
+         ~ [C]
+        type C = C;
+             ~ [C]
+        namespace C {
+                  ~ [C]
+            interface C<C> {}
+                      ~ [C]
+                        ~ [C]
+        }
+    }
+}
+
+
+// Allow mergeable declarations.
+interface I {}
+interface I {}
+
+// Do not allow non-mergeable declarations.
+function f() {
+    const f = 0;
+          ~ [f]
+}
+
+// Exempt 'this'
+function f(this): void {
+    function inner(this): void {}
+}
+
+[C]: Shadowed variable: 'C'
+[f]: Shadowed variable: 'f'


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2214
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### Overview of change:

Complete rewrite of `no-shadowed-variable`.
Now checks for shadowing of types too (e.g. `interface Foo { m<Foo>(): Foo }`).
Also now no ignores variables named 'this'.