### PR TITLE
no-conditional-assignment: rewrite and check conditional expressions

### DIFF
--- a/test/rules/no-conditional-assignment/test.ts.lint
+++ b/test/rules/no-conditional-assignment/test.ts.lint
@@ -16,11 +16,11 @@ for (var x = 8; x == 8; x = 12) { }
 for (;;) { }
 
 while (--i) {}
-while ((a = b) ++) {} // don't bother, it's a compile error anyway
+while ((a = b)++) {} // don't bother, it's a compile error anyway
 
-while ((a || a = b).foo) {}
+while ((a || (a = b)).foo) {}
 while (a[b = c]) {}
-while ((function() {a = b})()) {}
+while ((() => a = b)()) {}
 while (fn(a = b)) {}
 a ? b = a : a = b;
 
@@ -58,9 +58,9 @@ while ((a = 5) && ((b == 4) || (c = 3))) {}
 while (+(a = b) || -(b = c)) {}
          ~~~~~ [0]
                      ~~~~~ [0]
-while ((a = (b = c)!)) {}
-        ~~~~~~~~~~~~ [0]
-             ~~~~~ [0]
+while (foo() || (a = (b = c)!)) {}
+                 ~~~~~~~~~~~~ [0]
+                      ~~~~~ [0]
 while (a == (b = fn()) as any) {}
              ~~~~~~~~ [0]
 while (a ? b : c) {}
@@ -71,5 +71,8 @@ while (!((a = b) ? c : d)) {}
           ~~~~~ [0]
 (a = b) ? c : d;
  ~~~~~ [0]
+(foo ? a = b : b = a) ? c : d;
+       ~~~~~ [0]
+               ~~~~~ [0]
 
 [0]: Assignments in conditional expressions are forbidden

--- a/test/rules/no-conditional-assignment/test.ts.lint
+++ b/test/rules/no-conditional-assignment/test.ts.lint
@@ -15,6 +15,7 @@ for (var x = 8; x == 8; ++x) { }
 for (var x = 8; x == 8; x = 12) { }
 for (;;) { }
 
+while (a ? b : c) {}
 while (--i) {}
 while ((a = b)++) {} // don't bother, it's a compile error anyway
 
@@ -63,12 +64,12 @@ while (foo() || (a = (b = c)!)) {}
                       ~~~~~ [0]
 while (a == (b = fn()) as any) {}
              ~~~~~~~~ [0]
-while (a ? b : c) {}
 while (a ? b = a : a = b) {}
            ~~~~~ [0]
                    ~~~~~ [0]
-while (!((a = b) ? c : d)) {}
+while (!((a = b) ? c : d) || (x = y)) {}
           ~~~~~ [0]
+                              ~~~~~ [0]
 (a = b) ? c : d;
  ~~~~~ [0]
 (foo ? a = b : b = a) ? c : d;

--- a/test/rules/no-conditional-assignment/test.ts.lint
+++ b/test/rules/no-conditional-assignment/test.ts.lint
@@ -15,6 +15,15 @@ for (var x = 8; x == 8; ++x) { }
 for (var x = 8; x == 8; x = 12) { }
 for (;;) { }
 
+while (--i) {}
+while ((a = b) ++) {} // don't bother, it's a compile error anyway
+
+while ((a || a = b).foo) {}
+while (a[b = c]) {}
+while ((function() {a = b})()) {}
+while (fn(a = b)) {}
+a ? b = a : a = b;
+
 // invalid cases
 if (x = 5) { }
     ~~~~~      [0]
@@ -43,8 +52,24 @@ else if (h || (x <<= 4)) { }
 
 do { } while (x ^= 4) { }
               ~~~~~~      [0]
-while ((a = 5) && ((b == 4) || (c = 3)))
+while ((a = 5) && ((b == 4) || (c = 3))) {}
         ~~~~~                            [0]
                                 ~~~~~    [0]
+while (+(a = b) || -(b = c)) {}
+         ~~~~~ [0]
+                     ~~~~~ [0]
+while ((a = (b = c)!)) {}
+        ~~~~~~~~~~~~ [0]
+             ~~~~~ [0]
+while (a == (b = fn()) as any) {}
+             ~~~~~~~~ [0]
+while (a ? b : c) {}
+while (a ? b = a : a = b) {}
+           ~~~~~ [0]
+                   ~~~~~ [0]
+while (!((a = b) ? c : d)) {}
+          ~~~~~ [0]
+(a = b) ? c : d;
+ ~~~~~ [0]
 
 [0]: Assignments in conditional expressions are forbidden


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Rewrite to walker function.

#### Is there anything you'd like reviewers to focus on?
The rule now allows intentional assignments like `if (foo(a = b));` or `if ((a || (a = b)).foo);`. If this is a typo the compiler should reveal that error.

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[bugfix] `no-conditional-assignment`: exclude intentional assignments, e.g. inside functions
[enhancement] `no-conditional-assignment` added check for conditional (ternary) expressions
