### PR TITLE
strict-boolean-expressions: new option allow-boolean-or-undefined

### DIFF
--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -435,7 +435,7 @@ function showExpectedTypes(options: Options): string[] {
     if (options.allowUndefinedUnion) { parts.push("undefined-union"); }
     if (options.allowString) { parts.push("string"); }
     if (options.allowNumber) { parts.push("number"); }
-    if (options.allowBooleanOrUndefined) { parts.push("boolean-undefined-union"); }
+    if (options.allowBooleanOrUndefined) { parts.push("boolean-or-undefined"); }
     return parts;
 }
 

--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -212,18 +212,17 @@ function getTypeFailure(type: ts.Type, options: Options): TypeFailure | undefine
 }
 
 function isBooleanUndefined(type: ts.UnionType): boolean | undefined {
-    // tracks whether we've seen a possibly truthy boolean type
-    let isBoolean = false;
+    let isTruthy = false;
     for (const ty of type.types) {
         if (Lint.isTypeFlagSet(ty, ts.TypeFlags.Boolean)) {
-            isBoolean = true;
+            isTruthy = true;
         } else if (Lint.isTypeFlagSet(ty, ts.TypeFlags.BooleanLiteral)) {
-            isBoolean = isBoolean || (ty as ts.IntrinsicType).intrinsicName === "true";
+            isTruthy = isTruthy || (ty as ts.IntrinsicType).intrinsicName === "true";
         } else if (!Lint.isTypeFlagSet(ty, ts.TypeFlags.Void | ts.TypeFlags.Undefined)) { // tslint:disable-line:no-bitwise
             return undefined;
         }
     }
-    return isBoolean;
+    return isTruthy;
 }
 
 function handleUnion(type: ts.UnionType, options: Options): TypeFailure | undefined {

--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -23,6 +23,7 @@ const OPTION_ALLOW_UNDEFINED_UNION = "allow-undefined-union";
 const OPTION_ALLOW_STRING = "allow-string";
 const OPTION_ALLOW_NUMBER = "allow-number";
 const OPTION_ALLOW_MIX = "allow-mix";
+const OPTION_ALLOW_BOOLEAN_OR_UNDEFINED = "allow-boolean-or-undefined";
 
 // tslint:disable object-literal-sort-keys switch-default
 
@@ -52,14 +53,25 @@ export class Rule extends Lint.Rules.TypedRule {
             * \`${OPTION_ALLOW_NUMBER}\` allows numbers.
               - It does *not* allow unions containing \`number\`.
               - It does *not* allow enums or number literal types.
-            * \`${OPTION_ALLOW_MIX}\` allow multiple of the above to appear together.
+            * \`${OPTION_ALLOW_MIX}\` allows multiple of the above to appear together.
               - For example, \`string | number\` or \`RegExp | null | undefined\` would normally not be allowed.
-              - A type like \`"foo" | "bar" | undefined\` is always allowed, because it has only one way to be false.`,
+              - A type like \`"foo" | "bar" | undefined\` is always allowed, because it has only one way to be false.
+            * \`${OPTION_ALLOW_BOOLEAN_OR_UNDEFINED}\` allows \`boolean | undefined\`.
+              - Also allows \`true | false | undefined\`.
+              - Does not allow \`false | undefined\`.
+              - This option is a subset of \`${OPTION_ALLOW_UNDEFINED_UNION}\`, so you don't need to enable both options at the same time.
+        `,
         options: {
             type: "array",
             items: {
                 type: "string",
-                enum: [OPTION_ALLOW_NULL_UNION, OPTION_ALLOW_UNDEFINED_UNION, OPTION_ALLOW_STRING, OPTION_ALLOW_NUMBER],
+                enum: [
+                    OPTION_ALLOW_NULL_UNION,
+                    OPTION_ALLOW_UNDEFINED_UNION,
+                    OPTION_ALLOW_STRING,
+                    OPTION_ALLOW_NUMBER,
+                    OPTION_ALLOW_BOOLEAN_OR_UNDEFINED,
+                ],
             },
             minLength: 0,
             maxLength: 5,
@@ -67,6 +79,7 @@ export class Rule extends Lint.Rules.TypedRule {
         optionExamples: [
             true,
             [true, OPTION_ALLOW_NULL_UNION, OPTION_ALLOW_UNDEFINED_UNION, OPTION_ALLOW_STRING, OPTION_ALLOW_NUMBER],
+            [true, OPTION_ALLOW_BOOLEAN_OR_UNDEFINED],
         ],
         type: "functionality",
         typescriptOnly: true,
@@ -86,6 +99,7 @@ interface Options {
     allowString: boolean;
     allowNumber: boolean;
     allowMix: boolean;
+    allowBooleanOrUndefined: boolean;
 }
 
 function parseOptions(ruleArguments: string[], strictNullChecks: boolean): Options {
@@ -96,6 +110,7 @@ function parseOptions(ruleArguments: string[], strictNullChecks: boolean): Optio
         allowString: has(OPTION_ALLOW_STRING),
         allowNumber: has(OPTION_ALLOW_NUMBER),
         allowMix: has(OPTION_ALLOW_MIX),
+        allowBooleanOrUndefined: has(OPTION_ALLOW_BOOLEAN_OR_UNDEFINED),
     };
 
     function has(name: string): boolean {
@@ -196,7 +211,30 @@ function getTypeFailure(type: ts.Type, options: Options): TypeFailure | undefine
     }
 }
 
+function isBooleanUndefined(type: ts.UnionType): boolean | undefined {
+    // tracks whether we've seen a possibly truthy boolean type
+    let isBoolean = false;
+    for (const ty of type.types) {
+        if (Lint.isTypeFlagSet(ty, ts.TypeFlags.Boolean)) {
+            isBoolean = true;
+        } else if (Lint.isTypeFlagSet(ty, ts.TypeFlags.BooleanLiteral)) {
+            isBoolean = isBoolean || (ty as ts.IntrinsicType).intrinsicName === "true";
+        } else if (!Lint.isTypeFlagSet(ty, ts.TypeFlags.Void | ts.TypeFlags.Undefined)) { // tslint:disable-line:no-bitwise
+            return undefined;
+        }
+    }
+    return isBoolean;
+}
+
 function handleUnion(type: ts.UnionType, options: Options): TypeFailure | undefined {
+    if (options.allowBooleanOrUndefined) {
+        switch (isBooleanUndefined(type)) {
+            case true:
+                return undefined;
+            case false:
+                return TypeFailure.AlwaysFalsy;
+        }
+    }
     // Tracks whether it's possibly truthy.
     let anyTruthy = false;
     // Counts falsy kinds to see if there's a mix. Also tracks whether it's possibly falsy.
@@ -398,6 +436,7 @@ function showExpectedTypes(options: Options): string[] {
     if (options.allowUndefinedUnion) { parts.push("undefined-union"); }
     if (options.allowString) { parts.push("string"); }
     if (options.allowNumber) { parts.push("number"); }
+    if (options.allowBooleanOrUndefined) { parts.push("boolean-undefined-union"); }
     return parts;
 }
 

--- a/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/test.ts.lint
@@ -35,4 +35,4 @@ if (get<RegExp>() || get<RegExp>()) {}
 if (get<number | undefined>()) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'could be undefined')]
 
-[err]: This type is not allowed in the %s because it %s. Allowed types are boolean or boolean-undefined-union.
+[err]: This type is not allowed in the %s because it %s. Allowed types are boolean or boolean-or-undefined.

--- a/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/test.ts.lint
@@ -1,0 +1,38 @@
+declare function get<T>(): T;
+
+declare const bu: boolean | undefined;
+if (get<boolean | undefined>()) {}
+if (get<true | undefined>()) {}
+if (get<true | false | undefined>()) {}
+if (get<true | false | undefined | void>()) {}
+
+if (get<true>()) {}
+    ~~~~~~~~~~~ [err % ("'if' condition", 'is always truthy')]
+if (get<true | true>()) {}
+    ~~~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'is always truthy')]
+if (get<false | undefined>()) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'is always falsy')]
+if (get<undefined>()) {}
+    ~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'is always falsy')]
+
+if (get<void>()) {}
+    ~~~~~~~~~~~ [err % ("'if' condition", 'is always falsy')]
+
+if (get<RegExp | undefined>()) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'could be undefined')]
+if (get<RegExp | null>()) {}
+    ~~~~~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'could be null')]
+
+// Type of the condition is actually boolean | RegExp, but OK since we check each part separately.
+if (get<RegExp | undefined>() || get<boolean>()) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ("operand for the '||' operator", 'could be undefined')]
+
+// This still fails of course!
+if (get<RegExp>() || get<RegExp>()) {}
+    ~~~~~~~~~~~~~ [err % ("operand for the '||' operator", 'is always truthy')]
+                     ~~~~~~~~~~~~~ [err % ("operand for the '||' operator", 'is always truthy')]
+
+if (get<number | undefined>()) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'could be undefined')]
+
+[err]: This type is not allowed in the %s because it %s. Allowed types are boolean or boolean-undefined-union.

--- a/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/tsconfig.json
+++ b/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    }
+}

--- a/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/tslint.json
+++ b/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "strict-boolean-expressions": [true, "allow-boolean-or-undefined"]
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -71,6 +71,7 @@
       "options": ["log"]
     },
     "no-switch-case-fall-through": true,
+    "strict-boolean-expressions": [true, "allow-boolean-or-undefined"],
     "switch-default": false,
     "variable-name": [true,
       "ban-keywords",


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
I find it weird to compare for strict equality on unions of boolean and undefined. Consider the following function:
```ts
function foo(bar?: boolean) {
    if (bar) // not allowed by default
       // do stuff
}
```
`allow-undefined-union` would allow too much, because it also allows for example `ts.Node | undefined`.

It's already awkward to use `ts.NodeArray#hasTrailingComma === true`. With my recent changes to typescripts typings (https://github.com/Microsoft/TypeScript/pull/15887, https://github.com/Microsoft/TypeScript/pull/15903), that will hit us with the next version of typescript, this pattern will occur in many more places (e.g. `ts.forEachChild`).
That's why I added this new option `allow-boolean-or-undefined`.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[new-rule-options] `strict-boolean-expressions` adds `allow-boolean-or-undefined`
