### PR TITLE
strict-type-predicates: Anything with a construct signature is a function

### DIFF
--- a/src/rules/strictTypePredicatesRule.ts
+++ b/src/rules/strictTypePredicatesRule.ts
@@ -202,7 +202,7 @@ function flagPredicate(testedFlag: ts.TypeFlags): Predicate {
 }
 
 function isFunction(t: ts.Type): boolean {
-    if (t.getCallSignatures().length !== 0) {
+    if (t.getConstructSignatures().length !== 0 || t.getCallSignatures().length !== 0) {
         return true;
     }
     const symbol = t.getSymbol();

--- a/test/rules/strict-type-predicates/test.ts.lint
+++ b/test/rules/strict-type-predicates/test.ts.lint
@@ -78,6 +78,12 @@ declare function get<T>(): T;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [F]
 
     typeof get<number | (() => void)>() === "function";
+
+    class X {}
+    typeof X === "function";
+    ~~~~~~~~~~~~~~~~~~~~~~~ [T]
+    typeof X === "object";
+    ~~~~~~~~~~~~~~~~~~~~~ [F]
 }
 
 // typeof object


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2472
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Check for construct signatures in `isFunction`.

#### CHANGELOG.md entry:

[bugfix] `strict-type-predicates`: Check for construct signatures in `isFunction`.
