### PR TITLE
indent: Simplify and avoid scanning

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "resolve": "^1.3.2",
     "semver": "^5.3.0",
     "tslib": "^1.7.1",
-    "tsutils": "^2.1.0"
+    "tsutils": "^2.2.0"
   },
   "peerDependencies": {
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev"

--- a/src/rules/indentRule.ts
+++ b/src/rules/indentRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { getLineRanges, getTokenAtPosition, isPositionInComment } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -96,85 +97,37 @@ interface Options {
     readonly size?: 2 | 4;
 }
 
-// visit every token and enforce that only the right character is used for indentation
 function walk(ctx: Lint.WalkContext<Options>): void {
     const { sourceFile, options: { tabs, size } } = ctx;
     const regExp = tabs ? new RegExp(" ".repeat(size === undefined ? 1 : size)) : /\t/;
+    const failure = Rule.FAILURE_STRING(tabs ? "tab" : size === undefined ? "space" : `${size} space`);
 
-    let endOfComment = -1;
-    let endOfTemplateString = -1;
-    const scanner = ts.createScanner(ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, sourceFile.text);
-    for (const lineStart of sourceFile.getLineStarts()) {
-        if (lineStart < endOfComment || lineStart < endOfTemplateString) {
-            // skip checking lines inside multi-line comments or template strings
+    for (const {pos, contentLength} of getLineRanges(sourceFile)) {
+        if (contentLength === 0) { continue; }
+        const line = sourceFile.text.substr(pos, contentLength);
+        let indentEnd = line.search(/\S/);
+        if (indentEnd === 0) { continue; }
+        if (indentEnd === -1) {
+            indentEnd = contentLength;
+        }
+        const whitespace = line.slice(0, indentEnd);
+        if (!regExp.test(whitespace)) { continue; }
+        const token = getTokenAtPosition(sourceFile, pos)!;
+        if (token.kind !== ts.SyntaxKind.JsxText &&
+            (pos >= token.getStart(sourceFile) || isPositionInComment(sourceFile, pos, token))) {
             continue;
         }
-
-        scanner.setTextPos(lineStart);
-
-        let currentScannedType = scanner.scan();
-        let fullLeadingWhitespace = "";
-        let lastStartPos = -1;
-
-        while (currentScannedType === ts.SyntaxKind.WhitespaceTrivia) {
-            const startPos = scanner.getStartPos();
-            if (startPos === lastStartPos) {
-                break;
-            }
-            lastStartPos = startPos;
-
-            fullLeadingWhitespace += scanner.getTokenText();
-            currentScannedType = scanner.scan();
-        }
-
-        const commentRanges = ts.getTrailingCommentRanges(sourceFile.text, lineStart);
-        if (commentRanges !== undefined) {
-            endOfComment = commentRanges[commentRanges.length - 1].end;
-        } else {
-            let scanType = currentScannedType;
-
-            // scan until we reach end of line, skipping over template strings
-            while (scanType !== ts.SyntaxKind.NewLineTrivia && scanType !== ts.SyntaxKind.EndOfFileToken) {
-                if (scanType === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
-                    // template string without expressions - skip past it
-                    endOfTemplateString = scanner.getStartPos() + scanner.getTokenText().length;
-                } else if (scanType === ts.SyntaxKind.TemplateHead) {
-                    // find end of template string containing expressions...
-                    while (scanType !== ts.SyntaxKind.TemplateTail && scanType !== ts.SyntaxKind.EndOfFileToken) {
-                        scanType = scanner.scan();
-                        if (scanType === ts.SyntaxKind.CloseBraceToken) {
-                            scanType = scanner.reScanTemplateToken();
-                        }
-                    }
-                    // ... and skip past it
-                    endOfTemplateString = scanner.getStartPos() + scanner.getTokenText().length;
-                }
-                scanType = scanner.scan();
-            }
-        }
-
-        switch (currentScannedType) {
-            case ts.SyntaxKind.SingleLineCommentTrivia:
-            case ts.SyntaxKind.MultiLineCommentTrivia:
-            case ts.SyntaxKind.NewLineTrivia:
-                // ignore lines that have comments before the first token
-                continue;
-        }
-
-        if (regExp.test(fullLeadingWhitespace)) {
-            const failure = Rule.FAILURE_STRING(tabs ? "tab" : size === undefined ? "space" : `${size} space`);
-            ctx.addFailureAt(lineStart, fullLeadingWhitespace.length, failure, createFix(lineStart, fullLeadingWhitespace));
-        }
+        ctx.addFailureAt(pos, indentEnd, failure, createFix(pos, whitespace, tabs, size));
     }
+}
 
-    function createFix(lineStart: number, fullLeadingWhitespace: string): Lint.Fix | undefined {
-        if (size === undefined) { return undefined; }
-        const replaceRegExp = tabs
-            // we want to find every group of `size` spaces, plus up to one 'incomplete' group
-            ? new RegExp(`^( {${size}})+( {1,${size - 1}})?`, "g")
-            : /\t/g;
-        const replacement = fullLeadingWhitespace.replace(replaceRegExp, (match) =>
-            (tabs ? "\t" : " ".repeat(size)).repeat(Math.ceil(match.length / size!)));
-        return new Lint.Replacement(lineStart, fullLeadingWhitespace.length, replacement);
-    }
+function createFix(lineStart: number, fullLeadingWhitespace: string, tabs: boolean, size?: number): Lint.Fix | undefined {
+    if (size === undefined) { return undefined; }
+    const replaceRegExp = tabs
+        // we want to find every group of `size` spaces, plus up to one 'incomplete' group
+        ? new RegExp(`^( {${size}})+( {1,${size - 1}})?`, "g")
+        : /\t/g;
+    const replacement = fullLeadingWhitespace.replace(replaceRegExp, (match) =>
+        (tabs ? "\t" : " ".repeat(size)).repeat(Math.ceil(match.length / size!)));
+    return new Lint.Replacement(lineStart, fullLeadingWhitespace.length, replacement);
 }

--- a/test/rules/indent/spaces-2/test.ts.fix
+++ b/test/rules/indent/spaces-2/test.ts.fix
@@ -25,7 +25,7 @@ module TestModule {
   var s2 = `
 		multiline ${ "A" }
 		template ${ "B"
-		+ "C" }
+    + "C" }
 		string`;
 
   export enum TestEnum {

--- a/test/rules/indent/spaces-2/test.ts.lint
+++ b/test/rules/indent/spaces-2/test.ts.lint
@@ -26,6 +26,7 @@ module TestModule {
 		multiline ${ "A" }
 		template ${ "B"
 		+ "C" }
+~~ [0]
 		string`;
 
   export enum TestEnum {

--- a/test/rules/indent/spaces-2/test.tsx.lint
+++ b/test/rules/indent/spaces-2/test.tsx.lint
@@ -1,0 +1,17 @@
+<foo>
+	<bar>
+~ [0]
+		baz
+~~ [0]
+	</bar>
+~ [0]
+  
+	{
+~ [0]
+		
+~~ [0]
+	}
+~ [0]
+</foo>
+
+[0]: 2 space indentation expected

--- a/test/rules/indent/spaces-4/test.ts.fix
+++ b/test/rules/indent/spaces-4/test.ts.fix
@@ -25,7 +25,7 @@ module TestModule {
     var s2 = `
 		multiline ${ "A" }
 		template ${ "B"
-		+ "C" }
+        + "C" }
 		string`;
 
     export enum TestEnum {

--- a/test/rules/indent/spaces-4/test.ts.lint
+++ b/test/rules/indent/spaces-4/test.ts.lint
@@ -26,6 +26,7 @@ module TestModule {
 		multiline ${ "A" }
 		template ${ "B"
 		+ "C" }
+~~ [0]
 		string`;
 
     export enum TestEnum {

--- a/test/rules/indent/tabs-2/test.ts.fix
+++ b/test/rules/indent/tabs-2/test.ts.fix
@@ -28,7 +28,7 @@ module TestModule {
 	var s2 = `
      multiline ${ "A" }
      template ${ "B"
-     + "C" }
+			+ "C" }
      string`;
 
 	export enum TestEnum {

--- a/test/rules/indent/tabs-2/test.ts.lint
+++ b/test/rules/indent/tabs-2/test.ts.lint
@@ -29,6 +29,7 @@ module TestModule {
      multiline ${ "A" }
      template ${ "B"
      + "C" }
+~~~~~ [0]
      string`;
 
 	export enum TestEnum {

--- a/test/rules/indent/tabs-4/test.ts.fix
+++ b/test/rules/indent/tabs-4/test.ts.fix
@@ -28,7 +28,7 @@ module TestModule {
 	var s2 = `
      multiline ${ "A" }
      template ${ "B"
-     + "C" }
+		+ "C" }
      string`;
 
 	export enum TestEnum {

--- a/test/rules/indent/tabs-4/test.ts.lint
+++ b/test/rules/indent/tabs-4/test.ts.lint
@@ -29,6 +29,7 @@ module TestModule {
      multiline ${ "A" }
      template ${ "B"
      + "C" }
+~~~~~ [0]
      string`;
 
 	export enum TestEnum {

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,10 +323,6 @@ core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
-core-util-is@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -646,7 +642,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.1:
+inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -745,10 +741,6 @@ is-symbol@^1.0.1:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0:
   version "1.0.0"
@@ -955,12 +947,6 @@ md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
 
-memory-streams@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/memory-streams/-/memory-streams-0.1.2.tgz#273ff777ab60fec599b116355255282cca2c50c2"
-  dependencies:
-    readable-stream "~1.0.2"
-
 merge-source-map@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.0.3.tgz#da1415f2722a5119db07b14c4f973410863a2abf"
@@ -995,13 +981,9 @@ minimatch@^3.0.2, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -1251,15 +1233,6 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@~1.0.2:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
@@ -1433,10 +1406,6 @@ string.prototype.padend@^3.0.0:
     es-abstract "^1.4.3"
     function-bind "^1.0.2"
 
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -1506,9 +1475,9 @@ tslint@latest:
     tslib "^1.6.0"
     tsutils "^2.0.0"
 
-tsutils@^2.0.0, tsutils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.1.0.tgz#5be8376c929528f65b302de9e17b0004e4c1eb20"
+tsutils@^2.0.0, tsutils@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.2.0.tgz#218614657f21c677e4536b4ba75daf8ebce1b367"
 
 type-detect@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Remove complex scanning logic. Only search for comments or template spans when indent is wrong.
Added a test for JSX.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[bugfix] `indent` now checks indentation of expressions inside template strings
