### PR TITLE
no-switch-case-fall-though: accept different comment formats

### DIFF
--- a/src/rules/noSwitchCaseFallThroughRule.ts
+++ b/src/rules/noSwitchCaseFallThroughRule.ts
@@ -93,10 +93,7 @@ export class NoSwitchCaseFallThroughWalker extends Lint.AbstractWalker<void> {
 
     private isFallThroughAllowed(clause: ts.CaseOrDefaultClause): boolean {
         const comments = ts.getLeadingCommentRanges(this.sourceFile.text, clause.end);
-        return comments !== undefined && comments.some((comment) => commentText(comment, this.sourceFile).trim() === "falls through");
+        return comments !== undefined &&
+            comments.some((comment) => /^\s*falls through\b/i.test(this.sourceFile.text.slice(comment.pos + 2, comment.end)));
     }
-}
-
-function commentText({ pos, end, kind }: ts.CommentRange, sourceFile: ts.SourceFile): string {
-    return sourceFile.text.slice(pos + 2, kind === ts.SyntaxKind.MultiLineCommentTrivia ? end - 2 : end);
 }

--- a/test/rules/no-switch-case-fall-through/test.ts.lint
+++ b/test/rules/no-switch-case-fall-through/test.ts.lint
@@ -125,7 +125,20 @@ switch (foo) {
                 foobar(); // this case clause falls through and returns in the default clause
             default:
             ~~~~~~~    [expected a 'break' before 'default']
-                return; 
+                return;
         }
     case 2:
+}
+
+switch (foo) {
+    case 1:
+        foo;
+        // Falls through
+    case 2:
+        foo;
+        // Falls through.
+    case 3:
+        foo;
+        // Falls through -- for reasons
+    default:
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: https://github.com/palantir/tslint/pull/2218#issuecomment-312481622
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[enhancement] `no-switch-case-fall-through` matches `// falls through` comments case insensitive and allows trailing text

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
