### PR TITLE
cli: Restore -v option

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -188,6 +188,23 @@ const options: Option[] = [
     },
 ];
 
+const builtinOptions: Option[] = [
+    {
+        short: "v",
+        name: "version",
+        type: "boolean",
+        describe: "current version",
+        description: "The current version of tslint.",
+    },
+    {
+        short: "h",
+        name: "help",
+        type: "boolean",
+        describe: "display detailed help",
+        description: "Prints this help message.",
+    },
+];
+
 commander.version(VERSION, "-v, --version");
 
 for (const option of options) {
@@ -201,7 +218,7 @@ for (const option of options) {
 
 commander.on("--help", () => {
     const indent = "\n        ";
-    const optionDetails = options.map((o) =>
+    const optionDetails = options.concat(builtinOptions).map((o) =>
         `${optionUsageTag(o)}:${o.description.startsWith("\n") ? o.description.replace(/\n/g, indent) : indent + o.description}`);
     console.log(`tslint accepts the following commandline options:\n\n    ${optionDetails.join("\n\n    ")}\n\n`);
 });

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -188,7 +188,7 @@ const options: Option[] = [
     },
 ];
 
-commander.version(VERSION);
+commander.version(VERSION, "-v, --version");
 
 for (const option of options) {
     const commanderStr = optionUsageTag(option) + optionParam(option);


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2925
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Commander by default adds a `-V` option as shorthand for `--version`.

This PR changes the shorthand back to `-v`.
[cli] restore `-v` option
Fixes: #2925

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
