### PR TITLE
switch from CircleCI -> local release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ Creating a new release
 4. Commit with message `Prepare release <version>`
 5. Push your branch to GitHub and make a PR
 6. Once your PR is merged, wait for the tests to pass on CircleCI for develop
-7. Create a "Release" on GitHub with the proper tag version and notes from the changelog
-8. Run 'yarn run publish:local 4.1.0' (replace with the appropriate tag name for the release)
+7. Create a "Release" on GitHub with the proper tag version and notes from the changelog.
+   The tag should be identical to the version in `package.json`
+8. Run 'yarn run publish:local'

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Creating a new release
 
 1. Bump the version number in `package.json` and `src/linter.ts`
 2. Add release notes in `CHANGELOG.md`
-3. `yarn verify` to build the latest sources from a clean state
 4. Commit with message `Prepare release <version>`
-5. Run `npm publish`
-6. Create a git tag for the new release and push it ([see existing tags here](https://github.com/palantir/tslint/tags))
+5. Push your branch to GitHub and make a PR
+6. Once your PR is merged, wait for the tests to pass on CircleCI for develop
+7. Create a "Release" on GitHub with the proper tag version and notes from the changelog
+8. Run 'yarn run publish:local 4.1.0' (replace with the appropriate tag name for the release)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "npm-run-all -p lint:global lint:from-bin",
     "lint:global": "tslint --project test/tsconfig.json --format stylish # test includes 'src' too",
     "lint:from-bin": "node bin/tslint --project test/tsconfig.json --format stylish",
+    "publish:local": "./scripts/npmPublish.sh",
     "test": "npm-run-all test:pre -p test:mocha test:rules",
     "test:pre": "cd ./test/config && npm install --no-save",
     "test:mocha": "mocha --reporter spec --colors \"build/test/**/*Tests.js\"",

--- a/scripts/npmPublish.sh
+++ b/scripts/npmPublish.sh
@@ -1,22 +1,17 @@
 #!/usr/bin/env bash
 
-# Publishes TSLint to NPM
-# This script must be run with yarn: "yarn run publish:local gitTagToPublish"
+# Publishes TSLint to NPM based on the current version in package.json
+# This script must be run with yarn: "yarn run publish:local"
 # A user running this script must have Palantir NPM organization credentials
 
 set -e
-
-if [[ $# -ne 1 ]]; then
-    echo "usage: yarn run publish:local gitTagToPublish"
-    exit 1
-fi
 
 rm -rf tempPublish
 mkdir tempPublish
 
 git clone git@github.com:palantir/tslint.git tempPublish
 cd tempPublish
-git checkout $1
+git checkout $npm_package_version
 
 yarn install --pure-lockfile
 yarn run verify

--- a/scripts/npmPublish.sh
+++ b/scripts/npmPublish.sh
@@ -1,10 +1,33 @@
 #!/usr/bin/env bash
 
-cd $(dirname $0)/..
+# Publishes TSLint to NPM
+# This script must be run with yarn: "yarn run publish:local gitTagToPublish"
+# A user running this script must have Palantir NPM organization credentials
+
 set -e
 
-echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-chmod 0600 .npmrc
+if [[ $# -ne 1 ]]; then
+    echo "usage: yarn run publish:local gitTagToPublish"
+    exit 1
+fi
 
-echo "Publishing..."
-npm publish --tag $1
+rm -rf tempPublish
+mkdir tempPublish
+
+git clone git@github.com:palantir/tslint.git tempPublish
+cd tempPublish
+git checkout $1
+
+yarn install --pure-lockfile
+yarn run verify
+
+# courtesy of https://stackoverflow.com/a/3232082/3124288
+read -r -p "Are you sure you want to publish version $npm_package_version? [y/N] " response
+if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+    yarn publish --tag latest
+else
+    echo "Publishing aborted"
+fi
+
+cd ..
+rm -rf tempPublish


### PR DESCRIPTION
**Warning: When this PR is merged `NPM_TOKEN` should be deleted from the CircleCI environment variables.**

- [x] Related to https://github.com/palantir/tslint/issues/2985
- [x] Documentation update

#### Overview of change:
Switches from a GH/CircleCI based publishing flow to a local one. This allows us to add contributors to TSLint without giving them publishing/releasing permissions. 

#### Is there anything you'd like reviewers to focus on?
Does the local publishing script seem reasonable? Does re-cloning the repo to a temporary directory seem reasonable? I tested the script myself, but obviously didn't publish an actual release.

Possible improvements to this PR:
* We could probably automate the creation of the git tag as well. For now, I decided to leave it as a manual step (since you have to paste the changelog into GH anyways).
* I only test the build locally with one version of TS. We could do what we do on CircleCI and make `publish:local` run the tests with multiple versions of TS.