### PR TITLE
Fix no-unnecessary-qualifier handling of implicit arguments

### DIFF
--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -114,7 +114,12 @@ class Walker extends Lint.ProgramAwareRuleWalker {
     }
 
     private symbolIsNamespaceInScope(symbol: ts.Symbol): boolean {
-        if (symbol.getDeclarations().some((decl) => this.namespacesInScope.some((ns) => ns === decl))) {
+        const symbolDeclarations = symbol.getDeclarations();
+        if (!symbolDeclarations) {
+          return false;
+        }
+
+        if (symbolDeclarations.some((decl) => this.namespacesInScope.some((ns) => ns === decl))) {
             return true;
         }
         const alias = this.tryGetAliasedSymbol(symbol);

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -115,13 +115,12 @@ class Walker extends Lint.ProgramAwareRuleWalker {
 
     private symbolIsNamespaceInScope(symbol: ts.Symbol): boolean {
         const symbolDeclarations = symbol.getDeclarations();
-        if (!symbolDeclarations) {
-          return false;
-        }
-
-        if (symbolDeclarations.some((decl) => this.namespacesInScope.some((ns) => ns === decl))) {
+        if (symbolDeclarations == null) {
+            return false;
+        } else if (symbolDeclarations.some((decl) => this.namespacesInScope.some((ns) => ns === decl))) {
             return true;
         }
+
         const alias = this.tryGetAliasedSymbol(symbol);
         return alias !== undefined && this.symbolIsNamespaceInScope(alias);
     }

--- a/test/rules/no-unnecessary-qualifier/arguments.ts.lint
+++ b/test/rules/no-unnecessary-qualifier/arguments.ts.lint
@@ -1,0 +1,12 @@
+namespace N {
+    export type T = number;
+    export const x: N.T = 0;
+                    ~ [N]
+    export function f() {
+      if (arguments.length > 0) {
+        console.log('arguments should not break this rule');
+      }
+    }
+}
+
+[N]: Qualifier is unnecessary since 'N' is in scope.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
`Symbol#getDeclarations` returns `null` when it's describing an `arguments` reference.  This change short-circuits `symbolIsNamespaceInScope` if declarations are `null`.

#### Is there anything you'd like reviewers to focus on?
Nope.

#### CHANGELOG.md entry:

[bugfix] `no-unnecessary-qualifier`: no longer breaks when walking a function that references `arguments`
