### PR TITLE
space-before-function-paren: Ignore async arrow function with no parentheses

### DIFF
--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -84,20 +84,27 @@ function walk(ctx: Lint.WalkContext<Options>): void {
     ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
         const option = getOption(node, options);
         if (option !== undefined) {
-            const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken)!;
-            const hasSpace = ts.isWhiteSpaceLike(sourceFile.text.charCodeAt(openParen.end - 2));
-
-            if (hasSpace && option === "never") {
-                const pos = openParen.getStart() - 1;
-                ctx.addFailureAt(pos, 1, Rule.INVALID_WHITESPACE_ERROR, Lint.Replacement.deleteText(pos, 1));
-            } else if (!hasSpace && option === "always") {
-                const pos = openParen.getStart();
-                ctx.addFailureAt(pos, 1, Rule.MISSING_WHITESPACE_ERROR, Lint.Replacement.appendText(pos, " "));
-            }
+            check(node, option);
         }
 
         ts.forEachChild(node, cb);
     });
+
+    function check(node: ts.Node, option: "always" | "never"): void {
+        const openParen = Lint.childOfKind(node, ts.SyntaxKind.OpenParenToken);
+        // openParen may be missing for an async arrow function `async x => ...`.
+        if (openParen === undefined) { return; }
+
+        const hasSpace = ts.isWhiteSpaceLike(sourceFile.text.charCodeAt(openParen.end - 2));
+
+        if (hasSpace && option === "never") {
+            const pos = openParen.getStart() - 1;
+            ctx.addFailureAt(pos, 1, Rule.INVALID_WHITESPACE_ERROR, Lint.Replacement.deleteText(pos, 1));
+        } else if (!hasSpace && option === "always") {
+            const pos = openParen.getStart();
+            ctx.addFailureAt(pos, 1, Rule.MISSING_WHITESPACE_ERROR, Lint.Replacement.appendText(pos, " "));
+        }
+    }
 }
 
 function getOption(node: ts.Node, options: Options): Option | undefined {

--- a/test/rules/space-before-function-paren/always/test.ts.fix
+++ b/test/rules/space-before-function-paren/always/test.ts.fix
@@ -30,6 +30,7 @@ var arrow = () => {};
 async () => {};
 var arrow = async () => {};
 
+async x => x;
 
 // Method
 interface IMyInterface {

--- a/test/rules/space-before-function-paren/always/test.ts.lint
+++ b/test/rules/space-before-function-paren/always/test.ts.lint
@@ -44,6 +44,7 @@ async() => {};
 var arrow = async() => {};
                  ~ [space-before-function-paren]
 
+async x => x;
 
 // Method
 interface IMyInterface {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Fix bug for `async x => x`.

#### CHANGELOG.md entry:

[bugfix] `space-before-function-paren`: Ignore async arrow function with no parentheses