### PR TITLE
Added NaN and (+/-)Infinity as numbers to no-inferrable-types

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -16,7 +16,7 @@
  */
 
 import * as path from "path";
-import { isBlockScopedVariableDeclarationList, isPrefixUnaryExpression } from "tsutils";
+import { isBlockScopedVariableDeclarationList, isIdentifier, isPrefixUnaryExpression } from "tsutils";
 import * as ts from "typescript";
 
 import {IDisabledInterval, RuleFailure} from "./rule/rule"; // tslint:disable-line deprecation
@@ -216,6 +216,19 @@ export function isLoop(node: ts.Node): node is ts.IterationStatement {
         || node.kind === ts.SyntaxKind.ForStatement
         || node.kind === ts.SyntaxKind.ForInStatement
         || node.kind === ts.SyntaxKind.ForOfStatement;
+}
+
+/**
+ * @returns Whether node is a numeric expression.
+ */
+export function isNumeric(node: ts.Expression) {
+    while (isPrefixUnaryExpression(node) &&
+           (node.operator === ts.SyntaxKind.PlusToken || node.operator === ts.SyntaxKind.MinusToken)) {
+        node = node.operand;
+    }
+
+    return node.kind === ts.SyntaxKind.NumericLiteral ||
+        isIdentifier(node) && (node.text === "NaN" || node.text === "Infinity");
 }
 
 export interface TokenPosition {

--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -23,8 +23,6 @@ import * as Lint from "../index";
 const OPTION_IGNORE_PARMS = "ignore-params";
 const OPTION_IGNORE_PROPERTIES = "ignore-properties";
 
-const INFINITY_TEXT = "Infinity";
-
 interface Options {
     ignoreParameters: boolean;
     ignoreProperties: boolean;
@@ -80,7 +78,7 @@ class NoInferrableTypesWalker extends Lint.AbstractWalker<Options> {
             if (shouldCheck(node, this.options)) {
                 const { name, type, initializer } = node;
                 if (type !== undefined && initializer !== undefined
-                    && typeIsInferrable(type.kind, initializer.kind, initializer.getText())) {
+                    && typeIsInferrable(type.kind, initializer)) {
                     const fix = Lint.Replacement.deleteFromTo(name.end, type.end);
                     this.addFailureAtNode(type, Rule.FAILURE_STRING_FACTORY(ts.tokenToString(type.kind)), fix);
                 }
@@ -107,14 +105,14 @@ function shouldCheck(node: ts.Node, { ignoreParameters, ignoreProperties }: Opti
     }
 }
 
-function typeIsInferrable(type: ts.SyntaxKind, initializer: ts.SyntaxKind, initializerText: string): boolean {
+function typeIsInferrable(type: ts.SyntaxKind, initializer: ts.Expression): boolean {
     switch (type) {
         case ts.SyntaxKind.BooleanKeyword:
-            return initializer === ts.SyntaxKind.TrueKeyword || initializer === ts.SyntaxKind.FalseKeyword;
+            return initializer.kind === ts.SyntaxKind.TrueKeyword || initializer.kind === ts.SyntaxKind.FalseKeyword;
         case ts.SyntaxKind.NumberKeyword:
-            return initializer === ts.SyntaxKind.NumericLiteral || initializerText.indexOf(INFINITY_TEXT) !== -1;
+            return Lint.isNumeric(initializer);
         case ts.SyntaxKind.StringKeyword:
-            switch (initializer) {
+            switch (initializer.kind) {
                 case ts.SyntaxKind.StringLiteral:
                 case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
                 case ts.SyntaxKind.TemplateExpression:

--- a/test/rules/no-inferrable-types/default/test.ts.fix
+++ b/test/rules/no-inferrable-types/default/test.ts.fix
@@ -1,7 +1,9 @@
 // errors, inferrable type is declared
-let x = 7;
-let y = false;
-let z = "foo";
+let a = 7;
+let b = false;
+let c = "foo";
+let d = Infinity;
+let e = -Infinity;
 class C {
     x = 1;
 }

--- a/test/rules/no-inferrable-types/default/test.ts.lint
+++ b/test/rules/no-inferrable-types/default/test.ts.lint
@@ -1,10 +1,14 @@
 // errors, inferrable type is declared
-let x: number = 7;
+let a: number = 7;
        ~~~~~~           [number]
-let y: boolean = false;
+let b: boolean = false;
        ~~~~~~~          [boolean]
-let z: string = "foo";
+let c: string = "foo";
        ~~~~~~           [string]
+let d: number = Infinity;
+       ~~~~~~           [number]
+let e: number = -Infinity;
+       ~~~~~~           [number]
 class C {
     x: number = 1;
        ~~~~~~           [number]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2777
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Adds the initializer text to logic in `typeIsInferrable`, and allows it to contain `Infinity`.
Fixes #2777.

#### CHANGELOG.md entry:

[enhancement] Added NaN and (+/-)Infinity as numbers to `no-inferrable-types`