### PR TITLE
Document that eofline fix is not supported for single-line files.

### DIFF
--- a/src/rules/eoflineRule.ts
+++ b/src/rules/eoflineRule.ts
@@ -24,6 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "eofline",
         description: "Ensures the file ends with a newline.",
+        descriptionDetails: "Fix for single-line files is not supported.",
         rationale: "It is a [standard convention](http://stackoverflow.com/q/729692/3124288) to end files with a newline.",
         optionsDescription: "Not configurable.",
         options: null,


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2186
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

I think we should clearly state that eofline fix is not supported for single-line files. It's not obvious without inspecting [source code](https://github.com/palantir/tslint/blob/master/src/rules/eoflineRule.ts#L47) and looks like bug.