### PR TITLE
CLI: handle directories passed with -p

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -146,11 +146,14 @@ export class Runner {
         let program: ts.Program | undefined;
 
         if (this.options.project != null) {
-            if (!fs.existsSync(this.options.project)) {
+            let project: string;
+            try {
+                project = findTsconfig(this.options.project);
+            } catch (e) {
                 console.error("Invalid option for project: " + this.options.project);
                 return onComplete(1);
             }
-            program = Linter.createProgram(this.options.project);
+            program = Linter.createProgram(project);
             if (files.length === 0) {
                 files = Linter.getFileNames(program);
             }
@@ -175,9 +178,6 @@ export class Runner {
                 // if not type checking, we don't need to pass in a program object
                 program = undefined;
             }
-        } else if (this.options.typeCheck) {
-            console.error("--project must be specified in order to enable type checking.");
-            return onComplete(1);
         }
 
         let ignorePatterns: string[] = [];
@@ -256,4 +256,13 @@ export class Runner {
             }
         });
     }
+}
+
+function findTsconfig(project: string): string {
+    const stats = fs.statSync(project);
+    if (stats.isDirectory()) {
+        project = path.join(project, "tsconfig.json");
+        fs.accessSync(project);
+    }
+    return project;
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -146,10 +146,8 @@ export class Runner {
         let program: ts.Program | undefined;
 
         if (this.options.project != null) {
-            let project: string;
-            try {
-                project = findTsconfig(this.options.project);
-            } catch (e) {
+            const project = findTsconfig(this.options.project);
+            if (project === undefined) {
                 console.error("Invalid option for project: " + this.options.project);
                 return onComplete(1);
             }
@@ -258,11 +256,15 @@ export class Runner {
     }
 }
 
-function findTsconfig(project: string): string {
-    const stats = fs.statSync(project);
-    if (stats.isDirectory()) {
-        project = path.join(project, "tsconfig.json");
-        fs.accessSync(project);
+function findTsconfig(project: string): string | undefined {
+    try {
+        const stats = fs.statSync(project); // throws if file does not exist
+        if (stats.isDirectory()) {
+            project = path.join(project, "tsconfig.json");
+            fs.accessSync(project); // throws if file does not exist
+        }
+    } catch (e) {
+        return undefined;
     }
     return project;
 }

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -55,6 +55,12 @@ const processed = optimist
         }
 
         // tslint:disable-next-line strict-boolean-expressions
+        if (argv["type-check"] && !argv.project) {
+            // tslint:disable-next-line:no-string-throw
+            throw "--project must be specified in order to enable type checking.";
+        }
+
+        // tslint:disable-next-line strict-boolean-expressions
         if (argv.f) {
             // throw a string, otherwise a call stack is printed for this message
             // tslint:disable-next-line:no-string-throw
@@ -214,7 +220,7 @@ tslint accepts the following commandline options:
         this can be used to test custom rules.
 
     -p, --project:
-        The location of a tsconfig.json file that will be used to determine which
+        The path or directory containing a tsconfig.json file that will be used to determine which
         files will be linted.
 
     --type-check

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -251,6 +251,29 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             });
         });
 
+        it("can be passed a directory and defaults to tsconfig.json", (done) => {
+            execCli(["-c", "test/files/tsconfig-test/tslint.json", "--project", "test/files/tsconfig-test"], (err) => {
+                assert.isNull(err, "process should exit without an error");
+                done();
+            });
+        });
+
+        it("exits with error if passed a directory and there is not tsconfig.json", (done) => {
+            execCli(["-c", "test/files/tsconfig-test/tslint.json", "--project", "test/files"], (err) => {
+                assert.isNotNull(err, "process should exit with an error");
+                assert.strictEqual(err.code, 1, "error code should be 1");
+                done();
+            });
+        });
+
+        it("exits with error if passed directory does not exist", (done) => {
+            execCli(["-c", "test/files/tsconfig-test/tslint.json", "--project", "test/files/non-existant"], (err) => {
+                assert.isNotNull(err, "process should exit with an error");
+                assert.strictEqual(err.code, 1, "error code should be 1");
+                done();
+            });
+        });
+
         it("exits with code 2 if both `tsconfig.json` and files arguments are passed and files contain lint errors", (done) => {
             execCli(
                 [


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2692 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Search for tsconfig.json in specified directory. Exit with error if  there is none.
Ref: #2692
[enhancement] cli: `-p` option handles directories

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
