### PR TITLE
no-unsafe-any: allow truthyness and falsyness checks

### DIFF
--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -60,6 +60,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
 
             case ts.SyntaxKind.Parameter: {
                 const { type, initializer } = node as ts.ParameterDeclaration;
+                // TODO handle destructuring
                 if (initializer !== undefined) {
                     return cb(initializer, /*anyOk*/ type !== undefined && type.kind === ts.SyntaxKind.AnyKeyword);
                 }
@@ -187,6 +188,29 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
                 return;
             }
 
+            case ts.SyntaxKind.IfStatement: {
+                const { expression, thenStatement, elseStatement } = node as ts.IfStatement;
+                cb(expression, true); // allow truthyness check
+                cb(thenStatement);
+                if (elseStatement !== undefined) { cb(elseStatement); }
+                return;
+            }
+
+            case ts.SyntaxKind.PrefixUnaryExpression: {
+                const {operator, operand} = node as ts.PrefixUnaryExpression;
+                cb(operand, operator === ts.SyntaxKind.ExclamationToken); // allow falsyness check
+                check();
+                return;
+            }
+
+            case ts.SyntaxKind.ForStatement: {
+                const { initializer, condition, incrementor, statement } = node as ts.ForStatement;
+                if (initializer !== undefined) { cb(initializer); }
+                if (condition !== undefined) { cb(condition, true); } // allow truthyness check
+                if (incrementor !== undefined) { cb(incrementor); }
+                return cb(statement);
+            }
+
             default:
                 if (!(isExpression(node) && check())) {
                     return ts.forEachChild(node, cb);
@@ -230,6 +254,8 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
                 return cb(right);
 
             case ts.SyntaxKind.CommaToken: // Allow `any, any`
+            case ts.SyntaxKind.BarBarToken: // Allow `any || any`
+            case ts.SyntaxKind.AmpersandAmpersandToken: // Allow `any && any`
                 cb(left, /*anyOk*/ true);
                 return cb(right, /*anyOk*/ true);
 

--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -211,6 +211,11 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
                 return cb(statement);
             }
 
+            case ts.SyntaxKind.DoStatement:
+            case ts.SyntaxKind.WhileStatement:
+                cb((node as ts.IterationStatement).statement);
+                return cb((node as ts.DoStatement | ts.WhileStatement).expression, true);
+
             default:
                 if (!(isExpression(node) && check())) {
                     return ts.forEachChild(node, cb);

--- a/test/rules/no-unsafe-any/test.ts.lint
+++ b/test/rules/no-unsafe-any/test.ts.lint
@@ -185,5 +185,7 @@ if (x) {}
 if (!x) {}
 if (!x || x) {}
 for (;x;) {}
+while (x) {}
+do {} while (x);
 
 [0]: Unsafe use of expression of type 'any'.

--- a/test/rules/no-unsafe-any/test.ts.lint
+++ b/test/rules/no-unsafe-any/test.ts.lint
@@ -181,4 +181,9 @@ switch (x.y) {
 
 declare global {}
 
+if (x) {}
+if (!x) {}
+if (!x || x) {}
+for (;x;) {}
+
 [0]: Unsafe use of expression of type 'any'.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2981
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `no-unsafe-any`: allow truthyness and falsyness checks
Fixes: #2981

#### Is there anything you'd like reviewers to focus on?

There's some more work to do in this rule. It simply ignores some branches of the AST like destructuring and LHS of some binary expressions. Will fix that after this PR lands.

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
