### PR TITLE
unified-signatures: Can't unify rest parameters

### DIFF
--- a/src/rules/unifiedSignaturesRule.ts
+++ b/src/rules/unifiedSignaturesRule.ts
@@ -206,7 +206,11 @@ function signaturesDifferBySingleParameter(types1: ts.ParameterDeclaration[], ty
 
     const a = types1[index];
     const b = types2[index];
-    return parametersHaveEqualSigils(a, b) ? { kind: "single-parameter-difference", p0: a, p1: b } : undefined;
+    // Can unify `a?: string` and `b?: number`. Can't unify `...args: string[]` and `...args: number[]`.
+    // See https://github.com/Microsoft/TypeScript/issues/5077
+    return parametersHaveEqualSigils(a, b) && a.dotDotDotToken === undefined
+        ? { kind: "single-parameter-difference", p0: a, p1: b }
+        : undefined;
 }
 
 /**

--- a/test/rules/unified-signatures/test.d.ts.lint
+++ b/test/rules/unified-signatures/test.d.ts.lint
@@ -36,10 +36,9 @@ interface I {
     b2(x: string): void;
     b2(...x: number[]): void;
 
-    // Error if both are rest parameters.
+    // No error if both are rest parameters. (https://github.com/Microsoft/TypeScript/issues/5077)
     b3(...x: number[]): void;
     b3(...x: string[]): void;
-       ~~~~~~~~~~~~~~ [These overloads can be combined into one signature taking `number[] | string[]`.]
 
     // Error if only one defines an optional parameter.
     c(): void;


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #2845
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Don't suggest to unify `...args: string[]` and `...args: number[]`.

#### CHANGELOG.md entry:

[bugfix] `unified-signatures`: Don't suggest to unify rest parameters.
