### PR TITLE
no-floating-promises: Allow 'promise.catch()'

### DIFF
--- a/src/rules/noFloatingPromisesRule.ts
+++ b/src/rules/noFloatingPromisesRule.ts
@@ -59,9 +59,8 @@ function walk(ctx: Lint.WalkContext<string[]>, tc: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
         if (isExpressionStatement(node)) {
             const { expression } = node;
-            if (isCallExpression(expression) &&
-                    !(isPropertyAccessExpression(expression.expression) && expression.expression.name.text === "catch")) {
-                const {symbol} = tc.getTypeAtLocation(expression);
+            if (isCallExpression(expression) && !isPromiseCatchCall(expression)) {
+                const { symbol } = tc.getTypeAtLocation(expression);
                 if (symbol !== undefined && ctx.options.indexOf(symbol.name) !== -1) {
                     ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);
                 }
@@ -69,4 +68,8 @@ function walk(ctx: Lint.WalkContext<string[]>, tc: ts.TypeChecker) {
         }
         return ts.forEachChild(node, cb);
     });
+}
+
+function isPromiseCatchCall(expression: ts.CallExpression): boolean {
+    return isPropertyAccessExpression(expression.expression) && expression.expression.name.text === "catch";
 }

--- a/src/rules/noFloatingPromisesRule.ts
+++ b/src/rules/noFloatingPromisesRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isExpressionStatement } from "tsutils";
+import { isCallExpression, isExpressionStatement, isPropertyAccessExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -57,10 +57,14 @@ export class Rule extends Lint.Rules.TypedRule {
 
 function walk(ctx: Lint.WalkContext<string[]>, tc: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
-        if (isExpressionStatement(node) && node.expression.kind === ts.SyntaxKind.CallExpression) {
-            const {symbol} = tc.getTypeAtLocation(node.expression);
-            if (symbol !== undefined && ctx.options.indexOf(symbol.name) !== -1) {
-                ctx.addFailureAtNode(node.expression, Rule.FAILURE_STRING);
+        if (isExpressionStatement(node)) {
+            const { expression } = node;
+            if (isCallExpression(expression) &&
+                    !(isPropertyAccessExpression(expression.expression) && expression.expression.name.text === "catch")) {
+                const {symbol} = tc.getTypeAtLocation(expression);
+                if (symbol !== undefined && ctx.options.indexOf(symbol.name) !== -1) {
+                    ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);
+                }
             }
         }
         return ts.forEachChild(node, cb);

--- a/test/rules/no-floating-promises/promises/test.ts.lint
+++ b/test/rules/no-floating-promises/promises/test.ts.lint
@@ -154,4 +154,6 @@ switch(foo) {
     }
 }
 
+returnsPromiseFunction().catch(e => { console.error(e.stack); });
+
 [0]: Promises must be handled appropriately


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Allow `p.catch()` since the promise is handled appropriately.

#### CHANGELOG.md entry:

[enhancement] `no-floating-promises`: Allow 'promise.catch()'