### PR TITLE
no-unnecessary-callback-wrapper: only check if callback is identifier

### DIFF
--- a/test/rules/no-unnecessary-callback-wrapper/test.ts.fix
+++ b/test/rules/no-unnecessary-callback-wrapper/test.ts.fix
@@ -13,6 +13,15 @@ f;
 
 // Not catching this case (obj.f may need a 'this' binding)
 (x) => obj.f(x);
+// x is not only used as argument
+(x) => obj[x](x);
+
+// ignore when callback is no identifier
+(x) => (++i)(x);
+(x) => foo()(x);
+
+// allow async arrows
+async (x) => f(x);
 
 // Not bothering to catch this case.
 ({ x, y }) => f({ x, y });

--- a/test/rules/no-unnecessary-callback-wrapper/test.ts.lint
+++ b/test/rules/no-unnecessary-callback-wrapper/test.ts.lint
@@ -17,6 +17,15 @@ x => f(x);
 
 // Not catching this case (obj.f may need a 'this' binding)
 (x) => obj.f(x);
+// x is not only used as argument
+(x) => obj[x](x);
+
+// ignore when callback is no identifier
+(x) => (++i)(x);
+(x) => foo()(x);
+
+// allow async arrows
+async (x) => f(x);
 
 // Not bothering to catch this case.
 ({ x, y }) => f({ x, y });


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2509
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `no-unnecessary-callback-wrapper`: allow async wrapper function
[bugfix] `no-unnecessary-callback-wrapper`: only check if callback is identifier, allow all other expressions
Fixes: #2509

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
