### PR TITLE
[Breaking change] Remove `createFix`, and just use the Replacement(s) as the fix.

### DIFF
--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -17,6 +17,7 @@
 
 import * as ts from "typescript";
 
+import {arrayify, flatMap} from "../../utils";
 import {IWalker} from "../walker";
 
 export interface IRuleMetadata {
@@ -132,14 +133,18 @@ export function isTypedRule(rule: IRule): rule is ITypedRule {
 }
 
 export class Replacement {
+    public static applyFixes(content: string, fixes: Fix[]): string {
+        return this.applyAll(content, flatMap(fixes, arrayify));
+    }
+
     public static applyAll(content: string, replacements: Replacement[]) {
         // sort in reverse so that diffs are properly applied
         replacements.sort((a, b) => b.end - a.end);
         return replacements.reduce((text, r) => r.apply(text), content);
     }
 
-    public static replaceNode(node: ts.Node, text: string): Replacement {
-        return this.replaceFromTo(node.getStart(), node.getEnd(), text);
+    public static replaceNode(node: ts.Node, text: string, sourceFile?: ts.SourceFile): Replacement {
+        return this.replaceFromTo(node.getStart(sourceFile), node.getEnd(), text);
     }
 
     public static replaceFromTo(start: number, end: number, text: string) {
@@ -158,23 +163,10 @@ export class Replacement {
         return new Replacement(start, 0, text);
     }
 
-    constructor(private innerStart: number, private innerLength: number, private innerText: string) {
-    }
-
-    get start() {
-        return this.innerStart;
-    }
-
-    get length() {
-        return this.innerLength;
-    }
+    constructor(readonly start: number, readonly length: number, readonly text: string) {}
 
     get end() {
-        return this.innerStart + this.innerLength;
-    }
-
-    get text() {
-        return this.innerText;
+        return this.start + this.length;
     }
 
     public apply(content: string) {
@@ -182,22 +174,7 @@ export class Replacement {
     }
 }
 
-export class Fix {
-    public static applyAll(content: string, fixes: Fix[]) {
-        // accumulate replacements
-        let replacements: Replacement[] = [];
-        for (const fix of fixes) {
-            replacements = replacements.concat(fix.replacements);
-        }
-        return Replacement.applyAll(content, replacements);
-    }
-
-    constructor(readonly replacements: Replacement[]) {}
-
-    public apply(content: string) {
-        return Replacement.applyAll(content, this.replacements);
-    }
-}
+export type Fix = Replacement | Replacement[];
 
 export class RuleFailurePosition {
     constructor(private position: number, private lineAndCharacter: ts.LineAndCharacter) {
@@ -242,14 +219,14 @@ export class RuleFailure {
                 end: number,
                 private failure: string,
                 private ruleName: string,
-                fix?: Replacement | Replacement[]) {
+                fix?: Fix) {
 
         this.fileName = sourceFile.fileName;
         this.startPosition = this.createFailurePosition(start);
         this.endPosition = this.createFailurePosition(end);
         this.rawLines = sourceFile.text;
         this.ruleSeverity = "error";
-        this.fix = fix ? new Fix(Array.isArray(fix) ? fix : [fix]) : undefined;
+        this.fix = fix;
     }
 
     public getFileName() {

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -17,7 +17,7 @@
 
 import * as ts from "typescript";
 
-import {IOptions, Replacement, RuleFailure} from "../rule/rule";
+import {Fix, IOptions, Replacement, RuleFailure} from "../rule/rule";
 import {SyntaxWalker} from "./syntaxWalker";
 import {IWalker} from "./walker";
 
@@ -65,7 +65,7 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
     }
 
     /** @deprecated Prefer `addFailureAt` and its variants. */
-    public createFailure(start: number, width: number, failure: string, fix?: Replacement | Replacement[]): RuleFailure {
+    public createFailure(start: number, width: number, failure: string, fix?: Fix): RuleFailure {
         const from = (start > this.limit) ? this.limit : start;
         const to = ((start + width) > this.limit) ? this.limit : (start + width);
         return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName, fix);
@@ -77,17 +77,17 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
     }
 
     /** Add a failure with any arbitrary span. Prefer `addFailureAtNode` if possible. */
-    public addFailureAt(start: number, width: number, failure: string, fix?: Replacement | Replacement[]) {
+    public addFailureAt(start: number, width: number, failure: string, fix?: Fix) {
         this.addFailure(this.createFailure(start, width, failure, fix));
     }
 
     /** Like `addFailureAt` but uses start and end instead of start and width. */
-    public addFailureFromStartToEnd(start: number, end: number, failure: string, fix?: Replacement | Replacement[]) {
+    public addFailureFromStartToEnd(start: number, end: number, failure: string, fix?: Fix) {
         this.addFailureAt(start, end - start, failure, fix);
     }
 
     /** Add a failure using a node's span. */
-    public addFailureAtNode(node: ts.Node, failure: string, fix?: Replacement | Replacement[]) {
+    public addFailureAtNode(node: ts.Node, failure: string, fix?: Fix) {
         this.addFailureAt(node.getStart(this.sourceFile), node.getWidth(this.sourceFile), failure, fix);
     }
 

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -17,7 +17,7 @@
 
 import * as ts from "typescript";
 
-import {Fix, IOptions, Replacement, RuleFailure} from "../rule/rule";
+import {IOptions, Replacement, RuleFailure} from "../rule/rule";
 import {SyntaxWalker} from "./syntaxWalker";
 import {IWalker} from "./walker";
 
@@ -65,7 +65,7 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
     }
 
     /** @deprecated Prefer `addFailureAt` and its variants. */
-    public createFailure(start: number, width: number, failure: string, fix?: Fix): RuleFailure {
+    public createFailure(start: number, width: number, failure: string, fix?: Replacement | Replacement[]): RuleFailure {
         const from = (start > this.limit) ? this.limit : start;
         const to = ((start + width) > this.limit) ? this.limit : (start + width);
         return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName, fix);
@@ -77,17 +77,17 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
     }
 
     /** Add a failure with any arbitrary span. Prefer `addFailureAtNode` if possible. */
-    public addFailureAt(start: number, width: number, failure: string, fix?: Fix) {
+    public addFailureAt(start: number, width: number, failure: string, fix?: Replacement | Replacement[]) {
         this.addFailure(this.createFailure(start, width, failure, fix));
     }
 
     /** Like `addFailureAt` but uses start and end instead of start and width. */
-    public addFailureFromStartToEnd(start: number, end: number, failure: string, fix?: Fix) {
+    public addFailureFromStartToEnd(start: number, end: number, failure: string, fix?: Replacement | Replacement[]) {
         this.addFailureAt(start, end - start, failure, fix);
     }
 
     /** Add a failure using a node's span. */
-    public addFailureAtNode(node: ts.Node, failure: string, fix?: Fix) {
+    public addFailureAtNode(node: ts.Node, failure: string, fix?: Replacement | Replacement[]) {
         this.addFailureAt(node.getStart(this.sourceFile), node.getWidth(this.sourceFile), failure, fix);
     }
 
@@ -109,9 +109,5 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
 
     public getRuleName(): string {
         return this.ruleName;
-    }
-
-    public createFix(...replacements: Replacement[]): Fix {
-        return new Fix(this.ruleName, replacements);
     }
 }

--- a/src/language/walker/walkContext.ts
+++ b/src/language/walker/walkContext.ts
@@ -17,7 +17,7 @@
 
 import * as ts from "typescript";
 
-import { Replacement, RuleFailure } from "../rule/rule";
+import { Fix, RuleFailure } from "../rule/rule";
 
 export class WalkContext<T> {
     public readonly failures: RuleFailure[] = [];
@@ -25,19 +25,18 @@ export class WalkContext<T> {
     constructor(public readonly sourceFile: ts.SourceFile, public readonly ruleName: string, public readonly options: T) {}
 
     /** Add a failure with any arbitrary span. Prefer `addFailureAtNode` if possible. */
-    public addFailureAt(start: number, width: number, failure: string, fix?: Replacement | Replacement[]) {
+    public addFailureAt(start: number, width: number, failure: string, fix?: Fix) {
         this.addFailure(start, start + width, failure, fix);
     }
 
-    public addFailure(start: number, end: number, failure: string, fix?: Replacement | Replacement[]) {
-        const fileLength = this.sourceFile.end;
-        start = Math.min(start, fileLength);
-        end = Math.min(end, fileLength);
+    public addFailure(start: number, end: number, failure: string, fix?: Fix) {
+        start = Math.min(start, this.sourceFile.end);
+        end = Math.min(end, this.sourceFile.end);
         this.failures.push(new RuleFailure(this.sourceFile, start, end, failure, this.ruleName, fix));
     }
 
     /** Add a failure using a node's span. */
-    public addFailureAtNode(node: ts.Node, failure: string, fix?: Replacement | Replacement[]) {
+    public addFailureAtNode(node: ts.Node, failure: string, fix?: Fix) {
         this.addFailure(node.getStart(this.sourceFile), node.getEnd(), failure, fix);
     }
 }

--- a/src/language/walker/walkContext.ts
+++ b/src/language/walker/walkContext.ts
@@ -17,7 +17,7 @@
 
 import * as ts from "typescript";
 
-import { Fix, Replacement, RuleFailure } from "../rule/rule";
+import { Replacement, RuleFailure } from "../rule/rule";
 
 export class WalkContext<T> {
     public readonly failures: RuleFailure[] = [];
@@ -25,23 +25,19 @@ export class WalkContext<T> {
     constructor(public readonly sourceFile: ts.SourceFile, public readonly ruleName: string, public readonly options: T) {}
 
     /** Add a failure with any arbitrary span. Prefer `addFailureAtNode` if possible. */
-    public addFailureAt(start: number, width: number, failure: string, fix?: Fix) {
+    public addFailureAt(start: number, width: number, failure: string, fix?: Replacement | Replacement[]) {
         this.addFailure(start, start + width, failure, fix);
     }
 
-    public addFailure(start: number, end: number, failure: string, fix?: Fix) {
+    public addFailure(start: number, end: number, failure: string, fix?: Replacement | Replacement[]) {
         const fileLength = this.sourceFile.end;
-        this.failures.push(
-            new RuleFailure(this.sourceFile, Math.min(start, fileLength), Math.min(end, fileLength), failure, this.ruleName, fix),
-        );
+        start = Math.min(start, fileLength);
+        end = Math.min(end, fileLength);
+        this.failures.push(new RuleFailure(this.sourceFile, start, end, failure, this.ruleName, fix));
     }
 
     /** Add a failure using a node's span. */
-    public addFailureAtNode(node: ts.Node, failure: string, fix?: Fix) {
+    public addFailureAtNode(node: ts.Node, failure: string, fix?: Replacement | Replacement[]) {
         this.addFailure(node.getStart(this.sourceFile), node.getEnd(), failure, fix);
-    }
-
-    public createFix(...replacements: Replacement[]) {
-        return new Fix(this.ruleName, replacements);
     }
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -34,7 +34,7 @@ import { isError, showWarningOnce } from "./error";
 import { findFormatter } from "./formatterLoader";
 import { ILinterOptions, LintResult } from "./index";
 import { IFormatter } from "./language/formatter/formatter";
-import { Fix, IRule, isTypedRule, RuleFailure, RuleSeverity } from "./language/rule/rule";
+import { Fix, IRule, isTypedRule, Replacement, RuleFailure, RuleSeverity } from "./language/rule/rule";
 import * as utils from "./language/utils";
 import { loadRules } from "./ruleLoader";
 import { arrayify, dedent } from "./utils";
@@ -108,7 +108,7 @@ class Linter {
                 source = fs.readFileSync(fileName, { encoding: "utf-8" });
                 if (fixes.length > 0) {
                     this.fixes = this.fixes.concat(ruleFailures);
-                    source = Fix.applyAll(source, fixes);
+                    source = Replacement.applyFixes(source, fixes);
                     fs.writeFileSync(fileName, source, { encoding: "utf-8" });
 
                     // reload AST if file is modified

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -108,13 +108,9 @@ class AlignWalker extends Lint.RuleWalker {
             const curPos = this.getLineAndCharacterOfPosition(node.getStart());
             if (curPos.line !== prevPos.line && curPos.character !== alignToColumn) {
                 const diff = alignToColumn - curPos.character;
-                let fix;
-                if (0 < diff) {
-                    fix = this.createFix(this.appendText(node.getStart(), " ".repeat(diff)));
-                } else {
-                    fix = this.createFix(this.deleteText(node.getStart() + diff, -diff));
-                }
-                this.addFailureAtNode(node, kind + Rule.FAILURE_STRING_SUFFIX, fix);
+                this.addFailureAtNode(node, kind + Rule.FAILURE_STRING_SUFFIX, 0 < diff
+                    ? this.appendText(node.getStart(), " ".repeat(diff))
+                    : this.deleteText(node.getStart() + diff, -diff));
             }
             prevPos = curPos;
         }

--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -65,12 +65,11 @@ class ArrayTypeWalker extends Lint.RuleWalker {
             // Add a space if the type is preceded by 'as' and the node has no leading whitespace
             const space = !parens && node.parent!.kind === ts.SyntaxKind.AsExpression &&
                 node.getStart() === node.getFullStart() ? " " : "";
-            const fix = this.createFix(
+            this.addFailureAtNode(node, failureString, [
                 this.createReplacement(typeName.getStart(), parens, space + "Array<"),
                 // Delete the square brackets and replace with an angle bracket
                 this.createReplacement(typeName.getEnd() - parens, node.getEnd() - typeName.getEnd() + parens, ">"),
-            );
-            this.addFailureAtNode(node, failureString, fix);
+            ]);
         }
 
         super.visitArrayType(node);
@@ -83,21 +82,19 @@ class ArrayTypeWalker extends Lint.RuleWalker {
             const typeArgs = node.typeArguments;
             if (!typeArgs || typeArgs.length === 0) {
                 // Create an 'any' array
-                const fix = this.createFix(this.createReplacement(node.getStart(), node.getWidth(), "any[]"));
-                this.addFailureAtNode(node, failureString, fix);
+                this.addFailureAtNode(node, failureString, this.createReplacement(node.getStart(), node.getWidth(), "any[]"));
             } else if (typeArgs && typeArgs.length === 1 && (!this.hasOption(OPTION_ARRAY_SIMPLE) || this.isSimpleType(typeArgs[0]))) {
                 const type = typeArgs[0];
                 const typeStart = type.getStart();
                 const typeEnd = type.getEnd();
                 const parens = type.kind === ts.SyntaxKind.UnionType ||
                     type.kind === ts.SyntaxKind.FunctionType || type.kind === ts.SyntaxKind.IntersectionType;
-                const fix = this.createFix(
+                this.addFailureAtNode(node, failureString, [
                     // Delete Array and the first angle bracket
                     this.createReplacement(node.getStart(), typeStart - node.getStart(), parens ? "(" : ""),
                     // Delete the last angle bracket and replace with square brackets
                     this.createReplacement(typeEnd, node.getEnd() - typeEnd, (parens ? ")" : "") + "[]"),
-                );
-                this.addFailureAtNode(node, failureString, fix);
+                ]);
             }
         }
 

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -65,17 +65,17 @@ function walk(ctx: Lint.WalkContext<Options>) {
                     const parameter = node.parameters[0];
                     const start = parameter.getStart(ctx.sourceFile);
                     const end = parameter.end;
-                    ctx.addFailure(start, end, Rule.FAILURE_STRING_MISSING, ctx.createFix(
+                    ctx.addFailure(start, end, Rule.FAILURE_STRING_MISSING, [
                         Lint.Replacement.appendText(start, "("),
                         Lint.Replacement.appendText(end, ")"),
-                    ));
+                    ]);
                 }
             } else if (ctx.options.banSingleArgParens) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
-                ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, ctx.createFix(
+                ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
                     Lint.Replacement.deleteText(openParen.end - 1, 1),
                     Lint.Replacement.deleteText(closeParen.end - 1, 1),
-                ));
+                ]);
             }
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -67,7 +67,8 @@ class Walker extends Lint.RuleWalker {
         return getLine(node.getEnd()) > getLine(node.getStart());
     }
 
-    private createArrowFunctionFix(arrowFunction: ts.FunctionLikeDeclaration, body: ts.Block, expr: ts.Expression): Lint.Fix | undefined {
+    private createArrowFunctionFix(arrowFunction: ts.FunctionLikeDeclaration, body: ts.Block, expr: ts.Expression,
+        ): Lint.Replacement[] | undefined {
         const text = this.getSourceFile().text;
         const statement = expr.parent!;
         const returnKeyword = Lint.childOfKind(statement, ts.SyntaxKind.ReturnKeyword)!;
@@ -78,7 +79,7 @@ class Walker extends Lint.RuleWalker {
 
         const anyComments = hasComments(arrow) || hasComments(openBrace) || hasComments(statement) || hasComments(returnKeyword) ||
             hasComments(expr) || (semicolon && hasComments(semicolon)) || hasComments(closeBrace);
-        return anyComments ? undefined : this.createFix(
+        return anyComments ? undefined : [
             // Object literal must be wrapped in `()`
             ...(expr.kind === ts.SyntaxKind.ObjectLiteralExpression ? [
                 this.appendText(expr.getStart(), "("),
@@ -90,7 +91,7 @@ class Walker extends Lint.RuleWalker {
             this.deleteFromTo(statement.getStart(), expr.getStart()),
             // " }" (may include semicolon)
             this.deleteFromTo(expr.end, closeBrace.end),
-        );
+        ];
 
         function hasComments(node: ts.Node): boolean {
             return ts.getTrailingCommentRanges(text, node.getEnd()) !== undefined;

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -17,6 +17,7 @@
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import {flatMap, mapDefined} from "../utils";
 
 const OPTION_ORDER = "order";
 const OPTION_ALPHABETIZE = "alphabetize";
@@ -477,23 +478,4 @@ function nameString(name: ts.PropertyName): string {
         default:
             return "";
     }
-}
-
-function mapDefined<T, U>(inputs: T[], getOutput: (input: T) => U | undefined): U[] {
-    const out = [];
-    for (const input of inputs) {
-        const output = getOutput(input);
-        if (output !== undefined) {
-            out.push(output);
-        }
-    }
-    return out;
-}
-
-function flatMap<T, U>(inputs: T[], getOutputs: (input: T) => U[]): U[] {
-    const out = [];
-    for (const input of inputs) {
-        out.push(...getOutputs(input));
-    }
-    return out;
 }

--- a/src/rules/noAngleBracketTypeAssertionRule.ts
+++ b/src/rules/noAngleBracketTypeAssertionRule.ts
@@ -47,13 +47,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoAngleBracketTypeAssertionWalker extends Lint.RuleWalker {
     public visitTypeAssertionExpression(node: ts.TypeAssertion) {
         const { expression, type } = node;
-        const fix = this.createFix(
+        this.addFailureAtNode(node, Rule.FAILURE_STRING, [
             // add 'as' syntax at end
             this.createReplacement(node.getEnd(), 0, ` as ${type.getText()}`),
             // delete the angle bracket assertion
             this.createReplacement(node.getStart(), expression.getStart() - node.getStart(), ""),
-        );
-        this.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
+        ]);
         super.visitTypeAssertionExpression(node);
     }
 }

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -39,16 +39,16 @@ export class Rule extends Lint.Rules.AbstractRule {
         "or suppress this occurrence.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoAnyWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoAnyWalker extends Lint.RuleWalker {
-    public visitAnyKeyword(node: ts.Node) {
-        const fix = this.createFix(
-            this.createReplacement(node.getStart(), node.getWidth(), "{}"),
-        );
-        this.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
-        super.visitAnyKeyword(node);
-    }
+function walk(ctx: Lint.WalkContext<void>): void {
+    ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.AnyKeyword) {
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING, Lint.Replacement.replaceNode(node, "{}"));
+        } else {
+            return ts.forEachChild(node, cb);
+        }
+    });
 }

--- a/src/rules/noBooleanLiteralCompareRule.ts
+++ b/src/rules/noBooleanLiteralCompareRule.ts
@@ -74,7 +74,7 @@ class Walker extends Lint.ProgramAwareRuleWalker {
             }
         }
 
-        this.addFailureAtNode(expression, Rule.FAILURE_STRING(negate), this.createFix(...replacements));
+        this.addFailureAtNode(expression, Rule.FAILURE_STRING(negate), replacements);
     }
 }
 

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -92,14 +92,12 @@ function walk(ctx: Lint.WalkContext<number>) {
     const templateRanges = getTemplateRanges(ctx.sourceFile);
     for (const possibleFailure of possibleFailures) {
         if (!templateRanges.some((template) => template.pos < possibleFailure.pos && possibleFailure.pos < template.end)) {
-            ctx.addFailureAt(possibleFailure.pos, 1, failureString, ctx.createFix(
-                Lint.Replacement.deleteFromTo(
-                    // special handling for fixing blank lines at the end of the file
-                    // to fix this we need to cut off the line break of the last allowed blank line, too
-                    possibleFailure.end === sourceText.length ? getStartOfLineBreak(sourceText, possibleFailure.pos) : possibleFailure.pos,
-                    possibleFailure.end,
-                ),
-            ));
+            // special handling for fixing blank lines at the end of the file
+            // to fix this we need to cut off the line break of the last allowed blank line, too
+            const start = possibleFailure.end === sourceText.length
+                ? getStartOfLineBreak(sourceText, possibleFailure.pos)
+                : possibleFailure.pos;
+            ctx.addFailureAt(possibleFailure.pos, 1, failureString, Lint.Replacement.deleteFromTo(start, possibleFailure.end));
         }
     }
 }

--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -98,23 +98,23 @@ class NoInferrableTypesWalker extends Lint.AbstractWalker<IOptions> {
         return ts.forEachChild(sourceFile, cb);
     }
 
-    private checkDeclaration(node: ts.VariableLikeDeclaration) {
-        if (node.type != null && node.initializer != null) {
-            let failure: string | null = null;
+    private checkDeclaration({ name, type, initializer }: ts.VariableLikeDeclaration) {
+        if (type != null && initializer != null) {
+            let failure: string | undefined;
 
-            switch (node.type.kind) {
+            switch (type.kind) {
                 case ts.SyntaxKind.BooleanKeyword:
-                    if (node.initializer.kind === ts.SyntaxKind.TrueKeyword || node.initializer.kind === ts.SyntaxKind.FalseKeyword) {
+                    if (initializer.kind === ts.SyntaxKind.TrueKeyword || initializer.kind === ts.SyntaxKind.FalseKeyword) {
                         failure = "boolean";
                     }
                     break;
                 case ts.SyntaxKind.NumberKeyword:
-                    if (node.initializer.kind === ts.SyntaxKind.NumericLiteral) {
+                    if (initializer.kind === ts.SyntaxKind.NumericLiteral) {
                         failure = "number";
                     }
                     break;
                 case ts.SyntaxKind.StringKeyword:
-                    switch (node.initializer.kind) {
+                    switch (initializer.kind) {
                         case ts.SyntaxKind.StringLiteral:
                         case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
                         case ts.SyntaxKind.TemplateExpression:
@@ -128,11 +128,8 @@ class NoInferrableTypesWalker extends Lint.AbstractWalker<IOptions> {
                     break;
             }
 
-            if (failure != null) {
-                this.addFailureAtNode(node.type,
-                                      Rule.FAILURE_STRING_FACTORY(failure),
-                                      this.createFix(Lint.Replacement.deleteFromTo(node.name.end, node.type.end)),
-                );
+            if (failure !== undefined) {
+                this.addFailureAtNode(type, Rule.FAILURE_STRING_FACTORY(failure), Lint.Replacement.deleteFromTo(name.end, type.end));
             }
         }
     }

--- a/src/rules/noStringThrowRule.ts
+++ b/src/rules/noStringThrowRule.ts
@@ -45,11 +45,8 @@ class Walker extends Lint.RuleWalker {
     public visitThrowStatement(node: ts.ThrowStatement) {
         const {expression} = node;
         if (this.stringConcatRecursive(expression)) {
-            const fix = this.createFix(this.createReplacement(expression.getStart(),
-                                                              expression.getEnd() - expression.getStart(),
-                                                              `new Error(${expression.getText()})`));
-            this.addFailure(this.createFailure(
-                    node.getStart(), node.getWidth(), Rule.FAILURE_STRING, fix));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING,
+                Lint.Replacement.replaceNode(expression, `new Error(${expression.getText()})`));
         }
 
         super.visitThrowStatement(node);

--- a/src/rules/noTrailingWhitespaceRule.ts
+++ b/src/rules/noTrailingWhitespaceRule.ts
@@ -120,5 +120,5 @@ function walk(ctx: Lint.WalkContext<IgnoreOption>) {
 }
 
 function reportFailure(ctx: Lint.WalkContext<IgnoreOption>, start: number, end: number) {
-    ctx.addFailure(start, end, Rule.FAILURE_STRING, ctx.createFix(Lint.Replacement.deleteFromTo(start, end)));
+    ctx.addFailure(start, end, Rule.FAILURE_STRING, Lint.Replacement.deleteFromTo(start, end));
 }

--- a/src/rules/noUnnecessaryCallbackWrapperRule.ts
+++ b/src/rules/noUnnecessaryCallbackWrapperRule.ts
@@ -45,19 +45,17 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function walk(ctx: Lint.WalkContext<void>) {
-    return ts.forEachChild(ctx.sourceFile, cb);
-    function cb(node: ts.Node): void {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         const fn = detectRedundantCallback(node);
         if (fn) {
-            const fix = ctx.createFix(
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING(fn.getText()), [
                 Lint.Replacement.deleteFromTo(node.getStart(), fn.getStart()),
-                Lint.Replacement.deleteFromTo(fn.getEnd(), node.getEnd()));
-            ctx.addFailureAtNode(node, Rule.FAILURE_STRING(fn.getText()), fix);
+                Lint.Replacement.deleteFromTo(fn.getEnd(), node.getEnd()),
+            ]);
         } else {
             return ts.forEachChild(node, cb);
         }
-    }
-
+    });
 }
 
 // Returns the `f` in `x => f(x)`.

--- a/src/rules/noUnnecessaryInitializerRule.ts
+++ b/src/rules/noUnnecessaryInitializerRule.ts
@@ -92,10 +92,8 @@ class Walker extends Lint.RuleWalker {
     }
 
     private failWithFix(node: ts.VariableDeclaration | ts.BindingElement | ts.ParameterDeclaration) {
-        const fix = this.createFix(this.deleteFromTo(
-            Lint.childOfKind(node, ts.SyntaxKind.EqualsToken)!.pos,
-            node.end));
-        this.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
+        const start = Lint.childOfKind(node, ts.SyntaxKind.EqualsToken)!.pos;
+        this.addFailureAtNode(node, Rule.FAILURE_STRING, this.deleteFromTo(start, node.end));
     }
 }
 

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -80,8 +80,8 @@ class Walker extends Lint.ProgramAwareRuleWalker {
 
     private visitNamespaceAccess(node: ts.Node, qualifier: ts.EntityNameOrEntityNameExpression, name: ts.Identifier) {
         if (this.qualifierIsUnnecessary(qualifier, name)) {
-            const fix = this.createFix(this.deleteFromTo(qualifier.getStart(), name.getStart()));
-            this.addFailureAtNode(qualifier, Rule.FAILURE_STRING(qualifier.getText()), fix);
+            this.addFailureAtNode(qualifier, Rule.FAILURE_STRING(qualifier.getText()),
+                this.deleteFromTo(qualifier.getStart(), name.getStart()));
         } else {
             // Only look for nested qualifier errors if we didn't already fail on the outer qualifier.
             super.visitNode(node);

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -179,17 +179,15 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<void>, failures: Map<t
             if (failure !== undefined) {
                 const start = defaultName.getStart();
                 const end = namedBindings ? namedBindings.getStart() : importNode.moduleSpecifier.getStart();
-                const fix = ctx.createFix(Lint.Replacement.deleteFromTo(start, end));
-                ctx.addFailureAtNode(defaultName, failure, fix);
+                ctx.addFailureAtNode(defaultName, failure, Lint.Replacement.deleteFromTo(start, end));
             }
         }
 
         if (namedBindings) {
             if (allNamedBindingsAreFailures) {
                 const start = defaultName ? defaultName.getEnd() : namedBindings.getStart();
-                const fix = ctx.createFix(Lint.Replacement.deleteFromTo(start, namedBindings.getEnd()));
                 const failure = "All named bindings are unused.";
-                ctx.addFailureAtNode(namedBindings, failure, fix);
+                ctx.addFailureAtNode(namedBindings, failure, Lint.Replacement.deleteFromTo(start, namedBindings.getEnd()));
             } else {
                 const { elements } = namedBindings;
                 for (let i = 0; i < elements.length; i++) {
@@ -203,8 +201,7 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<void>, failures: Map<t
                     const nextElement = elements[i + 1];
                     const start = prevElement ? prevElement.getEnd() : element.getStart();
                     const end = nextElement && !prevElement ? nextElement.getStart() : element.getEnd();
-                    const fix = ctx.createFix(Lint.Replacement.deleteFromTo(start, end));
-                    ctx.addFailureAtNode(element.name, failure, fix);
+                    ctx.addFailureAtNode(element.name, failure, Lint.Replacement.deleteFromTo(start, end));
                 }
             }
         }
@@ -217,8 +214,7 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<void>, failures: Map<t
         }
 
         function removeAll(errorNode: ts.Node, failure: string): void {
-            const fix = ctx.createFix(Lint.Replacement.deleteFromTo(importNode.getStart(), importNode.getEnd()));
-            ctx.addFailureAtNode(errorNode, failure, fix);
+            ctx.addFailureAtNode(errorNode, failure, Lint.Replacement.deleteFromTo(importNode.getStart(), importNode.getEnd()));
         }
     });
 

--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -76,8 +76,6 @@ class NoVarKeywordWalker extends Lint.RuleWalker {
 
     private reportFailure(node: ts.Node) {
         const nodeStart = node.getStart(this.getSourceFile());
-        this.addFailureAt(nodeStart, "var".length, Rule.FAILURE_STRING, this.createFix(
-            this.createReplacement(nodeStart, "var".length, "let"),
-        ));
+        this.addFailureAt(nodeStart, "var".length, Rule.FAILURE_STRING, this.createReplacement(nodeStart, "var".length, "let"));
     }
 }

--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -122,7 +122,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
     private allMustHaveQuotes(properties: ts.ObjectLiteralElementLike[]) {
         for (const { name } of properties) {
             if (name !== undefined && name.kind !== ts.SyntaxKind.StringLiteral && name.kind !== ts.SyntaxKind.ComputedPropertyName) {
-                const fix = this.createFix(this.appendText(name.getStart(), '"'), this.appendText(name.getEnd(), '"'));
+                const fix = [this.appendText(name.getStart(), '"'), this.appendText(name.getEnd(), '"')];
                 this.addFailureAtNode(name, Rule.UNQUOTED_PROPERTY(name.getText()), fix);
             }
         }
@@ -131,7 +131,7 @@ class ObjectLiteralKeyQuotesWalker extends Lint.RuleWalker {
     private noneMayHaveQuotes(properties: ts.ObjectLiteralElementLike[], noneNeedQuotes?: boolean) {
         for (const { name } of properties) {
             if (name !== undefined && name.kind === ts.SyntaxKind.StringLiteral && (noneNeedQuotes || !propertyNeedsQuotes(name.text))) {
-                const fix = this.createFix(this.deleteText(name.getStart(), 1), this.deleteText(name.getEnd() - 1, 1));
+                const fix = [this.deleteText(name.getStart(), 1), this.deleteText(name.getEnd() - 1, 1)];
                 this.addFailureAtNode(name, Rule.UNNEEDED_QUOTES(name.text), fix);
             }
         }

--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -51,10 +51,7 @@ class ObjectLiteralShorthandWalker extends Lint.RuleWalker {
             value.kind === ts.SyntaxKind.Identifier &&
             name.getText() === value.getText()) {
                 // Delete from name start up to value to include the ':'.
-                const lengthToValueStart = value.getStart() - name.getStart();
-                const fix = this.createFix(
-                    this.deleteText(name.getStart(), lengthToValueStart),
-                );
+                const fix = this.deleteFromTo(name.getStart(), value.getStart());
                 this.addFailureAtNode(node, Rule.LONGHAND_PROPERTY + `('{${name.getText()}}').`, fix);
         }
 

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -154,7 +154,7 @@ const TRANSFORMS: {[ordering: string]: (x: string) => string} = {
 class OrderedImportsWalker extends Lint.RuleWalker {
     private currentImportsBlock: ImportsBlock = new ImportsBlock();
     // keep a reference to the last Fix object so when the entire block is replaced, the replacement can be added
-    private lastFix: Lint.Fix | null;
+    private lastFix: Lint.Replacement[] | null;
     private importSourcesOrderTransform: (x: string) => string;
     private namedImportsOrderTransform: (x: string) => string;
 
@@ -177,7 +177,7 @@ class OrderedImportsWalker extends Lint.RuleWalker {
         this.currentImportsBlock.addImportDeclaration(this.getSourceFile(), node, source);
 
         if (previousSource && compare(source, previousSource) === -1) {
-            this.lastFix = this.createFix();
+            this.lastFix = [];
             this.addFailureAtNode(node, Rule.IMPORT_SOURCES_UNORDERED, this.lastFix);
         }
 
@@ -202,7 +202,7 @@ class OrderedImportsWalker extends Lint.RuleWalker {
                 this.currentImportsBlock.replaceNamedImports(start, length, sortedDeclarations[i]);
             }
 
-            this.lastFix = this.createFix();
+            this.lastFix = [];
             this.addFailureFromStartToEnd(a.getStart(), b.getEnd(), Rule.NAMED_IMPORTS_UNORDERED, this.lastFix);
         }
 
@@ -224,7 +224,7 @@ class OrderedImportsWalker extends Lint.RuleWalker {
             if (this.lastFix != null) {
                 const replacement = this.currentImportsBlock.getReplacement();
                 if (replacement != null) {
-                    this.lastFix.replacements.push(replacement);
+                    this.lastFix.push(replacement);
                 }
                 this.lastFix = null;
             }

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -88,7 +88,7 @@ class QuotemarkWalker extends Lint.RuleWalker {
             const escapedText = text.slice(1, -1).replace(new RegExp(expectedQuoteMark, "g"), `\\${expectedQuoteMark}`);
             const newText = expectedQuoteMark + escapedText + expectedQuoteMark;
             this.addFailureAtNode(node, Rule.FAILURE_STRING(actualQuoteMark, expectedQuoteMark),
-                this.createFix(this.createReplacement(node.getStart(), node.getWidth(), newText)));
+                this.createReplacement(node.getStart(), node.getWidth(), newText));
         }
     }
 }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -189,9 +189,7 @@ class SemicolonWalker extends Lint.AbstractWalker<Options> {
             const hasSemicolon = lastChar === ";";
             if (this.options.always && !hasSemicolon) {
                 if (lastChar === ",") {
-                    this.addFailureAt(member.end - 1, 1, Rule.FAILURE_STRING_COMMA, this.createFix(
-                        new Lint.Replacement(member.end - 1, 1, ";"),
-                    ));
+                    this.addFailureAt(member.end - 1, 1, Rule.FAILURE_STRING_COMMA, new Lint.Replacement(member.end - 1, 1, ";"));
                 } else {
                     this.reportMissing(member.end);
                 }
@@ -203,15 +201,11 @@ class SemicolonWalker extends Lint.AbstractWalker<Options> {
     }
 
     private reportMissing(pos: number) {
-        this.addFailureAt(pos, 0, Rule.FAILURE_STRING_MISSING, this.createFix(
-            Lint.Replacement.appendText(pos, ";"),
-        ));
+        this.addFailureAt(pos, 0, Rule.FAILURE_STRING_MISSING, Lint.Replacement.appendText(pos, ";"));
     }
 
     private reportUnnecessary(pos: number, noFix?: boolean) {
-        this.addFailureAt(pos, 1, Rule.FAILURE_STRING_UNNECESSARY, noFix ? undefined : this.createFix(
-            Lint.Replacement.deleteText(pos, 1),
-        ));
+        this.addFailureAt(pos, 1, Rule.FAILURE_STRING_UNNECESSARY, noFix ? undefined : Lint.Replacement.deleteText(pos, 1));
     }
 
     private checkSemicolonAt(node: ts.Node) {

--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -159,12 +159,10 @@ class FunctionWalker extends Lint.RuleWalker {
 
         if (hasSpace && option === "never") {
             const pos = openParen.getStart() - 1;
-            const fix = new Lint.Fix(Rule.metadata.ruleName, [ this.deleteText(pos, 1) ]);
-            this.addFailureAt(pos, 1, Rule.INVALID_WHITESPACE_ERROR, fix);
+            this.addFailureAt(pos, 1, Rule.INVALID_WHITESPACE_ERROR, this.deleteText(pos, 1));
         } else if (!hasSpace && option === "always") {
             const pos = openParen.getStart();
-            const fix = new Lint.Fix(Rule.metadata.ruleName, [ this.appendText(pos, " ") ]);
-            this.addFailureAt(pos, 1, Rule.MISSING_WHITESPACE_ERROR, fix);
+            this.addFailureAt(pos, 1, Rule.MISSING_WHITESPACE_ERROR, this.appendText(pos, " "));
         }
     }
 

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -161,13 +161,9 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         const closeTokenLine = ts.getLineAndCharacterOfPosition(this.sourceFile, closeTokenPos).line;
         const option = lastElementLine === closeTokenLine ? this.options.singleline : this.options.multiline;
         if (hasTrailingComma && option === "never") {
-            this.addFailureAt(list.end - 1, 1, Rule.FAILURE_STRING_NEVER, this.createFix(
-                Lint.Replacement.deleteText(list.end - 1, 1),
-            ));
+            this.addFailureAt(list.end - 1, 1, Rule.FAILURE_STRING_NEVER, Lint.Replacement.deleteText(list.end - 1, 1));
         } else if (!hasTrailingComma && option === "always") {
-            this.addFailureAt(list.end, 0, Rule.FAILURE_STRING_ALWAYS, this.createFix(
-                Lint.Replacement.appendText(list.end, ","),
-            ));
+            this.addFailureAt(list.end, 0, Rule.FAILURE_STRING_ALWAYS, Lint.Replacement.appendText(list.end, ","));
         }
     }
 }

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -256,7 +256,6 @@ class WhitespaceWalker extends Lint.RuleWalker {
     }
 
     private addMissingWhitespaceErrorAt(position: number) {
-        const fix = this.createFix(this.appendText(position, " "));
-        this.addFailureAt(position, 1, Rule.FAILURE_STRING, fix);
+        this.addFailureAt(position, 1, Rule.FAILURE_STRING, [this.appendText(position, " ")]);
     }
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -23,10 +23,11 @@ import * as path from "path";
 import * as semver from "semver";
 import * as ts from "typescript";
 
-import {Fix} from "./language/rule/rule";
+import {Replacement} from "./language/rule/rule";
 import * as Linter from "./linter";
 import {LintError} from "./test/lintError";
 import * as parse from "./test/parse";
+import {mapDefined} from "./utils";
 
 const MARKUP_FILE_EXTENSION = ".lint";
 const FIXES_FILE_EXTENSION = ".fix";
@@ -177,8 +178,8 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
             const stat = fs.statSync(fixedFile);
             if (stat.isFile()) {
                 fixedFileText = fs.readFileSync(fixedFile, "utf8");
-                const fixes = failures.filter((f) => f.hasFix()).map((f) => f.getFix()) as Fix[];
-                newFileText = Fix.applyAll(fileTextWithoutMarkup, fixes);
+                const fixes = mapDefined(failures, (f) => f.getFix());
+                newFileText = Replacement.applyFixes(fileTextWithoutMarkup, fixes);
             }
         } catch (e) {
             fixedFileText = "";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,3 +114,24 @@ export type Equal<T> = (a: T, b: T) => boolean;
 export function arraysAreEqual<T>(a: T[] | undefined, b: T[] | undefined, eq: Equal<T>): boolean {
     return a === b || !!a && !!b && a.length === b.length && a.every((x, idx) => eq(x, b[idx]));
 }
+
+/** Returns an array that is the concatenation of all output arrays. */
+export function flatMap<T, U>(inputs: T[], getOutputs: (input: T) => U[]): U[] {
+    const out = [];
+    for (const input of inputs) {
+        out.push(...getOutputs(input));
+    }
+    return out;
+}
+
+/** Returns an array of all outputs that are not `undefined`. */
+export function mapDefined<T, U>(inputs: T[], getOutput: (input: T) => U | undefined): U[] {
+    const out = [];
+    for (const input of inputs) {
+        const output = getOutput(input);
+        if (output !== undefined) {
+            out.push(output);
+        }
+    }
+    return out;
+}

--- a/test/formatters/jsonFormatterTests.ts
+++ b/test/formatters/jsonFormatterTests.ts
@@ -16,7 +16,7 @@
 
 import * as ts from "typescript";
 
-import { Fix, IFormatter, Replacement, TestUtils } from "../lint";
+import { IFormatter, Replacement, TestUtils } from "../lint";
 import { createFailure } from "./utils";
 
 describe("JSON Formatter", () => {
@@ -37,9 +37,7 @@ describe("JSON Formatter", () => {
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
             createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
             createFailure(sourceFile, 0, maxPosition, "full failure", "full-name",
-                new Fix("full-name", [
-                    new Replacement(0, 0, ""),
-                ]),
+                new Replacement(0, 0, ""),
                 "error"),
         ];
 

--- a/test/formatters/utils.ts
+++ b/test/formatters/utils.ts
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 import * as ts from "typescript";
-import { Fix, RuleFailure, RuleSeverity } from "../../src/language/rule/rule";
+import { Replacement, RuleFailure, RuleSeverity } from "../../src/language/rule/rule";
 
 export function createFailure(sourceFile: ts.SourceFile,
                               start: number,
                               end: number,
                               failure: string,
                               ruleName: string,
-                              fix?: Fix,
+                              fix?: Replacement | Replacement[],
                               ruleSeverity: RuleSeverity = "warning") {
 
     const rule = new RuleFailure(sourceFile, start, end, failure, ruleName, fix);


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

The `Fix` class is not really necessary. It's easier to just pass parameters to `addFailure`.
This could be viewed as a continuation of #1845. So now instead of `this.addFailure(this.createFailure(..., this.createFix(foo)))`, you just `this.addFailure(..., foo)`.

#### CHANGELOG.md entry:

[api] Remove `createFix`. Replacements should be passed directly into `addFailure`.
