### PR TITLE
Fix various `return-undefined` bugs

### DIFF
--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -113,7 +113,7 @@ function getReturnKind(node: FunctionLike, checker: ts.TypeChecker): ReturnKind 
     } else if (Lint.isTypeFlagSet(returnType, ts.TypeFlags.Void)) {
         return ReturnKind.Void;
     } else if (Lint.hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword)) {
-        // TODO: Would need access to `checker.getPromisedTypeOfPromise` to do this properly.
+        // Would need access to `checker.getPromisedTypeOfPromise` to do this properly.
         // Assume that the return type is the global Promise (since this is an async function) and get its type argument.
         const typeArguments = (returnType as ts.GenericType).typeArguments;
         if (typeArguments !== undefined && typeArguments.length === 1) {
@@ -153,11 +153,5 @@ function isFunctionLike(node: ts.Node): node is FunctionLike {
 }
 
 function isFunctionExpressionLike(node: ts.Node): node is ts.FunctionExpression | ts.ArrowFunction {
-    switch (node.kind) {
-        case ts.SyntaxKind.FunctionExpression:
-        case ts.SyntaxKind.ArrowFunction:
-            return true;
-        default:
-            return false;
-    }
+    return node.kind === ts.SyntaxKind.FunctionExpression || node.kind === ts.SyntaxKind.ArrowFunction;
 }

--- a/test/rules/return-undefined/test.ts.lint
+++ b/test/rules/return-undefined/test.ts.lint
@@ -24,5 +24,40 @@ function voidRight(): void {
     ~~~~~~~ [UNDEFINED]
 });
 
+type Cb = () => void;
+declare function badContextualType(cb: Cb | Cb[]): void;
+// Uses typeAtLocation instead of contextual type.
+badContextualType(() => {
+    if (1 === 2) return 1;
+    else return;
+         ~~~~~~~ [UNDEFINED]
+});
+
+// Allow anything in callback taking 'any'.
+function takesAnyCb(cb: () => any): void;
+takesAnyCb(() => { return; });
+takesAnyCb(() => { return undefined; });
+takesAnyCb(() => {
+    if (1 === 2) return;
+                 ~~~~~~~ [UNDEFINED]
+    else return 1;
+});
+takesAnyCb(() => {
+    if (1 === 2) return;
+    else return undefined;
+});
+
+async function promiseVoid(): Promise<void> {
+    if (1 === 2) return;
+    else return undefined;
+         ~~~~~~~~~~~~~~~~~ [VOID]
+}
+
+async function promiseValue(): Promise<number | undefined> {
+    if (1 === 2) return 1;
+    else return;
+         ~~~~~~~ [UNDEFINED]
+}
+
 [VOID]: `void` function should use `return;`, not `return undefined;`.
 [UNDEFINED]: Value-returning function should use `return undefined;`, not just `return;`.


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2573, #2566, #2565
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

#2573: Handle a contextual type with ambiguous signatures and fall back to `getTypeAtLocation`.
#2566: Allow 'any'.
#2565: Treat an async function returning `Promise<void>` like a regular function returning `void`.

#### CHANGELOG.md entry:

[bugfix] `return-undefined`: Handle contextual types with ambiguous signatures; allow `any`; and handle async functions.
