### PR TITLE
Bugfix trailing-comma for new without parens

### DIFF
--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -94,9 +94,13 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
                 case ts.SyntaxKind.EnumDeclaration:
                     this.checkList((node as ts.EnumDeclaration).members, node.end);
                     break;
-                case ts.SyntaxKind.CallExpression:
                 case ts.SyntaxKind.NewExpression:
-                    this.checkList((node as ts.CallExpression | ts.NewExpression).arguments, node.end);
+                    if ((node as ts.NewExpression).arguments === undefined) {
+                        break;
+                    }
+                    // falls through
+                case ts.SyntaxKind.CallExpression:
+                    this.checkList((node as ts.CallExpression | ts.NewExpression).arguments!, node.end);
                     break;
                 case ts.SyntaxKind.ArrowFunction:
                 case ts.SyntaxKind.Constructor:

--- a/test/rules/trailing-comma/multiline-always/test.ts.fix
+++ b/test/rules/trailing-comma/multiline-always/test.ts.fix
@@ -544,3 +544,6 @@ export {
     foo,
     bar,
 };
+
+// don't crash
+new Foo

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -573,3 +573,6 @@ export {
     bar
        ~nil [Missing trailing comma]
 };
+
+// don't crash
+new Foo


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `trailing-comma` no longer crashes on new without parentheses (e.g. `new Foo`)

