### PR TITLE
Enable typed rules with --project

### DIFF
--- a/docs/usage/type-checking/index.md
+++ b/docs/usage/type-checking/index.md
@@ -20,4 +20,6 @@ const results = files.map(file => {
 });
 ```
 
-When using the CLI, the `--project` flag will automatically create a program from the specified `tsconfig.json` file. Adding the `--type-check` flag then enables rules that require the type checker.
+When using the CLI, the `--project` flag will automatically create a program from the specified `tsconfig.json` file and enable rules that require the type checker.
+
+Use the `--type-check` flag to make sure your program has no type errors. TSLint will check for any errors before before linting. This flag requires `--project` to be specified.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "compile:test": "tsc -p test",
     "lint": "npm-run-all -p lint:global lint:from-bin",
     "lint:global": "tslint --project test/tsconfig.json --format stylish --type-check # test includes 'src' too",
-    "lint:from-bin": "node bin/tslint --project test/tsconfig.json --format stylish --type-check",
+    "lint:from-bin": "node bin/tslint --project test/tsconfig.json --format stylish",
     "test": "npm-run-all test:pre -p test:mocha test:rules",
     "test:pre": "cd ./test/config && npm install",
     "test:mocha": "mocha --reporter spec --colors \"build/test/**/*Tests.js\"",

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -224,10 +224,6 @@ class Linter {
                 `;
                 throw new Error(INVALID_SOURCE_ERROR);
             }
-            // check if the program has been type checked
-            if (!("resolvedModules" in sourceFile)) {
-                throw new Error("Program must be type checked before linting");
-            }
             return sourceFile;
         } else {
             return utils.getSourceFile(fileName, source);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -182,9 +182,6 @@ export class Runner {
                     console.error(messages.join("\n"));
                     return onComplete(this.options.force ? 0 : 1);
                 }
-            } else {
-                // if not type checking, we don't need to pass in a program object
-                program = undefined;
             }
         }
 

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -132,7 +132,7 @@ const processed = optimist
             type: "boolean",
         },
         "type-check": {
-            describe: "enable type checking when linting a project",
+            describe: "check for type errors before linting the project",
             type: "boolean",
         },
         "v": {
@@ -225,11 +225,12 @@ tslint accepts the following commandline options:
         this can be used to test custom rules.
 
     -p, --project:
-        The path or directory containing a tsconfig.json file that will be used to determine which
-        files will be linted.
+        The path or directory containing a tsconfig.json file that will be
+        used to determine which files will be linted. This flag also enables
+        rules that require the type checker.
 
     --type-check
-        Enables the type checker when running linting rules. --project must be
+        Checks for type errors before linting a project. --project must be
         specified in order to enable type checking.
 
     -v, --version:

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -243,7 +243,7 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
         });
     });
 
-    describe("tsconfig.json", () => {
+    describe("--project flag", () => {
         it("exits with code 0 if `tsconfig.json` is passed and it specifies files without errors", (done) => {
             execCli(["-c", "test/files/tsconfig-test/tslint.json", "--project", "test/files/tsconfig-test/tsconfig.json"], (err) => {
                 assert.isNull(err, "process should exit without an error");
@@ -274,7 +274,7 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             });
         });
 
-        it("exits with code 2 if both `tsconfig.json` and files arguments are passed and files contain lint errors", (done) => {
+        it("exits with code 1 if file is not included in project", (done) => {
             execCli(
                 [
                     "-c",
@@ -285,7 +285,7 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
                 ],
                 (err) => {
                     assert.isNotNull(err, "process should exit with error");
-                    assert.strictEqual(err.code, 2, "error code should be 2");
+                    assert.strictEqual(err.code, 1, "error code should be 1");
                     done();
                 });
         });
@@ -312,6 +312,16 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             execCli(
                 ["-c", "test/files/tsconfig-extends-relative/tslint-fail.json", "-p",
                  "test/files/tsconfig-extends-relative/test/tsconfig.json"],
+                (err) => {
+                    assert.isNotNull(err, "process should exit with error");
+                    assert.strictEqual(err.code, 2, "error code should be 2");
+                    done();
+                });
+        });
+
+        it("can execute typed rules without --type-check", (done) => {
+            execCli(
+                [ "-p", "test/files/typed-rule/tsconfig.json"],
                 (err) => {
                     assert.isNotNull(err, "process should exit with error");
                     assert.strictEqual(err.code, 2, "error code should be 2");

--- a/test/files/typed-rule/fail.test.ts
+++ b/test/files/typed-rule/fail.test.ts
@@ -1,0 +1,2 @@
+declare const fn: any;
+fn();

--- a/test/files/typed-rule/tsconfig.json
+++ b/test/files/typed-rule/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    }
+}

--- a/test/files/typed-rule/tslint.json
+++ b/test/files/typed-rule/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "no-unsafe-any": true
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
`getPreEmitDiagnostics` is not necessary to enable typed rules. This PR enables typed rules when `--project` is passed. `--type-check` now only checks for type errors in the project before doing the actual linting.
This reduces the time needed to lint this repo by around 17% with the current configuration.
Ref: #2769 

#### Is there anything you'd like reviewers to focus on?
This may cause problems for users that pass `--project` and explicitly specify files that are not included in the project. Before the change these files were linted as if `--project` was not passed. After the change it throws an exception because the filename is not found in the program.
The latter seems to be the correct behavior. Though this may break some users.

This may also break users that have typed rules enabled but run tslint without `--type-check`.

#### CHANGELOG.md entry:

[enhancement] `--project` (or `-p`) enables rules that require the type checker. `--type-check` only checks for errors before linting is no longer required
