### PR TITLE
[docs] fixed invalid template in noConsecutiveBlankLines rule

### DIFF
--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -31,10 +31,10 @@ export class Rule extends Lint.Rules.AbstractRule {
         rationale: "Helps maintain a readable style in your codebase.",
         optionsDescription: Lint.Utils.dedent`
             An optional number of maximum allowed sequential blanks can be specified. If no value
-            is provided, a default of $(Rule.DEFAULT_ALLOWED_BLANKS) will be used.`,
+            is provided, a default of ${Rule.DEFAULT_ALLOWED_BLANKS} will be used.`,
         options: {
             type: "number",
-            minimum: "$(Rule.MINIMUM_ALLOWED_BLANKS)",
+            minimum: "1",
         },
         optionExamples: [true, [true, 2]],
         type: "style",


### PR DESCRIPTION
The current docs do not make sense because the values were not
replaced, see
https://palantir.github.io/tslint/rules/no-consecutive-blank-lines/

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

Fixed noConsecutiveBlankLines rule documentation. Since `Rule.MINIMUM_ALLOWED_BLANKS` does not exist I have changed the value in the `options` property to 1 (instead of `Rule.DEFAULT_ALLOWED_BLANKS`) in case the `Rule.DEFAULT_ALLOWED_BLANKS` value changes in the future.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
