### PR TITLE
no-unsafe-any: Allow `declare global {}`

### DIFF
--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -163,6 +163,13 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
                 return;
             }
 
+            case ts.SyntaxKind.ModuleDeclaration: {
+                // In `declare global { ... }`, don't mark `global` as unsafe any.
+                const { body } = node as ts.ModuleDeclaration;
+                if (body !== undefined) { cb(body); }
+                return;
+            }
+
             default:
                 if (!(isExpression(node) && check())) {
                     return ts.forEachChild(node, cb);

--- a/test/rules/no-unsafe-any/test.ts.lint
+++ b/test/rules/no-unsafe-any/test.ts.lint
@@ -166,4 +166,6 @@ const obj: { x: number, y: number } = {
      ~ [0]
 };
 
+declare global {}
+
 [0]: Unsafe use of expression of type 'any'.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Avoid adding a failure for the `global` in `declare global {}`.

#### CHANGELOG.md entry:

[bugfix] `no-unsafe-any`: Don't mark `declare global {}` as an unsafe any.