### PR TITLE
Ensure compatibility with older typescript in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
     - yarn
 test:
   override:
-    - case $CIRCLE_NODE_INDEX in [0-2]) yarn verify ;; 3) npm run clean && yarn compile && yarn add typescript@next && yarn test ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) npm run clean && yarn compile && yarn add typescript@2.1 && yarn test ;; 1) npm run clean && yarn compile && yarn add typescript@2.2 && yarn test ;; 2) yarn verify ;; 3) npm run clean && yarn compile && yarn add typescript@next && yarn test ;; esac:
         parallel: true
 deployment:
   npm-latest:

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -436,3 +436,9 @@ export function isNegativeNumberLiteral(node: ts.Node): node is ts.PrefixUnaryEx
         node.operator === ts.SyntaxKind.MinusToken &&
         node.operand.kind === ts.SyntaxKind.NumericLiteral;
 }
+
+/** Wrapper for compatibility with typescript@<2.3.1 */
+export function isWhiteSpace(ch: number): boolean {
+    // tslint:disable-next-line
+    return (ts.isWhiteSpaceLike || (ts as any).isWhiteSpace)(ch);
+}

--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -95,7 +95,7 @@ function walk(ctx: Lint.WalkContext<Options>): void {
         // openParen may be missing for an async arrow function `async x => ...`.
         if (openParen === undefined) { return; }
 
-        const hasSpace = ts.isWhiteSpaceLike(sourceFile.text.charCodeAt(openParen.end - 2));
+        const hasSpace = Lint.isWhiteSpace(sourceFile.text.charCodeAt(openParen.end - 2));
 
         if (hasSpace && option === "never") {
             const pos = openParen.getStart() - 1;

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -247,7 +247,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
     }
 
     function checkForTrailingWhitespace(position: number): void {
-        if (position !== sourceFile.end && !ts.isWhiteSpaceLike(sourceFile.text.charCodeAt(position))) {
+        if (position !== sourceFile.end && !Lint.isWhiteSpace(sourceFile.text.charCodeAt(position))) {
             addMissingWhitespaceErrorAt(position);
         }
     }

--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: >=2.3.0
 import def, {other, other2 as foobar, notDeprecated, notDeprecated2} from './other.test';
        ~~~ [errmsg % ('def', 'deprecated default export')]
              ~~~~~          [errmsg % ('other', 'reason')]

--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -1,4 +1,3 @@
-[typescript]: >=2.3.0
 import def, {other, other2 as foobar, notDeprecated, notDeprecated2} from './other.test';
        ~~~ [errmsg % ('def', 'deprecated default export')]
              ~~~~~          [errmsg % ('other', 'reason')]

--- a/test/rules/return-undefined/test.ts.lint
+++ b/test/rules/return-undefined/test.ts.lint
@@ -1,4 +1,6 @@
-[typescript]: >=2.2.0
+class Promise<T> {
+    then(): Promise<T>;
+}
 function valueWrong(): number | undefined {
     return;
     ~~~~~~~ [UNDEFINED]

--- a/test/rules/return-undefined/test.ts.lint
+++ b/test/rules/return-undefined/test.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: >=2.2.0
 function valueWrong(): number | undefined {
     return;
     ~~~~~~~ [UNDEFINED]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2891
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Added a wrapper function for `ts.isWhiteSpaceLike` or `ts.isWhiteSpace`. Fixes `whitespace` and `space-before-function-paren`. Fixes: #2891
Added a workaround for the missing `symbol.getJsDocTags()` in `deprecationRule`.
Make `Promise<T>` available for tests of `return-undefined` to make it work with typescript@<2.2.0.

Circle node | TypeScript version
--- | ---
0 | 2.1.x
1 | 2.2.x
2 | current dev dependency (2.3.4)
3 | next


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] Restore compatibility with typescript@2.1 and 2.2 for `whitespace`, `space-before-function-paren` and `deprecation`