### PR TITLE
Update tsutils and remove redundant typeguards

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "resolve": "^1.3.2",
     "semver": "^5.3.0",
     "tslib": "^1.6.0",
-    "tsutils": "^1.9.0"
+    "tsutils": "^1.9.1"
   },
   "peerDependencies": {
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "resolve": "^1.3.2",
     "semver": "^5.3.0",
     "tslib": "^1.6.0",
-    "tsutils": "^1.8.0"
+    "tsutils": "^1.9.0"
   },
   "peerDependencies": {
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev"

--- a/src/rules/restrictPlusOperandsRule.ts
+++ b/src/rules/restrictPlusOperandsRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isBinaryExpression } from "tsutils";
+import { isBinaryExpression, isEnumLiteralType, isUnionType } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -63,16 +63,12 @@ function getBaseTypeOfLiteralType(type: ts.Type): "string" | "number" | "invalid
     } else if (isUnionType(type) && !Lint.isTypeFlagSet(type, ts.TypeFlags.Enum)) {
         const types = type.types.map(getBaseTypeOfLiteralType);
         return allSame(types) ? types[0] : "invalid";
-    } else if (Lint.isTypeFlagSet(type, ts.TypeFlags.EnumLiteral)) {
-        return getBaseTypeOfLiteralType((type as ts.EnumLiteralType).baseType);
+    } else if (isEnumLiteralType(type)) {
+        return getBaseTypeOfLiteralType(type.baseType);
     }
     return "invalid";
 }
 
 function allSame(array: string[]) {
     return array.every((value) => value === array[0]);
-}
-
-function isUnionType(type: ts.Type): type is ts.UnionType {
-    return Lint.isTypeFlagSet(type, ts.TypeFlags.Union);
 }

--- a/src/rules/strictTypePredicatesRule.ts
+++ b/src/rules/strictTypePredicatesRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as utils from "tsutils";
+import { isBinaryExpression, isUnionType } from "tsutils";
 
 import * as ts from "typescript";
 import * as Lint from "../index";
@@ -58,7 +58,7 @@ export class Rule extends Lint.Rules.TypedRule {
 
 function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (utils.isBinaryExpression(node)) {
+        if (isBinaryExpression(node)) {
             const equals = Lint.getEqualsKind(node.operatorToken);
             if (equals !== undefined) {
                 checkEquals(node, equals);
@@ -254,9 +254,4 @@ function testNonStrictNullUndefined(type: ts.Type): boolean | "null" | "undefine
 
 function unionParts(type: ts.Type) {
     return isUnionType(type) ? type.types : [type];
-}
-
-/** Type predicate to test for a union type. */
-function isUnionType(type: ts.Type): type is ts.UnionType {
-    return Lint.isTypeFlagSet(type, ts.TypeFlags.Union);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,9 +1441,9 @@ tslint@latest:
     tslib "^1.6.0"
     tsutils "^1.8.0"
 
-tsutils@^1.8.0, tsutils@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.0.tgz#ac9be83dc0e4ae5b066f6cdcbe4a692ec2d5f0a8"
+tsutils@^1.8.0, tsutils@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
 type-detect@0.1.1:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,9 +1441,9 @@ tslint@latest:
     tslib "^1.6.0"
     tsutils "^1.8.0"
 
-tsutils@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.8.0.tgz#bf8118ed8e80cd5c9fc7d75728c7963d44ed2f52"
+tsutils@^1.8.0, tsutils@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.0.tgz#ac9be83dc0e4ae5b066f6cdcbe4a692ec2d5f0a8"
 
 type-detect@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
The new version of `tsutils` contains typeguards for types. We can therefore remove the redundant typeguards. 
I left `awaitPromiseRule.ts` untouched, because there is an open PR for that rule.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[no-log]
