### PR TITLE
Deprecate "objectify"

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,7 @@ export function arrayify<T>(arg?: T | T[]): T[] {
 }
 
 /**
+ * @deprecated (no longer used)
  * Enforces the invariant that the input is an object.
  */
 export function objectify(arg: any): any {

--- a/test/utilsTests.ts
+++ b/test/utilsTests.ts
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import {arrayify, dedent, escapeRegExp, objectify} from "../src/utils";
+import {arrayify, dedent, escapeRegExp} from "../src/utils";
 
 describe("Utils", () => {
     it("arrayify", () => {
@@ -27,14 +27,6 @@ describe("Utils", () => {
         assert.deepEqual(arrayify({foo: 2}), [{foo: 2}]);
         assert.deepEqual(arrayify([1, 2]), [1, 2]);
         assert.deepEqual(arrayify(["foo"]), ["foo"]);
-    });
-
-    it("objectify", () => {
-        assert.deepEqual(objectify(undefined), {});
-        assert.deepEqual(objectify(null), {});
-        assert.deepEqual(objectify("foo"), {});
-        assert.deepEqual(objectify(1), {});
-        assert.deepEqual(objectify({foo: 1, mar: {baz: 2}}), {foo: 1, mar: {baz: 2}});
     });
 
     it("dedent", () => {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

This utility isn't being used any more. Since utilities are exposed by `Lint.Utils`, deprecated instead of deleting.

#### CHANGELOG.md entry:

[api] Deprecate `Lint.Utils.objectify`
