### PR TITLE
Removed "prefer-switch" because tslint 5.3 is out

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,9 +4,6 @@
   },
   "extends": "tslint:all",
   "rules": {
-    // TODO: remove this when tslint 5.3 released
-    "prefer-switch": [true, { "min-cases": 3 }],
-
     // Don't want these
     "cyclomatic-complexity": false,
     "newline-before-return": false,


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests (linter will warn if commit has conflicts)
- [ ] Documentation update

#### Overview of change:

The TODO said that the line should be removed when tslint 5.3 has been released, which happend [23 days ago](https://github.com/palantir/tslint/releases/tag/5.3.0).

#### Is there anything you'd like reviewers to focus on?

The JSON standard doesn't allow comments, so there shouldn't be any comments in JSON files.

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
