### PR TITLE
Fix #2986 await-promise accept intersection

### DIFF
--- a/src/rules/awaitPromiseRule.ts
+++ b/src/rules/awaitPromiseRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isAwaitExpression } from "tsutils";
+import { isAwaitExpression, isUnionOrIntersectionType } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -65,7 +65,7 @@ function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker, promiseTypes: Set
             return true;
         }
 
-        if (isUnionType(type)) {
+        if (isUnionOrIntersectionType(type)) {
             return type.types.some(couldBePromise);
         }
 
@@ -77,8 +77,4 @@ function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker, promiseTypes: Set
         const { target } = type as ts.TypeReference;
         return target !== undefined && target.symbol !== undefined && promiseTypes.has(target.symbol.name);
     }
-}
-
-function isUnionType(type: ts.Type): type is ts.UnionType {
-    return Lint.isTypeFlagSet(type, ts.TypeFlags.Union);
 }

--- a/test/rules/await-promise/custom-promise/test.ts.lint
+++ b/test/rules/await-promise/custom-promise/test.ts.lint
@@ -44,6 +44,10 @@ async function fStandardPromise() {
     await (Math.random() > 0.5 ? numberPromise : 0);
     await (Math.random() > 0.5 ? foo : 0);
     await (Math.random() > 0.5 ? bar : 0);
+
+    // intersection type
+    const intersectionPromise: Promise<number> & number;
+    await intersectionPromise;
 }
 
 async function fCustomPromise() {
@@ -65,6 +69,10 @@ async function fCustomPromise() {
     await (Math.random() > 0.5 ? numberPromise : 0);
     await (Math.random() > 0.5 ? foo : 0);
     await (Math.random() > 0.5 ? bar : 0);
+
+    // intersection type
+    const intersectionPromise: CustomPromise<number> & number;
+    await intersectionPromise;
 }
 
 [0]: 'await' of non-Promise.

--- a/test/rules/await-promise/es6-promise/test.ts.lint
+++ b/test/rules/await-promise/es6-promise/test.ts.lint
@@ -42,6 +42,10 @@ async function fPromise() {
     await (Math.random() > 0.5 ? numberPromise : 0);
     await (Math.random() > 0.5 ? foo : 0);
     await (Math.random() > 0.5 ? bar : 0);
+
+    // intersection type
+    const intersectionPromise: Promise<number> & number;
+    await intersectionPromise;
 }
 
 [0]: 'await' of non-Promise.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2986
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Rule await-promise accepts not only union type but intersection type.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
