### PR TITLE
prefer-template: Allow `"a" + "b" + "c"`, and enable rule

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -168,7 +168,7 @@ function findup(filename: string, directory: string): string | undefined {
         const filenameLower = filename.toLowerCase();
         const result = fs.readdirSync(cwd).find((entry) => entry.toLowerCase() === filenameLower);
         if (result !== undefined) {
-            showWarningOnce(`Using mixed case tslint.json is deprecated. Found: ` + path.join(cwd, result));
+            showWarningOnce(`Using mixed case tslint.json is deprecated. Found: ${path.join(cwd, result)}`);
         }
         return result;
     }
@@ -243,6 +243,7 @@ function resolveConfigurationPath(filePath: string, relativeTo?: string) {
         try {
             return require.resolve(filePath);
         } catch (err) {
+            // tslint:disable-next-line prefer-template (fixed in 5.3)
             throw new Error(`Invalid "extends" configuration value - could not require "${filePath}". ` +
                 "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +
                 "for the approximate method TSLint uses to find the referenced configuration file.");

--- a/src/formatters/checkstyleFormatter.ts
+++ b/src/formatters/checkstyleFormatter.ts
@@ -54,14 +54,14 @@ export class Formatter extends AbstractFormatter {
                         output += "</file>";
                     }
                     previousFilename = failure.getFileName();
-                    output += "<file name=\"" + this.escapeXml(failure.getFileName()) + "\">";
+                    output += `<file name="${this.escapeXml(failure.getFileName())}">`;
                 }
-                output += "<error line=\"" + (failure.getStartPosition().getLineAndCharacter().line + 1) + "\" ";
-                output += "column=\"" + (failure.getStartPosition().getLineAndCharacter().character + 1) + "\" ";
-                output += "severity=\"" + severity + "\" ";
-                output += "message=\"" + this.escapeXml(failure.getFailure()) + "\" ";
+                output += `<error line="${failure.getStartPosition().getLineAndCharacter().line + 1}" `;
+                output += `column="${failure.getStartPosition().getLineAndCharacter().character + 1}" `;
+                output += `severity="${severity}" `;
+                output += `message="${this.escapeXml(failure.getFailure())}" `;
                 // checkstyle parser wants "source" to have structure like <anything>dot<category>dot<type>
-                output += "source=\"failure.tslint." + this.escapeXml(failure.getRuleName()) + "\" />";
+                output += `source="failure.tslint.${this.escapeXml(failure.getRuleName())}" />`;
             }
             if (previousFilename !== null) {
                 output += "</file>";

--- a/src/formatters/codeFrameFormatter.ts
+++ b/src/formatters/codeFrameFormatter.ts
@@ -95,6 +95,6 @@ export class Formatter extends AbstractFormatter {
             outputLines.shift();
         }
 
-        return outputLines.join("\n") + "\n";
+        return `${outputLines.join("\n")}\n`;
     }
 }

--- a/src/formatters/fileslistFormatter.ts
+++ b/src/formatters/fileslistFormatter.ts
@@ -45,6 +45,6 @@ export class Formatter extends AbstractFormatter {
             }
         }
 
-        return files.join("\n") + "\n";
+        return `${files.join("\n")}\n`;
     }
 }

--- a/src/formatters/msbuildFormatter.ts
+++ b/src/formatters/msbuildFormatter.ts
@@ -47,6 +47,6 @@ export class Formatter extends AbstractFormatter {
             return `${fileName}${positionTuple}: ${severity} ${camelizedRule}: ${failureString}`;
         });
 
-        return outputLines.join("\n") + "\n";
+        return `${outputLines.join("\n")}\n`;
     }
 }

--- a/src/formatters/pmdFormatter.ts
+++ b/src/formatters/pmdFormatter.ts
@@ -51,11 +51,11 @@ export class Formatter extends AbstractFormatter {
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
             const priority = failure.getRuleSeverity() === "warning" ? 4 : 3;
 
-            output += "<file name=\"" + failure.getFileName();
-            output += "\"><violation begincolumn=\"" + (lineAndCharacter.character + 1);
-            output += "\" beginline=\"" + (lineAndCharacter.line + 1);
-            output += "\" priority=\"" + priority + "\"";
-            output += " rule=\"" + failureString + "\"> </violation></file>";
+            output += `<file name="${failure.getFileName()}`;
+            output += `"><violation begincolumn="${lineAndCharacter.character + 1}`;
+            output += `" beginline="${lineAndCharacter.line + 1}`;
+            output += `" priority="${priority}"`;
+            output += ` rule="${failureString}"></violation></file>`;
         }
 
         output += "</pmd>";

--- a/src/formatters/proseFormatter.ts
+++ b/src/formatters/proseFormatter.ts
@@ -58,6 +58,6 @@ export class Formatter extends AbstractFormatter {
             return `${failure.getRuleSeverity().toUpperCase()}: ${fileName}${positionTuple}: ${failureString}`;
         });
 
-        return fixLines.concat(errorLines).join("\n") + "\n";
+        return `${fixLines.concat(errorLines).join("\n")}\n`;
     }
 }

--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -46,7 +46,7 @@ export class Formatter extends AbstractFormatter {
             outputLines.shift();
         }
 
-        return outputLines.join("\n") + "\n";
+        return `${outputLines.join("\n")}\n`;
     }
 
     private mapToMessages(failures: RuleFailure[]): string[] {
@@ -84,9 +84,9 @@ export class Formatter extends AbstractFormatter {
             positionTuple = this.pad(positionTuple, positionMaxSize);
 
             if (failure.getRuleSeverity() === "warning") {
-                positionTuple = colors.blue(failure.getRuleSeverity().toUpperCase() + ": " + positionTuple);
+                positionTuple = colors.blue(`${failure.getRuleSeverity().toUpperCase()}: ${positionTuple}`);
             } else {
-                positionTuple = colors.red(failure.getRuleSeverity().toUpperCase() + ": " + positionTuple);
+                positionTuple = colors.red(`${failure.getRuleSeverity().toUpperCase()}: ${positionTuple}`);
             }
 
             // Output

--- a/src/formatters/tapFormatter.ts
+++ b/src/formatters/tapFormatter.ts
@@ -57,7 +57,7 @@ export class Formatter extends AbstractFormatter {
             output = output.concat([`1..${failures.length}`]).concat(this.mapToMessages(failures));
         }
 
-        return output.join("\n") + "\n";
+        return `${output.join("\n")}\n`;
     }
 
     private mapToMessages(failures: RuleFailure[]): string[] {

--- a/src/formatters/verboseFormatter.ts
+++ b/src/formatters/verboseFormatter.ts
@@ -31,9 +31,7 @@ export class Formatter extends AbstractFormatter {
     /* tslint:enable:object-literal-sort-keys */
 
     public format(failures: RuleFailure[]): string {
-
-        return this.mapToMessages(failures)
-            .join("\n") + "\n";
+        return `${this.mapToMessages(failures).join("\n")}\n`;
     }
 
     private mapToMessages(failures: RuleFailure[]): string[] {
@@ -43,7 +41,7 @@ export class Formatter extends AbstractFormatter {
             const ruleName = failure.getRuleName();
 
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
-            const positionTuple = "[" + (lineAndCharacter.line + 1) + ", " + (lineAndCharacter.character + 1) + "]";
+            const positionTuple = `[${lineAndCharacter.line + 1}, ${lineAndCharacter.character + 1}]`;
 
             return `${failure.getRuleSeverity().toUpperCase()}: (${ruleName}) ${fileName}${positionTuple}: ${failureString}`;
         });

--- a/src/formatters/vsoFormatter.ts
+++ b/src/formatters/vsoFormatter.ts
@@ -49,6 +49,6 @@ export class Formatter extends AbstractFormatter {
             return `##vso[task.logissue type=warning;${properties}]${failureString}`;
         });
 
-        return outputLines.join("\n") + "\n";
+        return `${outputLines.join("\n")}\n`;
     }
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -81,7 +81,7 @@ class Linter {
 
     constructor(private options: ILinterOptions, private program?: ts.Program) {
         if (typeof options !== "object") {
-            throw new Error("Unknown Linter options type: " + typeof options);
+            throw new Error(`Unknown Linter options type: ${typeof options}`);
         }
         if ((options as any).configuration != null) {
             throw new Error("ILinterOptions does not contain the property `configuration` as of version 4. " +

--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -96,10 +96,10 @@ function transformName(name: string): string {
     // camelize strips out leading and trailing underscores and dashes, so make sure they aren't passed to camelize
     // the regex matches the groups (leading underscores and dashes)(other characters)(trailing underscores and dashes)
     const nameMatch = name.match(/^([-_]*)(.*?)([-_]*)$/);
-    if (nameMatch == null) {
-        return name + "Rule";
+    if (nameMatch === null) {
+        return `${name}Rule`;
     }
-    return nameMatch[1] + camelize(nameMatch[2]) + nameMatch[3] + "Rule";
+    return `${nameMatch[1]}${camelize(nameMatch[2])}${nameMatch[3]}Rule`;
 }
 
 /**
@@ -108,7 +108,7 @@ function transformName(name: string): string {
  */
 function loadRule(directory: string, ruleName: string): RuleConstructor | "not-found" {
     const fullPath = path.join(directory, ruleName);
-    if (fs.existsSync(fullPath + ".js")) {
+    if (fs.existsSync(`${fullPath}.js`)) {
         const ruleModule = require(fullPath) as { Rule: RuleConstructor } | undefined;
         if (ruleModule !== undefined) {
             return ruleModule.Rule;

--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -81,7 +81,7 @@ function walk(ctx: Lint.WalkContext<Option>): void {
         // Add a space if the type is preceded by 'as' and the node has no leading whitespace
         const space = parens === 0 && parent!.kind === ts.SyntaxKind.AsExpression && node.getStart() === node.getFullStart();
         const fix = [
-            new Lint.Replacement(elementType.getStart(), parens, (space ? " " : "") + "Array<"),
+            new Lint.Replacement(elementType.getStart(), parens, `${space ? " " : ""}Array<`),
             // Delete the square brackets and replace with an angle bracket
             Lint.Replacement.replaceFromTo(elementType.getEnd() - parens, node.getEnd(), ">"),
         ];

--- a/src/rules/banRule.ts
+++ b/src/rules/banRule.ts
@@ -50,7 +50,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING_FACTORY(expression: string, messageAddition?: string) {
-        return `Calls to '${expression}' are not allowed.${messageAddition !== undefined ? " " + messageAddition : ""}`;
+        return `Calls to '${expression}' are not allowed.${messageAddition !== undefined ? ` ${messageAddition}` : ""}`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/src/rules/banTypesRule.ts
+++ b/src/rules/banTypesRule.ts
@@ -51,8 +51,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING_FACTORY(typeName: string, messageAddition?: string) {
-        return `Don't use '${typeName}' as a type.` +
-            (messageAddition !== undefined ? " " + messageAddition : "");
+        return `Don't use '${typeName}' as a type.${messageAddition !== undefined ? ` ${messageAddition}` : ""}`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/src/rules/callableTypesRule.ts
+++ b/src/rules/callableTypesRule.ts
@@ -82,7 +82,7 @@ function renderSuggestion(call: ts.CallSignatureDeclaration,
     const start = call.getStart(sourceFile);
     const colonPos = call.type!.pos - 1 - start;
     const text = sourceFile.text.substring(start, call.end);
-    const suggestion = text.substr(0, colonPos) + " =>" + text.substr(colonPos + 1);
+    const suggestion = `${text.substr(0, colonPos)} =>${text.substr(colonPos + 1)}`;
 
     if (parent.kind === ts.SyntaxKind.InterfaceDeclaration) {
         if (parent.typeParameters !== undefined) {

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -425,10 +425,10 @@ class CompletedDocsWalker extends Lint.ProgramAwareRuleWalker {
         let description = Rule.FAILURE_STRING_EXIST;
 
         if (node.modifiers !== undefined) {
-            description += node.modifiers.map((modifier) => this.describeModifier(modifier.kind)) + " ";
+            description += `${node.modifiers.map((modifier) => this.describeModifier(modifier.kind)).join(",")} `;
         }
 
-        return description + nodeType + ".";
+        return `${description}${nodeType}.`;
     }
 
     private describeModifier(kind: ts.SyntaxKind) {

--- a/src/rules/cyclomaticComplexityRule.ts
+++ b/src/rules/cyclomaticComplexityRule.ts
@@ -56,7 +56,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING(expected: number, actual: number, name?: string): string {
-        return `The function${name === undefined ? "" : " " + name} has a cyclomatic complexity of ` +
+        return `The function${name === undefined ? "" : ` ${name}`} has a cyclomatic complexity of ` +
             `${actual} which is higher than the threshold of ${expected}`;
     }
 

--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -86,7 +86,7 @@ class Walker extends Lint.ProgramAwareRuleWalker {
       for (const {pos, end} of range) {
         const jsDocText = commentNode.getFullText().substring(pos, end);
         if (jsDocText.includes("@deprecated")) {
-            this.addFailureAtNode(node, node.text + " is deprecated.");
+            this.addFailureAtNode(node, `${node.text} is deprecated.`);
         }
       }
     }

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -134,6 +134,6 @@ function memberType(node: ts.ClassElement): string {
         case ts.SyntaxKind.SetAccessor:
             return "set property accessor";
         default:
-            throw new Error("unhandled node type " + ts.SyntaxKind[node.kind]);
+            throw new Error(`unhandled node type ${ts.SyntaxKind[node.kind]}`);
     }
 }

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -91,11 +91,11 @@ const PRESET_NAMES = Array.from(PRESETS.keys());
 
 const allMemberKindNames = mapDefined(Object.keys(MemberKind), (key) => {
     const mk = (MemberKind as any)[key];
-    return typeof mk === "number" ? MemberKind[mk].replace(/[A-Z]/g, (cap) => "-" + cap.toLowerCase()) : undefined;
+    return typeof mk === "number" ? MemberKind[mk].replace(/[A-Z]/g, (cap) => `-${cap.toLowerCase()}`) : undefined;
 });
 
 function namesMarkdown(names: string[]): string {
-    return names.map((name) => "* `" + name + "`").join("\n    ");
+    return names.map((name) => `* \`${name}\``).join("\n    ");
 }
 
 const optionsDescription = Lint.Utils.dedent`
@@ -308,7 +308,7 @@ function caseInsensitiveLess(a: string, b: string) {
 }
 
 function memberKindForConstructor(access: Access): MemberKind {
-    return (MemberKind as any)[access + "Constructor"] as MemberKind;
+    return (MemberKind as any)[`${access}Constructor`] as MemberKind;
 }
 
 function memberKindForMethodOrField(access: Access, membership: "Static" | "Instance", kind: "Method" | "Field"): MemberKind {
@@ -322,7 +322,7 @@ function memberKindFromName(name: string): MemberKind[] {
     return typeof kind === "number" ? [kind as MemberKind] : allAccess.map(addModifier);
 
     function addModifier(modifier: string) {
-        const modifiedKind = (MemberKind as any)[Lint.Utils.camelize(modifier + "-" + name)];
+        const modifiedKind = (MemberKind as any)[Lint.Utils.camelize(`${modifier}-${name}`)];
         if (typeof modifiedKind !== "number") {
             throw new Error(`Bad member kind: ${name}`);
         }

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -34,6 +34,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
+    // tslint:disable-next-line prefer-template (fixed in 5.3)
     public static FAILURE_STRING = "Type declaration of 'any' loses type-safety. " +
         "Consider replacing it with a more precise type, the empty type ('{}'), " +
         "or suppress this occurrence.";

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -76,7 +76,7 @@ class NoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
             if (isPrefixUnaryExpression(node) &&
                 node.operator === ts.SyntaxKind.MinusToken &&
                 node.operand.kind === ts.SyntaxKind.NumericLiteral) {
-                return this.checkNumericLiteral(node, "-" + (node.operand as ts.NumericLiteral).text);
+                return this.checkNumericLiteral(node, `-${(node.operand as ts.NumericLiteral).text}`);
             }
             return ts.forEachChild(node, cb);
         };

--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -51,7 +51,7 @@ function walk(ctx: Lint.WalkContext<void>) {
                     argument,
                     Rule.FAILURE_STRING,
                     // expr['foo'] -> expr.foo
-                    Lint.Replacement.replaceFromTo(node.expression.end, node.end, "." + argument.text),
+                    Lint.Replacement.replaceFromTo(node.expression.end, node.end, `.${argument.text}`),
                 );
             }
         }

--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -53,7 +53,7 @@ class ObjectLiteralShorthandWalker extends Lint.RuleWalker {
                 // Delete from name start up to value to include the ':'.
                 const lengthToValueStart = value.getStart() - name.getStart();
                 const fix = this.deleteText(name.getStart(), lengthToValueStart);
-                this.addFailureAtNode(node, Rule.LONGHAND_PROPERTY + `('{${name.getText()}}').`, fix);
+                this.addFailureAtNode(node, `${Rule.LONGHAND_PROPERTY}('{${name.getText()}}').`, fix);
         }
 
         if (value.kind === ts.SyntaxKind.FunctionExpression) {
@@ -62,7 +62,7 @@ class ObjectLiteralShorthandWalker extends Lint.RuleWalker {
                 return;  // named function expressions are OK.
             }
             const star = fnNode.asteriskToken !== undefined ? fnNode.asteriskToken.getText() : "";
-            this.addFailureAtNode(node, Rule.LONGHAND_METHOD + `('{${name.getText()}${star}() {...}}').`);
+            this.addFailureAtNode(node, `${Rule.LONGHAND_METHOD}('{${name.getText()}${star}() {...}}').`);
         }
 
         super.visitPropertyAssignment(node);

--- a/src/rules/preferTemplateRule.ts
+++ b/src/rules/preferTemplateRule.ts
@@ -78,14 +78,15 @@ function getError(node: ts.Node, allowSingleConcat: boolean): string | undefined
         // Otherwise ignore. ("a" + "b", probably writing a long newline-less string on many lines.)
         return containsNewline(left as StringLike) || containsNewline(right as StringLike) ? Rule.FAILURE_STRING_MULTILINE : undefined;
     } else if (!l && !r) {
-        // Watch out for `"a" + b + c`.
+        // Watch out for `"a" + b + c`. Parsed as `("a" + b) + c`.
         return containsAnyStringLiterals(left) ? Rule.FAILURE_STRING : undefined;
     } else if (l) {
         // `"x" + y`
         return !allowSingleConcat ? Rule.FAILURE_STRING : undefined;
     } else {
         // `? + "b"`
-        return !allowSingleConcat || isPlusExpression(left) ? Rule.FAILURE_STRING : undefined;
+        // If LHS consists of only string literals (as in `"a" + "b" + "c"`, allow it.)
+        return !containsOnlyStringLiterals(left) && (!allowSingleConcat || isPlusExpression(left))  ? Rule.FAILURE_STRING : undefined;
     }
 }
 
@@ -99,13 +100,12 @@ function containsNewline(node: StringLike): boolean {
     }
 }
 
-function containsAnyStringLiterals(node: ts.Expression): boolean {
-    if (!isPlusExpression(node)) {
-        return false;
-    }
+function containsOnlyStringLiterals(node: ts.Expression): boolean {
+    return isPlusExpression(node) && isStringLike(node.right) && (isStringLike(node.left) || containsAnyStringLiterals(node.left));
+}
 
-    const { left, right } = node;
-    return isStringLike(right) || isStringLike(left) || containsAnyStringLiterals(left);
+function containsAnyStringLiterals(node: ts.Expression): boolean {
+    return isPlusExpression(node) && (isStringLike(node.right) || isStringLike(node.left) || containsAnyStringLiterals(node.left));
 }
 
 function isPlusExpression(node: ts.Node): node is ts.BinaryExpression {

--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -342,13 +342,13 @@ function stringOr(parts: string[]): string {
         case 1:
             return parts[0];
         case 2:
-            return parts[0] + " or " + parts[1];
+            return `${parts[0]} or ${parts[1]}`;
         default:
             let res = "";
             for (let i = 0; i < parts.length - 1; i++) {
-                res += parts[i] + ", ";
+                res += `${parts[i]}, `;
             }
-            return res + "or " + parts[parts.length - 1];
+            return `${res}or ${parts[parts.length - 1]}`;
     }
 }
 

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -223,7 +223,7 @@ class TypedefWalker extends Lint.RuleWalker {
                                 typeAnnotation: ts.TypeNode | undefined,
                                 name?: ts.Node) {
         if (this.hasOption(option) && typeAnnotation == null) {
-            this.addFailureAt(location, 1, "expected " + option + getName(name, ": '", "'") + " to have a typedef");
+            this.addFailureAt(location, 1, `expected ${option}${getName(name, ": '", "'")} to have a typedef`);
         }
     }
 }

--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -232,7 +232,7 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
             }
 
             const optionValue = this.getLeftOption(option);
-            const message = "expected " + optionValue + " before colon in " + option;
+            const message = `expected ${optionValue} before colon in ${option}`;
             this.performFailureCheck(
                 optionValue!,
                 hasLeadingWhitespace,
@@ -274,7 +274,7 @@ class TypedefWhitespaceWalker extends Lint.RuleWalker {
             }
 
             const optionValue = this.getRightOption(option);
-            const message = "expected " + optionValue + " after colon in " + option;
+            const message = `expected ${optionValue} after colon in ${option}`;
             this.performFailureCheck(
                 optionValue!,
                 hasTrailingWhitespace,

--- a/src/rules/unifiedSignaturesRule.ts
+++ b/src/rules/unifiedSignaturesRule.ts
@@ -48,7 +48,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     private static FAILURE_STRING_START(otherLine?: number): string {
         // For only 2 overloads we don't need to specify which is the other one.
         const overloads = otherLine === undefined ? "These overloads" : `This overload and the one on line ${otherLine}`;
-        return overloads + " can be combined into one signature";
+        return `${overloads} can be combined into one signature`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -171,7 +171,7 @@ function walk(ctx: Lint.WalkContext<Options>): void {
         if (options.allowSnakeCase) {
             failureMessage += ", snake_case";
         }
-        return failureMessage + " or UPPER_CASE";
+        return `${failureMessage} or UPPER_CASE`;
     }
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-// tslint:disable strict-boolean-expressions (wait on https://github.com/palantir/tslint/pull/2572)
+// tslint:disable strict-boolean-expressions prefer-template
+// (wait on https://github.com/palantir/tslint/pull/2572)
 
 import * as fs from "fs";
 import * as glob from "glob";

--- a/src/test/lines.ts
+++ b/src/test/lines.ts
@@ -92,7 +92,7 @@ export function printLine(line: Line, code?: string): string | null {
             let tildes = "~".repeat(line.endCol - line.startCol);
             if (code.length < line.endCol) {
                 // Better than crashing in String.repeat
-                throw new Error("Bad error marker at " + JSON.stringify(line));
+                throw new Error(`Bad error marker at ${JSON.stringify(line)}`);
             }
             let endSpaces = " ".repeat(code.length - line.endCol);
             if (tildes.length === 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,9 +62,9 @@ export function isLowerCase(str: string): boolean {
 /**
  * Removes leading indents from a template string without removing all leading whitespace
  */
-export function dedent(strings: TemplateStringsArray, ...values: string[]) {
+export function dedent(strings: TemplateStringsArray, ...values: any[]) {
     let fullString = strings.reduce((accumulator, str, i) => {
-        return accumulator + values[i - 1] + str;
+        return `${accumulator}${values[i - 1]}${str}`;
     });
 
     // match all leading spaces/tabs at the start of each line
@@ -76,7 +76,7 @@ export function dedent(strings: TemplateStringsArray, ...values: string[]) {
 
     // find the smallest indent, we don't want to remove all leading whitespace
     const indent = Math.min(...match.map((el) => el.length));
-    const regexp = new RegExp("^[ \\t]{" + indent + "}", "gm");
+    const regexp = new RegExp(`^[ \\t]{${indent}}`, "gm");
     fullString = indent > 0 ? fullString.replace(regexp, "") : fullString;
     return fullString;
 }

--- a/test/formatters/checkstyleFormatterTests.ts
+++ b/test/formatters/checkstyleFormatterTests.ts
@@ -47,21 +47,21 @@ describe("Checkstyle Formatter", () => {
             createFailure(sourceFile2, 2, 3, "&<>'\" should be escaped", "escape", undefined, "warning"),
             createFailure(sourceFile2, maxPosition2 - 1, maxPosition2, "last failure", "last-name", undefined, "warning"),
         ];
+        // tslint:disable max-line-length
         const expectedResult =
-            '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">' +
-            `<file name="${TEST_FILE_1}">` +
-            '<error line="1" column="1" severity="error" message="first failure" source="failure.tslint.first-name" />' +
-            '<error line="1" column="3" severity="error" message="&amp;&lt;&gt;&#39;&quot; should be escaped" ' +
-            'source="failure.tslint.escape" />' +
-            '<error line="6" column="3" severity="error" message="last failure" source="failure.tslint.last-name" />' +
-            "</file>" +
-            `<file name="${TEST_FILE_2}">` +
-            '<error line="1" column="1" severity="error" message="first failure" source="failure.tslint.first-name" />' +
-            '<error line="1" column="3" severity="warning" message="&amp;&lt;&gt;&#39;&quot; should be escaped" ' +
-            'source="failure.tslint.escape" />' +
-            '<error line="6" column="3" severity="warning" message="last failure" source="failure.tslint.last-name" />' +
-            "</file>" +
-            "</checkstyle>";
+            `<?xml version="1.0" encoding="utf-8"?>
+            <checkstyle version="4.3">
+            <file name="${TEST_FILE_1}">
+                <error line="1" column="1" severity="error" message="first failure" source="failure.tslint.first-name" />
+                <error line="1" column="3" severity="error" message="&amp;&lt;&gt;&#39;&quot; should be escaped" source="failure.tslint.escape" />
+                <error line="6" column="3" severity="error" message="last failure" source="failure.tslint.last-name" />
+            </file>
+            <file name="${TEST_FILE_2}">
+                <error line="1" column="1" severity="error" message="first failure" source="failure.tslint.first-name" />
+                <error line="1" column="3" severity="warning" message="&amp;&lt;&gt;&#39;&quot; should be escaped" source="failure.tslint.escape" />
+                <error line="6" column="3" severity="warning" message="last failure" source="failure.tslint.last-name" />
+            </file>
+            </checkstyle>`.replace(/>\s+/g, ">"); // Remove whitespace between tags
 
         assert.equal(formatter.format(failures), expectedResult);
     });

--- a/test/formatters/externalFormatterTests.ts
+++ b/test/formatters/externalFormatterTests.ts
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import * as ts from "typescript";
 
+import { dedent } from "../../src/utils";
 import { IFormatter, TestUtils } from "../lint";
 import { createFailure } from "./utils";
 
@@ -40,17 +41,17 @@ describe("External Formatter", () => {
             createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
         ];
 
-        const expectedResult =
-            getPositionString(1, 1) + TEST_FILE + "\n" +
-            getPositionString(2, 11) + TEST_FILE + "\n" +
-            getPositionString(9, 2) + TEST_FILE + "\n";
+        const expectedResult = dedent`
+            ${getPositionString(1, 1)}${TEST_FILE}
+            ${getPositionString(2, 11)}${TEST_FILE}
+            ${getPositionString(9, 2)}${TEST_FILE}\n`.slice(1); // remove leading newline
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);
     });
 
     it("returns undefined for unresolvable module", () => {
-        assert.isUndefined(TestUtils.getFormatter(TEST_FILE + "/__non-existent__"));
+        assert.isUndefined(TestUtils.getFormatter(`${TEST_FILE}/__non-existent__`));
     });
 
     it("handles no failures", () => {
@@ -59,6 +60,6 @@ describe("External Formatter", () => {
     });
 
     function getPositionString(line: number, character: number) {
-        return "[" + line + ", " + character + "]";
+        return `[${line}, ${character}]`;
     }
 });

--- a/test/formatters/fileslistFormatterTests.ts
+++ b/test/formatters/fileslistFormatterTests.ts
@@ -39,7 +39,7 @@ describe("Files-list Formatter", () => {
         ];
 
         // we only print file-names in this formatter
-        const expectedResult = TEST_FILE + "\n";
+        const expectedResult = `${TEST_FILE}\n`;
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);

--- a/test/formatters/pmdFormatterTests.ts
+++ b/test/formatters/pmdFormatterTests.ts
@@ -41,30 +41,30 @@ describe("PMD Formatter", () => {
             createFailure(sourceFile, 0, maxPosition, "full failure", "full-name", undefined, "warning"),
         ];
         const expectedResult =
-            "<pmd version=\"tslint\">" +
-                "<file name=\"formatters/pmdFormatter.test.ts\">" +
-                    "<violation begincolumn=\"1\" beginline=\"1\" priority=\"3\" rule=\"first failure\"> " +
-                    "</violation>" +
-                "</file>" +
-                "<file name=\"formatters/pmdFormatter.test.ts\">" +
-                    "<violation begincolumn=\"3\" beginline=\"1\" priority=\"3\" rule=\"&amp;&lt;&gt;&#39;&quot; should be escaped\"> " +
-                    "</violation>" +
-                "</file>" +
-                "<file name=\"formatters/pmdFormatter.test.ts\">" +
-                    "<violation begincolumn=\"3\" beginline=\"6\" priority=\"4\" rule=\"last failure\"> " +
-                    "</violation>" +
-                "</file>" +
-                "<file name=\"formatters/pmdFormatter.test.ts\">" +
-                    "<violation begincolumn=\"1\" beginline=\"1\" priority=\"4\" rule=\"full failure\"> " +
-                    "</violation>" +
-                "</file>" +
-            "</pmd>";
+            `<pmd version="tslint">
+                <file name="formatters/pmdFormatter.test.ts">
+                    <violation begincolumn="1" beginline="1" priority="3" rule="first failure">
+                    </violation>
+                </file>
+                <file name="formatters/pmdFormatter.test.ts">
+                    <violation begincolumn="3" beginline="1" priority="3" rule="&amp;&lt;&gt;&#39;&quot; should be escaped">
+                    </violation>
+                </file>
+                <file name="formatters/pmdFormatter.test.ts">
+                    <violation begincolumn="3" beginline="6" priority="4" rule="last failure">
+                    </violation>
+                </file>
+                <file name="formatters/pmdFormatter.test.ts">
+                    <violation begincolumn="1" beginline="1" priority="4" rule="full failure">
+                    </violation>
+                </file>
+            </pmd>`.replace(/>\s+/g, ">"); // Remove whitespace between tags
 
         assert.equal(formatter.format(failures), expectedResult);
     });
 
     it("handles no failures", () => {
         const result = formatter.format([]);
-        assert.deepEqual(result, "<pmd version=\"tslint\"></pmd>");
+        assert.deepEqual(result, '<pmd version="tslint"></pmd>');
     });
 });

--- a/test/formatters/proseFormatterTests.ts
+++ b/test/formatters/proseFormatterTests.ts
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import * as ts from "typescript";
 
+import { dedent } from "../../src/utils";
 import { IFormatter, RuleFailure, TestUtils } from "../lint";
 import { createFailure } from "./utils";
 
@@ -40,10 +41,10 @@ describe("Prose Formatter", () => {
             createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "warning"),
         ];
 
-        const expectedResult =
-            "ERROR: " + TEST_FILE + getPositionString(1, 1) + "first failure\n" +
-            "ERROR: " + TEST_FILE + getPositionString(2, 12) + "mid failure\n" +
-            "WARNING: " + TEST_FILE + getPositionString(9, 2) + "last failure\n";
+        const expectedResult = dedent`
+            ERROR: ${TEST_FILE}${getPositionString(1, 1)}first failure
+            ERROR: ${TEST_FILE}${getPositionString(2, 12)}mid failure
+            WARNING: ${TEST_FILE}${getPositionString(9, 2)}last failure\n`.slice(1); // remove leading newline
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);
@@ -62,10 +63,11 @@ describe("Prose Formatter", () => {
             mockFix,
         ];
 
-        const expectedResult =
-            `Fixed 2 error(s) in ${TEST_FILE}\n` +
-            `Fixed 1 error(s) in file2\n\n` +
-            `ERROR: ${TEST_FILE}${getPositionString(1, 1)}first failure\n`;
+        const expectedResult = dedent`
+            Fixed 2 error(s) in ${TEST_FILE}
+            Fixed 1 error(s) in file2
+
+            ERROR: ${TEST_FILE}${getPositionString(1, 1)}first failure\n`.slice(1); // remove leading newline
 
         const actualResult = formatter.format(failures, fixes);
         assert.equal(actualResult, expectedResult);

--- a/test/formatters/stylishFormatterTests.ts
+++ b/test/formatters/stylishFormatterTests.ts
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import * as ts from "typescript";
 
+import { dedent } from "../../src/utils";
 import { IFormatter, TestUtils } from "../lint";
 import { createFailure } from "./utils";
 
@@ -45,11 +46,13 @@ describe("Stylish Formatter", () => {
 
         const maxPositionTuple = `${maxPositionObj.line + 1}:${maxPositionObj.character + 1}`;
 
-        const expectedResult = "formatters/stylishFormatter.test.ts" + "\n" +
-            "\u001b[31mERROR: 1:1\u001b[39m  \u001b[90mfirst-name\u001b[39m  \u001b[33mfirst failure\u001b[39m" + "\n" +
-            "\u001b[31mERROR: 1:3\u001b[39m  \u001b[90mescape    \u001b[39m  \u001b[33m&<>'\" should be escaped\u001b[39m" + "\n" +
-            `\u001b[31mERROR: ${maxPositionTuple}\u001b[39m  \u001b[90mlast-name \u001b[39m  \u001b[33mlast failure\u001b[39m` + "\n" +
-            "\u001b[31mERROR: 1:1\u001b[39m  \u001b[90mfull-name \u001b[39m  \u001b[33mfull failure\u001b[39m" + "\n";
+        const expectedResult = dedent`
+            formatters/stylishFormatter.test.ts
+            \u001b[31mERROR: 1:1\u001b[39m  \u001b[90mfirst-name\u001b[39m  \u001b[33mfirst failure\u001b[39m
+            \u001b[31mERROR: 1:3\u001b[39m  \u001b[90mescape    \u001b[39m  \u001b[33m&<>'\" should be escaped\u001b[39m
+            \u001b[31mERROR: ${maxPositionTuple}\u001b[39m  \u001b[90mlast-name \u001b[39m  \u001b[33mlast failure\u001b[39m
+            \u001b[31mERROR: 1:1\u001b[39m  \u001b[90mfull-name \u001b[39m  \u001b[33mfull failure\u001b[39m\n`
+            .slice(1); // remove leading newline
 
         assert.equal(formatter.format(failures), expectedResult);
     });

--- a/test/formatters/tapFormatterTests.ts
+++ b/test/formatters/tapFormatterTests.ts
@@ -17,10 +17,9 @@
 import { assert } from "chai";
 import * as ts from "typescript";
 
+import { dedent } from "../../src/utils";
 import { IFormatter, TestUtils } from "../lint";
 import { createFailure } from "./utils";
-
-import * as Utils from "../../src/utils";
 
 describe("TAP Formatter", () => {
     const TEST_FILE = "formatters/tapFormatter.test.ts";
@@ -42,13 +41,14 @@ describe("TAP Formatter", () => {
             createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
         ];
 
-        const expectedResult =
-            getFailureString(1, "first-name", "error", TEST_FILE, 0, 0, "first failure") + "\n" +
-            getFailureString(2, "mid-name", "error", TEST_FILE, 1, 19, "mid failure") + "\n" +
-            getFailureString(3, "last-name", "error", TEST_FILE, 0, 12, "last failure") + "\n";
+        const failureStrings = [
+            getFailureString(1, "first-name", "error", TEST_FILE, 0, 0, "first failure"),
+            getFailureString(2, "mid-name", "error", TEST_FILE, 1, 19, "mid failure"),
+            getFailureString(3, "last-name", "error", TEST_FILE, 0, 12, "last failure"),
+        ];
 
         const actualResult = formatter.format(failures);
-        assert.equal(actualResult, `TAP version 13\n1..${failures.length}\n` + expectedResult);
+        assert.equal(actualResult, `TAP version 13\n1..${failures.length}\n${failureStrings.join("\n")}\n`);
     });
 
     it("handles no failures", () => {
@@ -63,16 +63,16 @@ describe("TAP Formatter", () => {
                               line: number,
                               character: number,
                               reason: string) {
-        return Utils.dedent`
-            not ok ${String(num)} - ${reason}
+        return dedent`
+            not ok ${num} - ${reason}
               ---
               message : ${reason}
               severity: ${severity}
               data:
                 ruleName: ${ruleName}
                 fileName: ${file}
-                line: ${String(line)}
-                character: ${String(character)}
+                line: ${line}
+                character: ${character}
                 failureString: ${reason}
                 rawLines: var x = 123;\n
               ...`;

--- a/test/formatters/verboseFormatterTests.ts
+++ b/test/formatters/verboseFormatterTests.ts
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import * as ts from "typescript";
 
+import { dedent } from "../../src/utils";
 import { IFormatter, TestUtils } from "../lint";
 import { createFailure } from "./utils";
 
@@ -40,10 +41,10 @@ describe("Verbose Formatter", () => {
             createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
         ];
 
-        const expectedResult =
-            "ERROR: (first-name) " + TEST_FILE + getPositionString(1, 1) + "first failure\n" +
-            "ERROR: (mid-name) " + TEST_FILE + getPositionString(2, 12) + "mid failure\n" +
-            "ERROR: (last-name) " + TEST_FILE + getPositionString(9, 2) + "last failure\n";
+        const expectedResult = dedent`
+            ERROR: (first-name) ${TEST_FILE}${getPositionString(1, 1)}first failure
+            ERROR: (mid-name) ${TEST_FILE}${getPositionString(2, 12)}mid failure
+            ERROR: (last-name) ${TEST_FILE}${getPositionString(9, 2)}last failure\n`.slice(1); // remove leading newline
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);

--- a/test/rules/prefer-template/allow-single-concat/test.ts.lint
+++ b/test/rules/prefer-template/allow-single-concat/test.ts.lint
@@ -16,6 +16,8 @@ x + "a" + y;
 `a` + x + `b${y}c`;
 ~~~~~~~~~~~~~~~~~~ [0]
 
+"a" + "b" + "c";
+
 x`a` + y; // OK, can't simplify something with a tag
 
 "a" + "b"; // OK to concatenate regular strings.

--- a/test/rules/prefer-template/default/test.ts.lint
+++ b/test/rules/prefer-template/default/test.ts.lint
@@ -18,6 +18,8 @@ x + "a" + y;
 `a` + x + `b${y}c`;
 ~~~~~~~~~~~~~~~~~~ [0]
 
+"a" + "b" + "c";
+
 x`a` + y; // OK, can't simplify something with a tag
 
 "a" + "b"; // OK to concatenate strings without newlines.

--- a/tslint.json
+++ b/tslint.json
@@ -59,8 +59,6 @@
     "no-use-before-declare": false,
     "no-void-expression": false,
     "prefer-function-over-method": false,
-    "prefer-template": false,
-    "restrict-plus-operands": false,
     "return-undefined": false,
     "strict-type-predicates": false,
     "triple-equals": false,


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Fixes `prefer-template` to allow string concatenation where the LHS is a series of string concatenations, as in `"a" + "b" + "c"`.
Enables the rule along with `restrict-plus-operands` (which is mostly fixed as a side-effect).

#### CHANGELOG.md entry:

[bugfix] `prefer-template`: Allow `"a" + "b" + "c"`.
