### PR TITLE
no-var-keyword: Allow global var declarations

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -16,6 +16,7 @@
  */
 
 import * as path from "path";
+import { isBlockScopedVariableDeclarationList } from "tsutils";
 import * as ts from "typescript";
 
 import {IDisabledInterval, RuleFailure} from "./rule/rule";
@@ -52,10 +53,6 @@ export function hasModifier(modifiers: ts.ModifiersArray | undefined, ...modifie
  */
 export function isBlockScopedVariable(node: ts.VariableDeclaration | ts.VariableStatement): boolean {
     return isBlockScopedVariableDeclarationList(node.kind === ts.SyntaxKind.VariableDeclaration ? node.parent! : node.declarationList);
-}
-
-export function isBlockScopedVariableDeclarationList(node: ts.VariableDeclarationList): boolean {// tslint:disable-next-line no-bitwise
-    return isNodeFlagSet(node, ts.NodeFlags.Let | ts.NodeFlags.Const);
 }
 
 export function isBlockScopedBindingElement(node: ts.BindingElement): boolean {

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -51,12 +51,11 @@ export function hasModifier(modifiers: ts.ModifiersArray | undefined, ...modifie
  * which indicates this is a "let" or "const".
  */
 export function isBlockScopedVariable(node: ts.VariableDeclaration | ts.VariableStatement): boolean {
-    const parentNode = (node.kind === ts.SyntaxKind.VariableDeclaration)
-        ? (node as ts.VariableDeclaration).parent
-        : (node as ts.VariableStatement).declarationList;
+    return isBlockScopedVariableDeclarationList(node.kind === ts.SyntaxKind.VariableDeclaration ? node.parent! : node.declarationList);
+}
 
-    return isNodeFlagSet(parentNode!, ts.NodeFlags.Let)
-        || isNodeFlagSet(parentNode!, ts.NodeFlags.Const);
+export function isBlockScopedVariableDeclarationList(node: ts.VariableDeclarationList): boolean {// tslint:disable-next-line no-bitwise
+    return isNodeFlagSet(node, ts.NodeFlags.Let | ts.NodeFlags.Const);
 }
 
 export function isBlockScopedBindingElement(node: ts.BindingElement): boolean {

--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { isModuleDeclaration, isVariableDeclarationList } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -37,46 +38,50 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Forbidden 'var' keyword, use 'let' or 'const' instead";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const noVarKeywordWalker = new NoVarKeywordWalker(sourceFile, this.getOptions());
-        return this.applyWithWalker(noVarKeywordWalker);
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoVarKeywordWalker extends Lint.RuleWalker {
-    public visitVariableStatement(node: ts.VariableStatement) {
-        if (!Lint.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
-                && !Lint.isBlockScopedVariable(node)) {
-            this.reportFailure(node.declarationList);
+function walk(ctx: Lint.WalkContext<void>): void {
+    const { sourceFile } = ctx;
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        switch (node.kind) {
+            case ts.SyntaxKind.VariableStatement: {
+                const vs = node as ts.VariableStatement;
+                if (!Lint.isBlockScopedVariableDeclarationList(vs.declarationList) && !isGlobalVarDeclaration(vs)) {
+                    fail(vs.declarationList);
+                }
+                break;
+            }
+
+            case ts.SyntaxKind.ForStatement:
+            case ts.SyntaxKind.ForInStatement:
+            case ts.SyntaxKind.ForOfStatement: {
+                const { initializer } = node as ts.ForStatement | ts.ForInStatement | ts.ForOfStatement;
+                if (initializer && isVariableDeclarationList(initializer) && !Lint.isBlockScopedVariableDeclarationList(initializer)) {
+                    fail(initializer);
+                }
+                break;
+            }
         }
 
-        super.visitVariableStatement(node);
-    }
+        return ts.forEachChild(node, cb);
+    });
 
-    public visitForStatement(node: ts.ForStatement) {
-        this.handleInitializerNode(node.initializer);
-        super.visitForStatement(node);
+    function fail(node: ts.Node): void {
+        // Don't apply fix in a declaration file, because may have meant 'const'.
+        const fix = sourceFile.isDeclarationFile ? undefined : new Lint.Replacement(node.getStart(), "var".length, "let");
+        ctx.addFailureAtNode(Lint.childOfKind(node, ts.SyntaxKind.VarKeyword)!, Rule.FAILURE_STRING, fix);
     }
+}
 
-    public visitForInStatement(node: ts.ForInStatement) {
-        this.handleInitializerNode(node.initializer);
-        super.visitForInStatement(node);
-    }
+// Allow `declare var x: number;` or `declare global { var x: number; }`
+function isGlobalVarDeclaration(node: ts.VariableStatement): boolean {
+    const parent = node.parent!;
+    return Lint.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
+        || parent.kind === ts.SyntaxKind.ModuleBlock && isDeclareGlobal(parent.parent!);
+}
 
-    public visitForOfStatement(node: ts.ForOfStatement) {
-        this.handleInitializerNode(node.initializer);
-        super.visitForOfStatement(node);
-    }
-
-    private handleInitializerNode(node: ts.VariableDeclarationList | ts.Expression | undefined) {
-        if (node && node.kind === ts.SyntaxKind.VariableDeclarationList &&
-                !(Lint.isNodeFlagSet(node, ts.NodeFlags.Let) || Lint.isNodeFlagSet(node, ts.NodeFlags.Const))) {
-            this.reportFailure(node);
-        }
-    }
-
-    private reportFailure(node: ts.Node) {
-        const nodeStart = node.getStart(this.getSourceFile());
-        this.addFailureAt(nodeStart, "var".length, Rule.FAILURE_STRING,
-            this.createReplacement(nodeStart, "var".length, "let"));
-    }
+function isDeclareGlobal(node: ts.Node): boolean {
+    return isModuleDeclaration(node) && node.name.kind === ts.SyntaxKind.Identifier && node.name.text === "global";
 }

--- a/test/rules/no-var-keyword/global.d.ts.lint
+++ b/test/rules/no-var-keyword/global.d.ts.lint
@@ -1,0 +1,8 @@
+declare var x: number;
+
+declare namespace N {
+    var y: number;
+    ~~~ [0]
+}
+
+[0]: Forbidden 'var' keyword, use 'let' or 'const' instead

--- a/test/rules/no-var-keyword/module.d.ts.lint
+++ b/test/rules/no-var-keyword/module.d.ts.lint
@@ -1,0 +1,8 @@
+export var x: number;
+       ~~~ [0]
+
+declare global {
+    var x: number;
+}
+
+[0]: Forbidden 'var' keyword, use 'let' or 'const' instead

--- a/test/rules/no-var-keyword/module.d.ts.lint
+++ b/test/rules/no-var-keyword/module.d.ts.lint
@@ -5,4 +5,13 @@ declare global {
     var x: number;
 }
 
+declare namespace foo.global {
+    var x: number;
+    ~~~ [0]
+    export namespace global {
+        var x: number;
+        ~~~ [0]
+    }
+}
+
 [0]: Forbidden 'var' keyword, use 'let' or 'const' instead


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

The `var` keyword is useful in one case: When you want to declare a global variable.
The problem with declaring a global `const` is that this is considered a block-scoped declaration, and will warn for duplicates.

```ts
declare global {
    var x: number;
    var x: number; // OK
    const y: number;
    const y: number; // Error
}
```

This PR changes the rule to allow `var` in a position where it *declares* a global variable.
It still warns for:

* `export var x: number;` (not global)
* `var x;` (not a declaration if not in `declare global`)

Note: Also disabled fixer in declaration files, because those should almost always be `const` instead of `let`, and we can't detect `prefer-const` in declarations (#2390).

#### CHANGELOG.md entry:

[enhancement] `no-var-keyword`: Allow global var declarations