### PR TITLE
Fix issue with case sensitivity of noUnusedVariable rule on Windows

### DIFF
--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -368,16 +368,13 @@ function getUnusedCheckedProgram(program: ts.Program, checkParameters: boolean):
 
 function makeUnusedCheckedProgram(program: ts.Program, checkParameters: boolean): ts.Program {
     const options = { ...program.getCompilerOptions(), noUnusedLocals: true, ...(checkParameters ? { noUnusedParameters: true } : null) };
-    const sourceFilesByName = new Map<string, ts.SourceFile>(program.getSourceFiles()
-      .map<[string, ts.SourceFile]>((s) => [getCanonicalFileName(s.fileName), s]));
+    const sourceFilesByName = new Map<string, ts.SourceFile>(
+        program.getSourceFiles().map<[string, ts.SourceFile]>((s) => [getCanonicalFileName(s.fileName), s]));
 
     // tslint:disable object-literal-sort-keys
     return ts.createProgram(Array.from(sourceFilesByName.keys()), options, {
         fileExists: (f) => sourceFilesByName.has(getCanonicalFileName(f)),
-        readFile(f) {
-            const s = sourceFilesByName.get(getCanonicalFileName(f))!;
-            return s.text;
-        },
+        readFile: (f) => sourceFilesByName.get(getCanonicalFileName(f))!.text,
         getSourceFile: (f) => sourceFilesByName.get(getCanonicalFileName(f))!,
         getDefaultLibFileName: () => ts.getDefaultLibFileName(options),
         writeFile: () => {}, // tslint:disable-line no-empty
@@ -389,8 +386,8 @@ function makeUnusedCheckedProgram(program: ts.Program, checkParameters: boolean)
     });
     // tslint:enable object-literal-sort-keys
 
-    // We need to be carefull with file system case sensitivity
-    function getCanonicalFileName(f: string): string {
-      return ts.sys.useCaseSensitiveFileNames ? f : f.toLowerCase();
+    // We need to be careful with file system case sensitivity
+    function getCanonicalFileName(fileName: string): string {
+        return ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
     }
 }

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -368,22 +368,29 @@ function getUnusedCheckedProgram(program: ts.Program, checkParameters: boolean):
 
 function makeUnusedCheckedProgram(program: ts.Program, checkParameters: boolean): ts.Program {
     const options = { ...program.getCompilerOptions(), noUnusedLocals: true, ...(checkParameters ? { noUnusedParameters: true } : null) };
-    const sourceFilesByName = new Map<string, ts.SourceFile>(program.getSourceFiles().map<[string, ts.SourceFile]>((s) => [s.fileName, s]));
+    const sourceFilesByName = new Map<string, ts.SourceFile>(program.getSourceFiles()
+      .map<[string, ts.SourceFile]>((s) => [getCanonicalFileName(s.fileName), s]));
+
     // tslint:disable object-literal-sort-keys
     return ts.createProgram(Array.from(sourceFilesByName.keys()), options, {
-        fileExists: (f) => sourceFilesByName.has(f),
+        fileExists: (f) => sourceFilesByName.has(getCanonicalFileName(f)),
         readFile(f) {
-            const s = sourceFilesByName.get(f)!;
+            const s = sourceFilesByName.get(getCanonicalFileName(f))!;
             return s.text;
         },
-        getSourceFile: (f) => sourceFilesByName.get(f)!,
+        getSourceFile: (f) => sourceFilesByName.get(getCanonicalFileName(f))!,
         getDefaultLibFileName: () => ts.getDefaultLibFileName(options),
         writeFile: () => {}, // tslint:disable-line no-empty
         getCurrentDirectory: () => "",
         getDirectories: () => [],
-        getCanonicalFileName: (f) => f,
-        useCaseSensitiveFileNames: () => true,
+        getCanonicalFileName,
+        useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
         getNewLine: () => "\n",
     });
     // tslint:enable object-literal-sort-keys
+
+    // We need to be carefull with file system case sensitivity
+    function getCanonicalFileName(f: string): string {
+      return ts.sys.useCaseSensitiveFileNames ? f : f.toLowerCase();
+    }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2649
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

When TSLint is being used to provide as-you-type linting as in Angular IDE, incorrect configuration of program created in makeUnusedCheckedProgram function is causing whole functionality to blow up. The core of the issue is that SourceFiles are being assigned case sensitive path when program is recreated for TSLint validation, which later causes that wrong path to stick and file not found problems appear in whole IDE.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] Fix issue with case sensitivity of noUnusedVariable rule on Windows
<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
