### PR TITLE
switch-final-break: don't fail for break statement with label

### DIFF
--- a/test/rules/switch-final-break/default/test.ts.lint
+++ b/test/rules/switch-final-break/default/test.ts.lint
@@ -46,4 +46,25 @@ switch (x) {
     case 0:
 }
 
+outer: while (true) {
+    switch (x) {
+        case 0:
+            x++;
+            break;
+        default:
+            break outer;
+    }
+}
+
+outer2: while (true) {
+    inner: switch (x) {
+        case 0:
+            ++x;
+            break;
+        default:
+            break inner;
+            ~~~~~~~~~~~~ [0]
+    }
+}
+
 [0]: Final clause in 'switch' statement should not end with 'break;'.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `switch-final-break`: don't fail if break jumps to a label outside of the switch

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
