### PR TITLE
completed-docs: Limit variable checking to file-level variables and use correct visibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[tslint.json]
+indent_size = 2

--- a/test/rules/completed-docs/variables/test.ts.lint
+++ b/test/rules/completed-docs/variables/test.ts.lint
@@ -1,0 +1,38 @@
+export const exportedVariable = 1;
+             ~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for exported variables.]
+
+const internalVariable = 2;
+      ~~~~~~~~~~~~~~~~~~~~              [Documentation must exist for variables.]
+
+// Variables in `catch` clauses should not be checked.
+try {
+} catch (ex) {
+}
+
+// Variables in `for` statements should not be checked.
+for (let i = 0; i < 1; i++) {}
+
+// Variables in `for in` statements should not be checked.
+for (let p in {}) {}
+
+// Variables in `for of` statements should not be checked.
+for (let p of [1,2,3]) {}
+
+// Variables that are not at the outer-most scope should not be checked.
+function(x) {
+    let foo = 1;
+}
+
+namespace FooNamespace {
+    export const exportedFromNamespace = 1;
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~      [Documentation must exist for exported variables.]
+    let inNamespace = 1;
+        ~~~~~~~~~~~~~~~                         [Documentation must exist for variables.]
+}
+
+module FooModule {
+    export const exportedFromModule = 1;
+                 ~~~~~~~~~~~~~~~~~~~~~~         [Documentation must exist for exported variables.]
+    let inModule = 1;
+        ~~~~~~~~~~~~                            [Documentation must exist for variables.]
+}

--- a/test/rules/completed-docs/variables/tsconfig.json
+++ b/test/rules/completed-docs/variables/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/completed-docs/variables/tslint.json
+++ b/test/rules/completed-docs/variables/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "completed-docs": [
+      true,
+      "variables"
+    ]
+  }
+}

--- a/test/rules/completed-docs/visibilities/test.ts.lint
+++ b/test/rules/completed-docs/visibilities/test.ts.lint
@@ -39,3 +39,8 @@ interface BadInternalInterface { }
  * ...
  */
 interface GoodInternalInterface { }
+
+const internalVariable = 1;
+
+export const exportedVariable = 2;
+             ~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for exported variables.]

--- a/test/rules/completed-docs/visibilities/tslint.json
+++ b/test/rules/completed-docs/visibilities/tslint.json
@@ -9,6 +9,9 @@
       },
       "interfaces": {
         "visibilities": ["internal"]
+      },
+      "variables": {
+        "visibilities": ["exported"]
       }
     }]
   }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2335, #2912 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

This PR fixes two issues:

1. When checking if a variable meets the required visibility, the modifiers on the variable were being used, but the variable doesn't have modifiers - the modifiers are on the variable statement which is two levels up. These changes step up two levels to get the correct modifiers.
2. When checking variables, _all_ variables were being checked, including those inside for loops, catch statements, and local variables inside functions. This PR limits variable checking to variables that have a parent of a `SourceFile` - i.e. variables at the file-level.

As a side note, I've also fixed the `.editorconfig` file to have a rule for tslint.json files that enforces an indent size of 2 instead of the default 4, because all tslint.json files I could see used an indentation of 2.

#### CHANGELOG.md entry:

[bugfix] `completed-docs`: Uses correct visibility of variables.
[bugfix] `completed-docs`: Only checks variables at the file-level.