### PR TITLE
no-unbound-method: Allow use as condition

### DIFF
--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -87,6 +87,14 @@ function isSafeUse(node: ts.Node): boolean {
         // Allow most binary operators, but don't allow e.g. `myArray.forEach(obj.method || otherObj.otherMethod)`.
         case ts.SyntaxKind.BinaryExpression:
             return (parent as ts.BinaryExpression).operatorToken.kind !== ts.SyntaxKind.BarBarToken;
+        // Allow use in conditions
+        case ts.SyntaxKind.ConditionalExpression:
+            return (parent as ts.ConditionalExpression).condition === node;
+        case ts.SyntaxKind.IfStatement:
+        case ts.SyntaxKind.WhileStatement:
+        case ts.SyntaxKind.DoStatement:
+        case ts.SyntaxKind.ForStatement:
+            return true;
         default:
             return false;
     }

--- a/test/rules/no-unbound-method/default/test.tsx.lint
+++ b/test/rules/no-unbound-method/default/test.tsx.lint
@@ -26,6 +26,18 @@ i.foo;
 i.bar;
 
 c.method === i.foo;
+
+// OK in condition
+c.method ? 1 : 2;
+1 ? c.method : c.method;
+    ~~~~~~~~ [0]
+               ~~~~~~~~ [0]
+if (c.method) {}
+while (c.method) {}
+do () while (c.method);
+for (c.method; c.method; c.method) {}
+
+
 [0].forEach(c.method || i.foo);
             ~~~~~~~~ [0]
                         ~~~~~ [0]


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Allows an unbound method to occur as a condition. This is useful if you don't have `strict-boolean-expressions` turned on and the method is optional, so you would use `if (x.method) x.method()`.

#### CHANGELOG.md entry:

[bugfix] `no-unbound-method`: Allow unbound method to be used as a condition