### PR TITLE
Refactor some rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "optimist": "~0.6.0",
     "resolve": "^1.1.7",
     "semver": "^5.3.0",
-    "tsutils": "^1.2.2"
+    "tsutils": "^1.4.0"
   },
   "peerDependencies": {
     "typescript": ">=2.0.0 || >=2.0.0-dev || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev"

--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -45,11 +45,11 @@ export class Rule extends Lint.Rules.AbstractRule {
                 * note that comments starting with \`///\` are also allowed, for things such as \`///<reference>\`
             * \`"check-lowercase"\` requires that the first non-whitespace character of a comment must be lowercase, if applicable.
             * \`"check-uppercase"\` requires that the first non-whitespace character of a comment must be uppercase, if applicable.
-            
+
             Exceptions to \`"check-lowercase"\` or \`"check-uppercase"\` can be managed with object that may be passed as last argument.
-            
+
             One of two options can be provided in this object:
-                
+
                 * \`"ignore-words"\`  - array of strings - words that will be ignored at the beginning of the comment.
                 * \`"ignore-pattern"\` - string - RegExp pattern that will be ignored at the beginning of the comment.
             `,

--- a/src/rules/maxFileLineCountRule.ts
+++ b/src/rules/maxFileLineCountRule.ts
@@ -44,14 +44,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public isEnabled(): boolean {
-        const ruleArguments = this.getOptions().ruleArguments;
-        if (super.isEnabled()) {
-            const option = ruleArguments[0];
-            if (typeof option === "number" && option > 0) {
-                return true;
-            }
-        }
-        return false;
+        return super.isEnabled() && this.ruleArguments[0] > 0;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/src/rules/maxLineLengthRule.ts
+++ b/src/rules/maxLineLengthRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { getLineRanges } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -44,40 +45,19 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public isEnabled(): boolean {
-        const ruleArguments = this.getOptions().ruleArguments;
-        if (super.isEnabled()) {
-            const option = ruleArguments[0];
-            if (typeof option === "number" && option > 0) {
-                return true;
-            }
-        }
-        return false;
+        return super.isEnabled() && this.ruleArguments[0] > 0;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const ruleFailures: Lint.RuleFailure[] = [];
-        const ruleArguments = this.getOptions().ruleArguments;
-        const lineLimit = ruleArguments[0];
-        const lineStarts = sourceFile.getLineStarts();
-        const errorString = Rule.FAILURE_STRING_FACTORY(lineLimit);
-        const disabledIntervals = this.getOptions().disabledIntervals;
-        const source = sourceFile.getFullText();
+        return this.applyWithFunction(sourceFile, walk, this.ruleArguments[0]);
+    }
+}
 
-        for (let i = 0; i < lineStarts.length - 1; ++i) {
-            const from = lineStarts[i];
-            const to = lineStarts[i + 1];
-            if ((to - from - 1) > lineLimit && !((to - from - 2) === lineLimit && source[to - 2] === "\r")) {
-                // first condition above is whether the line (minus the newline) is larger than the line limit
-                // second two check for windows line endings, that is, check to make sure it is not the case
-                // that we are only over by the limit by exactly one and that the character we are over the
-                // limit by is a '\r' character which does not count against the limit
-                // (and thus we are not actually over the limit).
-                const ruleFailure = new Lint.RuleFailure(sourceFile, from, to - 1, errorString, this.getOptions().ruleName);
-                if (!Lint.doesIntersect(ruleFailure, disabledIntervals)) {
-                    ruleFailures.push(ruleFailure);
-                }
-            }
+function walk(ctx: Lint.WalkContext<number>) {
+    const limit = ctx.options;
+    for (const line of getLineRanges(ctx.sourceFile)) {
+        if (line.contentLength > limit) {
+            ctx.addFailureAt(line.pos, line.contentLength, Rule.FAILURE_STRING_FACTORY(limit));
         }
-        return ruleFailures;
     }
 }

--- a/src/rules/newParensRule.ts
+++ b/src/rules/newParensRule.ts
@@ -36,16 +36,15 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Parentheses are required when invoking a constructor";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const newParensWalker = new NewParensWalker(sourceFile, this.getOptions());
-        return this.applyWithWalker(newParensWalker);
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NewParensWalker extends Lint.RuleWalker {
-    public visitNewExpression(node: ts.NewExpression) {
-        if (node.arguments === undefined) {
-            this.addFailureAtNode(node, Rule.FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.NewExpression && (node as ts.NewExpression).arguments === undefined) {
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
-        super.visitNewExpression(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/src/rules/noAngleBracketTypeAssertionRule.ts
+++ b/src/rules/noAngleBracketTypeAssertionRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { isTypeAssertion } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -40,20 +41,19 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoAngleBracketTypeAssertionWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoAngleBracketTypeAssertionWalker extends Lint.RuleWalker {
-    public visitTypeAssertionExpression(node: ts.TypeAssertion) {
-        const { expression, type } = node;
-        const fix = this.createFix(
-            // add 'as' syntax at end
-            this.createReplacement(node.getEnd(), 0, ` as ${type.getText()}`),
-            // delete the angle bracket assertion
-            this.createReplacement(node.getStart(), expression.getStart() - node.getStart(), ""),
-        );
-        this.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
-        super.visitTypeAssertionExpression(node);
-    }
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (isTypeAssertion(node)) {
+            const start = node.getStart(ctx.sourceFile);
+            ctx.addFailure(start, node.end, Rule.FAILURE_STRING, ctx.createFix(
+                Lint.Replacement.appendText(node.end, ` as ${ node.type.getText(ctx.sourceFile) }`),
+                Lint.Replacement.deleteFromTo(start, node.expression.getStart(ctx.sourceFile)),
+            ));
+        }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -47,10 +47,9 @@ function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (node.kind === ts.SyntaxKind.AnyKeyword) {
             const start = node.end - 3;
-            ctx.addFailure(start, node.end, Rule.FAILURE_STRING, ctx.createFix(
+            return ctx.addFailure(start, node.end, Rule.FAILURE_STRING, ctx.createFix(
                 new Lint.Replacement(start, 3, "{}"),
             ));
-            return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);
     });

--- a/src/rules/noBitwiseRule.ts
+++ b/src/rules/noBitwiseRule.ts
@@ -65,8 +65,6 @@ function walk(ctx: Lint.WalkContext<void>) {
                 case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
                 case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
                     ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
-                    break;
-                default:
             }
         } else if (node.kind === ts.SyntaxKind.PrefixUnaryExpression &&
                    (node as ts.PrefixUnaryExpression).operator === ts.SyntaxKind.TildeToken) {

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -52,9 +52,7 @@ export class Rule extends Lint.Rules.AbstractRule {
      * Disable the rule if the option is provided but non-numeric or less than the minimum.
      */
     public isEnabled(): boolean {
-        return super.isEnabled() &&
-            (!this.ruleArguments[0] ||
-             typeof this.ruleArguments[0] === "number" && this.ruleArguments[0] > 0);
+        return super.isEnabled() && (!this.ruleArguments[0] || this.ruleArguments[0] > 0);
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -70,7 +68,7 @@ function walk(ctx: Lint.WalkContext<number>) {
     let consecutiveBlankLines = 0;
 
     for (const line of utils.getLineRanges(ctx.sourceFile)) {
-        if (sourceText.substring(line.pos, line.end).search(/\S/) === -1) {
+        if (line.contentLength === 0 || sourceText.substr(line.pos, line.contentLength).search(/\S/) === -1) {
             ++consecutiveBlankLines;
             if (consecutiveBlankLines === threshold) {
                 possibleFailures.push({

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -108,7 +108,7 @@ function getStartOfLineBreak(sourceText: string, pos: number) {
     return sourceText[pos - 2] === "\r" ? pos - 1 : pos - 1;
 }
 
-function getTemplateRanges(sourceFile: ts.SourceFile): ts.TextRange[] {
+export function getTemplateRanges(sourceFile: ts.SourceFile): ts.TextRange[] {
     const intervals: ts.TextRange[] = [];
     const cb = (node: ts.Node): void => {
         if (node.kind >= ts.SyntaxKind.FirstTemplateToken &&

--- a/src/rules/noConstructRule.ts
+++ b/src/rules/noConstructRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { isNewExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -40,25 +41,22 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Forbidden constructor, use a literal or simple function call instead";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoConstructWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoConstructWalker extends Lint.RuleWalker {
-    private static FORBIDDEN_CONSTRUCTORS = [
-        "Boolean",
-        "Number",
-        "String",
-    ];
-
-    public visitNewExpression(node: ts.NewExpression) {
-        if (node.expression.kind === ts.SyntaxKind.Identifier) {
-            const identifier = node.expression as ts.Identifier;
-            const constructorName = identifier.text;
-            if (NoConstructWalker.FORBIDDEN_CONSTRUCTORS.indexOf(constructorName) !== -1) {
-                this.addFailureAt(node.getStart(), identifier.getEnd() - node.getStart(), Rule.FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (isNewExpression(node) && node.expression.kind === ts.SyntaxKind.Identifier) {
+            switch ((node.expression as ts.Identifier).text) {
+                case "Boolean":
+                case "String":
+                case "Number":
+                    ctx.addFailureAtNode(node.expression, Rule.FAILURE_STRING);
+                    break;
+                default:
             }
         }
-        super.visitNewExpression(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/src/rules/noConstructRule.ts
+++ b/src/rules/noConstructRule.ts
@@ -52,9 +52,7 @@ function walk(ctx: Lint.WalkContext<void>) {
                 case "Boolean":
                 case "String":
                 case "Number":
-                    ctx.addFailureAtNode(node.expression, Rule.FAILURE_STRING);
-                    break;
-                default:
+                    ctx.addFailure(node.getStart(ctx.sourceFile), node.expression.end, Rule.FAILURE_STRING);
             }
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/noDebuggerRule.ts
+++ b/src/rules/noDebuggerRule.ts
@@ -36,14 +36,15 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Use of debugger statements is forbidden";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoDebuggerWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoDebuggerWalker extends Lint.RuleWalker {
-    public visitDebuggerStatement(node: ts.Statement) {
-        const debuggerKeywordNode = node.getChildAt(0);
-        this.addFailureAtNode(debuggerKeywordNode, Rule.FAILURE_STRING);
-        super.visitDebuggerStatement(node);
-   }
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.DebuggerStatement) {
+            return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+        }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/src/rules/noEmptyInterfaceRule.ts
+++ b/src/rules/noEmptyInterfaceRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { isInterfaceDeclaration } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -36,18 +37,20 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_FOR_EXTENDS = "An interface declaring no members is equivalent to its supertype.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class Walker extends Lint.RuleWalker {
-    public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
-        if (node.members.length === 0 &&
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (isInterfaceDeclaration(node) &&
+            node.members.length === 0 &&
             (node.heritageClauses === undefined ||
              node.heritageClauses[0].types === undefined ||
              // allow interfaces that extend 2 or more interfaces
              node.heritageClauses[0].types!.length < 2)) {
-            this.addFailureAtNode(node.name, node.heritageClauses ? Rule.FAILURE_STRING_FOR_EXTENDS : Rule.FAILURE_STRING);
+            return ctx.addFailureAtNode(node.name, node.heritageClauses ? Rule.FAILURE_STRING_FOR_EXTENDS : Rule.FAILURE_STRING);
         }
-    }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { hasModifier, isConstructorDeclaration, isParameterProperty } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -37,44 +38,35 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "block is empty";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new BlockWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class BlockWalker extends Lint.RuleWalker {
-    public visitBlock(node: ts.Block) {
-        if (node.statements.length === 0 && !isExcludedConstructor(node.parent!)) {
-            const sourceFile = this.getSourceFile();
-            const start = node.getStart(sourceFile);
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.Block &&
+            (node as ts.Block).statements.length === 0 &&
+            !isExcludedConstructor(node.parent!)) {
+            const start = node.getStart(ctx.sourceFile);
             // Block always starts with open brace. Adding 1 to its start gives us the end of the brace,
             // which can be used to conveniently check for comments between braces
-            if (!Lint.hasCommentAfterPosition(sourceFile.text, start + 1)) {
-                this.addFailureFromStartToEnd(start , node.getEnd(), Rule.FAILURE_STRING);
+            if (Lint.hasCommentAfterPosition(ctx.sourceFile.text, start + 1)) {
+                return;
             }
+            return ctx.addFailure(start , node.end, Rule.FAILURE_STRING);
         }
-
-        super.visitBlock(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
 }
 
 function isExcludedConstructor(node: ts.Node): boolean {
-    if (node.kind === ts.SyntaxKind.Constructor) {
-        if (Lint.hasModifier(node.modifiers, ts.SyntaxKind.PrivateKeyword, ts.SyntaxKind.ProtectedKeyword)) {
+    return isConstructorDeclaration(node) &&
+        (
             /* If constructor is private or protected, the block is allowed to be empty.
                The constructor is there on purpose to disallow instantiation from outside the class */
             /* The public modifier does not serve a purpose here. It can only be used to allow instantiation of a base class where
                the super constructor is protected. But then the block would not be empty, because of the call to super() */
-            return true;
-        }
-        for (const parameter of (node as ts.ConstructorDeclaration).parameters) {
-            if (Lint.hasModifier(parameter.modifiers,
-                                 ts.SyntaxKind.PrivateKeyword,
-                                 ts.SyntaxKind.ProtectedKeyword,
-                                 ts.SyntaxKind.PublicKeyword,
-                                 ts.SyntaxKind.ReadonlyKeyword)) {
-                return true;
-            }
-        }
-    }
-    return false;
+            hasModifier(node.modifiers, ts.SyntaxKind.PrivateKeyword, ts.SyntaxKind.ProtectedKeyword) ||
+            node.parameters.some(isParameterProperty)
+        );
 }

--- a/src/rules/noForInArrayRule.ts
+++ b/src/rules/noForInArrayRule.ts
@@ -50,25 +50,20 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING = "for-in loops over arrays are forbidden. Use for-of or array.forEach instead.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoForInArrayWalker(sourceFile, this.getOptions(), program));
+        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program));
     }
 }
 
-class NoForInArrayWalker extends Lint.ProgramAwareRuleWalker {
-    public visitForInStatement(node: ts.ForInStatement) {
-        const iteratee = node.expression;
-        const tc = this.getTypeChecker();
-        const type = tc.getTypeAtLocation(iteratee);
-
-        /* tslint:disable:no-bitwise */
-        const isArrayType = type.symbol && type.symbol.name === "Array";
-        const isStringType = (type.flags & ts.TypeFlags.StringLike) !== 0;
-        /* tslint:enable:no-bitwise */
-
-        if (isArrayType || isStringType) {
-            this.addFailureAtNode(node, Rule.FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<void>, program: ts.Program) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.ForInStatement) {
+            const type = program.getTypeChecker().getTypeAtLocation((node as ts.ForInStatement).expression);
+            if (type.symbol !== undefined && type.symbol.name === "Array" ||
+                // tslint:disable-next-line:no-bitwise
+                (type.flags & ts.TypeFlags.StringLike) !== 0) {
+                ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+            }
         }
-
-        super.visitForInStatement(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/src/rules/noInternalModuleRule.ts
+++ b/src/rules/noInternalModuleRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { getChildOfKind } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -36,35 +37,41 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "The internal 'module' syntax is deprecated, use the 'namespace' keyword instead.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoInternalModuleWalker(sourceFile, this.getOptions()));
+        return this.applyWithWalker(new NoInternalModuleWalker(sourceFile, this.ruleName, undefined));
     }
 }
 
-class NoInternalModuleWalker extends Lint.RuleWalker {
-    public visitModuleDeclaration(node: ts.ModuleDeclaration) {
-        if (this.isInternalModuleDeclaration(node)) {
-            const start = this.getStartBeforeModule(node);
-            this.addFailureAt(node.getStart() + start, "module".length, Rule.FAILURE_STRING);
+class NoInternalModuleWalker extends Lint.AbstractWalker<void> {
+    public walk(sourceFile: ts.SourceFile) {
+        return this.checkStatements(sourceFile.statements);
+    }
+
+    private checkStatements(statements: ts.Statement[]) {
+        for (const statement of statements) {
+            if (statement.kind === ts.SyntaxKind.ModuleDeclaration) {
+                this.checkModuleDeclaration(statement as ts.ModuleDeclaration);
+            }
         }
-        super.visitModuleDeclaration(node);
     }
 
-    private isInternalModuleDeclaration(node: ts.ModuleDeclaration) {
-        // an internal module declaration is not a namespace or a nested declaration
-        // for external modules, node.name.kind will be a LiteralExpression instead of Identifier
-        return !Lint.isNodeFlagSet(node, ts.NodeFlags.Namespace)
-            && !Lint.isNestedModuleDeclaration(node)
-            && node.name.kind === ts.SyntaxKind.Identifier
-            && !isGlobalAugmentation(node);
+    private checkModuleDeclaration(node: ts.ModuleDeclaration, nested?: boolean): void {
+        if (!nested &&
+            node.name.kind === ts.SyntaxKind.Identifier &&
+            // augmenting global uses a special syntax that is allowed
+            // see https://github.com/Microsoft/TypeScript/pull/6213
+            node.name.text !== "global") {
+            const moduleKeyword = getChildOfKind(node, ts.SyntaxKind.ModuleKeyword, this.sourceFile);
+            if (moduleKeyword) {
+                this.addFailureAtNode(moduleKeyword, Rule.FAILURE_STRING);
+            }
+        }
+        if (node.body !== undefined) {
+            switch (node.body.kind) {
+                case ts.SyntaxKind.ModuleBlock:
+                    return this.checkStatements(node.body.statements);
+                case ts.SyntaxKind.ModuleDeclaration:
+                    return this.checkModuleDeclaration(node.body, true);
+            }
+        }
     }
-
-    private getStartBeforeModule(node: ts.ModuleDeclaration) {
-        return node.getText().indexOf("module");
-    }
-}
-
-function isGlobalAugmentation(node: ts.ModuleDeclaration) {
-    // augmenting global uses a special syntax that is allowed
-    // see https://github.com/Microsoft/TypeScript/pull/6213
-    return node.name.kind === ts.SyntaxKind.Identifier && node.name.text === "global";
 }

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { isPrefixUnaryExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -70,13 +71,14 @@ class NoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
             if (node.kind === ts.SyntaxKind.NumericLiteral) {
-                this.checkNumericLiteral(node, (node as ts.NumericLiteral).text);
-            } else if (node.kind === ts.SyntaxKind.PrefixUnaryExpression &&
-                       (node as ts.PrefixUnaryExpression).operator === ts.SyntaxKind.MinusToken) {
-                this.checkNumericLiteral(node, "-" + ((node as ts.PrefixUnaryExpression).operand as ts.NumericLiteral).text);
-            } else {
-                ts.forEachChild(node, cb);
+                return this.checkNumericLiteral(node, (node as ts.NumericLiteral).text);
             }
+            if (isPrefixUnaryExpression(node) &&
+                node.operator === ts.SyntaxKind.MinusToken &&
+                node.operand.kind === ts.SyntaxKind.NumericLiteral) {
+                return this.checkNumericLiteral(node, "-" + (node.operand as ts.NumericLiteral).text);
+            }
+            return ts.forEachChild(node, cb);
         };
         return ts.forEachChild(sourceFile, cb);
     }

--- a/src/rules/noNamespaceRule.ts
+++ b/src/rules/noNamespaceRule.ts
@@ -15,9 +15,16 @@
  * limitations under the License.
  */
 
+import { hasModifier } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+
+const OPTION_ALLOW_DECLARATIONS = "allow-declarations";
+
+interface Options {
+    allowDeclarations: boolean;
+}
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -31,17 +38,17 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: Lint.Utils.dedent`
             One argument may be optionally provided:
 
-            * \`allow-declarations\` allows \`declare namespace ... {}\` to describe external APIs.`,
+            * \`${OPTION_ALLOW_DECLARATIONS}\` allows \`declare namespace ... {}\` to describe external APIs.`,
         options: {
             type: "array",
             items: {
                 type: "string",
-                enum: ["allow-declarations"],
+                enum: [OPTION_ALLOW_DECLARATIONS],
             },
             minLength: 0,
             maxLength: 1,
         },
-        optionExamples: ["true", '[true, "allow-declarations"]'],
+        optionExamples: ["true", `[true, "${OPTION_ALLOW_DECLARATIONS}"]`],
         type: "typescript",
         typescriptOnly: true,
     };
@@ -50,26 +57,24 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "'namespace' and 'module' are disallowed";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoNamespaceWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk, {
+            allowDeclarations: this.ruleArguments.indexOf(OPTION_ALLOW_DECLARATIONS) !== -1,
+        });
     }
 }
 
-class NoNamespaceWalker extends Lint.RuleWalker {
-    public visitSourceFile(node: ts.SourceFile) {
-        // Ignore all .d.ts files by returning and not walking their ASTs.
-        // .d.ts declarations do not have the Ambient flag set, but are still declarations.
-        if (this.hasOption("allow-declarations") && node.isDeclarationFile) {
-            return;
-        }
-        this.walkChildren(node);
+function walk(ctx: Lint.WalkContext<Options>) {
+    // Ignore all .d.ts files by returning and not walking their ASTs.
+    // .d.ts declarations do not have the Ambient flag set, but are still declarations.
+    if (ctx.sourceFile.isDeclarationFile && ctx.options.allowDeclarations) {
+        return;
     }
-
-    public visitModuleDeclaration(decl: ts.ModuleDeclaration) {
-        // declare module 'foo' {} is an external module, not a namespace.
-        if (decl.name.kind === ts.SyntaxKind.StringLiteral ||
-            this.hasOption("allow-declarations") && Lint.hasModifier(decl.modifiers, ts.SyntaxKind.DeclareKeyword)) {
-            return;
+    for (const node of ctx.sourceFile.statements){
+        if (node.kind === ts.SyntaxKind.ModuleDeclaration) {
+            if ((node as ts.ModuleDeclaration).name.kind !== ts.SyntaxKind.StringLiteral &&
+                (!ctx.options.allowDeclarations || !hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword))) {
+                ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+            }
         }
-        this.addFailureAtNode(decl, Rule.FAILURE_STRING);
     }
 }

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -37,7 +37,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         hasFix: true,
         optionsDescription: Lint.Utils.dedent`
             An optional object containing the property "destructuring" with two possible values:
-            
+
             * "${OPTION_DESTRUCTURING_ANY}" (default) - If any variable in destructuring can be const, this rule warns for those variables.
             * "${OPTION_DESTRUCTURING_ALL}" - Only warns if all variables in destructuring can be const.`,
         options: {

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -19,6 +19,18 @@ import * as ts from "typescript";
 
 import * as Lint from "../index";
 
+const OPTION_SINGLE = "single";
+const OPTION_DOUBLE = "double";
+const OPTION_JSX_SINGLE = "jsx-single";
+const OPTION_JSX_DOUBLE = "jsx-double";
+const OPTION_AVOID_ESCAPE = "avoid-escape";
+
+interface Options {
+    quoteMark: string;
+    jsxQuoteMark: string;
+    avoidEscape: boolean;
+}
+
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
@@ -28,22 +40,26 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: Lint.Utils.dedent`
             Five arguments may be optionally provided:
 
-            * \`"single"\` enforces single quotes.
-            * \`"double"\` enforces double quotes.
-            * \`"jsx-single"\` enforces single quotes for JSX attributes.
-            * \`"jsx-double"\` enforces double quotes for JSX attributes.
-            * \`"avoid-escape"\` allows you to use the "other" quotemark in cases where escaping would normally be required.
-            For example, \`[true, "double", "avoid-escape"]\` would not report a failure on the string literal \`'Hello "World"'\`.`,
+            * \`"${OPTION_SINGLE}"\` enforces single quotes.
+            * \`"${OPTION_DOUBLE}"\` enforces double quotes.
+            * \`"${OPTION_JSX_SINGLE}"\` enforces single quotes for JSX attributes.
+            * \`"${OPTION_JSX_DOUBLE}"\` enforces double quotes for JSX attributes.
+            * \`"${OPTION_AVOID_ESCAPE}"\` allows you to use the "other" quotemark in cases where escaping would normally be required.
+            For example, \`[true, "${OPTION_DOUBLE}", "${OPTION_AVOID_ESCAPE}"]\` would not report a failure on the string literal
+            \`'Hello "World"'\`.`,
         options: {
             type: "array",
             items: {
                 type: "string",
-                enum: ["single", "double", "jsx-single", "jsx-double", "avoid-escape"],
+                enum: [OPTION_SINGLE, OPTION_DOUBLE, OPTION_JSX_SINGLE, OPTION_JSX_DOUBLE, OPTION_AVOID_ESCAPE],
             },
             minLength: 0,
             maxLength: 5,
         },
-        optionExamples: ['[true, "single", "avoid-escape"]', '[true, "single", "jsx-double"]'],
+        optionExamples: [
+            `[true, "${OPTION_SINGLE}", "${OPTION_AVOID_ESCAPE}"]`,
+            `[true, "${OPTION_SINGLE}", "${OPTION_JSX_DOUBLE}"]`,
+            ],
         type: "style",
         typescriptOnly: false,
     };
@@ -54,41 +70,44 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public isEnabled(): boolean {
-        if (super.isEnabled()) {
-            const ruleArguments = this.getOptions().ruleArguments;
-            const quoteMarkString = ruleArguments[0];
-            return (quoteMarkString === "single" || quoteMarkString === "double");
-        }
-
-        return false;
+        return super.isEnabled() && (this.ruleArguments[0] === OPTION_SINGLE || this.ruleArguments[0] === OPTION_DOUBLE);
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new QuotemarkWalker(sourceFile, this.getOptions()));
+        const args = this.ruleArguments;
+        const quoteMark = args[0] === OPTION_SINGLE ? "'" : '"';
+        return this.applyWithFunction(sourceFile, walk, {
+            quoteMark,
+            avoidEscape: args.indexOf(OPTION_AVOID_ESCAPE) !== -1,
+            jsxQuoteMark: args.indexOf(OPTION_JSX_SINGLE) !== -1
+                          ? "'"
+                          : args.indexOf(OPTION_JSX_DOUBLE) ? '"' : quoteMark,
+        });
     }
 }
 
-class QuotemarkWalker extends Lint.RuleWalker {
-    private quoteMark: string;
-    private jsxQuoteMark: string;
-    private avoidEscape: boolean;
+function walk(ctx: Lint.WalkContext<Options>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.StringLiteral) {
+            const expectedQuoteMark = node.parent!.kind === ts.SyntaxKind.JsxAttribute ? ctx.options.jsxQuoteMark : ctx.options.quoteMark;
+            const actualQuoteMark = ctx.sourceFile.text[node.end - 1];
+            if (actualQuoteMark === expectedQuoteMark) {
+                return;
+            }
+            const start = node.getStart(ctx.sourceFile);
+            let text = ctx.sourceFile.text.substring(start + 1, node.end - 1);
+            if ((node as ts.StringLiteral).text.includes(expectedQuoteMark)) {
+                if (ctx.options.avoidEscape) {
+                    return;
+                }
+                text = text.replace(new RegExp(expectedQuoteMark, "g"), `\\${expectedQuoteMark}`);
+            }
+            text = text.replace(new RegExp(`\\\\${actualQuoteMark}`, "g"), actualQuoteMark);
 
-    constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
-        super(sourceFile, options);
-        this.quoteMark = this.hasOption("single") ? "'" : '"';
-        this.jsxQuoteMark = this.hasOption("jsx-single") ? "'" : this.hasOption("jsx-double") ? '"' : this.quoteMark;
-        this.avoidEscape = this.hasOption("avoid-escape");
-    }
-
-    public visitStringLiteral(node: ts.StringLiteral) {
-        const expectedQuoteMark = node.parent!.kind === ts.SyntaxKind.JsxAttribute ? this.jsxQuoteMark : this.quoteMark;
-        const text = node.getText();
-        const actualQuoteMark = text[0];
-        if (actualQuoteMark !== expectedQuoteMark && !(this.avoidEscape && node.text.includes(expectedQuoteMark))) {
-            const escapedText = text.slice(1, -1).replace(new RegExp(expectedQuoteMark, "g"), `\\${expectedQuoteMark}`);
-            const newText = expectedQuoteMark + escapedText + expectedQuoteMark;
-            this.addFailureAtNode(node, Rule.FAILURE_STRING(actualQuoteMark, expectedQuoteMark),
-                this.createFix(this.createReplacement(node.getStart(), node.getWidth(), newText)));
+            return ctx.addFailure(start, node.end, Rule.FAILURE_STRING(actualQuoteMark, expectedQuoteMark), ctx.createFix(
+                new Lint.Replacement(start, node.end - start, expectedQuoteMark + text + expectedQuoteMark),
+            ));
         }
-    }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/src/rules/restrictPlusOperandsRule.ts
+++ b/src/rules/restrictPlusOperandsRule.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
+import { isBinaryExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { isTypeFlagSet } from "../language/utils";
 
 export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -37,39 +37,33 @@ export class Rule extends Lint.Rules.TypedRule {
     public static INVALID_TYPES_ERROR = "Operands of '+' operation must either be both strings or both numbers";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithWalker(new RestrictPlusOperandsWalker(sourceFile, this.getOptions(), program));
+        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program));
     }
 }
 
-class RestrictPlusOperandsWalker extends Lint.ProgramAwareRuleWalker {
-    public visitBinaryExpression(node: ts.BinaryExpression) {
-        if (node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
-            const tc = this.getTypeChecker();
-
+function walk(ctx: Lint.WalkContext<void>, program: ts.Program) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (isBinaryExpression(node)) {
+            const tc = program.getTypeChecker();
             const leftType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.left));
             const rightType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.right));
-
-            const width = node.getWidth();
-            const position = node.getStart();
-
             if (leftType === "invalid" || rightType === "invalid" || leftType !== rightType) {
-                this.addFailureAt(position, width, Rule.INVALID_TYPES_ERROR);
+                return ctx.addFailureAtNode(node, Rule.INVALID_TYPES_ERROR);
             }
         }
-
-        super.visitBinaryExpression(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
 }
 
 function getBaseTypeOfLiteralType(type: ts.Type): "string" | "number" | "invalid" {
-    if (isTypeFlagSet(type, ts.TypeFlags.StringLiteral) || isTypeFlagSet(type, ts.TypeFlags.String)) {
+    if (Lint.isTypeFlagSet(type, ts.TypeFlags.StringLiteral) || Lint.isTypeFlagSet(type, ts.TypeFlags.String)) {
         return "string";
-    } else if (isTypeFlagSet(type, ts.TypeFlags.NumberLiteral) || isTypeFlagSet(type, ts.TypeFlags.Number)) {
+    } else if (Lint.isTypeFlagSet(type, ts.TypeFlags.NumberLiteral) || Lint.isTypeFlagSet(type, ts.TypeFlags.Number)) {
         return "number";
-    } else if (isUnionType(type) && !isTypeFlagSet(type, ts.TypeFlags.Enum)) {
+    } else if (isUnionType(type) && !Lint.isTypeFlagSet(type, ts.TypeFlags.Enum)) {
         const types = type.types.map(getBaseTypeOfLiteralType);
         return allSame(types) ? types[0] : "invalid";
-    } else if (isTypeFlagSet(type, ts.TypeFlags.EnumLiteral)) {
+    } else if (Lint.isTypeFlagSet(type, ts.TypeFlags.EnumLiteral)) {
         return getBaseTypeOfLiteralType((type as ts.EnumLiteralType).baseType);
     }
     return "invalid";

--- a/src/rules/switchDefaultRule.ts
+++ b/src/rules/switchDefaultRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { isDefaultClause } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -35,18 +36,16 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Switch statement should include a 'default' case";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new SwitchDefaultWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-export class SwitchDefaultWalker extends Lint.RuleWalker {
-    public visitSwitchStatement(node: ts.SwitchStatement) {
-        const hasDefaultCase = node.caseBlock.clauses.some((clause) => clause.kind === ts.SyntaxKind.DefaultClause);
-
-        if (!hasDefaultCase) {
-            this.addFailureAtNode(node, Rule.FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<void>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.SwitchStatement &&
+            !(node as ts.SwitchStatement).caseBlock.clauses.some(isDefaultClause)) {
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
-
-        super.visitSwitchStatement(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
 }

--- a/src/rules/tripleEqualsRule.ts
+++ b/src/rules/tripleEqualsRule.ts
@@ -15,12 +15,18 @@
  * limitations under the License.
  */
 
+import { isBinaryExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
 
 const OPTION_ALLOW_NULL_CHECK = "allow-null-check";
 const OPTION_ALLOW_UNDEFINED_CHECK = "allow-undefined-check";
+
+interface Options {
+    allowNull: boolean;
+    allowUndefined: boolean;
+}
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -51,29 +57,33 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static NEQ_FAILURE_STRING = "!= should be !==";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const comparisonWalker = new ComparisonWalker(sourceFile, this.getOptions());
-        return this.applyWithWalker(comparisonWalker);
+        return this.applyWithFunction(sourceFile, walk, {
+            allowNull: this.ruleArguments.indexOf(OPTION_ALLOW_NULL_CHECK) !== -1,
+            allowUndefined: this.ruleArguments.indexOf(OPTION_ALLOW_UNDEFINED_CHECK) !== -1,
+        });
     }
 }
 
-class ComparisonWalker extends Lint.RuleWalker {
-    private allowNull = this.hasOption(OPTION_ALLOW_NULL_CHECK);
-    private allowUndefined = this.hasOption(OPTION_ALLOW_UNDEFINED_CHECK);
-
-    public visitBinaryExpression(node: ts.BinaryExpression) {
-        const eq = Lint.getEqualsKind(node.operatorToken);
-        if (eq && !eq.isStrict && !this.isExpressionAllowed(node)) {
-            this.addFailureAtNode(node.operatorToken, eq.isPositive ? Rule.EQ_FAILURE_STRING : Rule.NEQ_FAILURE_STRING);
+function walk(ctx: Lint.WalkContext<Options>) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (isBinaryExpression(node)) {
+            if ((node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+                 node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken) &&
+                !(isExpressionAllowed(node.right, ctx.options) || isExpressionAllowed(node.left, ctx.options))) {
+                ctx.addFailureAtNode(node.operatorToken, node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken
+                                                         ? Rule.EQ_FAILURE_STRING
+                                                         : Rule.NEQ_FAILURE_STRING);
+            }
         }
-        super.visitBinaryExpression(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
+}
 
-    private isExpressionAllowed({ left, right }: ts.BinaryExpression) {
-        const isAllowed = (n: ts.Expression) =>
-            n.kind === ts.SyntaxKind.NullKeyword ? this.allowNull
-            : this.allowUndefined &&
-                n.kind === ts.SyntaxKind.Identifier &&
-                (n as ts.Identifier).originalKeywordKind === ts.SyntaxKind.UndefinedKeyword;
-        return isAllowed(left) || isAllowed(right);
+function isExpressionAllowed(node: ts.Expression, options: Options) {
+    if (node.kind === ts.SyntaxKind.NullKeyword) {
+        return options.allowNull;
     }
+    return options.allowUndefined &&
+        node.kind === ts.SyntaxKind.Identifier &&
+        (node as ts.Identifier).originalKeywordKind === ts.SyntaxKind.UndefinedKeyword;
 }

--- a/test/rules/no-arg/test.js.lint
+++ b/test/rules/no-arg/test.js.lint
@@ -2,7 +2,7 @@ var testVariable = 123;
 
 function testFunction(): number {
     if(arguments.callee.caller === testFunction) {
-       ~~~~~~~~~                                   [Access to arguments.callee is forbidden]
+       ~~~~~~~~~~~~~~~~                                   [Access to arguments.callee is forbidden]
         console.log("called");
     }
 

--- a/test/rules/no-arg/test.ts.lint
+++ b/test/rules/no-arg/test.ts.lint
@@ -2,7 +2,7 @@ var testVariable = 123;
 
 function testFunction(): number {
     if(arguments.callee.caller === testFunction) {
-       ~~~~~~~~~                                   [Access to arguments.callee is forbidden]
+       ~~~~~~~~~~~~~~~~                                   [Access to arguments.callee is forbidden]
         console.log("called");
     }
 

--- a/test/rules/no-debugger/test.js.lint
+++ b/test/rules/no-debugger/test.js.lint
@@ -3,6 +3,6 @@ var testVariable = "debugger";
 function testFunction(): number {
     if (testVariable === "debugger") {
         debugger;
-        ~~~~~~~~  [Use of debugger statements is forbidden]
+        ~~~~~~~~~  [Use of debugger statements is forbidden]
     }
 }

--- a/test/rules/no-debugger/test.ts.lint
+++ b/test/rules/no-debugger/test.ts.lint
@@ -3,6 +3,6 @@ var testVariable = "debugger";
 function testFunction(): number {
     if (testVariable === "debugger") {
         debugger;
-        ~~~~~~~~  [Use of debugger statements is forbidden]
+        ~~~~~~~~~  [Use of debugger statements is forbidden]
     }
 }

--- a/test/rules/no-trailing-whitespace/ignore-template-strings/test.ts.fix
+++ b/test/rules/no-trailing-whitespace/ignore-template-strings/test.ts.fix
@@ -7,8 +7,8 @@ class Clazz {
     private foobar() {
     }
 }
-const template = `
-I have trailing whitespace
+const template = ` 
+I have trailing whitespace  
 `;
 // single line comment without trailing whitespace
 // single line comment with trailing whitespace

--- a/test/rules/no-trailing-whitespace/ignore-template-strings/test.ts.lint
+++ b/test/rules/no-trailing-whitespace/ignore-template-strings/test.ts.lint
@@ -13,9 +13,7 @@ class Clazz {
 }    
  ~~~~ [trailing whitespace]
 const template = ` 
-                  ~ [trailing whitespace]
 I have trailing whitespace  
-                          ~~ [trailing whitespace]
 `;
 // single line comment without trailing whitespace
 // single line comment with trailing whitespace   

--- a/test/rules/no-trailing-whitespace/ignore-template-strings/tslint.json
+++ b/test/rules/no-trailing-whitespace/ignore-template-strings/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-trailing-whitespace": [
+      true,
+      "ignore-template-strings"
+    ]
+  }
+}

--- a/test/rules/quotemark/double/test.ts.fix
+++ b/test/rules/quotemark/double/test.ts.fix
@@ -3,3 +3,4 @@ var single = "single";
 var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = "\"doubleWithinSingle\"";
 var tabNewlineWithinSingle = "tab\tNewline\nWithinSingle";
+"escaped'quotemark";

--- a/test/rules/quotemark/double/test.ts.lint
+++ b/test/rules/quotemark/double/test.ts.lint
@@ -6,3 +6,5 @@ var doubleWithinSingle = '"doubleWithinSingle"';
                          ~~~~~~~~~~~~~~~~~~~~~~  [' should be "]
 var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [' should be "]
+'escaped\'quotemark';
+~~~~~~~~~~~~~~~~~~~~ [' should be "]

--- a/test/rules/quotemark/single/test.ts.fix
+++ b/test/rules/quotemark/single/test.ts.fix
@@ -3,3 +3,4 @@ var single = 'single';
 var singleWithinDouble = '\'singleWithinDouble\'';
 var doubleWithinSingle = '"doubleWithinSingle"';
 var tabNewlineWithinDouble = 'tab\tNewline\nWithinDouble';
+'escaped"quotemark';

--- a/test/rules/quotemark/single/test.ts.lint
+++ b/test/rules/quotemark/single/test.ts.lint
@@ -6,3 +6,5 @@ var singleWithinDouble = "'singleWithinDouble'";
 var doubleWithinSingle = '"doubleWithinSingle"';
 var tabNewlineWithinDouble = "tab\tNewline\nWithinDouble";
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [" should be ']
+"escaped\"quotemark";
+~~~~~~~~~~~~~~~~~~~~ [" should be ']

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,9 +1039,13 @@ tslint@latest:
     tsutils "^1.1.0"
     update-notifier "^2.0.0"
 
-tsutils@^1.1.0, tsutils@^1.2.2:
+tsutils@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.2.2.tgz#7e165c601367b9f89200b97ff47d9e38d1a6e4c8"
+
+tsutils@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.4.0.tgz#84f8a83df9967d35bf1ff3aa48c7339593d64e19"
 
 type-detect@0.1.1:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,8 +1026,8 @@ timed-out@^4.0.0:
   version "0.0.1"
 
 tslint@latest:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.5.0.tgz#12b384a339d456ee1d3cc665f13f4e759bbe5d64"
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.5.1.tgz#05356871bef23a434906734006fc188336ba824b"
   dependencies:
     babel-code-frame "^6.20.0"
     colors "^1.1.2"
@@ -1039,11 +1039,7 @@ tslint@latest:
     tsutils "^1.1.0"
     update-notifier "^2.0.0"
 
-tsutils@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.2.2.tgz#7e165c601367b9f89200b97ff47d9e38d1a6e4c8"
-
-tsutils@^1.4.0:
+tsutils@^1.1.0, tsutils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.4.0.tgz#84f8a83df9967d35bf1ff3aa48c7339593d64e19"
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Refactored some of the rather simple rules to `WalkContext` or `AbstractWalker`.
`no-trailing-whitespace` is the only rule where the logic changes: now it looks for trailing whitespace in the source text and iff there are lines found, it searches the AST for template spans and comments. 
[rule-change] `no-trailing-whitespace` now checks template strings by default. Use the new options `ignore-template-strings` to restore the old behavior.
[new-rule-option] added `ignore-template-strings` to `no-trailing-whitespace`
[enhancement] fixer of `quotemark` unescapes original quotemark (e.g. `'\''` -> `"'"`)

Refactoring is not done yet, but the perf improvement already looks pretty good: (linting this project with itself):
master: 7.7s
this PR: 6.7s

