### PR TITLE
strict-boolean-expressions: Support code without strictNullChecks

### DIFF
--- a/test/rules/strict-boolean-expressions/allow-number/tsconfig.json
+++ b/test/rules/strict-boolean-expressions/allow-number/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    }
+}

--- a/test/rules/strict-boolean-expressions/allow-string/tsconfig.json
+++ b/test/rules/strict-boolean-expressions/allow-string/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    }
+}

--- a/test/rules/strict-boolean-expressions/default/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/default/test.ts.lint
@@ -95,6 +95,7 @@ boolType ? strType : undefined;
 !enumType;
  ~~~~~~~~  [This type is not allowed in the operand for the '!' operator because it is an enum. Only booleans are allowed.]
 !!classType;
+ ~~~~~~~~~~ [This type is not allowed in the operand for the '!' operator because it is always falsy. Only booleans are allowed.]
   ~~~~~~~~~  [This type is not allowed in the operand for the '!' operator because it is always truthy. Only booleans are allowed.]
 !bwrapType;
  ~~~~~~~~~  [This type is not allowed in the operand for the '!' operator because it is always truthy. Only booleans are allowed.]
@@ -109,73 +110,73 @@ boolType ? strType : undefined;
 
 /*** If Statement ***/
 /*** Invalid ***/
-if (numType) { /* statements */ }
+if (numType) { }
     ~~~~~~~                       [This type is not allowed in the 'if' condition because it is a number. Only booleans are allowed.]
-if (objType) { /* statements */ }
+if (objType) { }
     ~~~~~~~                       [This type is not allowed in the 'if' condition because it is always truthy. Only booleans are allowed.]
-if (strType) { /* statements */ }
+if (strType) { }
     ~~~~~~~                       [This type is not allowed in the 'if' condition because it is a string. Only booleans are allowed.]
-if (bwrapType) { /* statements */ }
+if (bwrapType) { }
     ~~~~~~~~~                       [This type is not allowed in the 'if' condition because it is always truthy. Only booleans are allowed.]
-if (strFn()) { /* statements */ }
+if (strFn()) { }
     ~~~~~~~                       [This type is not allowed in the 'if' condition because it is a string. Only booleans are allowed.]
-if (MyEnum.A) { /* statements */ }
+if (MyEnum.A) { }
     ~~~~~~~~                       [This type is not allowed in the 'if' condition because it is an enum. Only booleans are allowed.]
-if (classType) { /* statements */ }
+if (classType) { }
     ~~~~~~~~~                       [This type is not allowed in the 'if' condition because it is always truthy. Only booleans are allowed.]
 
 /*** Valid ***/
-if (boolFn()) { /* statements */ }
-if (boolExpr) { /* statements */ }
-if (boolType) { /* statements */ }
+if (boolFn()) { }
+if (boolExpr) { }
+if (boolType) { }
 
 /*** While Statement ***/
 /*** Invalid ***/
-while (numType) { /* statements */ }
+while (numType) { break; }
        ~~~~~~~                       [This type is not allowed in the 'while' condition because it is a number. Only booleans are allowed.]
-while (objType) { /* statements */ }
+while (objType) { break; }
        ~~~~~~~                       [This type is not allowed in the 'while' condition because it is always truthy. Only booleans are allowed.]
-while (strType) { /* statements */ }
+while (strType) { break; }
        ~~~~~~~                       [This type is not allowed in the 'while' condition because it is a string. Only booleans are allowed.]
-while (strFn()) { /* statements */ }
+while (strFn()) { break; }
        ~~~~~~~                       [This type is not allowed in the 'while' condition because it is a string. Only booleans are allowed.]
-while (bwrapType) { /* statements */ }
+while (bwrapType) { break; }
        ~~~~~~~~~                       [This type is not allowed in the 'while' condition because it is always truthy. Only booleans are allowed.]
-while (MyEnum.A) { /* statements */ }
+while (MyEnum.A) { break; }
        ~~~~~~~~                       [This type is not allowed in the 'while' condition because it is an enum. Only booleans are allowed.]
-while (classType) { /* statements */ }
+while (classType) { break; }
        ~~~~~~~~~                       [This type is not allowed in the 'while' condition because it is always truthy. Only booleans are allowed.]
 
 /*** Valid ***/
-while (boolFn()) { /* statements */ }
-while (boolExpr) { /* statements */ }
-while (boolType) { /* statements */ }
+while (boolFn()) { break; }
+while (boolExpr) { break; }
+while (boolType) { break; }
 
 /*** Do Statement ***/
 /*** Invalid ***/
-do { /* statements */ } while (numType);
-                               ~~~~~~~   [This type is not allowed in the 'do-while' condition because it is a number. Only booleans are allowed.]
-do { /* statements */ } while (objType);
-                               ~~~~~~~   [This type is not allowed in the 'do-while' condition because it is always truthy. Only booleans are allowed.]
-do { /* statements */ } while (strType);
-                               ~~~~~~~   [This type is not allowed in the 'do-while' condition because it is a string. Only booleans are allowed.]
-do { /* statements */ } while (bwrapType);
-                               ~~~~~~~~~   [This type is not allowed in the 'do-while' condition because it is always truthy. Only booleans are allowed.]
-do { /* statements */ } while (strFn());
-                               ~~~~~~~   [This type is not allowed in the 'do-while' condition because it is a string. Only booleans are allowed.]
-do { /* statements */ } while (MyEnum.A);
-                               ~~~~~~~~   [This type is not allowed in the 'do-while' condition because it is an enum. Only booleans are allowed.]
-do { /* statements */ } while (classType);
-                               ~~~~~~~~~   [This type is not allowed in the 'do-while' condition because it is always truthy. Only booleans are allowed.]
+do { break; } while (numType);
+                     ~~~~~~~   [This type is not allowed in the 'do-while' condition because it is a number. Only booleans are allowed.]
+do { break; } while (objType);
+                     ~~~~~~~   [This type is not allowed in the 'do-while' condition because it is always truthy. Only booleans are allowed.]
+do { break; } while (strType);
+                     ~~~~~~~   [This type is not allowed in the 'do-while' condition because it is a string. Only booleans are allowed.]
+do { break; } while (bwrapType);
+                     ~~~~~~~~~   [This type is not allowed in the 'do-while' condition because it is always truthy. Only booleans are allowed.]
+do { break; } while (strFn());
+                     ~~~~~~~   [This type is not allowed in the 'do-while' condition because it is a string. Only booleans are allowed.]
+do { break; } while (MyEnum.A);
+                     ~~~~~~~~   [This type is not allowed in the 'do-while' condition because it is an enum. Only booleans are allowed.]
+do { break; } while (classType);
+                     ~~~~~~~~~   [This type is not allowed in the 'do-while' condition because it is always truthy. Only booleans are allowed.]
 
 /*** Valid ***/
-do { /* statements */ } while (boolFn());
-do { /* statements */ } while (boolExpr);
-do { /* statements */ } while (boolType);
+do { break; } while (boolFn());
+do { break; } while (boolExpr);
+do { break; } while (boolType);
 
 /*** For Statement ***/
 /*** Invalid ***/
-for (let j = 0; j; j++) { /* statements */ }
-                ~                            [This type is not allowed in the 'for' condition because it is a number. Only booleans are allowed.]
+for (let j = 0; j; j++) { break; }
+                ~                  [This type is not allowed in the 'for' condition because it is a number. Only booleans are allowed.]
 /*** Valid ***/
-for (let j = 0; j > numType; j++) { /* statements */ }
+for (let j = 0; j > numType; j++) { break; }

--- a/test/rules/strict-boolean-expressions/default/tsconfig.json
+++ b/test/rules/strict-boolean-expressions/default/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    }
+}

--- a/test/rules/strict-boolean-expressions/no-null-checks-allow-null-union/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/no-null-checks-allow-null-union/test.ts.lint
@@ -1,0 +1,17 @@
+declare function get<T>(): T;
+
+// Everything except string/number/enum is allowed.
+if (get<{ x: number }>) {}
+
+if (get<string>()) {}
+    ~~~~~~~~~~~~~ [This type is not allowed in the 'if' condition because it is a string. Allowed types are boolean or null-union.]
+
+if (get<number>()) {}
+    ~~~~~~~~~~~~~ [This type is not allowed in the 'if' condition because it is a number. Allowed types are boolean or null-union.]
+
+enum E {}
+if (get<E>()) {}
+    ~~~~~~~~ [This type is not allowed in the 'if' condition because it is an enum. Allowed types are boolean or null-union.]
+
+if (get<E | { x: number }>()) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~ [This type is not allowed in the 'if' condition because it could be an enum. Allowed types are boolean or null-union.]

--- a/test/rules/strict-boolean-expressions/no-null-checks-allow-null-union/tslint.json
+++ b/test/rules/strict-boolean-expressions/no-null-checks-allow-null-union/tslint.json
@@ -1,0 +1,8 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "strict-boolean-expressions": [true, "allow-null-union"]
+  }
+}

--- a/test/rules/strict-boolean-expressions/no-null-checks-allow-number-string/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/no-null-checks-allow-number-string/test.ts.lint
@@ -1,0 +1,9 @@
+declare function get<T>(): T;
+
+if (get<number>()) {}
+
+if (get<string>()) {}
+
+enum E {}
+if (get<E>()) {}
+    ~~~~~~~~     [This type is not allowed in the 'if' condition because it is an enum. Allowed types are boolean, string, or number.]

--- a/test/rules/strict-boolean-expressions/no-null-checks-allow-number-string/tslint.json
+++ b/test/rules/strict-boolean-expressions/no-null-checks-allow-number-string/tslint.json
@@ -1,0 +1,8 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "strict-boolean-expressions": [true, "allow-number", "allow-string"]
+  }
+}

--- a/test/rules/strict-boolean-expressions/no-null-checks/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/no-null-checks/test.ts.lint
@@ -1,0 +1,17 @@
+declare function get<T>(): T;
+
+if (get<{ x: number }>) {}
+    ~~~~~~~~~~~~~~~~~~~ [This type is not allowed in the 'if' condition because it is always truthy. It may be null/undefined, but neither 'allow-null-union' nor 'allow-undefined-union' is set. Only booleans are allowed.]
+
+if (get<string>()) {}
+    ~~~~~~~~~~~~~ [This type is not allowed in the 'if' condition because it is a string. Only booleans are allowed.]
+
+if (get<number>()) {}
+    ~~~~~~~~~~~~~ [This type is not allowed in the 'if' condition because it is a number. Only booleans are allowed.]
+
+enum E {}
+if (get<E>()) {}
+    ~~~~~~~~ [This type is not allowed in the 'if' condition because it is an enum. Only booleans are allowed.]
+
+if (get<E | { x: number }>()) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~ [This type is not allowed in the 'if' condition because it could be an enum. Only booleans are allowed.]

--- a/test/rules/strict-boolean-expressions/no-null-checks/tslint.json
+++ b/test/rules/strict-boolean-expressions/no-null-checks/tslint.json
@@ -1,0 +1,8 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "strict-boolean-expressions": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2172, #1555
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### Overview of change:

If `--strictNullChecks` mode is not enabled, we will consider every value to potentially be a null/undefined union, so we won't consider anything as "always truthy".

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[enhancement] `strict-boolean-expressions`: When `--strictNullChecks` is turned off, `allow-null-union` and `allow-undefined-union` turn off "always truthy" errors.
