### PR TITLE
Bugfix for radix rule and property access

### DIFF
--- a/src/rules/radixRule.ts
+++ b/src/rules/radixRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { isCallExpression, isIdentifier, isPropertyAccessExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -39,21 +40,27 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Missing radix parameter";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const radixWalker = new RadixWalker(sourceFile, this.getOptions());
-        return this.applyWithWalker(radixWalker);
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class RadixWalker extends Lint.RuleWalker {
-    public visitCallExpression(node: ts.CallExpression) {
-        const expression = node.expression;
-
-        if (expression.kind === ts.SyntaxKind.Identifier
-                && node.getFirstToken().getText() === "parseInt"
-                && node.arguments.length < 2) {
-            this.addFailureAtNode(node, Rule.FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (isCallExpression(node) && node.arguments.length === 1 &&
+            (
+                // parseInt("123")
+                isIdentifier(node.expression) && node.expression.text === "parseInt" ||
+                // window.parseInt("123") || global.parseInt("123")
+                isPropertyAccessExpression(node.expression) &&
+                node.expression.name.text === "parseInt" &&
+                isIdentifier(node.expression.expression) &&
+                (
+                    node.expression.expression.text === "global" ||
+                    node.expression.expression.text === "window"
+                )
+            )) {
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
-
-        super.visitCallExpression(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/test/rules/radix/test.ts.lint
+++ b/test/rules/radix/test.ts.lint
@@ -2,3 +2,12 @@ var x = parseInt(3, 10) +
         parseInt(4);
         ~~~~~~~~~~~  [Missing radix parameter]
 var y = parseFloat("2.5");
+
+parser.parseInt("123");
+obj.parser.parseInt("123");
+
+global.parseInt("123");
+~~~~~~~~~~~~~~~~~~~~~~  [Missing radix parameter]
+global.global.parseInt("123");
+window.parseInt("123");
+~~~~~~~~~~~~~~~~~~~~~~  [Missing radix parameter]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2281 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] don't warn for missing radix on method calls
[enhancement] added check for global.parseInt and window.parseInt