### PR TITLE
no-null-keyword: Allow strict comparison

### DIFF
--- a/test/rules/no-null-keyword/test.ts.fix
+++ b/test/rules/no-null-keyword/test.ts.fix
@@ -1,0 +1,12 @@
+var x = null; // error
+console.log(null, x); // error
+
+let match: string | null;
+interface foo {
+    bar: [number, null, string];
+}
+
+if (document.querySelector('.foo') === null) {}
+if (document.querySelector('.foo') == undefined) {}
+if (null !== document.querySelector('.foo')) {}
+if (undefined != document.querySelector('.foo')) {}

--- a/test/rules/no-null-keyword/test.ts.lint
+++ b/test/rules/no-null-keyword/test.ts.lint
@@ -1,9 +1,18 @@
 var x = null; // error
-        ~~~~           [Use 'undefined' instead of 'null']
+        ~~~~           [0]
 console.log(null, x); // error
-            ~~~~               [Use 'undefined' instead of 'null']
+            ~~~~               [0]
 
-let match(): string | null;
+let match: string | null;
 interface foo {
     bar: [number, null, string];
 }
+
+if (document.querySelector('.foo') === null) {}
+if (document.querySelector('.foo') == null) {}
+                                      ~~~~ [0]
+if (null !== document.querySelector('.foo')) {}
+if (null != document.querySelector('.foo')) {}
+    ~~~~ [0]
+
+[0]: Use 'undefined' instead of 'null'


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2782
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Allows `x === null`, but disallows `x == null`. The latter will be automatically fixed to `x == undefined`.
Fixes: #2782

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[new-fixer] `no-null-keyword`: fix `x == null` to `x == undefined`
[enhancement] `no-null-keyword` allows strict comparison