### PR TITLE
no-magic-numbers: allow magic numbers for ElementAccessExpression

### DIFF
--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -47,6 +47,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "'magic numbers' are not allowed";
 
     public static ALLOWED_NODES = new Set<ts.SyntaxKind>([
+        ts.SyntaxKind.ElementAccessExpression,
         ts.SyntaxKind.ExportAssignment,
         ts.SyntaxKind.FirstAssignment,
         ts.SyntaxKind.LastAssignment,

--- a/test/rules/no-magic-numbers/default/test.ts.lint
+++ b/test/rules/no-magic-numbers/default/test.ts.lint
@@ -18,6 +18,9 @@ for(let i = 0;i>1341;++i) {
 throw 1342;
       ~~~~                          ['magic numbers' are not allowed]
 
+const c = ['a', 'b', 'c'];
+console.log(c[2]);
+
 class A {
     static test = 1337;
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2721
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Allow magic numbers for ElementAccessExpression fixes(#2721)

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[bugfix] `no-magic-number` Allow ElementAccessExpressions to use numbers directly