### PR TITLE
Set "min-cases" for "prefer-switch" in tslint.json

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,9 @@
   },
   "extends": "tslint:all",
   "rules": {
+    // TODO: remove this when tslint 5.3 released
+    "prefer-switch": [true, { "min-cases": 3 }],
+
     // Don't want these
     "newline-before-return": false,
     "no-parameter-properties": false,


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

#2669 didn't take into account that the global version of "prefer-switch" would still have the old "min-cases".