### PR TITLE
Fix 'trailing-comma' wrapped expression treated as multiline

### DIFF
--- a/test/rules/trailing-comma/multiline-always/test.ts.fix
+++ b/test/rules/trailing-comma/multiline-always/test.ts.fix
@@ -547,3 +547,11 @@ export {
 
 // don't crash
 new Foo
+
+const foo = array.map(item =>
+    mapArrayItem(item)
+);
+
+const foo = array.map(
+    item => mapArrayItem(item),
+);

--- a/test/rules/trailing-comma/multiline-always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-always/test.ts.lint
@@ -576,3 +576,12 @@ export {
 
 // don't crash
 new Foo
+
+const foo = array.map(item =>
+    mapArrayItem(item)
+);
+
+const foo = array.map(
+    item => mapArrayItem(item)
+                              ~nil [Missing trailing comma]
+);

--- a/test/rules/trailing-comma/multiline-custom/always/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-custom/always/test.ts.lint
@@ -576,3 +576,12 @@ export {
 
 // don't crash
 new Foo
+
+const foo = array.map(item =>
+    mapArrayItem(item)
+);
+
+const foo = array.map(
+    item => mapArrayItem(item)
+                              ~nil [Missing trailing comma]
+);

--- a/test/rules/trailing-comma/multiline-custom/ignore/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-custom/ignore/test.ts.lint
@@ -547,3 +547,11 @@ export {
 
 // don't crash
 new Foo
+
+const foo = array.map(item =>
+    mapArrayItem(item)
+);
+
+const foo = array.map(
+    item => mapArrayItem(item)
+);

--- a/test/rules/trailing-comma/multiline-custom/mixed/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-custom/mixed/test.ts.lint
@@ -76,3 +76,27 @@ interface Foo {
     foo: string;
     bar: string;
 }
+
+const foo = [isTrue
+    && valueWhenIsTrue
+    || valueWhenIsNot,
+];
+
+const foo = [
+    isTrue
+        && valueWhenIsTrue
+        || valueWhenIsNot,
+                         ~ [Unnecessary trailing comma]
+];
+
+const foo = { bar: isTrue
+    ? valueWhenIsTrue
+    : valueWhenIsNot
+};
+
+const foo = {
+    bar: isTrue
+        ? valueWhenIsTrue
+        : valueWhenIsNot
+                        ~nil [Missing trailing comma]
+};

--- a/test/rules/trailing-comma/multiline-custom/never/test.ts.fix
+++ b/test/rules/trailing-comma/multiline-custom/never/test.ts.fix
@@ -496,3 +496,10 @@ const enum Foo {
     Baz = 2
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item),
+);
+
+const foo = array.map(
+    item => mapArrayItem(item)
+);

--- a/test/rules/trailing-comma/multiline-custom/never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-custom/never/test.ts.lint
@@ -525,3 +525,11 @@ const enum Foo {
            ~ [Unnecessary trailing comma]
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item),
+);
+
+const foo = array.map(
+    item => mapArrayItem(item),
+                              ~ [Unnecessary trailing comma]
+);

--- a/test/rules/trailing-comma/multiline-never/test.ts.fix
+++ b/test/rules/trailing-comma/multiline-never/test.ts.fix
@@ -496,3 +496,10 @@ const enum Foo {
     Baz = 2
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item),
+);
+
+const foo = array.map(
+    item => mapArrayItem(item)
+);

--- a/test/rules/trailing-comma/multiline-never/test.ts.lint
+++ b/test/rules/trailing-comma/multiline-never/test.ts.lint
@@ -525,3 +525,11 @@ const enum Foo {
            ~ [Unnecessary trailing comma]
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item),
+);
+
+const foo = array.map(
+    item => mapArrayItem(item),
+                              ~ [Unnecessary trailing comma]
+);

--- a/test/rules/trailing-comma/singleline-always/test.ts.fix
+++ b/test/rules/trailing-comma/singleline-always/test.ts.fix
@@ -538,3 +538,10 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item,),
+);
+
+const foo = array.map(
+    item => mapArrayItem(item,)
+);

--- a/test/rules/trailing-comma/singleline-always/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-always/test.ts.lint
@@ -563,3 +563,11 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item,)
+                       ~nil [Missing trailing comma]
+);
+
+const foo = array.map(
+    item => mapArrayItem(item,)
+);

--- a/test/rules/trailing-comma/singleline-custom/always/test.ts.fix
+++ b/test/rules/trailing-comma/singleline-custom/always/test.ts.fix
@@ -538,3 +538,10 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item,),
+);
+
+const foo = array.map(
+    item => mapArrayItem(item,)
+);

--- a/test/rules/trailing-comma/singleline-custom/always/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-custom/always/test.ts.lint
@@ -563,3 +563,11 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item,)
+                       ~nil [Missing trailing comma]
+);
+
+const foo = array.map(
+    item => mapArrayItem(item,)
+);

--- a/test/rules/trailing-comma/singleline-custom/ignore/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-custom/ignore/test.ts.lint
@@ -538,3 +538,10 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item)
+);
+
+const foo = array.map(
+    item => mapArrayItem(item)
+);

--- a/test/rules/trailing-comma/singleline-custom/mixed/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-custom/mixed/test.ts.lint
@@ -26,3 +26,27 @@ interface Foo { foo: string, bar: string }
 interface Foo { foo: string, bar: string, }
 
 interface Foo { foo: string; bar: string; }
+
+const foo = [isTrue
+    && valueWhenIsTrue
+    || valueWhenIsNot,
+                     ~ [Unnecessary trailing comma]
+];
+
+const foo = [
+    isTrue
+        && valueWhenIsTrue
+        || valueWhenIsNot,
+];
+
+const foo = { bar: isTrue
+    ? valueWhenIsTrue
+    : valueWhenIsNot
+                    ~nil [Missing trailing comma]
+};
+
+const foo = {
+    bar: isTrue
+        ? valueWhenIsTrue
+        : valueWhenIsNot
+};

--- a/test/rules/trailing-comma/singleline-custom/never/test.ts.fix
+++ b/test/rules/trailing-comma/singleline-custom/never/test.ts.fix
@@ -498,3 +498,10 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item)
+);
+
+const foo = array.map(
+    item => mapArrayItem(item),
+);

--- a/test/rules/trailing-comma/singleline-custom/never/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-custom/never/test.ts.lint
@@ -521,3 +521,11 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item),
+                      ~ [Unnecessary trailing comma]
+);
+
+const foo = array.map(
+    item => mapArrayItem(item),
+);

--- a/test/rules/trailing-comma/singleline-never/test.ts.fix
+++ b/test/rules/trailing-comma/singleline-never/test.ts.fix
@@ -498,3 +498,10 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item)
+);
+
+const foo = array.map(
+    item => mapArrayItem(item),
+);

--- a/test/rules/trailing-comma/singleline-never/test.ts.lint
+++ b/test/rules/trailing-comma/singleline-never/test.ts.lint
@@ -521,3 +521,11 @@ const enum Foo {
     Baz = 2,
 }
 
+const foo = array.map(item =>
+    mapArrayItem(item),
+                      ~ [Unnecessary trailing comma]
+);
+
+const foo = array.map(
+    item => mapArrayItem(item),
+);


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2795 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Preface

As stated in the issue, sometimes we want multiline expressions to be treated as single-line.
That applies to long single-line expressions that we want to break for the sake of readability.

Some examples of such cases:
```ts
const foo = array.map(arrayItem =>
    new ObjectWithPrettyDamnLongConstructorName(arrayItem)
);

const foo = { bar: isStatementTrue
    ? getSomeValueForBarPropertyIfStatementIsTrue
    : getSomeValueForBarPropertyIfStatementIsFalse
};
```

Linting the code above would cause 'missing trailing comma' errors in both cases.

#### Overview of change:

Added some code to check if an expression is on the same line with a previous open token, and if so - treat it as a single-line expression.

#### CHANGELOG.md entry:

[bugfix] `trailing-comma`: treat wrapped expressions as single-line if they are on the same line
