### PR TITLE
no-unused-variable: don't crash at destructuring

### DIFF
--- a/test/rules/no-unused-variable/type-checked/destructuring.ts.lint
+++ b/test/rules/no-unused-variable/type-checked/destructuring.ts.lint
@@ -1,0 +1,6 @@
+import { SomeClass, someVar } from "./some.test";
+const person = { name: "alice" };
+const { name } = person;
+        ~~~~ ['name' is declared but never used.]
+
+export const {prop} = someVar;

--- a/test/rules/no-unused-variable/type-checked/some.test.ts
+++ b/test/rules/no-unused-variable/type-checked/some.test.ts
@@ -1,0 +1,3 @@
+export class SomeClass {}
+
+export const someVar = {prop: new SomeClass()};


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2876, #3001
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Avoid typescript crash when trying to get type of destructured variable declaration.
Also avoid walking the AST multiple times when `--declaration` is not enabled. That should result in better performance and fewer false negatives.

[bugfix] `no-unused-variable` fixed crash when using destructuring
Fixes: #2876
Fixes: #3001

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
