### PR TITLE
one-line: bugfix for multiline type parameters

### DIFF
--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { getPreviousToken } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -262,16 +263,8 @@ class OneLineWalker extends Lint.RuleWalker {
     }
 
     private handleClassLikeDeclaration(node: ts.ClassDeclaration | ts.InterfaceDeclaration) {
-        let lastNodeOfDeclaration: ts.Node | undefined = node.name;
         const openBraceToken = Lint.childOfKind(node, ts.SyntaxKind.OpenBraceToken)!;
-
-        if (node.heritageClauses != null) {
-            lastNodeOfDeclaration = node.heritageClauses[node.heritageClauses.length - 1];
-        } else if (node.typeParameters != null) {
-            lastNodeOfDeclaration = node.typeParameters[node.typeParameters.length - 1];
-        }
-
-        this.handleOpeningBrace(lastNodeOfDeclaration, openBraceToken);
+        this.handleOpeningBrace(getPreviousToken(openBraceToken), openBraceToken);
     }
 
     private handleIterationStatement(node: ts.IterationStatement) {

--- a/test/rules/one-line/all/test.ts.lint
+++ b/test/rules/one-line/all/test.ts.lint
@@ -149,3 +149,11 @@ if (true)
     true;
 else
     false;
+
+class Foo<
+    Bar,
+    Baz,
+    Bas
+> {
+    // works for multiline type parameters
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2952
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `one-line` correctly handles multiline type parameters
Fixes: #2952

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
