### PR TITLE
WIP: Add fixer for object-literal-sort-keys

### DIFF
--- a/test/rules/object-literal-sort-keys/test.ts.fix
+++ b/test/rules/object-literal-sort-keys/test.ts.fix
@@ -1,0 +1,151 @@
+var passA = {
+    a: 1,
+    b: 2
+};
+
+var failA = {
+    a: 2,
+    b: 1
+};
+
+var passB = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4
+};
+
+var failB = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4
+};
+
+var passC = {
+    a: 1,
+    b: {
+        aa: 1,
+        bb: 2
+    }
+};
+
+var failC = {
+    a: 1,
+    b: {
+        aa: 1,
+        bb: 2
+    }
+};
+
+var passD = {
+    a: 1,
+    b: {
+        aa: 1,
+        bb: 2
+    },
+    c: 3
+};
+
+var failD = {
+    a: 1,
+    b: 3,
+    c: {
+        aa: 1,
+        bb: 2
+    }
+};
+
+var passE = {};
+
+var passF = {
+    asdf: [1, 2, 3],
+    sdfa: {}
+};
+
+var failF = {
+    asdf: [1, 2, 3],
+    sdfa: {}
+};
+
+var passG = {
+    asdfn: function () {},
+    sdafn: function () {}
+};
+
+var failG = {
+    asdfn: function () {},
+    sdafn: function () {}
+};
+
+var passH = {
+    a: 1,
+    'b': 2,
+    c: 3
+}
+
+var failH = {
+    a: 1,
+    'b': 2,
+    c: 3
+}
+
+var passI = {
+    'Z': 1,
+    À: 2,
+    è: 3
+}
+
+var failI = {
+    'Z': 1,
+    À: 2,
+    è: 3,
+}
+
+var passJ = {
+    1: 1,
+    '11': 2
+    2: 4,
+    A: 3,
+}
+
+var failJ = {
+    1: 1,
+    2: 4,
+    '11': 2,
+    A: 3
+}
+
+var passK = {
+    a: 1,
+    'b': {
+        'd': 4,
+        e: 5
+    },
+    c: 3
+}
+
+var failK = {
+    a: 1,
+
+        'd': 4,
+        e: 5    'd': 4
+    },
+    c: 3
+}
+
+var passL = {z: 1, y: '1', x: [1, 2]};
+
+var failL = {x: 1, y: {
+    a: 2,
+    b: 1
+}, z: [1, 2]};
+
+var passM = {
+    x: 1,
+    y: {
+        a: 1,
+        b: 2
+    },
+    z: {z: 1, y: '1', x: [1, 2]}
+};


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
This is a work in progress to add a fixer for the rule `object-literal-sort-keys`. I find sorting by hand quite annoying, especially when dealing with objects that have values that are multiline expressions.

#### Is there anything you'd like reviewers to focus on?
It's a work in progress as there's a test case in here that completely breaks the code - I would love some feedback on exactly why and how this is happening such that I can get a proper fix for that ready.

#### CHANGELOG.md entry:
 * [new-fixer] `object-literal-sort-keys`