### PR TITLE
callable-types: preserve modifiers

### DIFF
--- a/src/rules/callableTypesRule.ts
+++ b/src/rules/callableTypesRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isCallSignatureDeclaration, isIdentifier, isInterfaceDeclaration, isTypeLiteralNode } from "tsutils";
+import { getChildOfKind, isCallSignatureDeclaration, isIdentifier, isInterfaceDeclaration, isTypeLiteralNode } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -53,10 +53,13 @@ function walk(ctx: Lint.WalkContext<void>) {
                 // avoid bad parse
                 member.type !== undefined) {
                 const suggestion = renderSuggestion(member, node, ctx.sourceFile);
+                const fixStart = node.kind === ts.SyntaxKind.TypeLiteral
+                    ? node.getStart(ctx.sourceFile)
+                    : getChildOfKind(node, ts.SyntaxKind.InterfaceKeyword)!.getStart(ctx.sourceFile);
                 ctx.addFailureAtNode(
                     member,
                     Rule.FAILURE_STRING_FACTORY(node.kind === ts.SyntaxKind.TypeLiteral ? "Type literal" : "Interface", suggestion),
-                    Lint.Replacement.replaceNode(node, suggestion),
+                    Lint.Replacement.replaceFromTo(fixStart, node.end, suggestion),
                 );
             }
         }

--- a/test/rules/callable-types/test.ts.fix
+++ b/test/rules/callable-types/test.ts.fix
@@ -18,3 +18,8 @@ interface K {
     (x: number): number;
     (x: string): string;
 }
+
+// handle modifiers
+export default type I = () => void;
+
+export type T = () => void

--- a/test/rules/callable-types/test.ts.fix
+++ b/test/rules/callable-types/test.ts.fix
@@ -20,6 +20,6 @@ interface K {
 }
 
 // handle modifiers
-export default type I = () => void;
+export type I = () => void;
 
 export type T = () => void

--- a/test/rules/callable-types/test.ts.lint
+++ b/test/rules/callable-types/test.ts.lint
@@ -1,40 +1,55 @@
 interface I {
     (): void;
-    ~~~~~~~~~   [Interface has only a call signature — use `type I = () => void;` instead.]
+    ~~~~~~~~~   [interface % ('type I = () => void;')]
 }
 
 interface J extends Function {
     (): void;
-    ~~~~~~~~~                    [Interface has only a call signature — use `type J = () => void;` instead.]
+    ~~~~~~~~~                    [interface % ('type J = () => void;')]
 }
 
 interface K<T> {
     <U extends T>(param1: U, param2: T): U;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Interface has only a call signature — use `type K<T> = <U extends T>(param1: U, param2: T) => U;` instead.]
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [interface % ('type K<T> = <U extends T>(param1: U, param2: T) => U;')]
 }
 
 interface L<T> {
     (): T
-    ~~~~~ [Interface has only a call signature — use `type L<T> = () => T` instead.]
+    ~~~~~ [interface % ('type L<T> = () => T')]
 }
 
 type T = {
     (): void;
-    ~~~~~~~~~ [Type literal has only a call signature — use `() => void` instead.]
+    ~~~~~~~~~ [type % ('() => void')]
 };
 
 type U = {
     <T>(t: T): T;
-    ~~~~~~~~~~~~~ [Type literal has only a call signature — use `<T>(t: T) => T` instead.]
+    ~~~~~~~~~~~~~ [type % ('<T>(t: T) => T')]
 }
 
 var fn: {(): void;};
-         ~~~~~~~~~ [Type literal has only a call signature — use `() => void` instead.]
+         ~~~~~~~~~ [type % ('() => void')]
 function f(x: { (): void }): void;
-                ~~~~~~~~ [Type literal has only a call signature — use `() => void` instead.]
+                ~~~~~~~~ [type % ('() => void')]
 
 // Overloads OK
 interface K {
     (x: number): number;
     (x: string): string;
 }
+
+// handle modifiers
+export default interface I {
+    (): void;
+    ~~~~~~~~~ [interface % ('type I = () => void;')]
+}
+
+export type T = {
+    (): void;
+    ~~~~~~~~~ [type % ('() => void')]
+}
+
+[_base]: %s has only a call signature — use `%s` instead.
+[interface]: _base % ('Interface')
+[type]: _base % ('Type literal')

--- a/test/rules/callable-types/test.ts.lint
+++ b/test/rules/callable-types/test.ts.lint
@@ -40,7 +40,7 @@ interface K {
 }
 
 // handle modifiers
-export default interface I {
+export interface I {
     (): void;
     ~~~~~~~~~ [interface % ('type I = () => void;')]
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2941
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `callable-types`: don't remove export modifier of interfaces
Fixes: #2941

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
