### PR TITLE
Fix semicolon rule on last line without EOF line.

### DIFF
--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -214,17 +214,21 @@ class SemicolonWalker extends Lint.AbstractWalker<Options> {
         if (this.options.always && !hasSemicolon) {
             this.reportMissing(node.end);
         } else if (!this.options.always && hasSemicolon) {
-            switch (utils.getNextToken(node, this.sourceFile)!.kind) {
-                case ts.SyntaxKind.OpenParenToken:
-                case ts.SyntaxKind.OpenBracketToken:
-                case ts.SyntaxKind.PlusToken:
-                case ts.SyntaxKind.MinusToken:
-                case ts.SyntaxKind.RegularExpressionLiteral:
-                    break;
-                default:
-                    if (!this.isFollowedByStatement(node)) {
-                        this.reportUnnecessary(node.end - 1);
-                    }
+            let shouldReport = true;
+            const nextToken = utils.getNextToken(node, this.sourceFile);
+            if (nextToken) {
+                switch (nextToken.kind) {
+                    case ts.SyntaxKind.OpenParenToken:
+                    case ts.SyntaxKind.OpenBracketToken:
+                    case ts.SyntaxKind.PlusToken:
+                    case ts.SyntaxKind.MinusToken:
+                    case ts.SyntaxKind.RegularExpressionLiteral:
+                        shouldReport = false;
+                        break;
+                }
+            }
+            if (shouldReport && !this.isFollowedByStatement(node)) {
+                this.reportUnnecessary(node.end - 1);
             }
         }
     }

--- a/test/rules/semicolon/never/no-eofline/test.ts.fix
+++ b/test/rules/semicolon/never/no-eofline/test.ts.fix
@@ -1,0 +1,1 @@
+export const test: string

--- a/test/rules/semicolon/never/no-eofline/test.ts.lint
+++ b/test/rules/semicolon/never/no-eofline/test.ts.lint
@@ -1,0 +1,2 @@
+export const test: string;
+                         ~ [Unnecessary semicolon]

--- a/test/rules/semicolon/never/no-eofline/tslint.json
+++ b/test/rules/semicolon/never/no-eofline/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "semicolon": [true, "never"]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] New bugfix
  - [x] Includes tests

#### Overview of change:

Currently when using `"semicolon": [true, "never"]` rule if semicolon is used in last line without next EOF line then linting fails with error:

> Warning: Cannot read property 'kind' of undefined

because [here](https://github.com/palantir/tslint/blob/3ad4573b8151b37586bbf32fcd77794c5d8b3201/src/rules/semicolonRule.ts#L217) `util.getNextToken()` return value is not tested for `undefined`.

I put tests in separate directory and not in `semicolon/never/test.ts.*` to avoid accidental appending to that files that will ruin this test.

#### CHANGELOG.md entry:

[bugfix] `semicolon`
