### PR TITLE
arrow-return-shorthand: Improve failure message when return expression is an object literal

### DIFF
--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -19,6 +19,7 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { hasCommentAfterPosition } from "../language/utils";
 
 const OPTION_MULTILINE = "multiline";
 
@@ -96,7 +97,7 @@ function createFix(arrowFunction: ts.FunctionLikeDeclaration, body: ts.Block, ex
     ];
 
     function hasComments(node: ts.Node): boolean {
-        return ts.getTrailingCommentRanges(text, node.getEnd()) !== undefined;
+        return hasCommentAfterPosition(text, node.getEnd());
     }
 }
 

--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -42,59 +43,60 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING =
-        "This arrow function body can be simplified by omitting the curly braces and the keyword 'return'.";
+    public static FAILURE_STRING(isObjectLiteral: boolean): string {
+        const start = "This arrow function body can be simplified by omitting the curly braces and the keyword 'return'";
+        return start + (isObjectLiteral ? ", and wrapping the object literal in parentheses." : ".");
+    }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new Walker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk, { multiline: this.ruleArguments.indexOf(OPTION_MULTILINE) !== -1 });
     }
 }
 
-class Walker extends Lint.RuleWalker {
-    public visitArrowFunction(node: ts.ArrowFunction) {
-        if (node.body && node.body.kind === ts.SyntaxKind.Block) {
-            const expr = getSimpleReturnExpression(node.body as ts.Block);
-            if (expr !== undefined && (this.hasOption(OPTION_MULTILINE) || !this.isMultiline(node.body))) {
-                this.addFailureAtNode(node.body, Rule.FAILURE_STRING, this.createArrowFunctionFix(node, node.body as ts.Block, expr));
+interface Options {
+    multiline: boolean;
+}
+
+function walk(ctx: Lint.WalkContext<Options>): void {
+    const { sourceFile, options: { multiline } } = ctx;
+    ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
+        if (utils.isArrowFunction(node) && utils.isBlock(node.body)) {
+            const expr = getSimpleReturnExpression(node.body);
+            if (expr !== undefined && (multiline || !node.body.getText(sourceFile).includes("\n"))) {
+                const isObjectLiteral = expr.kind === ts.SyntaxKind.ObjectLiteralExpression;
+                ctx.addFailureAtNode(node.body, Rule.FAILURE_STRING(isObjectLiteral), createFix(node, node.body, expr, sourceFile.text));
             }
         }
+        return ts.forEachChild(node, cb);
+    });
+}
 
-        super.visitArrowFunction(node);
-    }
+function createFix(arrowFunction: ts.FunctionLikeDeclaration, body: ts.Block, expr: ts.Expression, text: string): Lint.Fix | undefined {
+    const statement = expr.parent!;
+    const returnKeyword = Lint.childOfKind(statement, ts.SyntaxKind.ReturnKeyword)!;
+    const arrow = Lint.childOfKind(arrowFunction, ts.SyntaxKind.EqualsGreaterThanToken)!;
+    const openBrace = Lint.childOfKind(body, ts.SyntaxKind.OpenBraceToken)!;
+    const closeBrace = Lint.childOfKind(body, ts.SyntaxKind.CloseBraceToken)!;
+    const semicolon = Lint.childOfKind(statement, ts.SyntaxKind.SemicolonToken);
 
-    private isMultiline(node: ts.Node): boolean {
-        const getLine = (position: number) => this.getLineAndCharacterOfPosition(position).line;
-        return getLine(node.getEnd()) > getLine(node.getStart());
-    }
+    const anyComments = hasComments(arrow) || hasComments(openBrace) || hasComments(statement) || hasComments(returnKeyword) ||
+        hasComments(expr) || (semicolon && hasComments(semicolon)) || hasComments(closeBrace);
+    return anyComments ? undefined : [
+        // Object literal must be wrapped in `()`
+        ...(expr.kind === ts.SyntaxKind.ObjectLiteralExpression ? [
+            Lint.Replacement.appendText(expr.getStart(), "("),
+            Lint.Replacement.appendText(expr.getEnd(), ")"),
+        ] : []),
+        // " {"
+        Lint.Replacement.deleteFromTo(arrow.end, openBrace.end),
+        // "return "
+        Lint.Replacement.deleteFromTo(statement.getStart(), expr.getStart()),
+        // " }" (may include semicolon)
+        Lint.Replacement.deleteFromTo(expr.end, closeBrace.end),
+    ];
 
-    private createArrowFunctionFix(arrowFunction: ts.FunctionLikeDeclaration, body: ts.Block, expr: ts.Expression): Lint.Fix | undefined {
-        const text = this.getSourceFile().text;
-        const statement = expr.parent!;
-        const returnKeyword = Lint.childOfKind(statement, ts.SyntaxKind.ReturnKeyword)!;
-        const arrow = Lint.childOfKind(arrowFunction, ts.SyntaxKind.EqualsGreaterThanToken)!;
-        const openBrace = Lint.childOfKind(body, ts.SyntaxKind.OpenBraceToken)!;
-        const closeBrace = Lint.childOfKind(body, ts.SyntaxKind.CloseBraceToken)!;
-        const semicolon = Lint.childOfKind(statement, ts.SyntaxKind.SemicolonToken);
-
-        const anyComments = hasComments(arrow) || hasComments(openBrace) || hasComments(statement) || hasComments(returnKeyword) ||
-            hasComments(expr) || (semicolon && hasComments(semicolon)) || hasComments(closeBrace);
-        return anyComments ? undefined : [
-            // Object literal must be wrapped in `()`
-            ...(expr.kind === ts.SyntaxKind.ObjectLiteralExpression ? [
-                this.appendText(expr.getStart(), "("),
-                this.appendText(expr.getEnd(), ")"),
-            ] : []),
-            // " {"
-            this.deleteFromTo(arrow.end, openBrace.end),
-            // "return "
-            this.deleteFromTo(statement.getStart(), expr.getStart()),
-            // " }" (may include semicolon)
-            this.deleteFromTo(expr.end, closeBrace.end),
-        ];
-
-        function hasComments(node: ts.Node): boolean {
-            return ts.getTrailingCommentRanges(text, node.getEnd()) !== undefined;
-        }
+    function hasComments(node: ts.Node): boolean {
+        return ts.getTrailingCommentRanges(text, node.getEnd()) !== undefined;
     }
 }
 

--- a/test/rules/arrow-return-shorthand/default/test.js.lint
+++ b/test/rules/arrow-return-shorthand/default/test.js.lint
@@ -4,7 +4,7 @@
 (() => { return 0; });
        ~~~~~~~~~~~~~ [0]
 (() => { return { x: 1 } });
-       ~~~~~~~~~~~~~~~~~~~ [0]
+       ~~~~~~~~~~~~~~~~~~~ [1]
 (() => {
     return 0;
 });
@@ -30,3 +30,4 @@
        ~~~~~~~~~~~~~~~~~~ [0]
 
 [0]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return'.
+[1]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return', and wrapping the object literal in parentheses.

--- a/test/rules/arrow-return-shorthand/default/test.ts.lint
+++ b/test/rules/arrow-return-shorthand/default/test.ts.lint
@@ -2,7 +2,7 @@
 (() => { return 0; });
        ~~~~~~~~~~~~~ [0]
 (() => { return { x: 1 } });
-       ~~~~~~~~~~~~~~~~~~~ [0]
+       ~~~~~~~~~~~~~~~~~~~ [1]
 (() => {
     return 0;
 });
@@ -28,3 +28,4 @@
        ~~~~~~~~~~~~~~~~~~ [0]
 
 [0]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return'.
+[1]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return', and wrapping the object literal in parentheses.

--- a/test/rules/arrow-return-shorthand/multiline/test.ts.lint
+++ b/test/rules/arrow-return-shorthand/multiline/test.ts.lint
@@ -2,7 +2,7 @@
 (() => { return 0; });
        ~~~~~~~~~~~~~ [0]
 (() => { return { x: 1 } });
-       ~~~~~~~~~~~~~~~~~~~ [0]
+       ~~~~~~~~~~~~~~~~~~~ [1]
 (() => {
        ~
     return 0;
@@ -31,3 +31,4 @@
        ~~~~~~~~~~~~~~~~~~ [0]
 
 [0]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return'.
+[1]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return', and wrapping the object literal in parentheses.


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2223
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Changes the failure message to mention that parentheses are needed when the expression is an object literal.
