### PR TITLE
Fix type parameter of applyWithFunction

### DIFF
--- a/src/language/rule/abstractRule.ts
+++ b/src/language/rule/abstractRule.ts
@@ -49,8 +49,16 @@ export abstract class AbstractRule implements IRule {
     }
 
     protected applyWithFunction(sourceFile: ts.SourceFile, walkFn: (ctx: WalkContext<void>) => void): RuleFailure[];
-    protected applyWithFunction<T>(sourceFile: ts.SourceFile, walkFn: (ctx: WalkContext<T>) => void, options: T): RuleFailure[];
-    protected applyWithFunction<T>(sourceFile: ts.SourceFile, walkFn: (ctx: WalkContext<T | void>) => void, options?: T): RuleFailure[] {
+    protected applyWithFunction<T, U extends T>(
+        sourceFile: ts.SourceFile,
+        walkFn: (ctx: WalkContext<T>) => void,
+        options: U,
+    ): RuleFailure[];
+    protected applyWithFunction<T, U extends T>(
+        sourceFile: ts.SourceFile,
+        walkFn: (ctx: WalkContext<T | void>) => void,
+        options?: U,
+    ): RuleFailure[] {
         const ctx = new WalkContext(sourceFile, this.ruleName, options);
         walkFn(ctx);
         return this.filterFailures(ctx.failures);


### PR DESCRIPTION
### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Type of `options` should not be used to infer type parameter `T`.
Refs: https://github.com/Microsoft/TypeScript/issues/14829

#### CHANGELOG.md entry:
[no-log]
