### PR TITLE
align: exclude SemicolonClassElement

### DIFF
--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { getNextToken, isBlockLike, isEmptyStatement } from "tsutils";
+import { getNextToken, isBlockLike } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -82,7 +82,7 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
             if (this.options.statements && isBlockLike(node)) {
-                this.checkAlignment(node.statements.filter((s) => !isEmptyStatement(s)), OPTION_STATEMENTS);
+                this.checkAlignment(node.statements.filter((s) => s.kind !== ts.SyntaxKind.EmptyStatement), OPTION_STATEMENTS);
             } else {
                 switch (node.kind) {
                     case ts.SyntaxKind.NewExpression:
@@ -131,12 +131,18 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
                         }
                         break;
                     case ts.SyntaxKind.ClassDeclaration:
-                    case ts.SyntaxKind.ClassDeclaration:
+                    case ts.SyntaxKind.ClassExpression:
+                        if (this.options.members) {
+                            this.checkAlignment(
+                                (node as ts.ClassLikeDeclaration).members.filter((m) => m.kind !== ts.SyntaxKind.SemicolonClassElement),
+                                OPTION_MEMBERS,
+                            );
+                        }
+                        break;
                     case ts.SyntaxKind.InterfaceDeclaration:
                     case ts.SyntaxKind.TypeLiteral:
                         if (this.options.members) {
-                            this.checkAlignment((node as ts.ClassLikeDeclaration | ts.InterfaceDeclaration | ts.TypeLiteralNode).members,
-                                                OPTION_MEMBERS);
+                            this.checkAlignment((node as ts.InterfaceDeclaration | ts.TypeLiteralNode).members, OPTION_MEMBERS);
                         }
                 }
             }

--- a/test/rules/align/members/test.ts.fix
+++ b/test/rules/align/members/test.ts.fix
@@ -7,9 +7,16 @@ interface Foo {
 
 class Foo {
     bar,
-    baz() {}
+    baz() {
+
+    };
     get bas() {}
     foo;
+}
+
+let Bar = class {
+  bar,
+  foo
 }
 
 let foo = {

--- a/test/rules/align/members/test.ts.lint
+++ b/test/rules/align/members/test.ts.lint
@@ -2,42 +2,52 @@ interface Foo {
     bar,
     baz
      bas
-     ~~~ [members are not aligned]
+     ~~~ [0]
   foo;
-  ~~~~ [members are not aligned]
+  ~~~~ [0]
 }
 
 class Foo {
     bar,
-    baz() {}
+    baz() {
+
+    };
      get bas() {}
-     ~~~~~~~~~~~~ [members are not aligned]
+     ~~~~~~~~~~~~ [0]
   foo;
-  ~~~~ [members are not aligned]
+  ~~~~ [0]
+}
+
+let Bar = class {
+  bar,
+    foo
+    ~~~ [0]
 }
 
 let foo = {
     foo,
     moep,
      baz,
-     ~~~ [members are not aligned]
+     ~~~ [0]
    baz: foo,
-   ~~~~~~~~ [members are not aligned]
+   ~~~~~~~~ [0]
 }
 
 let {
     foo,
     boo,
      baz,
-     ~~~ [members are not aligned]
+     ~~~ [0]
    baz,
-   ~~~ [members are not aligned]
+   ~~~ [0]
 } = foo;
 
 let foo: {
     foo
      bar
-     ~~~ [members are not aligned]
+     ~~~ [0]
    baz
-   ~~~ [members are not aligned]
+   ~~~ [0]
 }
+
+[0]: members are not aligned


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: https://github.com/palantir/tslint/issues/2608#issuecomment-298176322
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `align` with option `"members"`: check members of class expressions; don't check semicolons in classes

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
