### PR TITLE
Refactor no-unnecessary-qualifier to use walker function

### DIFF
--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -19,7 +19,6 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { arraysAreEqual } from "../utils";
 
 export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -41,98 +40,85 @@ export class Rule extends Lint.Rules.TypedRule {
     }
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithWalker(new Walker(sourceFile, this.getOptions(), program));
+        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
     }
 }
 
-class Walker extends Lint.ProgramAwareRuleWalker {
-    private namespacesInScope: Array<ts.ModuleDeclaration | ts.EnumDeclaration> = [];
+function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
+    const { sourceFile } = ctx;
+    const namespacesInScope: Array<ts.ModuleDeclaration | ts.EnumDeclaration> = [];
 
-    public visitModuleDeclaration(node: ts.ModuleDeclaration) {
-        this.namespacesInScope.push(node);
-        super.visitModuleDeclaration(node);
-        this.namespacesInScope.pop();
-    }
-
-    public visitEnumDeclaration(node: ts.EnumDeclaration) {
-        this.namespacesInScope.push(node);
-        super.visitEnumDeclaration(node);
-        this.namespacesInScope.pop();
-    }
-
-    public visitNode(node: ts.Node) {
+    ts.forEachChild(sourceFile, cb);
+    function cb(node: ts.Node): void {
         switch (node.kind) {
-            case ts.SyntaxKind.QualifiedName:
-                const { left, right } = node as ts.QualifiedName;
-                this.visitNamespaceAccess(node, left, right);
+            case ts.SyntaxKind.ModuleDeclaration:
+            case ts.SyntaxKind.EnumDeclaration:
+                namespacesInScope.push(node as ts.ModuleDeclaration | ts.EnumDeclaration);
+                ts.forEachChild(node, cb);
+                namespacesInScope.pop();
                 break;
-            case ts.SyntaxKind.PropertyAccessExpression:
+
+            case ts.SyntaxKind.QualifiedName: {
+                const { left, right } = node as ts.QualifiedName;
+                visitNamespaceAccess(left, right);
+                break;
+            }
+
+            case ts.SyntaxKind.PropertyAccessExpression: {
                 const { expression, name } = node as ts.PropertyAccessExpression;
                 if (utils.isEntityNameExpression(expression)) {
-                    this.visitNamespaceAccess(node, expression, name);
+                    visitNamespaceAccess(expression, name);
                     break;
                 }
+            }
                 // falls through
+
             default:
-                super.visitNode(node);
+                ts.forEachChild(node, cb);
         }
     }
 
-    private visitNamespaceAccess(node: ts.Node, qualifier: ts.EntityNameOrEntityNameExpression, name: ts.Identifier) {
-        if (this.qualifierIsUnnecessary(qualifier, name)) {
-            const fix = this.createFix(this.deleteFromTo(qualifier.getStart(), name.getStart()));
-            this.addFailureAtNode(qualifier, Rule.FAILURE_STRING(qualifier.getText()), fix);
+    function visitNamespaceAccess(qualifier: ts.EntityNameOrEntityNameExpression, name: ts.Identifier) {
+        if (qualifierIsUnnecessary(qualifier, name)) {
+            const fix = ctx.createFix(Lint.Replacement.deleteFromTo(qualifier.getStart(), name.getStart()));
+            ctx.addFailureAtNode(qualifier, Rule.FAILURE_STRING(qualifier.getText()), fix);
         } else {
             // Only look for nested qualifier errors if we didn't already fail on the outer qualifier.
-            super.visitNode(node);
+            cb(qualifier);
         }
     }
 
-    private qualifierIsUnnecessary(qualifier: ts.EntityNameOrEntityNameExpression, name: ts.Identifier): boolean {
-        const namespaceSymbol = this.symbolAtLocation(qualifier);
-        if (namespaceSymbol === undefined || !this.symbolIsNamespaceInScope(namespaceSymbol)) {
+    function qualifierIsUnnecessary(qualifier: ts.EntityNameOrEntityNameExpression, name: ts.Identifier): boolean {
+        const namespaceSymbol = checker.getSymbolAtLocation(qualifier);
+        if (namespaceSymbol === undefined || !symbolIsNamespaceInScope(namespaceSymbol)) {
             return false;
         }
 
-        const accessedSymbol = this.symbolAtLocation(name);
+        const accessedSymbol = checker.getSymbolAtLocation(name);
         if (accessedSymbol === undefined) {
             return false;
         }
 
-        // If the symbol in scope is different, the qualifier is necessary.
-        const fromScope = this.getSymbolInScope(qualifier, accessedSymbol.flags, name.text);
-        return fromScope === undefined || symbolsAreEqual(fromScope, accessedSymbol);
+        // If the symbol in scope is different than the namespace (due to shadowing), the qualifier is necessary.
+        const fromScope = getSymbolInScope(qualifier, accessedSymbol.flags, name.text, checker);
+        return fromScope === undefined || fromScope === accessedSymbol;
     }
 
-    private getSymbolInScope(node: ts.Node, flags: ts.SymbolFlags, name: string): ts.Symbol | undefined {
-        // TODO:PERF `getSymbolsInScope` gets a long list. Is there a better way?
-        const scope = this.getTypeChecker().getSymbolsInScope(node, flags);
-        return scope.find((scopeSymbol) => scopeSymbol.name === name);
-    }
-
-    private symbolAtLocation(node: ts.Node): ts.Symbol | undefined {
-        return this.getTypeChecker().getSymbolAtLocation(node);
-    }
-
-    private symbolIsNamespaceInScope(symbol: ts.Symbol): boolean {
-        if (symbol.getDeclarations().some((decl) => this.namespacesInScope.some((ns) => nodesAreEqual(ns, decl)))) {
+    function symbolIsNamespaceInScope(symbol: ts.Symbol): boolean {
+        if (symbol.getDeclarations().some((decl) => namespacesInScope.some((ns) => ns === decl))) {
             return true;
         }
-        const alias = this.tryGetAliasedSymbol(symbol);
-        return alias !== undefined && this.symbolIsNamespaceInScope(alias);
-    }
-
-    private tryGetAliasedSymbol(symbol: ts.Symbol): ts.Symbol | undefined {
-        return Lint.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias) ? this.getTypeChecker().getAliasedSymbol(symbol) : undefined;
+        const alias = tryGetAliasedSymbol(symbol, checker);
+        return alias !== undefined && symbolIsNamespaceInScope(alias);
     }
 }
 
-// TODO: Should just be `===`. See https://github.com/palantir/tslint/issues/1969
-function nodesAreEqual(a: ts.Node, b: ts.Node) {
-    return a.pos === b.pos;
+function getSymbolInScope(node: ts.Node, flags: ts.SymbolFlags, name: string, checker: ts.TypeChecker): ts.Symbol | undefined {
+    // TODO:PERF `getSymbolsInScope` gets a long list. Is there a better way?
+    const scope = checker.getSymbolsInScope(node, flags);
+    return scope.find((scopeSymbol) => scopeSymbol.name === name);
 }
 
-// Only needed in global files. Likely due to https://github.com/palantir/tslint/issues/1969. See `test.global.ts.lint`.
-function symbolsAreEqual(a: ts.Symbol, b: ts.Symbol): boolean {
-    return arraysAreEqual(a.declarations, b.declarations, nodesAreEqual);
+function tryGetAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol | undefined {
+    return Lint.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias) ? checker.getAliasedSymbol(symbol) : undefined;
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

Just a refactor. Also no longer need `nodesAreEqual` or `symbolsAreEqual` thanks to #2235.