### PR TITLE
Deprecate ScopeAwareRuleWalker and BlockScopeAwareRuleWalker

### DIFF
--- a/src/language/walker/blockScopeAwareRuleWalker.ts
+++ b/src/language/walker/blockScopeAwareRuleWalker.ts
@@ -21,6 +21,8 @@ import {isBlockScopeBoundary} from "../utils";
 import {ScopeAwareRuleWalker} from "./scopeAwareRuleWalker";
 
 /**
+ * @deprecated See comment on ScopeAwareRuleWalker.
+ *
  * An AST walker that is aware of block scopes in addition to regular scopes. Block scopes
  * are a superset of regular scopes (new block scopes are created more frequently in a program).
  */

--- a/src/language/walker/scopeAwareRuleWalker.ts
+++ b/src/language/walker/scopeAwareRuleWalker.ts
@@ -20,6 +20,40 @@ import * as ts from "typescript";
 import {isScopeBoundary} from "../utils";
 import {RuleWalker} from "./ruleWalker";
 
+/**
+ * @deprecated Prefer to manually maintain any contextual information.
+ *
+ * For example, imagine a `no-break` rule that warns on `break` in `for` but not in `switch`:
+ *
+ * function walk(ctx: Lint.WalkContext<void>): void {
+ *     let isInFor = false;
+ *     ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+ *         switch (node.kind) {
+ *             case ts.SyntaxKind.Break:
+ *                 if (isInFor) {
+ *                     ctx.addFailureAtNode(node, "!");
+ *                 }
+ *                 break;
+ *             case ts.SyntaxKind.ForStatement: {
+ *                 const old = isInFor;
+ *                 isInFor = true;
+ *                 ts.forEachChild(node, cb);
+ *                 isInFor = old;
+ *                 break;
+ *             }
+ *             case ts.SyntaxKind.SwitchStatement: {
+ *                 const old = isInFor;
+ *                 isInFor = false;
+ *                 ts.forEachChild(node, cb);
+ *                 isInFor = old;
+ *                 break;
+ *             }
+ *             default:
+ *                 ts.forEachChild(node, cb);
+ *         }
+ *     });
+ * }
+ */
 export abstract class ScopeAwareRuleWalker<T> extends RuleWalker {
     private scopeStack: T[];
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: https://github.com/palantir/tslint/issues/2514#issuecomment-292737640
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

See the discussion in #2514.
Saves us from needing a `ProgramAwareBlockScopeAwareRuleWalker`.
After ##2339 and #2341 are in, we will no longer be using these internally.

#### CHANGELOG.md entry:

[api] Deprecate `ScopeAwareRuleWalker` and `BlockScopeAwareRuleWalker`.