### PR TITLE
no-object-literal-type-assertion: Enable and allow cast to 'any'

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -265,6 +265,7 @@ abstract class Requirement<TDescriptor extends RequirementDescriptor> {
         }
     }
 
+    // tslint:disable-next-line no-object-literal-type-assertion
     protected constructor(public readonly descriptor: TDescriptor = {} as TDescriptor) { }
 
     public abstract shouldNodeBeDocumented(node: ts.Declaration): boolean;

--- a/src/rules/noObjectLiteralTypeAssertionRule.ts
+++ b/src/rules/noObjectLiteralTypeAssertionRule.ts
@@ -23,7 +23,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-object-literal-type-assertion",
-        description: "Forbids an object literal to appear in a type assertion expression.",
+        description: Lint.Utils.dedent`
+            Forbids an object literal to appear in a type assertion expression.
+            Casting to \`any\` is still allowed.`,
         rationale: Lint.Utils.dedent`
             Always prefer \`const x: T = { ... };\` to \`const x = { ... } as T;\`.
             The type assertion in the latter case is either unnecessary or hides an error.
@@ -45,7 +47,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isTypeAssertionLike(node) && isObjectLiteral(node.expression)) {
+        if (isTypeAssertionLike(node) && isObjectLiteral(node.expression) && node.type.kind !== ts.SyntaxKind.AnyKeyword) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/test/rules/no-object-literal-type-assertion/test.ts.lint
+++ b/test/rules/no-object-literal-type-assertion/test.ts.lint
@@ -8,4 +8,8 @@
 
 x as T;
 
+// Allow cast to 'any'
+{} as any;
+<any> {};
+
 [0]: Type assertion applied to object literal.

--- a/tslint.json
+++ b/tslint.json
@@ -48,7 +48,6 @@
     "no-magic-numbers": false,
     "no-non-null-assertion": false,
     "no-null-keyword": false,
-    "no-object-literal-type-assertion": false,
     "no-require-imports": false,
     "no-unbound-method": false,
     "no-unnecessary-callback-wrapper": false,
@@ -82,7 +81,7 @@
       "public-before-private",
       "static-before-instance",
       "variables-before-functions"
-    ],    
+    ],
     "no-console": {
       "options": ["log"]
     },


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### Overview of change:

Allow `const x = {} as any` since it's equivalent to `const x: any = {}` anyway.
Also enable the rule in tslint itself, which is easy once the above is done.

#### CHANGELOG.md entry:

[enhancement] `no-object-literal-type-assertion`: Allow cast to `any`