### PR TITLE
Fix error saying severity is missing

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -121,19 +121,20 @@ class Linter {
                 }
             }
         }
-        this.failures = this.failures.concat(fileFailures);
 
         // add rule severity to failures
         const ruleSeverityMap = new Map(enabledRules.map((rule) => {
             return [rule.getOptions().ruleName, rule.getOptions().ruleSeverity] as [string, RuleSeverity];
         }));
-        for (const failure of this.failures) {
+        for (const failure of fileFailures) {
             const severity = ruleSeverityMap.get(failure.getRuleName());
             if (severity === undefined) {
                 throw new Error(`Severity for rule '${failure.getRuleName()} not found`);
             }
             failure.setRuleSeverity(severity);
         }
+
+        this.failures = this.failures.concat(fileFailures);
     }
 
     public getResult(): LintResult {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2476
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
TSLint was looking up the rule severity for all failures even if the rule was already assigned a severity in a previous file linting. This is a problem when there are multiple tslint.json files in different directories (TSLint uses Node resolution to determine which one applies) and if a rule is enabled and becomes disabled later. If failure for rule X occurs, then X is disabled, it will attempt to look up the severity of X again, and it won't be found

fixes #2476 

#### Is there anything you'd like reviewers to focus on?

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[bugfix] Fixes "Severity for rule not found" error