### PR TITLE
no-unnecessary-qualifier: make it work with typescript@next

### DIFF
--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -98,7 +98,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
 
         // If the symbol in scope is different, the qualifier is necessary.
         const fromScope = getSymbolInScope(qualifier, accessedSymbol.flags, name.text);
-        return fromScope === undefined || fromScope === accessedSymbol;
+        return fromScope === undefined || Lint.Utils.arraysAreEqual(fromScope.declarations, accessedSymbol.declarations, (a, b) => a === b);
     }
 
     function getSymbolInScope(node: ts.Node, flags: ts.SymbolFlags, name: string): ts.Symbol | undefined {

--- a/test/rules/no-unnecessary-qualifier/arguments.ts.lint
+++ b/test/rules/no-unnecessary-qualifier/arguments.ts.lint
@@ -1,4 +1,3 @@
-[typescript]: < 2.5.0
 namespace N {
     export type T = number;
     export const x: N.T = 0;

--- a/test/rules/no-unnecessary-qualifier/test-global.ts.lint
+++ b/test/rules/no-unnecessary-qualifier/test-global.ts.lint
@@ -1,4 +1,3 @@
-[typescript]: < 2.5.0
 namespace N {
     export type T = number;
     export const x: N.T = 0;

--- a/test/rules/no-unnecessary-qualifier/test.ts.lint
+++ b/test/rules/no-unnecessary-qualifier/test.ts.lint
@@ -1,4 +1,3 @@
-[typescript]: < 2.5.0
 namespace N {
     export type T = number;
     export const x: N.T = 0;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3047
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Seems like typescript used to return the same symbol. That was changed in typescript@2.5.0-dev and caused the tests to fail.
This fix now compares the declarations of the symbols instead of checking the symbols for equality.
Fixes: #3047

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[no-log]