### PR TITLE
Enable "no-boolean-literal-compare"

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -400,7 +400,7 @@ function parseRuleOptions(ruleConfigValue: RawRuleConfig, rawDefaultRuleSeverity
     } else if (typeof ruleConfigValue === "boolean") {
         // old style: boolean
         ruleArguments = [];
-        ruleSeverity = ruleConfigValue === true ? defaultRuleSeverity : "off";
+        ruleSeverity = ruleConfigValue ? defaultRuleSeverity : "off";
     } else if (typeof ruleConfigValue === "object") {
         if (ruleConfigValue.severity !== undefined) {
             switch (ruleConfigValue.severity.toLowerCase()) {

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -390,7 +390,7 @@ function getOptionsJson(allOptions: any[]): { order: MemberCategoryJson[], alpha
         throw new Error("Got empty options");
     }
 
-    const firstOption = allOptions[0] as Options | string;
+    const firstOption = allOptions[0] as { order: MemberCategoryJson[] | string, alphabetize?: boolean } | string;
     if (typeof firstOption !== "object") {
         // Undocumented direct string option. Deprecate eventually.
         return { order: convertFromOldStyleOptions(allOptions), alphabetize: false }; // presume allOptions to be string[]
@@ -398,7 +398,7 @@ function getOptionsJson(allOptions: any[]): { order: MemberCategoryJson[], alpha
 
     return { order: categoryFromOption(firstOption[OPTION_ORDER]), alphabetize: firstOption[OPTION_ALPHABETIZE] === true };
 }
-function categoryFromOption(orderOption: {}): MemberCategoryJson[] {
+function categoryFromOption(orderOption: MemberCategoryJson[] | string): MemberCategoryJson[] {
     if (Array.isArray(orderOption)) {
         return orderOption;
     }

--- a/tslint.json
+++ b/tslint.json
@@ -45,7 +45,6 @@
     "completed-docs": false,
     "cyclomatic-complexity": false,
     "no-any": false,
-    "no-boolean-literal-compare": false,
     "no-inferrable-types": false,
     "no-inferred-empty-object-type": false,
     "no-magic-numbers": false,


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

Just enables the lint rule.
Figure the use of `=== true` in `memberOrderingRule.ts` was probably necessary, so updated the types instead.