### PR TITLE
Fix --out: Only set exitCode instead of exiting immediately

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:global": "tslint --project test/tsconfig.json --format stylish --type-check # test includes 'src' too",
     "lint:from-bin": "node bin/tslint --project test/tsconfig.json --format stylish",
     "test": "npm-run-all test:pre -p test:mocha test:rules",
-    "test:pre": "cd ./test/config && npm install",
+    "test:pre": "cd ./test/config && npm install --no-save",
     "test:mocha": "mocha --reporter spec --colors \"build/test/**/*Tests.js\"",
     "test:rules": "node ./build/test/ruleTestRunner.js",
     "verify": "npm-run-all clean compile lint test docs",

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -254,7 +254,12 @@ run({
 }, {
     log,
     error: (m) => console.error(m),
-}).then(process.exit);
+}).then((rc) => {
+    process.exitCode = rc;
+}).catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+});
 
 function optionUsageTag({short, name}: Option) {
     return short !== undefined ? `-${short}, --${name}` : `--${name}`;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2863
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
`process.exit()` kills the process immediately and cancels all pending async writes.
After linting finishes, we only set the exitCode and let the program exit when all async stuff is done.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] Fixed regression with empty `--out` file
Fixes: #2863
