### PR TITLE
binary-expression-operand-order: Allow both sides to be literals

### DIFF
--- a/src/rules/binaryExpressionOperandOrderRule.ts
+++ b/src/rules/binaryExpressionOperandOrderRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>): void {
     ts.forEachChild(ctx.sourceFile, function cb(node) {
-        if (isBinaryExpression(node) && isLiteral(node.left) && !isAllowedOrderedOperator(node)) {
+        if (isBinaryExpression(node) && isLiteral(node.left) && !isLiteral(node.right) && !isAllowedOrderedOperator(node)) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         ts.forEachChild(node, cb);

--- a/test/rules/binary-expression-operand-order/test.ts.lint
+++ b/test/rules/binary-expression-operand-order/test.ts.lint
@@ -36,4 +36,10 @@ undefined != x;
 "key" in x;
 "foo", x;
 
+// Allows literals on both sides.
+1 + 1;
+1 + 1 + 1;
+1 + x + 1;
+~~~~~ [0]
+
 [0]: Literal expression should be on the right-hand side of a binary expression.


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue:  #2866
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Allow `1 + 1`.

#### CHANGELOG.md entry:

[bugfix] `binary-expression-operand-order`: Allow if both sides of the binary expression are literals.