### PR TITLE
Remove remaining uses of `createFailure`

### DIFF
--- a/src/rules/banTypesRule.ts
+++ b/src/rules/banTypesRule.ts
@@ -68,9 +68,7 @@ class BanTypeWalker extends Lint.RuleWalker {
             this.bans.find(([bannedType]) =>
                 typeName.match(`^${bannedType}$`) != null) as string[];
         if (ban) {
-            this.addFailure(this.createFailure(
-                node.getStart(), node.getWidth(),
-                Rule.FAILURE_STRING_FACTORY(typeName, ban[1])));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(typeName, ban[1]));
         }
         super.visitTypeReference(node);
     }

--- a/src/rules/importSpacingRule.ts
+++ b/src/rules/importSpacingRule.ts
@@ -61,33 +61,33 @@ class ImportStatementWalker extends Lint.RuleWalker {
             const importClauseStart = node.importClause.getStart();
 
             if (importKeywordEnd === importClauseStart) {
-                this.addFailure(this.createFailure(nodeStart, "import".length, Rule.ADD_SPACE_AFTER_IMPORT));
+                this.addFailureAt(nodeStart, "import".length, Rule.ADD_SPACE_AFTER_IMPORT);
             } else if (importClauseStart > (importKeywordEnd + 1)) {
-                this.addFailure(this.createFailure(nodeStart, importClauseStart - nodeStart, Rule.TOO_MANY_SPACES_AFTER_IMPORT));
+                this.addFailureFromStartToEnd(nodeStart, importClauseStart, Rule.TOO_MANY_SPACES_AFTER_IMPORT);
             }
 
             const fromString = node.getText().substring(importClauseEnd - nodeStart, moduleSpecifierStart - nodeStart);
 
             if (/from$/.test(fromString)) {
-                this.addFailure(this.createFailure(importClauseEnd, fromString.length, Rule.ADD_SPACE_AFTER_FROM));
+                this.addFailureAt(importClauseEnd, fromString.length, Rule.ADD_SPACE_AFTER_FROM);
             } else if (/from\s{2,}$/.test(fromString)) {
-                this.addFailure(this.createFailure(importClauseEnd, fromString.length, Rule.TOO_MANY_SPACES_AFTER_FROM));
+                this.addFailureAt(importClauseEnd, fromString.length, Rule.TOO_MANY_SPACES_AFTER_FROM);
             }
 
             if (/^\s{2,}from/.test(fromString)) {
-                this.addFailure(this.createFailure(importClauseEnd, fromString.length, Rule.TOO_MANY_SPACES_BEFORE_FROM));
+                this.addFailureAt(importClauseEnd, fromString.length, Rule.TOO_MANY_SPACES_BEFORE_FROM);
             } else if (/^from/.test(fromString)) {
-                this.addFailure(this.createFailure(importClauseEnd, fromString.length, Rule.ADD_SPACE_BEFORE_FROM));
+                this.addFailureAt(importClauseEnd, fromString.length, Rule.ADD_SPACE_BEFORE_FROM);
             }
 
             const text = node.getText();
             const beforeImportClauseText = text.substring(0, importClauseStart - nodeStart);
             const afterImportClauseText = text.substring(importClauseEnd - nodeStart);
             if (LINE_BREAK_REGEX.test(beforeImportClauseText)) {
-                this.addFailure(this.createFailure(nodeStart, importClauseStart - nodeStart - 1, Rule.NO_LINE_BREAKS));
+                this.addFailureFromStartToEnd(nodeStart, importClauseStart - 1, Rule.NO_LINE_BREAKS);
             }
             if (LINE_BREAK_REGEX.test(afterImportClauseText)) {
-                this.addFailure(this.createFailure(importClauseEnd, node.getEnd() - importClauseEnd, Rule.NO_LINE_BREAKS));
+                this.addFailureFromStartToEnd(importClauseEnd, node.getEnd(), Rule.NO_LINE_BREAKS);
             }
         }
         super.visitImportDeclaration(node);
@@ -96,11 +96,11 @@ class ImportStatementWalker extends Lint.RuleWalker {
     public visitNamespaceImport(node: ts.NamespaceImport) {
         const text = node.getText();
         if (text.indexOf("*as") > -1) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.ADD_SPACE_AFTER_STAR));
+            this.addFailureAtNode(node, Rule.ADD_SPACE_AFTER_STAR);
         } else if (/\*\s{2,}as/.test(text)) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.TOO_MANY_SPACES_AFTER_STAR));
+            this.addFailureAtNode(node, Rule.TOO_MANY_SPACES_AFTER_STAR);
         } else if (LINE_BREAK_REGEX.test(text)) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.NO_LINE_BREAKS));
+            this.addFailureAtNode(node, Rule.NO_LINE_BREAKS);
         }
         super.visitNamespaceImport(node);
     }
@@ -110,13 +110,13 @@ class ImportStatementWalker extends Lint.RuleWalker {
         const nodeStart = node.getStart();
 
         if ((nodeStart + "import".length + 1) < moduleSpecifierStart) {
-            this.addFailure(this.createFailure(nodeStart, moduleSpecifierStart - nodeStart, Rule.TOO_MANY_SPACES_AFTER_IMPORT));
+            this.addFailureAt(nodeStart, moduleSpecifierStart - nodeStart, Rule.TOO_MANY_SPACES_AFTER_IMPORT);
         } else if ((nodeStart + "import".length) === moduleSpecifierStart) {
-            this.addFailure(this.createFailure(nodeStart,  "import".length, Rule.ADD_SPACE_AFTER_IMPORT));
+            this.addFailureAt(nodeStart,  "import".length, Rule.ADD_SPACE_AFTER_IMPORT);
         }
 
         if (LINE_BREAK_REGEX.test(node.getText())) {
-            this.addFailure(this.createFailure(nodeStart, node.getWidth(), Rule.NO_LINE_BREAKS));
+            this.addFailureAt(nodeStart, node.getWidth(), Rule.NO_LINE_BREAKS);
         }
     }
 }

--- a/src/rules/importSpacingRule.ts
+++ b/src/rules/importSpacingRule.ts
@@ -110,7 +110,7 @@ class ImportStatementWalker extends Lint.RuleWalker {
         const nodeStart = node.getStart();
 
         if ((nodeStart + "import".length + 1) < moduleSpecifierStart) {
-            this.addFailureAt(nodeStart, moduleSpecifierStart - nodeStart, Rule.TOO_MANY_SPACES_AFTER_IMPORT);
+            this.addFailureFromStartToEnd(nodeStart, moduleSpecifierStart, Rule.TOO_MANY_SPACES_AFTER_IMPORT);
         } else if ((nodeStart + "import".length) === moduleSpecifierStart) {
             this.addFailureAt(nodeStart,  "import".length, Rule.ADD_SPACE_AFTER_IMPORT);
         }

--- a/src/rules/noFloatingPromisesRule.ts
+++ b/src/rules/noFloatingPromisesRule.ts
@@ -87,7 +87,7 @@ class NoFloatingPromisesWalker extends Lint.ProgramAwareRuleWalker {
         const type = typeChecker.getTypeAtLocation(node);
 
         if (this.symbolIsPromise(type.symbol)) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
     }
 

--- a/src/rules/noStringThrowRule.ts
+++ b/src/rules/noStringThrowRule.ts
@@ -49,8 +49,7 @@ class Walker extends Lint.RuleWalker {
                 expression.getStart(),
                 expression.getEnd() - expression.getStart(),
                 `new Error(${expression.getText()})`);
-            this.addFailure(this.createFailure(
-                    node.getStart(), node.getWidth(), Rule.FAILURE_STRING, fix));
+            this.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
         }
 
         super.visitThrowStatement(node);


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1867
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

Removed all remaning uses of `RuleWalker.createFailure`.