### PR TITLE
Print stack trace of exceptions

### DIFF
--- a/src/language/rule/typedRule.ts
+++ b/src/language/rule/typedRule.ts
@@ -17,14 +17,16 @@
 
 import * as ts from "typescript";
 
+import { showWarningOnce } from "../../error";
 import {AbstractRule} from "./abstractRule";
 import {ITypedRule, RuleFailure} from "./rule";
 
 export abstract class TypedRule extends AbstractRule implements ITypedRule {
 
     public apply(): RuleFailure[] {
-        // if no program is given to the linter, throw an error
-        throw new Error(`The '${this.ruleName}' rule requires type checking`);
+        // if no program is given to the linter, show an error
+        showWarningOnce(`Warning: The '${this.ruleName}' rule requires type infomation.`);
+        return [];
     }
 
     public abstract applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[];

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -200,10 +200,10 @@ class Linter {
                 return rule.apply(sourceFile);
             }
         } catch (error) {
-            if (isError(error)) {
-                showWarningOnce(`Warning: ${error.message}`);
+            if (isError(error) && error.stack !== undefined) {
+                showWarningOnce(error.stack);
             } else {
-                console.warn(`Warning: ${error}`);
+                showWarningOnce(error);
             }
             return [];
         }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -203,7 +203,7 @@ class Linter {
             if (isError(error) && error.stack !== undefined) {
                 showWarningOnce(error.stack);
             } else {
-                showWarningOnce(error);
+                showWarningOnce(String(error));
             }
             return [];
         }

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -199,7 +199,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         try {
             options = parseOptions(this.ruleArguments);
         } catch (e) {
-            showWarningOnce(`Warning: ${this.ruleName} - ${e.message}`);
+            showWarningOnce(`Warning: ${this.ruleName} - ${(e as Error).message}`);
             return [];
         }
         return this.applyWithWalker(new MemberOrderingWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)));

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -202,7 +202,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             showWarningOnce(`Warning: ${this.ruleName} - ${(e as Error).message}`);
             return [];
         }
-        return this.applyWithWalker(new MemberOrderingWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)));
+        return this.applyWithWalker(new MemberOrderingWalker(sourceFile, this.ruleName, options));
     }
 }
 

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -17,6 +17,7 @@
 
 import * as ts from "typescript";
 
+import { showWarningOnce } from "../error";
 import * as Lint from "../index";
 import {flatMap, mapDefined} from "../utils";
 
@@ -194,6 +195,13 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     /* tslint:enable:object-literal-sort-keys */
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        let options: Options;
+        try {
+            options = parseOptions(this.ruleArguments);
+        } catch (e) {
+            showWarningOnce(`Warning: ${this.ruleName} - ${e.message}`);
+            return [];
+        }
         return this.applyWithWalker(new MemberOrderingWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)));
     }
 }

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -18,6 +18,7 @@
 import { isNoSubstitutionTemplateLiteral, isSameLine, isStringLiteral } from "tsutils";
 import * as ts from "typescript";
 
+import { showWarningOnce } from "../error";
 import * as Lint from "../index";
 
 const OPTION_SINGLE = "single";
@@ -81,7 +82,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         const args = this.ruleArguments;
         if (args.length > 0) {
             if (args[0] !== OPTION_SINGLE && args[0] !== OPTION_DOUBLE) {
-                throw new Error(`First argument to 'quotemark' rule should be "${OPTION_SINGLE}" or "${OPTION_DOUBLE}"`);
+                showWarningOnce(`Warning: First argument to 'quotemark' rule should be "${OPTION_SINGLE}" or "${OPTION_DOUBLE}"`);
+                return [];
             }
         }
         const quoteMark = args[0] === OPTION_SINGLE ? "'" : '"';


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2704
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
[enhancement] Print stack trace of exceptions
Rules that used to throw an exceptions just to warn about something have been converted to show the warning and return.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
