### PR TITLE
no-string-literal: Fix documentation

### DIFF
--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -24,8 +24,13 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-string-literal",
-        description: "Disallows object access via string literals.",
-        rationale: "Encourages using strongly-typed property access.",
+        description: Lint.Utils.dedent`
+            Forbids unnecessary string literal property access.
+            Allows \`obj["prop-erty"]\` (can't be a regular property access).
+            Disallows \`obj["property"]\` (should be \`obj.property\`).`,
+        rationale: Lint.Utils.dedent`
+            If \`--noImplicitAny\` is turned off,
+            property access via a string literal will be 'any' if the property does not exist.`,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### Overview of change:

Clarified the rule documentation.
* The rule does nothing when a string literal is necessary, as in `obj["foo-bar"]`.
* There's nothing unsafe about string literal access if `--noImplicitAny` is turned on.