### PR TITLE
Use isSameLine helper

### DIFF
--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -60,10 +60,10 @@ interface Options {
 
 function walk(ctx: Lint.WalkContext<Options>): void {
     const { sourceFile, options: { multiline } } = ctx;
-    ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
+    return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
         if (utils.isArrowFunction(node) && utils.isBlock(node.body)) {
             const expr = getSimpleReturnExpression(node.body);
-            if (expr !== undefined && (multiline || !node.body.getText(sourceFile).includes("\n"))) {
+            if (expr !== undefined && (multiline || utils.isSameLine(sourceFile, node.body.getStart(sourceFile), node.body.end))) {
                 const isObjectLiteral = expr.kind === ts.SyntaxKind.ObjectLiteralExpression;
                 ctx.addFailureAtNode(node.body, Rule.FAILURE_STRING(isObjectLiteral), createFix(node, node.body, expr, sourceFile.text));
             }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -140,8 +140,7 @@ class SemicolonWalker extends Lint.AbstractWalker<Options> {
         // check if this is a multi-line arrow function
         if (node.initializer !== undefined &&
             node.initializer.kind === ts.SyntaxKind.ArrowFunction &&
-            ts.getLineAndCharacterOfPosition(this.sourceFile, node.getStart(this.sourceFile)).line
-                !== ts.getLineAndCharacterOfPosition(this.sourceFile, node.getEnd()).line) {
+            !utils.isSameLine(this.sourceFile, node.getStart(this.sourceFile), node.end)) {
             if (this.options.boundClassMethods) {
                 if (this.sourceFile.text[node.end - 1] === ";" &&
                     this.isFollowedByLineBreak(node.end)) {
@@ -234,7 +233,6 @@ class SemicolonWalker extends Lint.AbstractWalker<Options> {
         if (nextStatement === undefined) {
             return false;
         }
-        return ts.getLineAndCharacterOfPosition(this.sourceFile, node.end).line
-            === ts.getLineAndCharacterOfPosition(this.sourceFile, nextStatement.getStart(this.sourceFile)).line;
+        return utils.isSameLine(this.sourceFile, node.end, nextStatement.getStart(this.sourceFile));
     }
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
This PR converts some uses of `ts.getLineAndCharacterOfPosition` to `tsutils.isSameLine` as suggested by @andy-hanson in https://github.com/palantir/tslint/pull/2591#discussion_r111692431

#### Is there anything you'd like reviewers to focus on?

`curly` and `one-line` are not included, because they are not refactored yet

#### CHANGELOG.md entry:

[no-log]
