### PR TITLE
Don't leave blank lines when no-unused-variable autofix removes whole import

### DIFF
--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -227,13 +227,27 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<void>, failures: Map<t
         function removeAll(errorNode: ts.Node, failure: string): void {
             const start = importNode.getStart();
             let end = importNode.getEnd();
-            if (ctx.sourceFile.getLineAndCharacterOfPosition(start).character === 0 &&
-                ctx.sourceFile.getLineEndOfPosition(end) === end) {
-                end++;
+            if (isEntireLine(start, end)) {
+                end = getNextLineStart(end);
             }
 
             const fix = Lint.Replacement.deleteFromTo(start, end);
             ctx.addFailureAtNode(errorNode, failure, fix);
+        }
+
+        function isEntireLine(start: number, end: number): boolean {
+            return ctx.sourceFile.getLineAndCharacterOfPosition(start).character === 0 &&
+                ctx.sourceFile.getLineEndOfPosition(end) === end;
+        }
+
+        function getNextLineStart(position: number): number {
+            const nextLine = ctx.sourceFile.getLineAndCharacterOfPosition(position).line + 1;
+            const lineStarts = ctx.sourceFile.getLineStarts();
+            if (nextLine < lineStarts.length) {
+                return lineStarts[nextLine];
+            } else {
+                return position;
+            }
         }
     });
 

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -225,12 +225,14 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<void>, failures: Map<t
         }
 
         function removeAll(errorNode: ts.Node, failure: string): void {
+            const start = importNode.getStart();
             let end = importNode.getEnd();
-            if (ctx.sourceFile.getLineEndOfPosition(end) === end) {
+            if (ctx.sourceFile.getLineAndCharacterOfPosition(start).character === 0 &&
+                ctx.sourceFile.getLineEndOfPosition(end) === end) {
                 end++;
             }
 
-            const fix = Lint.Replacement.deleteFromTo(importNode.getStart(), end);
+            const fix = Lint.Replacement.deleteFromTo(start, end);
             ctx.addFailureAtNode(errorNode, failure, fix);
         }
     });

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -225,7 +225,12 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<void>, failures: Map<t
         }
 
         function removeAll(errorNode: ts.Node, failure: string): void {
-            const fix = Lint.Replacement.deleteFromTo(importNode.getStart(), importNode.getEnd());
+            let end = importNode.getEnd();
+            if (ctx.sourceFile.getLineEndOfPosition(end) === end) {
+                end++;
+            }
+
+            const fix = Lint.Replacement.deleteFromTo(importNode.getStart(), end);
             ctx.addFailureAtNode(errorNode, failure, fix);
         }
     });

--- a/test/rules/no-unused-variable/default/import.ts.fix
+++ b/test/rules/no-unused-variable/default/import.ts.fix
@@ -31,6 +31,10 @@ import * as bar from "a";
 import baz from "a";
 import { namedExport } from "a";
 import d3 from "a";
+d3;
+
+d3;
+d3;
 d3;d3;
 
 bar.someFunc();

--- a/test/rules/no-unused-variable/default/import.ts.fix
+++ b/test/rules/no-unused-variable/default/import.ts.fix
@@ -2,7 +2,6 @@
  * Some license that appears in the leading trivia of a statement that will be deleted.
  * This text will not be deleted.
  */
-
 import  $ = require("a");
 import  _ = require("a");
 import {a2 as aa2} from "a";
@@ -10,8 +9,6 @@ aa2;
 import {a3 as aa3} from "a";
 aa3;
 // This import statement is unused and will be deleted along with this comment.
-
-
 import {a8} from "a";
 a8;
 import {a13} from "a";
@@ -30,13 +27,11 @@ module S {
   var template = "";
 }
 
-
 import * as bar from "a";
 import baz from "a";
 import { namedExport } from "a";
-
 import d3 from "a";
-d3;
+d3;d3;
 
 bar.someFunc();
 baz();

--- a/test/rules/no-unused-variable/default/import.ts.lint
+++ b/test/rules/no-unused-variable/default/import.ts.lint
@@ -52,7 +52,13 @@ import d1, { d2 } from "a";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~                     [All imports are unused.]
 import d3, { d4 } from "a";
            ~~~~~~                                  [All named bindings are unused.]
-d3;import d5 from "a";d3;
+d3;
+
+d3;import d5 from "a";
+   ~~~~~~~~~~~~~~~~~~~                          [All imports are unused.]
+import d6 from "a";d3;
+~~~~~~~~~~~~~~~~~~~                             [All imports are unused.]
+d3;import d7 from "a";d3;
    ~~~~~~~~~~~~~~~~~~~                          [All imports are unused.]
 
 bar.someFunc();

--- a/test/rules/no-unused-variable/default/import.ts.lint
+++ b/test/rules/no-unused-variable/default/import.ts.lint
@@ -52,7 +52,8 @@ import d1, { d2 } from "a";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~                     [All imports are unused.]
 import d3, { d4 } from "a";
            ~~~~~~                                  [All named bindings are unused.]
-d3;
+d3;import d5 from "a";d3;
+   ~~~~~~~~~~~~~~~~~~~                          [All imports are unused.]
 
 bar.someFunc();
 baz();


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2898 
- [x] New enhancement
  - [x] Includes tests

#### Overview of change:

When an unused import is deleted, the line break is removed too.
Unless there are more sentences in the same line, so the break is preserved.

#### Is there anything you'd like reviewers to focus on?

- Can you think on other scenarios we need to cover?
- This is my first time contributing to TSLint and consuming TS compiler API. Let me know if there's something that can be improved.

#### CHANGELOG.md entry:

"[enhancement] `no-unused-variable`: Don't leave empty lines when import is removed"
