### PR TITLE
strict-boolean-expressions: Allow 'any', and 'true' and 'false' literal types

### DIFF
--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -188,9 +188,12 @@ function getTypeFailure(type: ts.Type, options: Options): TypeFailure | undefine
 
     switch (triState(kind)) {
         case true:
-            return TypeFailure.AlwaysTruthy;
+            // Allow 'any'. Allow 'true' itself, but not any other always-truthy type.
+            // tslint:disable-next-line no-bitwise
+            return Lint.isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.BooleanLiteral) ? undefined : TypeFailure.AlwaysTruthy;
         case false:
-            return TypeFailure.AlwaysFalsy;
+            // Allow 'false' itself, but not any other always-falsy type
+            return Lint.isTypeFlagSet(type, ts.TypeFlags.BooleanLiteral) ? undefined : TypeFailure.AlwaysFalsy;
         case undefined:
             return undefined;
     }

--- a/test/rules/strict-boolean-expressions/default/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/default/test.ts.lint
@@ -95,12 +95,10 @@ boolType ? strType : undefined;
 !enumType;
  ~~~~~~~~  [This type is not allowed in the operand for the '!' operator because it is an enum. Only booleans are allowed.]
 !!classType;
- ~~~~~~~~~~ [This type is not allowed in the operand for the '!' operator because it is always falsy. Only booleans are allowed.]
   ~~~~~~~~~  [This type is not allowed in the operand for the '!' operator because it is always truthy. Only booleans are allowed.]
 !bwrapType;
  ~~~~~~~~~  [This type is not allowed in the operand for the '!' operator because it is always truthy. Only booleans are allowed.]
 !!undefined;
- ~~~~~~~~~~  [This type is not allowed in the operand for the '!' operator because it is always truthy. Only booleans are allowed.]
   ~~~~~~~~~  [This type is not allowed in the operand for the '!' operator because it is always falsy. Only booleans are allowed.]
 
 /*** Valid ***/
@@ -180,3 +178,15 @@ for (let j = 0; j; j++) { break; }
                 ~                  [This type is not allowed in the 'for' condition because it is a number. Only booleans are allowed.]
 /*** Valid ***/
 for (let j = 0; j > numType; j++) { break; }
+
+// Allow always-truthy or always-falsy in the case of 'true' and 'false'
+while (true) {}
+if (false) {}
+// Do *not* allow 'true' in a union
+declare var trueOrDate: true | Date;
+if (trueOrDate) {}
+    ~~~~~~~~~~ [This type is not allowed in the 'if' condition because it is always truthy. Only booleans are allowed.]
+
+declare var a: any;
+// Allow 'any'
+if (a) {}


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2757, #2385
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Starts allowing the types 'any', 'true', or 'false' if they appear exactly.
Will still not allow an always-truthy/falsy union (e.g. `true | Date`).

#### CHANGELOG.md entry:

[enhancement] `strict-boolean-expression`: Allow `any`, and `true` and `false` literal types
