### PR TITLE
prefer-for-of: No error if 'delete' is used

### DIFF
--- a/test/rules/prefer-for-of/test.ts.lint
+++ b/test/rules/prefer-for-of/test.ts.lint
@@ -150,4 +150,9 @@ for (let shadow = 0; shadow < arr.length; shadow++) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   [0]
     }
 }
+
+for (let i = 0; i < arr.length; i++) {
+    delete arr[i];
+}
+
 [0]: Expected a 'for-of' loop instead of a 'for' loop with this simple iteration


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2257
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Handle `delete` expressions in prefer-for-of

#### CHANGELOG.md entry:

[bugfix] `prefer-for-of`: No error if `delete` is used
