### PR TITLE
no-unnecessary-callback-wrapper: Handle non-identifier functions

### DIFF
--- a/test/rules/no-unnecessary-callback-wrapper/test.ts.fix
+++ b/test/rules/no-unnecessary-callback-wrapper/test.ts.fix
@@ -11,16 +11,12 @@ f;
 
 f;
 
-// Not catching this case (obj.f may need a 'this' binding)
+// Ignore if function is not an identifier
 (x) => obj.f(x);
 (x) => obj["f"](x);
+x => foo()(x);
 // x is not only used as argument
 (x) => obj[x](x);
-
-foo();
-// Not fooled by property access to '.x'
-foo.x();
-
 x => x(x);
 
 // allow async arrows

--- a/test/rules/no-unnecessary-callback-wrapper/test.ts.fix
+++ b/test/rules/no-unnecessary-callback-wrapper/test.ts.fix
@@ -13,12 +13,15 @@ f;
 
 // Not catching this case (obj.f may need a 'this' binding)
 (x) => obj.f(x);
+(x) => obj["f"](x);
 // x is not only used as argument
 (x) => obj[x](x);
 
-// ignore when callback is no identifier
-(x) => (++i)(x);
-(x) => foo()(x);
+foo();
+// Not fooled by property access to '.x'
+foo.x();
+
+x => x(x);
 
 // allow async arrows
 async (x) => f(x);

--- a/test/rules/no-unnecessary-callback-wrapper/test.ts.lint
+++ b/test/rules/no-unnecessary-callback-wrapper/test.ts.lint
@@ -17,12 +17,17 @@ x => f(x);
 
 // Not catching this case (obj.f may need a 'this' binding)
 (x) => obj.f(x);
+(x) => obj["f"](x);
 // x is not only used as argument
 (x) => obj[x](x);
 
-// ignore when callback is no identifier
-(x) => (++i)(x);
-(x) => foo()(x);
+x => foo()(x);
+~~~~~~~~~~~~~ [No need to wrap 'foo()' in another function. Just use it directly.]
+// Not fooled by property access to '.x'
+x => foo.x()(x);
+~~~~~~~~~~~~~~~ [No need to wrap 'foo.x()' in another function. Just use it directly.]
+
+x => x(x);
 
 // allow async arrows
 async (x) => f(x);

--- a/test/rules/no-unnecessary-callback-wrapper/test.ts.lint
+++ b/test/rules/no-unnecessary-callback-wrapper/test.ts.lint
@@ -15,18 +15,12 @@ x => f(x);
 (...args) => f(...args);
 ~~~~~~~~~~~~~~~~~~~~~~~ [0]
 
-// Not catching this case (obj.f may need a 'this' binding)
+// Ignore if function is not an identifier
 (x) => obj.f(x);
 (x) => obj["f"](x);
+x => foo()(x);
 // x is not only used as argument
 (x) => obj[x](x);
-
-x => foo()(x);
-~~~~~~~~~~~~~ [No need to wrap 'foo()' in another function. Just use it directly.]
-// Not fooled by property access to '.x'
-x => foo.x()(x);
-~~~~~~~~~~~~~~~ [No need to wrap 'foo.x()' in another function. Just use it directly.]
-
 x => x(x);
 
 // allow async arrows


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

#2510 is too simple; there are cases of non-identifier calls that are still an unnecessary callback, like `x => f()(x)`. We can solve #2509 by looking for uses of the parameters in the called expression, so that `x => x(x)` is still not a failure.

#### CHANGELOG.md entry:

[enhancement] `no-unnecessary-callback-wrapper`: Handle non-identifier functions