### PR TITLE
Added a no-jsdoc-types rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -190,6 +190,7 @@ export const rules = {
     "no-angle-bracket-type-assertion": true,
     "no-boolean-literal-compare": true,
     "no-consecutive-blank-lines": true,
+    "no-jsdoc-types": true,
     "no-parameter-properties": true,
     "no-reference-import": true,
     "no-unnecessary-callback-wrapper": true,

--- a/src/rules/noJsdocTypesRule.ts
+++ b/src/rules/noJsdocTypesRule.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as utils from "tsutils";
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static metadata: Lint.IRuleMetadata = {
+        description: "Disallows `{type}` annotations within JSDoc comments.",
+        optionExamples: [true],
+        options: null,
+        optionsDescription: "Not configurable.",
+        rationale: "Type annotations in JSDoc comments are unnecessary in TypeScript.",
+        ruleName: "no-jsdoc-types",
+        type: "style",
+        typescriptOnly: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "type annotations in JSDoc comments are unnecessary in TypeScript";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+const violationSearcher = /\@(param|return|returns)( *)\{.*\}/g;
+const fixReplacer = /( *)\{.*\}/;
+
+function walk(ctx: Lint.WalkContext<void>) {
+    return utils.forEachComment(ctx.sourceFile, (fullText, { kind, pos }) => {
+        if (kind !== ts.SyntaxKind.MultiLineCommentTrivia ||
+            fullText[pos + 2] !== "*" || fullText[pos + 3] === "*" || fullText[pos + 3] === "/") {
+            return;
+        }
+
+        while (true) {
+            const violation = violationSearcher.exec(fullText);
+            if (violation === null) {
+                break;
+            }
+
+            const text = violation[0];
+            const start = pos + violation.index;
+            const end = start + text.length;
+            const replacement = new Lint.Replacement(start, text.length, text.replace(fixReplacer, ""));
+
+            ctx.addFailure(start, end, Rule.FAILURE_STRING, replacement);
+        }
+    });
+}

--- a/src/rules/noJsdocTypesRule.ts
+++ b/src/rules/noJsdocTypesRule.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2013 Palantir Technologies, Inc.
+ * Copyright 2017 Palantir Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: "style",
         typescriptOnly: true,
     };
-    /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING = "type annotations in JSDoc comments are unnecessary in TypeScript";
 

--- a/test/rules/no-jsdoc-types/default.ts.fix
+++ b/test/rules/no-jsdoc-types/default.ts.fix
@@ -1,0 +1,20 @@
+/**
+ * Performs an action a number of times.
+ *
+ * @param action
+ * @param action   Does a thing.
+ * @param {function} action
+ * @param {() => {}} action
+ * @param {Function} action   Does a thing.
+ * @param {Function} action
+ * @param  {Function} action
+ * @param {Function}  action
+ * @param  {Function}  action
+ * @param times
+ * @param times   How many times to do the thing.
+ * @param {number} times   How many times to do the thing.
+ * @param {Number} times   How many times to do the thing.
+ * @returns {Array} results   Results of the action.
+ * @returns {any[]} results   Results of the action.
+ */
+function _() {}

--- a/test/rules/no-jsdoc-types/default.ts.lint
+++ b/test/rules/no-jsdoc-types/default.ts.lint
@@ -1,0 +1,33 @@
+/**
+ * Performs an action a number of times.
+ *
+ * @param action
+ * @param action   Does a thing.
+ * @param {function} action
+   ~~~~~~~~~~~~~~~~~       [error]
+ * @param {() => {}} action
+   ~~~~~~~~~~~~~~~~~       [error]
+ * @param {Function} action   Does a thing.
+   ~~~~~~~~~~~~~~~~~       [error]
+ * @param {Function} action
+   ~~~~~~~~~~~~~~~~~       [error]
+ * @param  {Function} action
+   ~~~~~~~~~~~~~~~~~~       [error]
+ * @param {Function}  action
+   ~~~~~~~~~~~~~~~~~       [error]
+ * @param  {Function}  action
+   ~~~~~~~~~~~~~~~~~~       [error]
+ * @param times
+ * @param times   How many times to do the thing.
+ * @param {number} times   How many times to do the thing.
+   ~~~~~~~~~~~~~~~       [error]
+ * @param {Number} times   How many times to do the thing.
+   ~~~~~~~~~~~~~~~       [error]
+ * @returns {Array} results   Results of the action.
+   ~~~~~~~~~~~~~~~~       [error]
+ * @returns {any[]} results   Results of the action.
+   ~~~~~~~~~~~~~~~~       [error]
+ */
+function _() {}
+
+[error]: type annotations in JSDoc comments are unnecessary in TypeScript

--- a/test/rules/no-jsdoc-types/tslint.json
+++ b/test/rules/no-jsdoc-types/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-jsdoc-types": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,8 @@
   },
   "extends": "tslint:all",
   "rules": {
+    "linebreak-style": false,
+
     // Don't want these
     "cyclomatic-complexity": false,
     "newline-before-return": false,

--- a/tslint.json
+++ b/tslint.json
@@ -4,8 +4,6 @@
   },
   "extends": "tslint:all",
   "rules": {
-    "linebreak-style": false,
-
     // Don't want these
     "cyclomatic-complexity": false,
     "newline-before-return": false,


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2979
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Adds a `no-jsdoc-types` rule to prevent unnecessary JSDoc type annotations.

#### CHANGELOG.md entry:

[new-rule] `no-jsdoc-types`