### PR TITLE
Don't report 'statements are not aligned' for empty statements

### DIFF
--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -82,7 +82,7 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
             if (this.options.statements && isBlockLike(node)) {
-                this.checkAlignment(node.statements.filter(s => !isEmptyStatement(s)), OPTION_STATEMENTS);
+                this.checkAlignment(node.statements.filter((s) => !isEmptyStatement(s)), OPTION_STATEMENTS);
             } else {
                 switch (node.kind) {
                     case ts.SyntaxKind.NewExpression:

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { getNextToken, isBlockLike } from "tsutils";
+import { getNextToken, isBlockLike, isEmptyStatement } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -82,7 +82,7 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
             if (this.options.statements && isBlockLike(node)) {
-                this.checkAlignment(node.statements, OPTION_STATEMENTS);
+                this.checkAlignment(node.statements.filter(s => !isEmptyStatement(s)), OPTION_STATEMENTS);
             } else {
                 switch (node.kind) {
                     case ts.SyntaxKind.NewExpression:

--- a/test/rules/align/statements/test.ts.lint
+++ b/test/rules/align/statements/test.ts.lint
@@ -153,9 +153,7 @@ function shouldntCrash() {
 if (foo) {
     bar;
 };
- ~ [statements are not aligned]
 
 if (foo) {
     bar;
 } /* should not be removed */;
-                             ~ [statements are not aligned]


### PR DESCRIPTION
See issue #2608

#### PR checklist

- [x] Addresses an existing issue: #2608
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Skip over empty statements when running the `align` rule on statements.  Empty statements can be caused by unnecessary semicolons, and in that case the error message "statements are not aligned" is confusing.  The problem is better handled by the `semicolons` rule.
