### PR TITLE
no-unbound-method: allow methods that are bound in the constructor

### DIFF
--- a/test/rules/no-unbound-method/default/test.ts.lint
+++ b/test/rules/no-unbound-method/default/test.ts.lint
@@ -1,3 +1,18 @@
+class C {
+    constructor() {
+        this.foo = 1;
+        this.methodA = this.methodA.bind(this);
+    }
+    methodA() {}
+    methodB() {}
+}
+
+const c = new C();
+// OK if bound in constructor
+[0].forEach(c.methodA);
+[0].forEach(c.methodB);
+            ~~~~~~~~~ [0]
+
 interface I { m?(): void; }
 function f(i: I) {
     i.m!();


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3016 
- [x] ~~New feature~~, bugfix, ~~or enhancement~~
  - [x] Includes tests
- [x] ~~Documentation update~~

#### Overview of change:

With this change no failure for `no-unbound-method` is added if the method is bound in the constructor.

#### Is there anything you'd like reviewers to focus on?

I’m not that familiar with the TypeScript AST so I’m not sure whether this pretty naïve implementation could be simplified or clarified.

1. Is the approach the right way to go?
2. I tried my best to keep it as readable as possible but I still find the result rather ugly. How could this be improved?
