### PR TITLE
More specific error message for the variable-name rule.

### DIFF
--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -40,11 +40,11 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: Lint.Utils.dedent`
             Five arguments may be optionally provided:
 
-            * \`"${OPTION_CHECK_FORMAT}"\`: allows only camelCased or UPPER_CASED variable names
+            * \`"${OPTION_CHECK_FORMAT}"\`: allows only lowerCamelCased or UPPER_CASED variable names
               * \`"${OPTION_LEADING_UNDERSCORE}"\` allows underscores at the beginning (only has an effect if "check-format" specified)
               * \`"${OPTION_TRAILING_UNDERSCORE}"\` allows underscores at the end. (only has an effect if "check-format" specified)
-              * \`"${OPTION_ALLOW_PASCAL_CASE}"\` allows PascalCase in addition to camelCase.
-              * \`"${OPTION_ALLOW_SNAKE_CASE}"\` allows snake_case in addition to camelCase.
+              * \`"${OPTION_ALLOW_PASCAL_CASE}"\` allows PascalCase in addition to lowerCamelCase.
+              * \`"${OPTION_ALLOW_SNAKE_CASE}"\` allows snake_case in addition to lowerCamelCase.
             * \`"${OPTION_BAN_KEYWORDS}"\`: disallows the use of certain TypeScript keywords as variable or parameter names.
               * These are: ${bannedKeywordsStr}`,
         options: {
@@ -164,14 +164,14 @@ function walk(ctx: Lint.WalkContext<Options>): void {
     }
 
     function formatFailure(): string {
-        let failureMessage = "variable name must be in camelcase";
+        let failureMessage = "variable name must be in lowerCamelCase";
         if (options.allowPascalCase) {
-            failureMessage += ", pascalcase";
+            failureMessage += ", PascalCase";
         }
         if (options.allowSnakeCase) {
-            failureMessage += ", snakecase";
+            failureMessage += ", snake_case";
         }
-        return failureMessage + " or uppercase";
+        return failureMessage + " or UPPER_CASE";
     }
 }
 

--- a/test/rules/_integration/enable-disable/test.ts.lint
+++ b/test/rules/_integration/enable-disable/test.ts.lint
@@ -1,6 +1,6 @@
 /* tslint:enable */
 var AAAaA = 'test'
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
             ~~~~~~ [' should be "]
 /* tslint:disable */
 var AAAaA = 'test'
@@ -11,7 +11,7 @@ var AAAaA = 'test'
             ~~~~~~ [' should be "]
 /* tslint:enable */
 var AAAaA = 'test'
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
             ~~~~~~ [' should be "]
 /* tslint:disable:quotemark variable-name */
 var AAAaA = 'test'
@@ -32,11 +32,11 @@ var AAAaA = 'test'
 var AAAaA = 'test'
 /* tslint:enable quotemark variable-name */
 var AAAaA = 'test'
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
             ~~~~~~ [' should be "]
 /* tslint:disable quotemark */
 var AAAaA = 'test'
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
 
 /* tslint:enable */
 var  re;
@@ -59,7 +59,7 @@ var AAAaA = 'test' // tslint:enable-line:quotemark
             ~~~~~~                                 [' should be "]
 // tslint:enable-next-line:variable-name
 var AAAaA = 'test'
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
 // tslint:enable
 
 /* tslint:disable:quotemark */
@@ -101,7 +101,7 @@ var AAAaA = 'test' // line should not be affected
 // ensure that next-line switch only switches next line
 var AAAaA = 'test'; /*tslint:enable-next-line*/ var AAAaA = 'test'
 var AAAaA = 'test'
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
             ~~~~~~ [' should be "]
 var AAAaA = 'test'
 var AAAaA = 'test'; //tslint:enable-next-line
@@ -111,18 +111,18 @@ var AAAaA = 'test'; //tslint:enable-next-line
 var AAAaA = 'test'; //tslint:enable
                       ~~~~~~~~~~~~~ [comment must start with a space]
 var AAAaA = 'test'; //tslint:disable
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
             ~~~~~~ [' should be "]
 var AAAaA = 'test'
 
 // ensure that "all" switches all rules
 var AAAaA = 'test'; //tslint:enable-line all
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
             ~~~~~~ [' should be "]
                       ~~~~~~~~~~~~~~~~~~~~~~ [comment must start with a space]
 
 // ensure that "all" switches all rules even if others are in the list
 var AAAaA = 'test'; //tslint:enable-line quotemark all
-    ~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
             ~~~~~~ [' should be "]
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [comment must start with a space]

--- a/test/rules/variable-name/allow-leading-trailing-underscore/test.ts.lint
+++ b/test/rules/variable-name/allow-leading-trailing-underscore/test.ts.lint
@@ -1,45 +1,45 @@
 var validName1 = "hi";
 var VALIDNAME2 = "there";
 var InvalidName1 = ","; // failure
-    ~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
 var invalid_name2 = " "; // failure
-    ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
 
 class Test {
     private Invalid_name3 = "how"; // failure
-            ~~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~~                     [variable name must be in lowerCamelCase or UPPER_CASE]
     private _optionallyValid = "are"; // sometimes a failure
 }
 
 function test() {
     () => {
         var InVaLiDnAmE4 = "you"; // failure
-            ~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~                     [variable name must be in lowerCamelCase or UPPER_CASE]
     };
 }
 
 declare var DeclaresAreValid: any;
 
 export function functionWithInvalidParamNames (bad_name, AnotherOne) { // 2 failures
-                                               ~~~~~~~~                              [variable name must be in camelcase or uppercase]
-                                                         ~~~~~~~~~~                  [variable name must be in camelcase or uppercase]
+                                               ~~~~~~~~                              [variable name must be in lowerCamelCase or UPPER_CASE]
+                                                         ~~~~~~~~~~                  [variable name must be in lowerCamelCase or UPPER_CASE]
     //
 }
 
 let { foo, bar } = { foo: 1, bar: 2 };
 let [ InvalidFoo, invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 3 failures
-      ~~~~~~~~~~                                                               [variable name must be in camelcase or uppercase]
-                  ~~~~~~~~~~~                                                  [variable name must be in camelcase or uppercase]
-                                  ~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
+      ~~~~~~~~~~                                                               [variable name must be in lowerCamelCase or UPPER_CASE]
+                  ~~~~~~~~~~~                                                  [variable name must be in lowerCamelCase or UPPER_CASE]
+                                  ~~~~~~~~~~~                                  [variable name must be in lowerCamelCase or UPPER_CASE]
 
 export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 2 failures
-                                                       ~~~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
-                                                                      ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+                                                       ~~~~~~~~~~~~~                                  [variable name must be in lowerCamelCase or UPPER_CASE]
+                                                                      ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
     //
 }
 
 export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
-                                          ~~~~~~~~~~~                            [variable name must be in camelcase or uppercase]
+                                          ~~~~~~~~~~~                            [variable name must be in lowerCamelCase or UPPER_CASE]
   //
 }
 

--- a/test/rules/variable-name/allow-leading-underscore/test.ts.lint
+++ b/test/rules/variable-name/allow-leading-underscore/test.ts.lint
@@ -1,49 +1,49 @@
 var validName1 = "hi";
 var VALIDNAME2 = "there";
 var InvalidName1 = ","; // failure
-    ~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
 var invalid_name2 = " "; // failure
-    ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
 
 class Test {
     private Invalid_name3 = "how"; // failure
-            ~~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~~                     [variable name must be in lowerCamelCase or UPPER_CASE]
     private _optionallyValid = "are"; // sometimes a failure
 }
 
 function test() {
     () => {
         var InVaLiDnAmE4 = "you"; // failure
-            ~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~                     [variable name must be in lowerCamelCase or UPPER_CASE]
     };
 }
 
 declare var DeclaresAreValid: any;
 
 export function functionWithInvalidParamNames (bad_name, AnotherOne) { // 2 failures
-                                               ~~~~~~~~                              [variable name must be in camelcase or uppercase]
-                                                         ~~~~~~~~~~                  [variable name must be in camelcase or uppercase]
+                                               ~~~~~~~~                              [variable name must be in lowerCamelCase or UPPER_CASE]
+                                                         ~~~~~~~~~~                  [variable name must be in lowerCamelCase or UPPER_CASE]
     //
 }
 
 let { foo, bar } = { foo: 1, bar: 2 };
 let [ InvalidFoo, invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 3 failures
-      ~~~~~~~~~~                                                               [variable name must be in camelcase or uppercase]
-                  ~~~~~~~~~~~                                                  [variable name must be in camelcase or uppercase]
-                                  ~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
+      ~~~~~~~~~~                                                               [variable name must be in lowerCamelCase or UPPER_CASE]
+                  ~~~~~~~~~~~                                                  [variable name must be in lowerCamelCase or UPPER_CASE]
+                                  ~~~~~~~~~~~                                  [variable name must be in lowerCamelCase or UPPER_CASE]
 
 export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 2 failures
-                                                       ~~~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
-                                                                      ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+                                                       ~~~~~~~~~~~~~                                  [variable name must be in lowerCamelCase or UPPER_CASE]
+                                                                      ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
     //
 }
 
 export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
-                                          ~~~~~~~~~~~                            [variable name must be in camelcase or uppercase]
+                                          ~~~~~~~~~~~                            [variable name must be in lowerCamelCase or UPPER_CASE]
   //
 }
 
 let optionallyValid_ = "bar";
-    ~~~~~~~~~~~~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
 let _$httpBackend_ = "leading and trailing";
-    ~~~~~~~~~~~~~~                           [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~~                           [variable name must be in lowerCamelCase or UPPER_CASE]

--- a/test/rules/variable-name/allow-pascal-case/test.ts.lint
+++ b/test/rules/variable-name/allow-pascal-case/test.ts.lint
@@ -2,13 +2,13 @@ var validName1 = "hi";
 var VALIDNAME2 = "there";
 var ValidName3 = ",";
 var invalid_name1 = " "; // failure
-    ~~~~~~~~~~~~~                   [variable name must be in camelcase, pascalcase or uppercase]
+    ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
 
 class Test {
     private Invalid_name3 = "how"; // failure
-            ~~~~~~~~~~~~~                     [variable name must be in camelcase, pascalcase or uppercase]
+            ~~~~~~~~~~~~~                     [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
     private _optionallyValid = "are"; // sometimes a failure
-            ~~~~~~~~~~~~~~~~                                 [variable name must be in camelcase, pascalcase or uppercase]
+            ~~~~~~~~~~~~~~~~                                 [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
 }
 
 function test() {
@@ -20,26 +20,26 @@ function test() {
 declare var DeclaresAreValid: any;
 
 export function functionWithInvalidParamNames (bad_name, AnotherOne) { // 1 failure
-                                               ~~~~~~~~                              [variable name must be in camelcase, pascalcase or uppercase]
+                                               ~~~~~~~~                              [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
     //
 }
 
 let { foo, bar } = { foo: 1, bar: 2 };
 let [ invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 3 failures
-      ~~~~~~~~~~~                                                  [variable name must be in camelcase, pascalcase or uppercase]
-                      ~~~~~~~~~~~                                  [variable name must be in camelcase, pascalcase or uppercase]
+      ~~~~~~~~~~~                                                  [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
+                      ~~~~~~~~~~~                                  [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
 
 export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 1 failure
-                                                       ~~~~~~~~~~~~~                                  [variable name must be in camelcase, pascalcase or uppercase]
+                                                       ~~~~~~~~~~~~~                                  [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
     //
 }
 
 export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
-                                          ~~~~~~~~~~~                            [variable name must be in camelcase, pascalcase or uppercase]
+                                          ~~~~~~~~~~~                            [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
   //
 }
 
 let optionallyValid_ = "bar";
-    ~~~~~~~~~~~~~~~~          [variable name must be in camelcase, pascalcase or uppercase]
+    ~~~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
 let _$httpBackend_ = "leading and trailing";
-    ~~~~~~~~~~~~~~          [variable name must be in camelcase, pascalcase or uppercase]
+    ~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]

--- a/test/rules/variable-name/allow-snake-case/test.ts.lint
+++ b/test/rules/variable-name/allow-snake-case/test.ts.lint
@@ -2,50 +2,50 @@ var validName1 = "hi";
 var VALIDNAME2 = "there";
 var valid_name3 = "tslint";
 var Invalid_name1 = " ";  // failure
-    ~~~~~~~~~~~~~                    [variable name must be in camelcase, snakecase or uppercase]
+    ~~~~~~~~~~~~~                    [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 var InvalidName2 = " ";  // failure
-    ~~~~~~~~~~~~                    [variable name must be in camelcase, snakecase or uppercase]
+    ~~~~~~~~~~~~                    [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 
 class Test {
     private valid_name = " ";
     private Invalid_name1 = "how"; // failure
-            ~~~~~~~~~~~~~                     [variable name must be in camelcase, snakecase or uppercase]
+            ~~~~~~~~~~~~~                     [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
     private _optionallyValid = "are"; // sometimes a failure
-            ~~~~~~~~~~~~~~~~                                 [variable name must be in camelcase, snakecase or uppercase]
+            ~~~~~~~~~~~~~~~~                                 [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 }
 
 function test() {
     () => {
         var valid_name = " ";
         var InVaLiDnAmE4 = "you"; // failure
-            ~~~~~~~~~~~~                     [variable name must be in camelcase, snakecase or uppercase]
+            ~~~~~~~~~~~~                     [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
     };
 }
 
 declare var DeclaresAreValid: any;
 
 export function functionWithInvalidParamNames (ok_name, BadName) { // 1 failure
-                                                        ~~~~~~~                  [variable name must be in camelcase, snakecase or uppercase]
+                                                        ~~~~~~~                  [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 }
 
 let { foo, bar } = { foo: 1, bar: 2 };
 let [ InvalidFoo, invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 1 failure
-      ~~~~~~~~~~                                                               [variable name must be in camelcase, snakecase or uppercase]
+      ~~~~~~~~~~                                                               [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 
 export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 1 failure
-                                                                      ~~~~~~~~~~~~~                   [variable name must be in camelcase, snakecase or uppercase]
+                                                                      ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
     //
 }
 
 export function functionWithInvalidSpread(InvalidArg: ...number) { // 1 failure
-                                          ~~~~~~~~~~                            [variable name must be in camelcase, snakecase or uppercase]
+                                          ~~~~~~~~~~                            [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
   //
 }
 
 let optionallyValid_ = "bar";
-    ~~~~~~~~~~~~~~~~          [variable name must be in camelcase, snakecase or uppercase]
+    ~~~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 let _$httpBackend_ = "leading and trailing";
-    ~~~~~~~~~~~~~~          [variable name must be in camelcase, snakecase or uppercase]
+    ~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 
 // Aliases.
 class X {
@@ -54,11 +54,11 @@ class X {
 
 var ValidAlias = some.ValidAlias;
 var ValidAlias = some.InValidAlias;
-    ~~~~~~~~~~                [variable name must be in camelcase, snakecase or uppercase]
+    ~~~~~~~~~~                [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 
 var someObject = {MoreValidAlias: 1};
 var {MoreValidAlias: localVar} = someObject;
 var {MoreValidAlias: local_var} = someObject;
 var {MoreValidAlias: LocalVar} = someObject;
-                     ~~~~~~~~                [variable name must be in camelcase, snakecase or uppercase]
+                     ~~~~~~~~                [variable name must be in lowerCamelCase, snake_case or UPPER_CASE]
 var {MoreValidAlias} = someObject;

--- a/test/rules/variable-name/allow-trailing-underscore/test.ts.lint
+++ b/test/rules/variable-name/allow-trailing-underscore/test.ts.lint
@@ -1,49 +1,49 @@
 var validName1 = "hi";
 var VALIDNAME2 = "there";
 var InvalidName1 = ","; // failure
-    ~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
 var invalid_name2 = " "; // failure
-    ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
 
 class Test {
     private Invalid_name3 = "how"; // failure
-            ~~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~~                     [variable name must be in lowerCamelCase or UPPER_CASE]
     private _optionallyValid = "are"; // sometimes a failure
-            ~~~~~~~~~~~~~~~~                                 [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~~~~~                                 [variable name must be in lowerCamelCase or UPPER_CASE]
 }
 
 function test() {
     () => {
         var InVaLiDnAmE4 = "you"; // failure
-            ~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~                     [variable name must be in lowerCamelCase or UPPER_CASE]
     };
 }
 
 declare var DeclaresAreValid: any;
 
 export function functionWithInvalidParamNames (bad_name, AnotherOne) { // 2 failures
-                                               ~~~~~~~~                              [variable name must be in camelcase or uppercase]
-                                                         ~~~~~~~~~~                  [variable name must be in camelcase or uppercase]
+                                               ~~~~~~~~                              [variable name must be in lowerCamelCase or UPPER_CASE]
+                                                         ~~~~~~~~~~                  [variable name must be in lowerCamelCase or UPPER_CASE]
     //
 }
 
 let { foo, bar } = { foo: 1, bar: 2 };
 let [ InvalidFoo, invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 3 failures
-      ~~~~~~~~~~                                                               [variable name must be in camelcase or uppercase]
-                  ~~~~~~~~~~~                                                  [variable name must be in camelcase or uppercase]
-                                  ~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
+      ~~~~~~~~~~                                                               [variable name must be in lowerCamelCase or UPPER_CASE]
+                  ~~~~~~~~~~~                                                  [variable name must be in lowerCamelCase or UPPER_CASE]
+                                  ~~~~~~~~~~~                                  [variable name must be in lowerCamelCase or UPPER_CASE]
 
 export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 2 failures
-                                                       ~~~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
-                                                                      ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+                                                       ~~~~~~~~~~~~~                                  [variable name must be in lowerCamelCase or UPPER_CASE]
+                                                                      ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
     //
 }
 
 export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
-                                          ~~~~~~~~~~~                            [variable name must be in camelcase or uppercase]
+                                          ~~~~~~~~~~~                            [variable name must be in lowerCamelCase or UPPER_CASE]
   //
 }
 
 let optionallyValid_ = "bar";
 let _$httpBackend_ = "leading and trailing";
-    ~~~~~~~~~~~~~~                           [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~~                           [variable name must be in lowerCamelCase or UPPER_CASE]

--- a/test/rules/variable-name/default/test.ts.lint
+++ b/test/rules/variable-name/default/test.ts.lint
@@ -1,53 +1,53 @@
 var validName1 = "hi";
 var VALIDNAME2 = "there";
 var InvalidName1 = ","; // failure
-    ~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
 var invalid_name2 = " "; // failure
-    ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
 
 class Test {
     private Invalid_name3 = "how"; // failure
-            ~~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~~                     [variable name must be in lowerCamelCase or UPPER_CASE]
     private _optionallyValid = "are"; // sometimes a failure
-            ~~~~~~~~~~~~~~~~                                 [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~~~~~                                 [variable name must be in lowerCamelCase or UPPER_CASE]
 }
 
 function test() {
     () => {
         var InVaLiDnAmE4 = "you"; // failure
-            ~~~~~~~~~~~~                     [variable name must be in camelcase or uppercase]
+            ~~~~~~~~~~~~                     [variable name must be in lowerCamelCase or UPPER_CASE]
     };
 }
 
 declare var DeclaresAreValid: any;
 
 export function functionWithInvalidParamNames (bad_name, AnotherOne) { // 2 failures
-                                               ~~~~~~~~                              [variable name must be in camelcase or uppercase]
-                                                         ~~~~~~~~~~                  [variable name must be in camelcase or uppercase]
+                                               ~~~~~~~~                              [variable name must be in lowerCamelCase or UPPER_CASE]
+                                                         ~~~~~~~~~~                  [variable name must be in lowerCamelCase or UPPER_CASE]
     //
 }
 
 let { foo, bar } = { foo: 1, bar: 2 };
 let [ InvalidFoo, invalid_bar, ...invalid_baz ] =  [1, 2, 3, 4]; // 3 failures
-      ~~~~~~~~~~                                                               [variable name must be in camelcase or uppercase]
-                  ~~~~~~~~~~~                                                  [variable name must be in camelcase or uppercase]
-                                  ~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
+      ~~~~~~~~~~                                                               [variable name must be in lowerCamelCase or UPPER_CASE]
+                  ~~~~~~~~~~~                                                  [variable name must be in lowerCamelCase or UPPER_CASE]
+                                  ~~~~~~~~~~~                                  [variable name must be in lowerCamelCase or UPPER_CASE]
 
 export function anotherFunctionWithInvalidParamNames ([first_element, SecondElement]) { // 2 failures
-                                                       ~~~~~~~~~~~~~                                  [variable name must be in camelcase or uppercase]
-                                                                      ~~~~~~~~~~~~~                   [variable name must be in camelcase or uppercase]
+                                                       ~~~~~~~~~~~~~                                  [variable name must be in lowerCamelCase or UPPER_CASE]
+                                                                      ~~~~~~~~~~~~~                   [variable name must be in lowerCamelCase or UPPER_CASE]
     //
 }
 
 export function functionWithInvalidSpread(invalid_arg: ...number) { // 1 failure
-                                          ~~~~~~~~~~~                            [variable name must be in camelcase or uppercase]
+                                          ~~~~~~~~~~~                            [variable name must be in lowerCamelCase or UPPER_CASE]
   //
 }
 
 let optionallyValid_ = "bar";
-    ~~~~~~~~~~~~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
 let _$httpBackend_ = "leading and trailing";
-    ~~~~~~~~~~~~~~          [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
 
 // Aliases.
 class X {
@@ -56,10 +56,10 @@ class X {
 
 var ValidAlias = some.ValidAlias;
 var ValidAlias = some.InValidAlias;
-    ~~~~~~~~~~                [variable name must be in camelcase or uppercase]
+    ~~~~~~~~~~                [variable name must be in lowerCamelCase or UPPER_CASE]
 
 var someObject = {MoreValidAlias: 1};
 var {MoreValidAlias: localVar} = someObject;
 var {MoreValidAlias: LocalVar} = someObject;
-                     ~~~~~~~~                [variable name must be in camelcase or uppercase]
+                     ~~~~~~~~                [variable name must be in lowerCamelCase or UPPER_CASE]
 var {MoreValidAlias} = someObject;


### PR DESCRIPTION
#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Overview of change:

Users were confused by the rule requiring `camelcase`, as they thought that should include `UpperCamelCase` (aka `PascalCase`). This change adjusts the error message to be more explicit.

[enhancement] better error messages in `variable-name`
