### PR TITLE
no-unsafe-any: Fix bug for number literal type

### DIFF
--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -80,7 +80,8 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
             case ts.SyntaxKind.ImportEqualsDeclaration:
             case ts.SyntaxKind.ImportDeclaration:
             case ts.SyntaxKind.ExportDeclaration:
-            // For some reason, these are of type "any".
+            // These show as type "any" if in type position.
+            case ts.SyntaxKind.NumericLiteral:
             case ts.SyntaxKind.StringLiteral:
                 return;
 

--- a/test/rules/no-unsafe-any/test.ts.lint
+++ b/test/rules/no-unsafe-any/test.ts.lint
@@ -15,8 +15,8 @@ const num: namespaceImport.T = 0;
     }
 }
 
-// Ignore string literal in type
-function returnsA(): "a";
+// Ignore number/string literal in type
+function returnsA(): 0 | "a" | null | undefined;
 
 label: for (const x of []) {
     break label;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

No longer fail for `function f(): 0 {}`.

#### CHANGELOG.md entry:

[bugfix] `no-unsafe-any`: Fix bug where number literal in type position was flagged as an unsafe `any`.
