### PR TITLE
Adds default severity

### DIFF
--- a/docs/usage/tslint-json/index.md
+++ b/docs/usage/tslint-json/index.md
@@ -9,73 +9,54 @@ configure which rules get run.
 
 `tslint.json` files can have the following fields specified:
 
-* `extends?: string | string[]`: 
-A path(s) to another configuration file which to extend.
+* `extends?: string | string[]`:
+A path or array of paths to other configuration files which are extended by this configuration.
 This value is handled using node module resolution semantics.
 For example a value of "tslint-config" would cause TSLint to try and load the main file of a module
 named "tslint-config" as a configuration file.
 A value of "./tslint-config", on the other hand, would be treated as a relative path to file.
 * `rulesDirectory?: string | string[]`:
-A path(s) to a directory of [custom rules][2]. This will always be treated as a relative or absolute path.
-* `rules?: any`: Pairs of keys and values where each key is a rule name and each value is the configuration for that rule.
-If a rule takes no options, you can simply set its value to a boolean, either `true` or `false`, to enable or disable it.
-If a rule takes options, you set its value to an array where the first value is a boolean indicating if the rule is enabled and the next values are options handled by the rule.
+A path or array of paths to a directories of [custom rules][2]. This will always be treated as a relative or absolute path.
+* `rules?: { [name: string]: RuleSetting }`: A map of rule names to their configuration settings.
+  - Each rule is associated with an object containing:
+    - `options?: any`: An array of values that are specific to a rule.
+    - `severity?: "default" | "error" | "warning" | "off"`: Severity level. Level "error" will cause exit code 2.
+  - A boolean value may be specified instead of the above object, and is equivalent to setting no options with default severity.
 Not all possible rules are listed here, be sure to [check out the full list][3]. These rules are applied to `.ts` and `.tsx` files.
-* `jsRules?: any`: Same format as `rules`. These rules are applied to `.js` and `.jsx` files. 
+* `jsRules?: any`: Same format as `rules`. These rules are applied to `.js` and `.jsx` files.
+* `defaultSeverity?: "error" | "warning" | "off"`: The severity level used when a rule specifies a default warning level. If undefined, "error" is used. This value is not inherited and is only applied to rules in this file.
 
 `tslint.json` configuration files may have JavaScript-style `// single-line` and `/* multi-line */` comments in them (even though this is technically invalid JSON). If this confuses your syntax highlighter, you may want to switch it to JavaScript format.
 
 An example `tslint.json` file might look like this:
 
-```ts
+```json
 {
     "rulesDirectory": ["path/to/custom/rules/directory/", "another/path/"],
     "rules": {
-        "class-name": true,
-        "comment-format": [true, "check-space"],
-        "indent": [true, "spaces"],
-        "no-duplicate-variable": true,
-        "no-eval": true,
-        "no-internal-module": true,
-        "no-trailing-whitespace": true,
-        "no-var-keyword": true,
-        "one-line": [true, "check-open-brace", "check-whitespace"],
-        "quotemark": [true, "double"],
-        "semicolon": false,
-        "triple-equals": [true, "allow-null-check"],
-        "typedef-whitespace": [true, {
-            "call-signature": "nospace",
-            "index-signature": "nospace",
-            "parameter": "nospace",
-            "property-declaration": "nospace",
-            "variable-declaration": "nospace"
-        }],
-        "variable-name": [true, "ban-keywords"],
-        "whitespace": [true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ]
+        "max-line-length": {
+            "options": [120],
+        },
+        "new-parens": true,
+        "no-arg": true,
+        "no-bitwise": true,
+        "no-conditional-assignment": true,
+        "no-consecutive-blank-lines": false,
+        "no-console": {
+            "options": [
+                "debug",
+                "info",
+                "log",
+                "time",
+                "timeEnd",
+                "trace",
+            ],
+        }
     },
     "jsRules": {
-        "indent": [true, "spaces"],
-        "no-duplicate-variable": true,
-        "no-eval": true,
-        "no-trailing-whitespace": true,
-        "one-line": [true, "check-open-brace", "check-whitespace"],
-        "quotemark": [true, "double"],
-        "semicolon": false,
-        "triple-equals": [true, "allow-null-check"],
-        "variable-name": [true, "ban-keywords"],
-        "whitespace": [true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ]
+        "max-line-length": {
+            "options": [120],
+        }
     }
 }
 ```

--- a/test/config/tslint-extends-package-warning.json
+++ b/test/config/tslint-extends-package-warning.json
@@ -1,0 +1,13 @@
+{
+  "extends": "tslint-test-custom-rules",
+  "jsRules": {
+    "always-fail": {
+      "severity": "warning"
+    }
+  },
+  "rules": {
+    "always-fail": {
+      "severity": "warning"
+    }
+  }
+}

--- a/test/configurationTests.ts
+++ b/test/configurationTests.ts
@@ -80,14 +80,14 @@ describe("Configuration", () => {
             expected.rules.set("i", { ruleArguments: undefined, ruleSeverity: "warning" });
             expected.rules.set("j", { ruleArguments: undefined, ruleSeverity: "error" });
             expected.rules.set("k", { ruleArguments: undefined, ruleSeverity: "off" });
-            expected.rules.set("l", { ruleArguments: [1], ruleSeverity: undefined });
-            expected.rules.set("m", { ruleArguments: [2], ruleSeverity: undefined });
-            expected.rules.set("n", { ruleArguments: [{ no: false }], ruleSeverity: undefined });
+            expected.rules.set("l", { ruleArguments: [1], ruleSeverity: "error" });
+            expected.rules.set("m", { ruleArguments: [2], ruleSeverity: "error" });
+            expected.rules.set("n", { ruleArguments: [{ no: false }], ruleSeverity: "error" });
             expected.rules.set("o", { ruleArguments: [1], ruleSeverity: "warning" });
             expected.rules.set("p", { ruleArguments: [], ruleSeverity: "off" });
-            expected.rules.set("q", { ruleArguments: undefined, ruleSeverity: undefined });
-            expected.rules.set("r", { ruleArguments: undefined, ruleSeverity: "off" });
-            expected.rules.set("s", { ruleArguments: undefined, ruleSeverity: undefined });
+            expected.rules.set("q", { ruleArguments: undefined, ruleSeverity: "error" });
+            expected.rules.set("r", { ruleArguments: undefined, ruleSeverity: "error" });
+            expected.rules.set("s", { ruleArguments: undefined, ruleSeverity: "error" });
             assertConfigEquals(parseConfigFile(rawConfig), expected);
         });
 
@@ -100,6 +100,27 @@ describe("Configuration", () => {
                 ruleName: "s",
                 ruleSeverity: "error",
             });
+        });
+    });
+
+    describe("defaultSeverity", () => {
+        it("uses defaultSeverity if severity is default", () => {
+            const rawConfig = {
+                defaultSeverity: "warning",
+                rules: {
+                    a: { severity: "error" },
+                    b: { severity: "warning" },
+                    c: { severity: "off" },
+                    d: { severity: "default" },
+                },
+            };
+
+            const expected = getEmptyConfig();
+            expected.rules.set("a", { ruleArguments: undefined, ruleSeverity: "error" });
+            expected.rules.set("b", { ruleArguments: undefined, ruleSeverity: "warning" });
+            expected.rules.set("c", { ruleArguments: undefined, ruleSeverity: "off" });
+            expected.rules.set("d", { ruleArguments: undefined, ruleSeverity: "warning" });
+            assertConfigEquals(parseConfigFile(rawConfig), expected);
         });
     });
 

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -113,6 +113,15 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             });
         });
 
+        it("exits with code 0 if custom rules directory is passed and file contains lint warnings", (done) => {
+            execCli(["-c", "./test/config/tslint-extends-package-warning.json", "-r", "./test/files/custom-rules", "src/test.ts"],
+                (err) => {
+                    assert.isNull(err, "process should exit without an error");
+                    done();
+                },
+            );
+        });
+
         it("exits with code 2 if custom rules directory is specified in config file and file contains lint errors", (done) => {
             execCli(["-c", "./test/config/tslint-custom-rules-with-dir.json", "src/test.ts"], (err) => {
                 assert.isNotNull(err, "process should exit with error");


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2279 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Adds a config setting `defaultSeverity` to the config file, which applies its severity level to any rule with a `default` setting in the _current_ file. This does not apply to configs that are extended. A future config setting may be added to override all of the severity levels of the extended rule sets.

fixes #2279 

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[new-config-option] Adds `defaultSeverity` with options `error`, `warning`, and `off`.
