### PR TITLE
Use ReadonlyArray for node arrays

### DIFF
--- a/src/rules/adjacentOverloadSignaturesRule.ts
+++ b/src/rules/adjacentOverloadSignaturesRule.ts
@@ -64,12 +64,12 @@ function walk(ctx: Lint.WalkContext<void>): void {
         return ts.forEachChild(node, cb);
     });
 
-    function visitStatements(statements: ts.Statement[]): void {
+    function visitStatements(statements: ReadonlyArray<ts.Statement>): void {
         addFailures(getMisplacedOverloads(statements, (statement) =>
             utils.isFunctionDeclaration(statement) && statement.name !== undefined ? statement.name.text : undefined));
     }
 
-    function addFailures(misplacedOverloads: ts.SignatureDeclaration[]): void {
+    function addFailures(misplacedOverloads: ReadonlyArray<ts.SignatureDeclaration>): void {
         for (const node of misplacedOverloads) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING(printOverload(node)));
         }
@@ -77,7 +77,9 @@ function walk(ctx: Lint.WalkContext<void>): void {
 }
 
 /** 'getOverloadName' may return undefined for nodes that cannot be overloads, e.g. a `const` declaration. */
-function getMisplacedOverloads<T extends ts.Node>(overloads: T[], getKey: (node: T) => string | undefined): ts.SignatureDeclaration[] {
+function getMisplacedOverloads<T extends ts.Node>(
+    overloads: ReadonlyArray<T>,
+    getKey: (node: T) => string | undefined): ts.SignatureDeclaration[] {
     const result: ts.SignatureDeclaration[] = [];
     let lastKey: string | undefined;
     const seen = new Set<string>();

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -151,7 +151,7 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
         return cb(sourceFile);
     }
 
-    private checkAlignment(nodes: ts.Node[], kind: string) {
+    private checkAlignment(nodes: ReadonlyArray<ts.Node>, kind: string) {
         if (nodes.length <= 1) {
             return;
         }

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -264,7 +264,7 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
     }
 
     /** Finds the lowest name higher than 'targetName'. */
-    private findLowerName(members: Member[], targetRank: Rank, targetName: string): string {
+    private findLowerName(members: ReadonlyArray<Member>, targetRank: Rank, targetName: string): string {
         for (const member of members) {
             if (member.name === undefined || this.memberRank(member) !== targetRank) {
                 continue;
@@ -278,7 +278,7 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
     }
 
     /** Finds the highest existing rank lower than `targetRank`. */
-    private findLowerRank(members: Member[], targetRank: Rank): Rank | -1 {
+    private findLowerRank(members: ReadonlyArray<Member>, targetRank: Rank): Rank | -1 {
         let max: Rank | -1 = -1;
         for (const member of members) {
             const rank = this.memberRank(member);

--- a/src/rules/noInternalModuleRule.ts
+++ b/src/rules/noInternalModuleRule.ts
@@ -46,7 +46,7 @@ class NoInternalModuleWalker extends Lint.AbstractWalker<void> {
         return this.checkStatements(sourceFile.statements);
     }
 
-    private checkStatements(statements: ts.Statement[]) {
+    private checkStatements(statements: ReadonlyArray<ts.Statement>) {
         for (const statement of statements) {
             if (statement.kind === ts.SyntaxKind.ModuleDeclaration) {
                 this.checkModuleDeclaration(statement as ts.ModuleDeclaration);

--- a/src/rules/noMergeableNamespaceRule.ts
+++ b/src/rules/noMergeableNamespaceRule.ts
@@ -46,7 +46,7 @@ class Walker extends Lint.AbstractWalker<void> {
         return this.checkStatements(node.statements);
     }
 
-    private checkStatements(statements: ts.Statement[]): void {
+    private checkStatements(statements: ReadonlyArray<ts.Statement>): void {
         const seen = new Map<string, ts.NamespaceDeclaration>();
 
         for (const statement of statements) {

--- a/src/rules/noReferenceImportRule.ts
+++ b/src/rules/noReferenceImportRule.ts
@@ -55,7 +55,7 @@ class NoReferenceImportWalker extends Lint.AbstractWalker<void> {
         }
     }
 
-    private findImports(statements: ts.Statement[]) {
+    private findImports(statements: ReadonlyArray<ts.Statement>) {
         for (const statement of statements) {
             if (isImportDeclaration(statement)) {
                 this.addImport(statement.moduleSpecifier);

--- a/src/rules/noUnnecessaryInitializerRule.ts
+++ b/src/rules/noUnnecessaryInitializerRule.ts
@@ -90,7 +90,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
     }
 }
 
-function parametersAllOptionalAfter(parameters: ts.ParameterDeclaration[], idx: number): boolean {
+function parametersAllOptionalAfter(parameters: ReadonlyArray<ts.ParameterDeclaration>, idx: number): boolean {
     for (let i = idx + 1; i < parameters.length; i++) {
         if (parameters[i].questionToken !== undefined) {
             return true;

--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -162,7 +162,7 @@ function mapPropertyName(property: ts.ObjectLiteralElementLike): ts.StringLitera
     return property.name;
 }
 
-function hasInconsistentQuotes(properties: ts.LiteralLikeNode[]) {
+function hasInconsistentQuotes(properties: ReadonlyArray<ts.LiteralLikeNode>) {
     if (properties.length < 2) {
         return false;
     }

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -302,7 +302,7 @@ function flipCase(str: string): string {
 
 // After applying a transformation, are the nodes sorted according to the text they contain?
 // If not, return the pair of nodes which are out of order.
-function findUnsortedPair(xs: ts.Node[], transform: (x: string) => string): [ts.Node, ts.Node] | undefined {
+function findUnsortedPair(xs: ReadonlyArray<ts.Node>, transform: (x: string) => string): [ts.Node, ts.Node] | undefined {
     for (let i = 1; i < xs.length; i++) {
         if (transform(xs[i].getText()) < transform(xs[i - 1].getText())) {
             return [xs[i - 1], xs[i]];
@@ -336,7 +336,7 @@ function removeQuotes(value: string): string {
     return value;
 }
 
-function sortByKey<T>(xs: T[], getSortKey: (x: T) => string): T[] {
+function sortByKey<T>(xs: ReadonlyArray<T>, getSortKey: (x: T) => string): T[] {
     return xs.slice().sort((a, b) => compare(getSortKey(a), getSortKey(b)));
 }
 

--- a/src/rules/unifiedSignaturesRule.ts
+++ b/src/rules/unifiedSignaturesRule.ts
@@ -77,7 +77,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
         return ts.forEachChild(node, cb);
     });
 
-    function checkStatements(statements: ts.Statement[]): void {
+    function checkStatements(statements: ReadonlyArray<ts.Statement>): void {
         addFailures(checkOverloads(statements, undefined, (statement) => {
             if (utils.isFunctionDeclaration(statement)) {
                 const { body, name } = statement;
@@ -88,7 +88,9 @@ function walk(ctx: Lint.WalkContext<void>): void {
         }));
     }
 
-    function checkMembers(members: Array<ts.TypeElement | ts.ClassElement>, typeParameters?: ts.TypeParameterDeclaration[]): void {
+    function checkMembers(
+        members: ReadonlyArray<ts.TypeElement | ts.ClassElement>,
+        typeParameters?: ReadonlyArray<ts.TypeParameterDeclaration>): void {
         addFailures(checkOverloads(members, typeParameters, (member) => {
             switch (member.kind) {
                 case ts.SyntaxKind.CallSignature:
@@ -149,8 +151,8 @@ type Unify =
     | { kind: "extra-parameter"; extraParameter: ts.ParameterDeclaration; otherSignature: ts.NodeArray<ts.ParameterDeclaration> };
 
 function checkOverloads<T>(
-        signatures: T[],
-        typeParameters: ts.TypeParameterDeclaration[] | undefined,
+        signatures: ReadonlyArray<T>,
+        typeParameters: ReadonlyArray<ts.TypeParameterDeclaration> | undefined,
         getOverload: GetOverload<T>): Failure[] {
     const result: Failure[] = [];
     const isTypeParameter = getIsTypeParameter(typeParameters);
@@ -192,7 +194,7 @@ function signaturesCanBeUnified(a: ts.SignatureDeclaration, b: ts.SignatureDecla
 }
 
 /** Detect `a(x: number, y: number, z: number)` and `a(x: number, y: string, z: number)`. */
-function signaturesDifferBySingleParameter(types1: ts.ParameterDeclaration[], types2: ts.ParameterDeclaration[],
+function signaturesDifferBySingleParameter(types1: ReadonlyArray<ts.ParameterDeclaration>, types2: ReadonlyArray<ts.ParameterDeclaration>,
     ): Unify | undefined {
     const index = getIndexOfFirstDifference(types1, types2, parametersAreEqual);
     if (index === undefined) {
@@ -258,7 +260,7 @@ type GetOverload<T> = (node: T) => { signature: ts.SignatureDeclaration; key: st
 type IsTypeParameter = (typeName: string) => boolean;
 
 /** Given type parameters, returns a function to test whether a type is one of those parameters. */
-function getIsTypeParameter(typeParameters?: ts.TypeParameterDeclaration[]): IsTypeParameter {
+function getIsTypeParameter(typeParameters?: ReadonlyArray<ts.TypeParameterDeclaration>): IsTypeParameter {
     if (typeParameters === undefined) {
         return () => false;
     }
@@ -289,7 +291,7 @@ function signatureUsesTypeParameter(sig: ts.SignatureDeclaration, isTypeParamete
  * Given all signatures, collects an array of arrays of signatures which are all overloads.
  * Does not rely on overloads being adjacent. This is similar to code in adjacentOverloadSignaturesRule.ts, but not the same.
  */
-function collectOverloads<T>(nodes: T[], getOverload: GetOverload<T>): ts.SignatureDeclaration[][] {
+function collectOverloads<T>(nodes: ReadonlyArray<T>, getOverload: GetOverload<T>): ts.SignatureDeclaration[][] {
     const map = new Map<string, ts.SignatureDeclaration[]>();
     for (const sig of nodes) {
         const overload = getOverload(sig);
@@ -333,7 +335,7 @@ function typesAreEqual(a: ts.TypeNode | undefined, b: ts.TypeNode | undefined): 
 }
 
 /** Returns the first index where `a` and `b` differ. */
-function getIndexOfFirstDifference<T>(a: T[], b: T[], equal: Equal<T>): number | undefined {
+function getIndexOfFirstDifference<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>, equal: Equal<T>): number | undefined {
     for (let i = 0; i < a.length && i < b.length; i++) {
         if (!equal(a[i], b[i])) {
             return i;
@@ -343,7 +345,7 @@ function getIndexOfFirstDifference<T>(a: T[], b: T[], equal: Equal<T>): number |
 }
 
 /** Calls `action` for every pair of values in `values`. */
-function forEachPair<T, Out>(values: T[], action: (a: T, b: T) => Out | undefined): Out | undefined {
+function forEachPair<T, Out>(values: ReadonlyArray<T>, action: (a: T, b: T) => Out | undefined): Out | undefined {
     for (let i = 0; i < values.length; i++) {
         for (let j = i + 1; j < values.length; j++) {
             const result = action(values[i], values[j]);

--- a/src/rules/useDefaultTypeParameterRule.ts
+++ b/src/rules/useDefaultTypeParameterRule.ts
@@ -42,8 +42,8 @@ export class Rule extends Lint.Rules.TypedRule {
 }
 
 interface ArgsAndParams {
-    typeArguments: ts.TypeNode[];
-    typeParameters: ts.TypeParameterDeclaration[];
+    typeArguments: ReadonlyArray<ts.TypeNode>;
+    typeParameters: ReadonlyArray<ts.TypeParameterDeclaration>;
 }
 
 function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
@@ -99,7 +99,7 @@ function getArgsAndParameters(node: ts.Node, checker: ts.TypeChecker): ArgsAndPa
     }
 }
 
-function typeParamsFromCall(node: ts.CallLikeExpression, checker: ts.TypeChecker): ts.TypeParameterDeclaration[] | undefined {
+function typeParamsFromCall(node: ts.CallLikeExpression, checker: ts.TypeChecker): ReadonlyArray<ts.TypeParameterDeclaration> | undefined {
     const sig = checker.getResolvedSignature(node);
     const sigDecl = sig === undefined ? undefined : sig.getDeclaration();
     if (sigDecl === undefined) {
@@ -109,7 +109,9 @@ function typeParamsFromCall(node: ts.CallLikeExpression, checker: ts.TypeChecker
     return sigDecl.typeParameters === undefined ? undefined : sigDecl.typeParameters;
 }
 
-function typeParamsFromType(type: ts.EntityName | ts.Expression, checker: ts.TypeChecker): ts.TypeParameterDeclaration[] | undefined {
+function typeParamsFromType(
+    type: ts.EntityName | ts.Expression,
+    checker: ts.TypeChecker): ReadonlyArray<ts.TypeParameterDeclaration> | undefined {
     const sym = getAliasedSymbol(checker.getSymbolAtLocation(type), checker);
     if (sym === undefined || sym.declarations === undefined) {
         return undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,7 +124,7 @@ export function escapeRegExp(re: string): string {
 /** Return true if both parameters are equal. */
 export type Equal<T> = (a: T, b: T) => boolean;
 
-export function arraysAreEqual<T>(a: T[] | undefined, b: T[] | undefined, eq: Equal<T>): boolean {
+export function arraysAreEqual<T>(a: ReadonlyArray<T> | undefined, b: ReadonlyArray<T> | undefined, eq: Equal<T>): boolean {
     return a === b || a !== undefined && b !== undefined && a.length === b.length && a.every((x, idx) => eq(x, b[idx]));
 }
 
@@ -140,7 +140,7 @@ export function find<T, U>(inputs: T[], getResult: (t: T) => U | undefined): U |
 }
 
 /** Returns an array that is the concatenation of all output arrays. */
-export function flatMap<T, U>(inputs: T[], getOutputs: (input: T, index: number) => U[]): U[] {
+export function flatMap<T, U>(inputs: ReadonlyArray<T>, getOutputs: (input: T, index: number) => ReadonlyArray<U>): U[] {
     const out = [];
     for (let i = 0; i < inputs.length; i++) {
         out.push(...getOutputs(inputs[i], i));


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

A recent change to TypeScript (Microsoft/TypeScript#17213) specified the NodeArray type to be readonly. This doesn't change the run-time behavior but will cause compile-time errors if compiling against ts2.5. This is fixed by changing types for node arrays to use the ReadonlyArray type.
