### PR TITLE
Clarify type of failure JSON

### DIFF
--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -116,7 +116,7 @@ export interface ITypedRule extends IRule {
 export interface IRuleFailureJson {
     endPosition: IRuleFailurePositionJson;
     failure: string;
-    fix?: Fix;
+    fix?: FixJson;
     name: string;
     ruleSeverity: string;
     ruleName: string;
@@ -133,6 +133,11 @@ export function isTypedRule(rule: IRule): rule is ITypedRule {
     return "applyWithProgram" in rule;
 }
 
+export interface ReplacementJson {
+    innerStart: number;
+    innerLength: number;
+    innerText: string;
+}
 export class Replacement {
     public static applyFixes(content: string, fixes: Fix[]): string {
         return this.applyAll(content, flatMap(fixes, arrayify));
@@ -164,27 +169,24 @@ export class Replacement {
         return new Replacement(start, 0, text);
     }
 
-    constructor(private innerStart: number, private innerLength: number, private innerText: string) {
-    }
-
-    get start() {
-        return this.innerStart;
-    }
-
-    get length() {
-        return this.innerLength;
-    }
+    constructor(readonly start: number, readonly length: number, readonly text: string) {}
 
     get end() {
-        return this.innerStart + this.innerLength;
-    }
-
-    get text() {
-        return this.innerText;
+        return this.start + this.length;
     }
 
     public apply(content: string) {
         return content.substring(0, this.start) + this.text + content.substring(this.start + this.length);
+    }
+
+    public toJson(): ReplacementJson {
+        // tslint:disable object-literal-sort-keys
+        return {
+            innerStart: this.start,
+            innerLength: this.length,
+            innerText: this.text,
+        };
+        // tslint:enable object-literal-sort-keys
     }
 }
 
@@ -219,6 +221,7 @@ export class RuleFailurePosition {
 }
 
 export type Fix = Replacement | Replacement[];
+export type FixJson = ReplacementJson | ReplacementJson[];
 
 export class RuleFailure {
     private fileName: string;
@@ -285,7 +288,7 @@ export class RuleFailure {
         return {
             endPosition: this.endPosition.toJson(),
             failure: this.failure,
-            fix: this.fix,
+            fix: this.fix === undefined ? undefined : Array.isArray(this.fix) ? this.fix.map((r) => r.toJson()) : this.fix.toJson(),
             name: this.fileName,
             ruleName: this.ruleName,
             ruleSeverity: this.ruleSeverity.toUpperCase(),

--- a/test/formatters/jsonFormatterTests.ts
+++ b/test/formatters/jsonFormatterTests.ts
@@ -17,7 +17,7 @@
 import { assert } from "chai";
 import * as ts from "typescript";
 
-import { IFormatter, Replacement, TestUtils } from "../lint";
+import { IFormatter, IRuleFailureJson, Replacement, TestUtils } from "../lint";
 import { createFailure } from "./utils";
 
 describe("JSON Formatter", () => {
@@ -43,7 +43,7 @@ describe("JSON Formatter", () => {
         ];
 
         /* tslint:disable:object-literal-sort-keys */
-        const expectedResult: any = [{
+        const expectedResult: IRuleFailureJson[] = [{
             name: TEST_FILE,
             failure: "first failure",
             startPosition: {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

This was declared to have a value of type `Fix`, but the rendered json is actually different.
We were exposing the `inner*` properties via `JSON.stringify`. Kept those in `toJson()` for backwards-compatibility.