### PR TITLE
Readme: Added VS 2017 link, updated VS 2015 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TSLint supports:
 - inline disabling and enabling of rules with comment flags
 - configuration presets (`tslint:latest`, `tslint-react`, etc.) and plugin composition
 - automatic fixing of formatting & style violations
-- integration with [msbuild](https://github.com/joshuakgoldberg/tslint.msbuild), [grunt](https://github.com/palantir/grunt-tslint), [gulp](https://github.com/panuhorsmalahti/gulp-tslint), [atom](https://github.com/AtomLinter/linter-tslint), [eclipse](https://github.com/palantir/eclipse-tslint), [emacs](http://flycheck.org), [sublime](https://packagecontrol.io/packages/SublimeLinter-contrib-tslint), [vim](https://github.com/scrooloose/syntastic), [visual studio](https://visualstudiogallery.msdn.microsoft.com/6edc26d4-47d8-4987-82ee-7c820d79be1d), [vscode](https://marketplace.visualstudio.com/items?itemName=eg2.tslint), [webstorm](https://www.jetbrains.com/webstorm/help/tslint.html), and more
+- integration with [msbuild](https://github.com/joshuakgoldberg/tslint.msbuild), [grunt](https://github.com/palantir/grunt-tslint), [gulp](https://github.com/panuhorsmalahti/gulp-tslint), [atom](https://github.com/AtomLinter/linter-tslint), [eclipse](https://github.com/palantir/eclipse-tslint), [emacs](http://flycheck.org), [sublime](https://packagecontrol.io/packages/SublimeLinter-contrib-tslint), [vim](https://github.com/scrooloose/syntastic), [visual studio 2015](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.WebAnalyzer), [visual studio 2017](https://marketplace.visualstudio.com/items?itemName=RichNewman.TypeScriptAnalyzer) [vscode](https://marketplace.visualstudio.com/items?itemName=eg2.tslint), [webstorm](https://www.jetbrains.com/webstorm/help/tslint.html), and more
 
 Installation & Usage
 ------------


### PR DESCRIPTION
#### PR checklist

- [x] Documentation update

#### Overview of change:
The current link for Visual Studio only works for Visual Studio 2015. There are no intentions to upgrade this plugin to Visual Studio 2017 :|

There is a fork (which works well) for Visual Studio 2017, I have added that link and renamed the old "Visual Studio" link to "Visual Studio 2015"

Also updated the link to marketplace.visualstudio.com


#### Is there anything you'd like reviewers to focus on?

Nope

