### PR TITLE
Make the "completed-docs" rule respect "public" privacies option

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -328,7 +328,7 @@ class ClassRequirement extends Requirement<IClassRequirementDescriptor> {
             return this.privacies.has(PRIVACY_PROTECTED);
         }
 
-        return Lint.hasModifier(node.modifiers, ts.SyntaxKind.PublicKeyword);
+        return this.privacies.has(PRIVACY_PUBLIC);
     }
 }
 

--- a/test/rules/completed-docs/privacies-private/test.ts.lint
+++ b/test/rules/completed-docs/privacies-private/test.ts.lint
@@ -1,0 +1,30 @@
+class Class {
+    badDefaultMethod() { }
+
+    /**
+     * ...
+     */
+    goodDefaultMethod() { }
+
+    public badPublicMethod() { }
+
+    /**
+     * ...
+     */
+    public goodPublicMethod() { }
+
+    protected badProtectedMethod() { }
+
+    /**
+     * ...
+     */
+    protected goodProtectedMethod() { }
+
+    private badPrivateMethod() { }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for private methods.]
+
+    /**
+     * ...
+     */
+    private goodPrivateMethod() { }
+}

--- a/test/rules/completed-docs/privacies-private/tslint.json
+++ b/test/rules/completed-docs/privacies-private/tslint.json
@@ -5,7 +5,7 @@
   "rules": {
     "completed-docs": [true, {
       "methods": {
-        "privacies": ["all"]
+        "privacies": ["private"]
       }
     }]
   }

--- a/test/rules/completed-docs/privacies-protected/test.ts.lint
+++ b/test/rules/completed-docs/privacies-protected/test.ts.lint
@@ -1,0 +1,30 @@
+class Class {
+    badDefaultMethod() { }
+
+    /**
+     * ...
+     */
+    goodDefaultMethod() { }
+
+    public badPublicMethod() { }
+
+    /**
+     * ...
+     */
+    public goodPublicMethod() { }
+
+    protected badProtectedMethod() { }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for protected methods.]
+
+    /**
+     * ...
+     */
+    protected goodProtectedMethod() { }
+
+    private badPrivateMethod() { }
+
+    /**
+     * ...
+     */
+    private goodPrivateMethod() { }
+}

--- a/test/rules/completed-docs/privacies-protected/tslint.json
+++ b/test/rules/completed-docs/privacies-protected/tslint.json
@@ -5,7 +5,7 @@
   "rules": {
     "completed-docs": [true, {
       "methods": {
-        "privacies": ["all"]
+        "privacies": ["protected"]
       }
     }]
   }

--- a/test/rules/completed-docs/privacies-public/test.ts.lint
+++ b/test/rules/completed-docs/privacies-public/test.ts.lint
@@ -1,0 +1,31 @@
+class Class {
+    badDefaultMethod() { }
+    ~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for methods.]
+
+    /**
+     * ...
+     */
+    goodDefaultMethod() { }
+
+    public badPublicMethod() { }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for public methods.]
+
+    /**
+     * ...
+     */
+    public goodPublicMethod() { }
+
+    protected badProtectedMethod() { }
+
+    /**
+     * ...
+     */
+    protected goodProtectedMethod() { }
+
+    private badPrivateMethod() { }
+
+    /**
+     * ...
+     */
+    private goodPrivateMethod() { }
+}

--- a/test/rules/completed-docs/privacies-public/tslint.json
+++ b/test/rules/completed-docs/privacies-public/tslint.json
@@ -5,7 +5,7 @@
   "rules": {
     "completed-docs": [true, {
       "methods": {
-        "privacies": ["all"]
+        "privacies": ["public"]
       }
     }]
   }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2701 (I believe)
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] ~~Documentation update~~

#### Overview of change:
+ I don't think the `public` "privacies" option (or its absence) was being respected at all. We encountered this in a React project where we wanted to require documentation for _just_ private & protected methods.
+ In addition it looks like the existing "privacies" test was specifying privacies under the "visibilities" key? 
+ Added tests for the individual "privacies" levels

#### CHANGELOG.md entry:
[bugfix] Make "completed-docs" rule respect "public" privacy (or lack thereof)