### PR TITLE
prefer-object-spread: lint more locations, allow first parameter with side effects

### DIFF
--- a/src/rules/preferObjectSpreadRule.ts
+++ b/src/rules/preferObjectSpreadRule.ts
@@ -16,8 +16,8 @@
  */
 
 import {
-    isBinaryExpression, isCallExpression, isIdentifier, isObjectLiteralExpression,
-    isPropertyAccessExpression, isSpreadElement,
+    hasSideEffects, isCallExpression, isIdentifier, isObjectLiteralExpression, isPropertyAccessExpression,
+    isSpreadElement, SideEffectOptions,
 } from "tsutils";
 import * as ts from "typescript";
 
@@ -54,16 +54,33 @@ function walk(ctx: Lint.WalkContext<void>) {
             !node.arguments.some(isSpreadElement)) {
             if (node.arguments[0].kind === ts.SyntaxKind.ObjectLiteralExpression) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING, createFix(node, ctx.sourceFile));
-            } else {
-                const parent = node.parent!;
-                if (parent.kind === ts.SyntaxKind.VariableDeclaration ||
-                    isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-                    ctx.addFailureAtNode(node, Rule.ASSIGNMENT_FAILURE_STRING, createFix(node, ctx.sourceFile));
-                }
+            } else if (isReturnValueUsed(node) && !hasSideEffects(node.arguments[0], SideEffectOptions.Constructor)) {
+                ctx.addFailureAtNode(node, Rule.ASSIGNMENT_FAILURE_STRING, createFix(node, ctx.sourceFile));
             }
         }
         return ts.forEachChild(node, cb);
     });
+}
+
+function isReturnValueUsed(node: ts.Expression): boolean {
+    const parent = node.parent!;
+    switch (parent.kind) {
+        case ts.SyntaxKind.VariableDeclaration:
+        case ts.SyntaxKind.PropertyAssignment:
+        case ts.SyntaxKind.PropertyDeclaration:
+        case ts.SyntaxKind.ReturnStatement:
+        case ts.SyntaxKind.BindingElement:
+        case ts.SyntaxKind.ArrayLiteralExpression:
+            return true;
+        case ts.SyntaxKind.BinaryExpression:
+            return (parent as ts.BinaryExpression).operatorToken.kind === ts.SyntaxKind.EqualsToken;
+        case ts.SyntaxKind.NewExpression:
+        case ts.SyntaxKind.CallExpression:
+            return (parent as ts.NewExpression | ts.CallExpression).arguments !== undefined &&
+                (parent as ts.NewExpression | ts.CallExpression).arguments!.indexOf(node) !== -1;
+        default:
+            return false;
+    }
 }
 
 function createFix(node: ts.CallExpression, sourceFile: ts.SourceFile): Lint.Fix {

--- a/test/rules/prefer-object-spread/test.ts.fix
+++ b/test/rules/prefer-object-spread/test.ts.fix
@@ -6,9 +6,18 @@ Object.assign(original, {c: 3});
 var result = {...original, c: 3};
 result = {...original, c: 3};
 var result = {...original, c: 3};
+foo({...original, c: 3});
+[{...original, c: 3}];
+({
+    foo: {...original, c: 3}
+})
 
 {a: 1,};
 {a: 1, ...(foo ? {b: 2} : {c: 3})};
 {a: 1, ...{b: 2}};
 {};
 {};
+
+// allowed
+result = Object.assign(new Foo(), {});
+result = Object.assign(createFoo(), {});

--- a/test/rules/prefer-object-spread/test.ts.lint
+++ b/test/rules/prefer-object-spread/test.ts.lint
@@ -11,6 +11,14 @@ result = Object.assign(original, {c: 3});
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1]
 var result = Object.assign({}, original, {c: 3});
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+foo(Object.assign(original, {c: 3}));
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1]
+[Object.assign(original, {c: 3})];
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1]
+({
+    foo: Object.assign(original, {c: 3})
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [1]
+})
 
 Object.assign({}, {}, {a: 1,},);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
@@ -22,6 +30,10 @@ Object.assign({}, {});
 ~~~~~~~~~~~~~~~~~~~~~ [0]
 Object.assign({}, {},);
 ~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+// allowed
+result = Object.assign(new Foo(), {});
+result = Object.assign(createFoo(), {});
 
 [0]: Use the object spread operator instead.
 [1]: 'Object.assign' returns the first argument. Prefer object spread if you want a new object.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2824
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `prefer-object-spread`:  allow constructor, function and method calls and more as first argument to `Object.assign`
Fixes: #2824
[enhancement] `prefer-object-spread`: lint more locations where return value is used.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
