### PR TITLE
no-unnecessary-qualifier: Stop using symbolsAreEqual

### DIFF
--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -19,7 +19,6 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { arraysAreEqual } from "../utils";
 
 export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -101,7 +100,7 @@ class Walker extends Lint.ProgramAwareRuleWalker {
 
         // If the symbol in scope is different, the qualifier is necessary.
         const fromScope = this.getSymbolInScope(qualifier, accessedSymbol.flags, name.text);
-        return fromScope === undefined || symbolsAreEqual(fromScope, accessedSymbol);
+        return fromScope === undefined || fromScope === accessedSymbol;
     }
 
     private getSymbolInScope(node: ts.Node, flags: ts.SymbolFlags, name: string): ts.Symbol | undefined {
@@ -115,7 +114,7 @@ class Walker extends Lint.ProgramAwareRuleWalker {
     }
 
     private symbolIsNamespaceInScope(symbol: ts.Symbol): boolean {
-        if (symbol.getDeclarations().some((decl) => this.namespacesInScope.some((ns) => nodesAreEqual(ns, decl)))) {
+        if (symbol.getDeclarations().some((decl) => this.namespacesInScope.some((ns) => ns === decl))) {
             return true;
         }
         const alias = this.tryGetAliasedSymbol(symbol);
@@ -125,14 +124,4 @@ class Walker extends Lint.ProgramAwareRuleWalker {
     private tryGetAliasedSymbol(symbol: ts.Symbol): ts.Symbol | undefined {
         return Lint.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias) ? this.getTypeChecker().getAliasedSymbol(symbol) : undefined;
     }
-}
-
-// TODO: Should just be `===`. See https://github.com/palantir/tslint/issues/1969
-function nodesAreEqual(a: ts.Node, b: ts.Node) {
-    return a.pos === b.pos;
-}
-
-// Only needed in global files. Likely due to https://github.com/palantir/tslint/issues/1969. See `test.global.ts.lint`.
-function symbolsAreEqual(a: ts.Symbol, b: ts.Symbol): boolean {
-    return arraysAreEqual(a.declarations, b.declarations, nodesAreEqual);
 }

--- a/test/rules/no-unnecessary-qualifier/test-global-2.ts.lint
+++ b/test/rules/no-unnecessary-qualifier/test-global-2.ts.lint
@@ -1,0 +1,4 @@
+namespace M {
+    // Used in test-global.ts
+    export type T = number;
+}

--- a/test/rules/no-unnecessary-qualifier/test-global.ts.fix
+++ b/test/rules/no-unnecessary-qualifier/test-global.ts.fix
@@ -1,5 +1,5 @@
-// We need `symbolsAreEqual` in global files.
 namespace N {
     export type T = number;
     export const x: T = 0;
+    export const x: M.T = 0;
 }

--- a/test/rules/no-unnecessary-qualifier/test-global.ts.lint
+++ b/test/rules/no-unnecessary-qualifier/test-global.ts.lint
@@ -1,6 +1,6 @@
-// We need `symbolsAreEqual` in global files.
 namespace N {
     export type T = number;
     export const x: N.T = 0;
                     ~ [Qualifier is unnecessary since 'N' is in scope.]
+    export const x: M.T = 0;
 }


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2413
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Now that  #2235 is in, we don't need to worry about multiple source files, so symbolsAreEqual is unnecessary.
Also fixes a bug where symbols with declarations at identical positions but different source files were considered equal.