### PR TITLE
prefer-const: don't check ambient declarations

### DIFF
--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -123,12 +123,21 @@ interface DestructuringInfo {
 class PreferConstWalker extends Lint.AbstractWalker<Options> {
     private scope: Scope;
     public walk(sourceFile: ts.SourceFile) {
+        // don't check anything on declaration files
+        if (sourceFile.isDeclarationFile) {
+            return;
+        }
+
         this.scope = new Scope();
         const cb = (node: ts.Node): void => {
             const savedScope = this.scope;
             const boundary = utils.isScopeBoundary(node);
             if (boundary !== utils.ScopeBoundary.None) {
                 if (boundary === utils.ScopeBoundary.Function) {
+                    if (node.kind === ts.SyntaxKind.ModuleDeclaration && utils.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)) {
+                        // don't check ambient namespaces
+                        return;
+                    }
                     this.scope = new Scope();
                     if (utils.isFunctionDeclaration(node) ||
                         utils.isMethodDeclaration(node) ||
@@ -240,11 +249,11 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
         let declarationInfo: DeclarationInfo;
         const kind = utils.getVariableDeclarationKind(declarationList);
         if (kind === utils.VariableDeclarationKind.Const ||
-            utils.hasModifier(declarationList.parent!.modifiers, ts.SyntaxKind.ExportKeyword)) {
+            utils.hasModifier(declarationList.parent!.modifiers, ts.SyntaxKind.ExportKeyword, ts.SyntaxKind.DeclareKeyword)) {
 
             declarationInfo = {
                 canBeConst: false,
-                isBlockScoped: true,
+                isBlockScoped: kind !== utils.VariableDeclarationKind.Var,
             };
         } else {
             declarationInfo = {

--- a/test/rules/prefer-const/default/ambient.d.ts.lint
+++ b/test/rules/prefer-const/default/ambient.d.ts.lint
@@ -1,0 +1,5 @@
+// no errors in declaration files
+let foo = 0;
+namespace bar {
+    let foo = 0;
+}

--- a/test/rules/prefer-const/default/test.ts.fix
+++ b/test/rules/prefer-const/default/test.ts.fix
@@ -187,3 +187,10 @@ for (let i = 1, l = arr.length; i < l; ++i) {
 // cannot fix, because of uninitialized variables
 let uninitialized;
 let initialized1 = 0, uninitialized2;
+
+// ambient declarations are not checked
+declare let ambient = 0;
+
+declare namespace ambient {
+    let foo = 0;
+}

--- a/test/rules/prefer-const/default/test.ts.lint
+++ b/test/rules/prefer-const/default/test.ts.lint
@@ -223,3 +223,10 @@ let uninitialized;
 let initialized1 = 0, uninitialized2;
     ~~~~~~~~~~~~           [Identifier 'initialized1' is never reassigned; use 'const' instead of 'let'.]
                       ~~~~~~~~~~~~~~           [Identifier 'uninitialized2' is never reassigned; use 'const' instead of 'let'.]
+
+// ambient declarations are not checked
+declare let ambient = 0;
+
+declare namespace ambient {
+    let foo = 0;
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2390
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `prefer-const` no longer shows warnings on ambient declarations
Fixes: #2390
