### PR TITLE
--test: allow passing path to tslint.json

### DIFF
--- a/docs/develop/testing-rules/index.md
+++ b/docs/develop/testing-rules/index.md
@@ -158,7 +158,9 @@ The following part can be any [version range](https://github.com/npm/node-semver
 ### Tips & Tricks ###
 
 * You can use this system to test rules outside of the TSLint build! Use the `tslint --test path/to/dir` command to test your own custom rules.
-The directory you pass should contain a `tslint.json` file and `.ts.lint` files. You can try this out on the TSLint rule test cases, for example, `tslint --test path/to/tslint-code/test/rules/quotemark/single`.
+You can specify one or more paths to `tslint.json` files or directories containing a `tslint.json`. Glob patterns are also supported.
+Besides the `tslint.json` each directory you pass should contain `*.ts.lint` files. You can try this out on the TSLint rule test cases, for example, `tslint --test path/to/tslint-code/test/rules/quotemark/single`.
+If you want to test all of your rules at once, you can use it like this: `tslint --test rules/test/**/tslint.json`
 
 * To test rules that need type information, you can simply add a `tsconfig.json` with the desired configuration next to `tslint.json`.
 
@@ -173,7 +175,5 @@ for (let key in obj) {
 ~ [for-in loops are not allowed]
 ```
 
-* If for some weird reason your lint rule generates a failure that has zero width, you can use the `~nil` mark to indicate this.
-In all reality though, you shouldn't have rules that do this, and this feature is more of a carryover to accomodate testing
-some of TSLint's legacy rules.
+* If for some reason your lint rule generates a failure that has zero width, you can use the `~nil` mark to indicate this.
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -56,16 +56,16 @@ export interface TestResult {
 
 export function runTests(patterns: string[], rulesDirectory?: string | string[]): TestResult[] {
     const files: string[] = [];
-    for (const pattern of patterns) {
-        files.push(...glob.sync(`${pattern}/tslint.json`));
+    for (let pattern of patterns) {
+        if (path.basename(pattern) !== "tslint.json") {
+            pattern = path.join(pattern, "tslint.json");
+        }
+        files.push(...glob.sync(pattern));
     }
     return files.map((directory: string): TestResult => runTest(path.dirname(directory), rulesDirectory));
 }
 
 export function runTest(testDirectory: string, rulesDirectory?: string | string[]): TestResult {
-    // needed to get colors to show up when passing through Grunt
-    (colors as any).enabled = true;
-
     const filesToLint = glob.sync(path.join(testDirectory, `**/*${MARKUP_FILE_EXTENSION}`));
     const tslintConfig = Linter.findConfiguration(path.join(testDirectory, "tslint.json"), "").results;
     const tsConfig = path.join(testDirectory, "tsconfig.json");
@@ -211,6 +211,9 @@ export function consoleTestResultsHandler(testResults: TestResult[]): boolean {
 }
 
 export function consoleTestResultHandler(testResult: TestResult): boolean {
+    // needed to get colors to show up when passing through Grunt
+    (colors as any).enabled = true;
+
     let didAllTestsPass = true;
 
     for (const fileName of Object.keys(testResult.results)) {

--- a/test/rules/_integration/react/tslint.json
+++ b/test/rules/_integration/react/tslint.json
@@ -6,8 +6,6 @@
     "max-line-length": [true, 120],
     "no-bitwise": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
-    "no-use-before-declare": true,
     "quotemark": [true, "double"],
     "semicolon": [true, "always"],
     "whitespace": [true,


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:
This add the ability to pass the path to `tslint.json` instead of the directory containing it to `tslint --test`.
That's useful if you have a test directory structure like tslint and want to call it like `tslint --test test/rules/**/tslint.json`.

In fact this feature makes `ruleTestRunner.ts` obsolete. It could be simply replaced by the above command. Though that would run all tests before printing any output and would not stop at the first failed test.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
