### PR TITLE
Fix variableNameRule compiler error

### DIFF
--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -70,7 +70,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static KEYWORD_FAILURE = "variable name clashes with keyword/type";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithFunction<Options>(sourceFile, walk, parseOptions(this.ruleArguments));
+        return this.applyWithFunction(sourceFile, walk, parseOptions(this.ruleArguments));
     }
 }
 


### PR DESCRIPTION
Fixes a compiler error introduced by merging https://github.com/palantir/tslint/pull/2396



