### PR TITLE
no-unsafe-any: Fix bug for `continue` with label

### DIFF
--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -71,6 +71,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
                 return cb((node as ts.LabeledStatement).statement);
 
             case ts.SyntaxKind.BreakStatement: // Ignore label
+            case ts.SyntaxKind.ContinueStatement:
             // Ignore types
             case ts.SyntaxKind.InterfaceDeclaration:
             case ts.SyntaxKind.TypeAliasDeclaration:

--- a/test/rules/no-unsafe-any/test.ts.lint
+++ b/test/rules/no-unsafe-any/test.ts.lint
@@ -20,6 +20,7 @@ function returnsA(): 0 | "a" | null | undefined;
 
 label: for (const x of []) {
     break label;
+    continue label;
 }
 
 importAlias.property;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

`continue foo;` mistakenly identified `foo;` as being of type `any`.

#### CHANGELOG.md entry:

[bugfix]: `no-unsafe-any`: Don't fail on `continue label;`