### PR TITLE
Add Emacs/Flycheck to third-party tool list

### DIFF
--- a/docs/usage/third-party-tools/index.md
+++ b/docs/usage/third-party-tools/index.md
@@ -19,6 +19,7 @@ _Note: Most of these tools are not maintained by TSLint._
 * [mocha-tslint][15] ([Mocha][16])
 * [tslint.tmbundle][17] ([TextMate][18])
 * [generator-tslint][19]
+* [Flycheck][20] ([Emacs][21])
 
 
 [0]: https://github.com/palantir/grunt-tslint
@@ -41,3 +42,5 @@ _Note: Most of these tools are not maintained by TSLint._
 [17]: https://github.com/natesilva/tslint.tmbundle
 [18]: https://macromates.com
 [19]: https://github.com/greybax/generator-tslint
+[20]: http://www.flycheck.org/
+[21]: https://www.gnu.org/software/emacs/


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

I've added Emacs/Flycheck, which comes with a tslint-based syntax checker, to the third-party tools list.
