### PR TITLE
completed-docs: Fix markdown formatting

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -163,15 +163,15 @@ export class Rule extends Lint.Rules.TypedRule {
 
             Types that may be enabled are:
 
-                * \`"${ARGUMENT_CLASSES}"\`
-                * \`"${ARGUMENT_ENUMS}"\`
-                * \`"${ARGUMENT_FUNCTIONS}"\`
-                * \`"${ARGUMENT_INTERFACES}"\`
-                * \`"${ARGUMENT_METHODS}"\`
-                * \`"${ARGUMENT_NAMESPACES}"\`
-                * \`"${ARGUMENT_PROPERTIES}"\`
-                * \`"${ARGUMENT_TYPES}"\`
-                * \`"${ARGUMENT_VARIABLES}"\``,
+            * \`"${ARGUMENT_CLASSES}"\`
+            * \`"${ARGUMENT_ENUMS}"\`
+            * \`"${ARGUMENT_FUNCTIONS}"\`
+            * \`"${ARGUMENT_INTERFACES}"\`
+            * \`"${ARGUMENT_METHODS}"\`
+            * \`"${ARGUMENT_NAMESPACES}"\`
+            * \`"${ARGUMENT_PROPERTIES}"\`
+            * \`"${ARGUMENT_TYPES}"\`
+            * \`"${ARGUMENT_VARIABLES}"\``,
         options: {
             type: "array",
             items: {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### Overview of change:

The list at the end was indented too much and was treated like a block of code. (See [here](https://palantir.github.io/tslint/rules/completed-docs/).)