### PR TITLE
requiresTypeInfo for completed-docs

### DIFF
--- a/rules/completed-docs/index.html
+++ b/rules/completed-docs/index.html
@@ -1,5 +1,6 @@
 ---
 ruleName: completed-docs
+requiresTypeInfo: true
 description: Enforces documentation for important items be filled out.
 optionsDescription: |-
 


### PR DESCRIPTION
#### PR checklist


- [X] Documentation update

#### Overview of change:
tslint told me that completed-docs needed typeInfo, so updated the docs. 

