### PR TITLE
Readme: Added link to flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Please refer to the full installation & usage documentation on the [TSLint websi
 - [core rules](https://palantir.github.io/tslint/rules/),
 - [core formatters](https://palantir.github.io/tslint/formatters/), and
 - [customization of TSLint](https://palantir.github.io/tslint/develop/custom-rules/).
+- [inline disabling and enabling of rules with comment flags](https://palantir.github.io/tslint/usage/rule-flags/)
 
 Custom Rules & Plugins
 ------------


### PR DESCRIPTION
Added a link to "inline disabling and enabling of rules with comment flags", as it a bit hard to find IMO.

#### PR checklist

- [x] Documentation update

#### Overview of change:
Added link to readme

