### PR TITLE
completed-docs: Add support for enum members

### DIFF
--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -126,6 +126,10 @@ export class SyntaxWalker {
         this.walkChildren(node);
     }
 
+    protected visitEnumMember(node: ts.EnumMember) {
+        this.walkChildren(node);
+    }
+
     protected visitExportAssignment(node: ts.ExportAssignment) {
         this.walkChildren(node);
     }
@@ -454,6 +458,10 @@ export class SyntaxWalker {
 
             case ts.SyntaxKind.EnumDeclaration:
                 this.visitEnumDeclaration(node as ts.EnumDeclaration);
+                break;
+
+            case ts.SyntaxKind.EnumMember:
+                this.visitEnumMember(node as ts.EnumMember);
                 break;
 
             case ts.SyntaxKind.ExportAssignment:

--- a/test/rules/completed-docs/types/test.ts.lint
+++ b/test/rules/completed-docs/types/test.ts.lint
@@ -138,6 +138,19 @@ enum EmptyEnum { }
  */
 enum GoodEnum { }
 
+/**
+ * ...
+ */
+enum EnumWithMembers {
+    BadEnumMember
+    ~~~~~~~~~~~~~       [Documentation must exist for enum members.]
+
+    /**
+     * ...
+     */
+    GoodEnumMember
+}
+
 function BadFunction() { }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~      [Documentation must exist for functions.]
 

--- a/test/rules/completed-docs/types/tslint.json
+++ b/test/rules/completed-docs/types/tslint.json
@@ -4,6 +4,7 @@
       true,
       "classes",
       "enums",
+      "enum-members",
       "functions",
       "interfaces",
       "methods",

--- a/test/rules/completed-docs/visibilities/test.ts.lint
+++ b/test/rules/completed-docs/visibilities/test.ts.lint
@@ -4,14 +4,29 @@ export enum BadExportedEnum { }
 /**
  * ...
  */
-export enum GoodExportedEnum { }
-
-enum BadInternalEnum { }
+export enum ExportedEnum {
+    BadExportedMember
+    ~~~~~~~~~~~~~~~~~      [Documentation must exist for exported enum members.]
+ }
 
 /**
  * ...
  */
-enum GoodInternalEnum { }
+export enum GoodExportedEnum { }
+
+enum BadInternalEnum {
+    InternalMember
+ }
+
+/**
+ * ...
+ */
+enum GoodInternalEnum {
+    /**
+     * ...
+     */
+    GoodInternalMember
+}
 
 export interface BadExportedInterface { }
 

--- a/test/rules/completed-docs/visibilities/tslint.json
+++ b/test/rules/completed-docs/visibilities/tslint.json
@@ -4,6 +4,9 @@
       "enums": {
         "visibilities": ["exported"]
       },
+      "enum-members": {
+        "visibilities": ["exported"]
+      },
       "interfaces": {
         "visibilities": ["internal"]
       }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2910 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

I've extended the `completed-docs` rule to check enum members. This is disabled by default and can be enabled by including a new argument "enum-members". This can also be configured to only require documentation for members of internal enums or exported enums.

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
[new-rule-option] `completed-docs`: Add `enum-members` option
