### PR TITLE
Recognize promise then call with rejection handler as valid floating promise handling

### DIFF
--- a/src/rules/noFloatingPromisesRule.ts
+++ b/src/rules/noFloatingPromisesRule.ts
@@ -59,7 +59,9 @@ function walk(ctx: Lint.WalkContext<string[]>, tc: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
         if (isExpressionStatement(node)) {
             const { expression } = node;
-            if (isCallExpression(expression) && !isPromiseCatchCall(expression)) {
+            if (isCallExpression(expression) &&
+                !isPromiseCatchCall(expression) &&
+                !isPromiseThenCallWithRejectionHandler(expression)) {
                 const { symbol } = tc.getTypeAtLocation(expression);
                 if (symbol !== undefined && ctx.options.indexOf(symbol.name) !== -1) {
                     ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);
@@ -72,4 +74,10 @@ function walk(ctx: Lint.WalkContext<string[]>, tc: ts.TypeChecker) {
 
 function isPromiseCatchCall(expression: ts.CallExpression): boolean {
     return isPropertyAccessExpression(expression.expression) && expression.expression.name.text === "catch";
+}
+
+function isPromiseThenCallWithRejectionHandler(expression: ts.CallExpression): boolean {
+    return isPropertyAccessExpression(expression.expression) &&
+        expression.expression.name.text === "then" &&
+        expression.arguments.length >= 2;
 }

--- a/test/rules/no-floating-promises/promises/test.ts.lint
+++ b/test/rules/no-floating-promises/promises/test.ts.lint
@@ -156,4 +156,6 @@ switch(foo) {
 
 returnsPromiseFunction().catch(e => { console.error(e.stack); });
 
+returnsPromiseFunction().then(() => {}, e => { console.error(e.stack); });
+
 [0]: Promises must be handled appropriately


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2879
- [x] enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

```ts
createPromise()
  .then(() => next(), next); // No longer an error when rule `no-floating-promise` is enabled.
```

[bugfix] `no-floating-promises`: recognize rejection handler passed as second argument to `promise.then()`