### PR TITLE
prefer-const: special handling for destructuring in for-of

### DIFF
--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -273,7 +273,8 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
                 canBeConst: true,
                 declarationList,
                 isBlockScoped: kind === utils.VariableDeclarationKind.Let,
-                isForLoop: declarationList.parent!.kind === ts.SyntaxKind.ForStatement,
+                isForLoop: declarationList.parent!.kind === ts.SyntaxKind.ForStatement ||
+                           declarationList.parent!.kind === ts.SyntaxKind.ForOfStatement,
                 reassignedSiblings: false,
             };
         }

--- a/test/rules/prefer-const/default/test.ts.fix
+++ b/test/rules/prefer-const/default/test.ts.fix
@@ -214,6 +214,7 @@ declare namespace ambient {
 for (let [var1, var2] of someArr) {
     var1 = null;
 }
+for (const [var1, var2] of someArr) {}
 for (let {var1, var2} of someArr) {
     var2 = null;
 }

--- a/test/rules/prefer-const/default/test.ts.fix
+++ b/test/rules/prefer-const/default/test.ts.fix
@@ -56,7 +56,7 @@ function myFunc2() {
 for (const n of [1, 1]) { // failure for 'n'
     console.log(n);
 }
-for (let {o, p} of [{1, 1}, {1, 1}]) { // failure for 'o'
+for (let {o, p} of [{1, 1}, {1, 1}]) {
     console.log(o);
     p = 2;
 }
@@ -210,5 +210,11 @@ declare namespace ambient {
 {
     let someVar: string, someObj: any;
     for ({someVar: someObj.val} of someArr) {}
+}
+for (let [var1, var2] of someArr) {
+    var1 = null;
+}
+for (let {var1, var2} of someArr) {
+    var2 = null;
 }
 

--- a/test/rules/prefer-const/default/test.ts.lint
+++ b/test/rules/prefer-const/default/test.ts.lint
@@ -251,6 +251,9 @@ declare namespace ambient {
 for (let [var1, var2] of someArr) {
     var1 = null;
 }
+for (let [var1, var2] of someArr) {}
+          ~~~~ [let % ('var1')]
+                ~~~~ [let % ('var2')]
 for (let {var1, var2} of someArr) {
     var2 = null;
 }

--- a/test/rules/prefer-const/default/test.ts.lint
+++ b/test/rules/prefer-const/default/test.ts.lint
@@ -68,8 +68,7 @@ for (let n of [1, 1]) { // failure for 'n'
          ~                                 [let % ('n')]
     console.log(n);
 }
-for (let {o, p} of [{1, 1}, {1, 1}]) { // failure for 'o'
-          ~                                               [let % ('o')]
+for (let {o, p} of [{1, 1}, {1, 1}]) {
     console.log(o);
     p = 2;
 }
@@ -248,6 +247,12 @@ declare namespace ambient {
         ~~~~~~~ [let % ('someVar')]
                          ~~~~~~~ [let % ('someObj')]
     for ({someVar: someObj.val} of someArr) {}
+}
+for (let [var1, var2] of someArr) {
+    var1 = null;
+}
+for (let {var1, var2} of someArr) {
+    var2 = null;
 }
 
 [_base]: Identifier '%%s' is never reassigned; use 'const' instead of '%s'.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2902
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[enhancement] `prefer-const`: handle destructuring in for-of loop initializer as if `{"destructuring": "all"}` was specified
Fixes: #2902 

/cc @WilcoBakker

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
