### PR TITLE
no-unsafe-any: Allow to switch on a value of type `any`

### DIFF
--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -163,6 +163,22 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
                 return;
             }
 
+            case ts.SyntaxKind.SwitchStatement: {
+                const { expression, caseBlock: { clauses } } = node as ts.SwitchStatement;
+                // Allow `switch (x) {}` where `x` is any
+                cb(expression, /*anyOk*/ true);
+                for (const clause of clauses) {
+                    if (clause.kind === ts.SyntaxKind.CaseClause) {
+                        // Allow `case x:` where `x` is any
+                        cb(clause.expression, /*anyOk*/ true);
+                    }
+                    for (const statement of clause.statements) {
+                        cb(statement);
+                    }
+                }
+                break;
+            }
+
             default:
                 if (!(isExpression(node) && check())) {
                     return ts.forEachChild(node, cb);

--- a/test/rules/no-unsafe-any/test.ts.lint
+++ b/test/rules/no-unsafe-any/test.ts.lint
@@ -166,4 +166,16 @@ const obj: { x: number, y: number } = {
      ~ [0]
 };
 
+switch (x) {}
+switch (x.y) {
+        ~ [0]
+    case x:
+        x.y;
+        ~ [0]
+        break;
+    case x.y:
+         ~ [0]
+        break;
+}
+
 [0]: Unsafe use of expression of type 'any'.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Allow `switch (x) { case x: ... }` where `x` is of type `any`.

#### CHANGELOG.md entry:

[bugfix] `no-unsafe-any`: Allow to switch on a value of type `any`