### PR TITLE
Fix regression in restrict-plus-operands

### DIFF
--- a/src/rules/restrictPlusOperandsRule.ts
+++ b/src/rules/restrictPlusOperandsRule.ts
@@ -43,7 +43,7 @@ export class Rule extends Lint.Rules.TypedRule {
 
 function walk(ctx: Lint.WalkContext<void>, program: ts.Program) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isBinaryExpression(node)) {
+        if (isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
             const tc = program.getTypeChecker();
             const leftType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.left));
             const rightType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.right));

--- a/test/rules/restrict-plus-operands/test.ts.lint
+++ b/test/rules/restrict-plus-operands/test.ts.lint
@@ -59,3 +59,7 @@ var good7 = pair.first + (10 as MyNumber);
 var good8 = "5.5" + pair.second;
 var good9 = ("5.5" as MyString) + pair.second;
 const good10 = 'hello' + (someBoolean ? 'a' : 'b') + (() => someBoolean ? 'c' : 'd')() + 'e';
+
+// don't check other binary expressions
+const balls = true;
+balls === true;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2443
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Fixes: #2443
[bugfix] `restrict-plus-operands` fixes regression where every assignment and comparison was checked

Sorry, my bad.
