### PR TITLE
member-access: Skip index signature, it can not have an access modifier

### DIFF
--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -74,8 +74,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function walk(ctx: Lint.WalkContext<void>, noPublic: boolean, checkAccessor: boolean, checkConstructor: boolean) {
-    return ts.forEachChild(ctx.sourceFile, recur);
-    function recur(node: ts.Node): void {
+    return ts.forEachChild(ctx.sourceFile, function recur(node: ts.Node): void {
         if (isClassLikeDeclaration(node)) {
             for (const child of node.members) {
                 if (shouldCheck(child)) {
@@ -84,7 +83,7 @@ function walk(ctx: Lint.WalkContext<void>, noPublic: boolean, checkAccessor: boo
             }
         }
         return ts.forEachChild(node, recur);
-    }
+    });
 
     function shouldCheck(node: ts.ClassElement): boolean {
         switch (node.kind) {
@@ -93,10 +92,11 @@ function walk(ctx: Lint.WalkContext<void>, noPublic: boolean, checkAccessor: boo
             case ts.SyntaxKind.GetAccessor:
             case ts.SyntaxKind.SetAccessor:
                 return checkAccessor;
-            case ts.SyntaxKind.SemicolonClassElement:
-                return false;
-            default:
+            case ts.SyntaxKind.MethodDeclaration:
+            case ts.SyntaxKind.PropertyDeclaration:
                 return true;
+            default:
+                return false;
         }
     }
 
@@ -131,8 +131,6 @@ function memberType(node: ts.ClassElement): string {
             return "get property accessor";
         case ts.SyntaxKind.SetAccessor:
             return "set property accessor";
-        case ts.SyntaxKind.IndexSignature:
-            return "index signature";
         default:
             throw new Error("unhandled node type " + ts.SyntaxKind[node.kind]);
     }

--- a/test/rules/member-access/default/test.ts.lint
+++ b/test/rules/member-access/default/test.ts.lint
@@ -13,7 +13,6 @@ declare class AmbientAccess {
 
 class Members {
     [x: string]: number;
-    ~~~~~~~~~~~~~~~~~~~~ [The index signature must be marked either 'private', 'public', or 'protected']
     i: number;
     ~ [The class property 'i' must be marked either 'private', 'public', or 'protected']
     static j: number;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Skips an index signature in `member-access`.
Previous PR #2435 was wrong, index signatures can not have access modifiers.
Also, it mentioned the wrong rule name!

#### CHANGELOG.md entry:

[bugfix] `member-access`: Skip index signature, it can not have an access modifier
