### PR TITLE
Add `number-literal-format` rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -177,6 +177,7 @@ export const rules = {
     "no-unnecessary-callback-wrapper": true,
     "no-unnecessary-initializer": true,
     "no-unnecessary-qualifier": true,
+    "number-literal-format": true,
     "object-literal-key-quotes": [true, "consistent-as-needed"],
     "object-literal-shorthand": true,
     "one-line": [true,

--- a/test/rules/number-literal-format/test.ts.lint
+++ b/test/rules/number-literal-format/test.ts.lint
@@ -1,18 +1,31 @@
 0;
 0.5;
 10;
+1.1e10;
+
+1.
+~~ [trailing-decimal]
 
 0.0;
-~~~ [trailing]
+~~~ [trailing-0]
 0.50;
-~~~~ [trailing]
+~~~~ [trailing-0]
 
 .5;
-~~ [decimal]
+~~ [leading-decimal]
 
 .50;
-~~~ [trailing]
-~~~ [decimal]
+~~~ [trailing-0]
+~~~ [leading-decimal]
 
-[trailing]: Number literal should not have a trailing '0'.
-[decimal]: Number literal should begin with '0.' and not just '.'.
+1e01;
+  ~~ [leading-0]
+1e-01;
+  ~~~ [leading-0]
+1.0e10;
+~~~ [trailing-0]
+
+[leading-0]: Exponent should not have a leading '0'.
+[trailing-0]: Number literal should not have a trailing '0'.
+[trailing-decimal]: Number literal should not end in '.'.
+[leading-decimal]: Number literal should begin with '0.' and not just '.'.

--- a/test/rules/number-literal-format/test.ts.lint
+++ b/test/rules/number-literal-format/test.ts.lint
@@ -20,6 +20,8 @@
 
 1e01;
   ~~ [leading-0]
+1E01;
+  ~~ [leading-0]
 1e-01;
   ~~~ [leading-0]
 1.0e10;

--- a/test/rules/number-literal-format/test.ts.lint
+++ b/test/rules/number-literal-format/test.ts.lint
@@ -3,6 +3,9 @@
 10;
 1.1e10;
 
+01;
+~~ [leading-0]
+
 1.
 ~~ [trailing-decimal]
 
@@ -27,7 +30,11 @@
 1.0e10;
 ~~~ [trailing-0]
 
-[leading-0]: Exponent should not have a leading '0'.
+0xDEAdBEEF;
+~~~~~~~~~~ [uppercase]
+
+[leading-0]: Number literal should not have a leading '0'.
 [trailing-0]: Number literal should not have a trailing '0'.
 [trailing-decimal]: Number literal should not end in '.'.
 [leading-decimal]: Number literal should begin with '0.' and not just '.'.
+[uppercase]: Hexadecimal number literal should be uppercase.

--- a/test/rules/number-literal-format/test.ts.lint
+++ b/test/rules/number-literal-format/test.ts.lint
@@ -1,0 +1,18 @@
+0;
+0.5;
+10;
+
+0.0;
+~~~ [trailing]
+0.50;
+~~~~ [trailing]
+
+.5;
+~~ [decimal]
+
+.50;
+~~~ [trailing]
+~~~ [decimal]
+
+[trailing]: Number literal should not have a trailing '0'.
+[decimal]: Number literal should begin with '0.' and not just '.'.

--- a/test/rules/number-literal-format/tslint.json
+++ b/test/rules/number-literal-format/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "number-literal-format": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### Overview of change:

Added the `number-literal-format` rule, which warns on `.5` and `0.50` (both: prefer `0.5`).
This could also be extended to implement #1391 if anyone wants that.

#### CHANGELOG.md entry:

[new-rule] `number-literal-format`