### PR TITLE
Add noEmit to compilerOptions

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -64,7 +64,7 @@ class Linter {
             readFile: (file) => fs.readFileSync(file, "utf8"),
             useCaseSensitiveFileNames: true,
         };
-        const parsed = ts.parseJsonConfigFileContent(config, parseConfigHost, path.resolve(projectDirectory));
+        const parsed = ts.parseJsonConfigFileContent(config, parseConfigHost, path.resolve(projectDirectory), {noEmit: true});
         const host = ts.createCompilerHost(parsed.options, true);
         const program = ts.createProgram(parsed.fileNames, parsed.options, host);
 

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -367,7 +367,12 @@ function getUnusedCheckedProgram(program: ts.Program, checkParameters: boolean):
 }
 
 function makeUnusedCheckedProgram(program: ts.Program, checkParameters: boolean): ts.Program {
-    const options = { ...program.getCompilerOptions(), noUnusedLocals: true, ...(checkParameters ? { noUnusedParameters: true } : null) };
+    const options = {
+        ...program.getCompilerOptions(),
+        noEmit: true,
+        noUnusedLocals: true,
+        ...(checkParameters ? { noUnusedParameters: true } : null),
+    };
     const sourceFilesByName = new Map<string, ts.SourceFile>(
         program.getSourceFiles().map<[string, ts.SourceFile]>((s) => [getCanonicalFileName(s.fileName), s]));
 

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -328,6 +328,16 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
                     done();
                 });
         });
+
+        it("can handles 'allowJs' correctly", (done) => {
+            execCli(
+                [ "-p", "test/files/tsconfig-allow-js/tsconfig.json"],
+                (err) => {
+                    assert.isNotNull(err, "process should exit with error");
+                    assert.strictEqual(err.code, 2, "error code should be 2");
+                    done();
+                });
+        });
     });
 
     describe("--type-check", () => {

--- a/test/files/tsconfig-allow-js/testfile.test.js
+++ b/test/files/tsconfig-allow-js/testfile.test.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/files/tsconfig-allow-js/tsconfig.json
+++ b/test/files/tsconfig-allow-js/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "noEmit": false
+    }
+}

--- a/test/files/tsconfig-allow-js/tslint.json
+++ b/test/files/tsconfig-allow-js/tslint.json
@@ -1,0 +1,8 @@
+{
+    "jsRules": {
+        "eofline": true,
+        "semicolon": [
+            true, "always"
+        ]
+    }
+}

--- a/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/allow-boolean-undefined-union/test.ts.lint
@@ -7,9 +7,7 @@ if (get<true | false | undefined>()) {}
 if (get<true | false | undefined | void>()) {}
 
 if (get<true>()) {}
-    ~~~~~~~~~~~ [err % ("'if' condition", 'is always truthy')]
 if (get<true | true>()) {}
-    ~~~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'is always truthy')]
 if (get<false | undefined>()) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~ [err % ("'if' condition", 'is always falsy')]
 if (get<undefined>()) {}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2568
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
By default typescript checks if compiled output files *would* overwrite input files. Since we are not compiling anything, we need to turn this check off.
[bugfix] don't crash `tslint --project` if `allowJs` is set in tsconfig.json
Fixes: #2568 

The second commit fixes the CI failures on master

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
