### PR TITLE
no-default-export: rewrite and fix export default bug

### DIFF
--- a/src/rules/noDefaultExportRule.ts
+++ b/src/rules/noDefaultExportRule.ts
@@ -50,12 +50,12 @@ function walk(ctx: Lint.WalkContext<void>) {
     }
     for (const statement of ctx.sourceFile.statements) {
         if (statement.kind === ts.SyntaxKind.ExportAssignment) {
-            if ((statement as ts.ExportAssignment).isExportEquals !== true) {
+            if (!(statement as ts.ExportAssignment).isExportEquals) {
                 ctx.addFailureAtNode(statement.getChildAt(1, ctx.sourceFile), Rule.FAILURE_STRING);
             }
         } else if (statement.modifiers !== undefined && statement.modifiers.length >= 2 &&
-                    statement.modifiers[0].kind === ts.SyntaxKind.ExportKeyword &&
-                    statement.modifiers[1].kind === ts.SyntaxKind.DefaultKeyword) {
+                   statement.modifiers[0].kind === ts.SyntaxKind.ExportKeyword &&
+                   statement.modifiers[1].kind === ts.SyntaxKind.DefaultKeyword) {
             ctx.addFailureAtNode(statement.modifiers[1], Rule.FAILURE_STRING);
         }
     }

--- a/src/rules/noDefaultExportRule.ts
+++ b/src/rules/noDefaultExportRule.ts
@@ -40,30 +40,23 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Use of default exports is forbidden";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoDefaultExportWalker(sourceFile, this.getOptions()));
+        return this.applyWithFunction(sourceFile, walk);
     }
 }
 
-class NoDefaultExportWalker extends Lint.RuleWalker {
-    public visitExportAssignment(node: ts.ExportAssignment) {
-        const exportMember = node.getChildAt(1);
-        if (exportMember != null && exportMember.kind === ts.SyntaxKind.DefaultKeyword) {
-            this.addFailureAtNode(exportMember, Rule.FAILURE_STRING);
-        }
-        super.visitExportAssignment(node);
+function walk(ctx: Lint.WalkContext<void>) {
+    if (ctx.sourceFile.isDeclarationFile || !ts.isExternalModule(ctx.sourceFile)) {
+        return;
     }
-
-    // inline class declaration and function declaration exports use modifiers
-    public visitNode(node: ts.Node) {
-        if (node.kind === ts.SyntaxKind.DefaultKeyword && node.parent != null) {
-            const nodes = node.parent.modifiers;
-            if (nodes != null &&
-                nodes.length === 2 &&
-                nodes[0].kind === ts.SyntaxKind.ExportKeyword &&
-                nodes[1].kind === ts.SyntaxKind.DefaultKeyword) {
-                    this.addFailureAtNode(nodes[1], Rule.FAILURE_STRING);
+    for (const statement of ctx.sourceFile.statements) {
+        if (statement.kind === ts.SyntaxKind.ExportAssignment) {
+            if ((statement as ts.ExportAssignment).isExportEquals !== true) {
+                ctx.addFailureAtNode(statement.getChildAt(1, ctx.sourceFile), Rule.FAILURE_STRING);
             }
+        } else if (statement.modifiers !== undefined && statement.modifiers.length >= 2 &&
+                    statement.modifiers[0].kind === ts.SyntaxKind.ExportKeyword &&
+                    statement.modifiers[1].kind === ts.SyntaxKind.DefaultKeyword) {
+            ctx.addFailureAtNode(statement.modifiers[1], Rule.FAILURE_STRING);
         }
-        super.visitNode(node);
     }
 }

--- a/test/rules/no-default-export/test.ts.lint
+++ b/test/rules/no-default-export/test.ts.lint
@@ -19,6 +19,8 @@ export import ItemAlias = someNamespace.Item;
 
 export const default = 'VALID';
 
+export = 'VALID';
+
 export default 'INVALID';
        ~~~~~~~ [0]
 
@@ -29,6 +31,9 @@ export default class { }
        ~~~~~~~ [0]
 
 export default class Test { }
+       ~~~~~~~ [0]
+
+export default abstract class { }
        ~~~~~~~ [0]
 
 export default function() { }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Rewrite to walker function and only check top level statements. Excluding declaration files, because they only declare what is already available from some module.
[bugfix] `no-default-export`: correctly handle `export default abstract class {...}`

#### Is there anything you'd like reviewers to focus on?
The rule only checks top level statements, because typescript doesn't allow default exports in namespaces.
Default exports are allowed in `declare module "foo"`, but they are not checked for the same reason as declaration files (see above)

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
