### PR TITLE
Handle unnamed default exports like anonymous functions (fixes #3040)

### DIFF
--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -116,8 +116,8 @@ function getOption(node: ts.Node, options: Options): Option | undefined {
             return options.constructor;
 
         case ts.SyntaxKind.FunctionDeclaration:
-            return options.named;
-
+            // name is optional for function declaration which is default export (TS will emit error in other cases).
+            // Can be handled in the same way as function expression.
         case ts.SyntaxKind.FunctionExpression:
             return (node as ts.FunctionExpression).name !== undefined ? options.named : options.anonymous;
 

--- a/test/rules/space-before-function-paren/always/test.ts.fix
+++ b/test/rules/space-before-function-paren/always/test.ts.fix
@@ -22,6 +22,9 @@ var f = function foobar (): void{
 var f = function foobar (a: string, cb: ()=>{}): void{};
 
 
+// Default export (name ommited)
+export default function () {}
+
 // Async Arrow
 // ignore
 () => {};

--- a/test/rules/space-before-function-paren/always/test.ts.lint
+++ b/test/rules/space-before-function-paren/always/test.ts.lint
@@ -34,6 +34,10 @@ var f = function foobar(a: string, cb: ()=>{}): void{};
                        ~  [space-before-function-paren]
 
 
+// Default export (name ommited)
+export default function() {}
+                       ~  [space-before-function-paren]
+
 // Async Arrow
 // ignore
 () => {};

--- a/test/rules/space-before-function-paren/mixed/test.ts.fix
+++ b/test/rules/space-before-function-paren/mixed/test.ts.fix
@@ -16,6 +16,8 @@ var f = function foobar(): void{
 };
 var f = function foobar(a: string, cb: ()=>{}): void{};
 
+// Default export (name ommited)
+export default function () {}
 
 // Async Arrow
 // ignore

--- a/test/rules/space-before-function-paren/mixed/test.ts.lint
+++ b/test/rules/space-before-function-paren/mixed/test.ts.lint
@@ -25,6 +25,9 @@ var f = function foobar (): void{
 var f = function foobar (a: string, cb: ()=>{}): void{};
                        ~  [invalid-space]
 
+// Default export (name ommited)
+export default function() {}
+                       ~  [missing-space]
 
 // Async Arrow
 // ignore

--- a/test/rules/space-before-function-paren/never/test.ts.fix
+++ b/test/rules/space-before-function-paren/never/test.ts.fix
@@ -21,6 +21,8 @@ var f = function foobar(): void{
 };
 var f = function foobar(a: string, cb: ()=>{}): void{};
 
+// Default export (name ommited)
+export default function() {}
 
 // Async Arrow
 // ignore

--- a/test/rules/space-before-function-paren/never/test.ts.lint
+++ b/test/rules/space-before-function-paren/never/test.ts.lint
@@ -33,6 +33,9 @@ var f = function foobar (): void{
 var f = function foobar (a: string, cb: ()=>{}): void{};
                        ~ [0]
 
+// Default export (name ommited)
+export default function () {}
+                       ~ [0]
 
 // Async Arrow
 // ignore


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #3040
- [X] ~New feature,~ bugfix, ~or enhancement~
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:
This PR applies options for anonymous functions expression to default exports of function declarations without name.

#### Is there anything you'd like reviewers to focus on?
With this change there are no distinction between function declarations and function expression, therefore this two cases were combined.

There is no addition check for `default` in `modifiers` for `FunctionDeclaration` because other cases with omitted name are errors in TS/JS. 

Optionally behavior for unnamed functions as default export might be controlled with separate options, however this is likely an overkill.

<!-- optional -->

#### CHANGELOG.md entry:

[bugfix] `space-before-function-paren` Handle default exports of functions without names like anonymous functions (fixes #3040)
