### PR TITLE
Add OPTION_ALLOW_SNAKE_CASE to variable name options

### DIFF
--- a/test/rules/variable-name/allow-pascal-case/test.ts.lint
+++ b/test/rules/variable-name/allow-pascal-case/test.ts.lint
@@ -1,14 +1,14 @@
 var validName1 = "hi";
 var VALIDNAME2 = "there";
 var ValidName3 = ",";
-var invalid_name2 = " "; // failure
-    ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+var invalid_name1 = " "; // failure
+    ~~~~~~~~~~~~~                   [variable name must be in camelcase, pascalcase or uppercase]
 
 class Test {
     private Invalid_name3 = "how"; // failure
-            ~~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~~                     [variable name must be in camelcase, pascalcase or uppercase]
     private _optionallyValid = "are"; // sometimes a failure
-            ~~~~~~~~~~~~~~~~                                 [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~~~~~                                 [variable name must be in camelcase, pascalcase or uppercase]
 }
 
 function test() {
@@ -20,26 +20,26 @@ function test() {
 declare var DeclaresAreValid: any;
 
 export function functionWithInvalidParamNames (bad_name, AnotherOne) { // 1 failure
-                                               ~~~~~~~~                              [variable name must be in camelcase or uppercase]
+                                               ~~~~~~~~                              [variable name must be in camelcase, pascalcase or uppercase]
     //
 }
 
 let { foo, bar } = { foo: 1, bar: 2 };
 let [ invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 3 failures
-      ~~~~~~~~~~~                                                  [variable name must be in camelcase or uppercase]
-                      ~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
+      ~~~~~~~~~~~                                                  [variable name must be in camelcase, pascalcase or uppercase]
+                      ~~~~~~~~~~~                                  [variable name must be in camelcase, pascalcase or uppercase]
 
 export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 1 failure
-                                                       ~~~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
+                                                       ~~~~~~~~~~~~~                                  [variable name must be in camelcase, pascalcase or uppercase]
     //
 }
 
 export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
-                                          ~~~~~~~~~~~                            [variable name must be in camelcase or uppercase]
+                                          ~~~~~~~~~~~                            [variable name must be in camelcase, pascalcase or uppercase]
   //
 }
 
 let optionallyValid_ = "bar";
-    ~~~~~~~~~~~~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~~~~          [variable name must be in camelcase, pascalcase or uppercase]
 let _$httpBackend_ = "leading and trailing";
-    ~~~~~~~~~~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~~          [variable name must be in camelcase, pascalcase or uppercase]

--- a/test/rules/variable-name/allow-snake-case/test.ts.lint
+++ b/test/rules/variable-name/allow-snake-case/test.ts.lint
@@ -1,0 +1,64 @@
+var validName1 = "hi";
+var VALIDNAME2 = "there";
+var valid_name3 = "tslint";
+var Invalid_name1 = " ";  // failure
+    ~~~~~~~~~~~~~                    [variable name must be in camelcase, snakecase or uppercase]
+var InvalidName2 = " ";  // failure
+    ~~~~~~~~~~~~                    [variable name must be in camelcase, snakecase or uppercase]
+
+class Test {
+    private valid_name = " ";
+    private Invalid_name1 = "how"; // failure
+            ~~~~~~~~~~~~~                     [variable name must be in camelcase, snakecase or uppercase]
+    private _optionallyValid = "are"; // sometimes a failure
+            ~~~~~~~~~~~~~~~~                                 [variable name must be in camelcase, snakecase or uppercase]
+}
+
+function test() {
+    () => {
+        var valid_name = " ";
+        var InVaLiDnAmE4 = "you"; // failure
+            ~~~~~~~~~~~~                     [variable name must be in camelcase, snakecase or uppercase]
+    };
+}
+
+declare var DeclaresAreValid: any;
+
+export function functionWithInvalidParamNames (ok_name, BadName) { // 1 failure
+                                                        ~~~~~~~                  [variable name must be in camelcase, snakecase or uppercase]
+}
+
+let { foo, bar } = { foo: 1, bar: 2 };
+let [ InvalidFoo, invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 1 failure
+      ~~~~~~~~~~                                                               [variable name must be in camelcase, snakecase or uppercase]
+
+export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 1 failure
+                                                                      ~~~~~~~~~~~~~                   [variable name must be in camelcase, snakecase or uppercase]
+    //
+}
+
+export function functionWithInvalidSpread(InvalidArg: ...number) { // 1 failure
+                                          ~~~~~~~~~~                            [variable name must be in camelcase, snakecase or uppercase]
+  //
+}
+
+let optionallyValid_ = "bar";
+    ~~~~~~~~~~~~~~~~          [variable name must be in camelcase, snakecase or uppercase]
+let _$httpBackend_ = "leading and trailing";
+    ~~~~~~~~~~~~~~          [variable name must be in camelcase, snakecase or uppercase]
+
+// Aliases.
+class X {
+  ValidAlias = ValidAlias;
+}
+
+var ValidAlias = some.ValidAlias;
+var ValidAlias = some.InValidAlias;
+    ~~~~~~~~~~                [variable name must be in camelcase, snakecase or uppercase]
+
+var someObject = {MoreValidAlias: 1};
+var {MoreValidAlias: localVar} = someObject;
+var {MoreValidAlias: local_var} = someObject;
+var {MoreValidAlias: LocalVar} = someObject;
+                     ~~~~~~~~                [variable name must be in camelcase, snakecase or uppercase]
+var {MoreValidAlias} = someObject;

--- a/test/rules/variable-name/allow-snake-case/tslint.json
+++ b/test/rules/variable-name/allow-snake-case/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "variable-name": [true, "allow-snake-case"]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2190
- [x] Is an enhancement
- [x] Does includes tests
- [x] Documentation is updated (assuming the documentation comes from `metadata` on the Rule itself).

#### Overview of change:

Add OPTION_ALLOW_SNAKE_CASE to variable name options

#### CHANGELOG.md entry:

    [new-rule-option] "allow-snake-case" option for `variable-name` rule (#2190)


Please let me know if there's anything else you need / would like to change.  Many thanks.