### PR TITLE
no-unbound-method: Skip past casts and parentheses

### DIFF
--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -87,6 +87,11 @@ function isSafeUse(node: ts.Node): boolean {
         // Allow most binary operators, but don't allow e.g. `myArray.forEach(obj.method || otherObj.otherMethod)`.
         case ts.SyntaxKind.BinaryExpression:
             return (parent as ts.BinaryExpression).operatorToken.kind !== ts.SyntaxKind.BarBarToken;
+        case ts.SyntaxKind.NonNullExpression:
+        case ts.SyntaxKind.AsExpression:
+        case ts.SyntaxKind.TypeAssertionExpression:
+        case ts.SyntaxKind.ParenthesizedExpression:
+            return isSafeUse(parent);
         default:
             return false;
     }

--- a/test/rules/no-unbound-method/default/test.ts.lint
+++ b/test/rules/no-unbound-method/default/test.ts.lint
@@ -1,0 +1,10 @@
+interface I { m?(): void; }
+function f(i: I) {
+    i.m!();
+    (i.m as any)(1);
+    (<any> i.m)(1);
+    return i.m!;
+           ~~~ [0]
+}
+
+[0]: Avoid referencing unbound methods which may cause unintentional scoping of 'this'.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Skips past the parent in the case of `obj.method as any` and the like.

#### CHANGELOG.md entry:

[bugfix] `no-unbound-method`: Skip past the parent if it is a cast or parenthesized expression