### PR TITLE
Add new rule: grouped-imports

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -182,6 +182,7 @@ export const rules = {
     // "file-header": No sensible default
     "deprecation": true,
     "encoding": true,
+    "grouped-imports": true,
     "import-spacing": true,
     "interface-name": true,
     "interface-over-type-literal": true,

--- a/src/configs/latest.ts
+++ b/src/configs/latest.ts
@@ -46,6 +46,7 @@ export const rules = {
 
     // added in v5.6
     "no-duplicate-imports": true,
+    "grouped-imports": true,
 };
 // tslint:enable object-literal-sort-keys
 

--- a/src/rules/groupedImportsRule.ts
+++ b/src/rules/groupedImportsRule.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "tslint";
+import { isImportDeclaration } from "tsutils";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "grouped-imports",
+        description: "Separate import groups by blank lines.",
+        rationale: "Keeps a clear overview on dependencies.",
+        optionsDescription: "Not configurable.",
+        hasFix: true,
+        options: {},
+        optionExamples: [true],
+        type: "style",
+        typescriptOnly: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static IMPORT_SOURCES_SEPARATED = "Import sources within a group must not be separated by blank lines";
+    public static IMPORT_SOURCES_NOT_SEPARATED =
+        "Import sources of different groups must be separated by a single blank line";
+    public static IMPORT_SOURCES_ORDER =
+        "Import sources of different groups must be sorted by: libraries, parent directories, current directory";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new Walker(sourceFile, this.ruleName, this.getOptions()));
+    }
+}
+
+enum ImportStatementType {
+    LIBRARY_IMPORT = 1,
+    PARENT_DIRECTORY_IMPORT = 2,
+    CURRENT_DIRECTORY_IMPORT = 3,
+}
+
+interface ImportStatement {
+    statement: ts.Statement;
+    type: ImportStatementType;
+    lineStart: number;
+    lineEnd: number;
+}
+
+class Walker extends Lint.AbstractWalker<Lint.IOptions> {
+    private lastImportStatement: ImportStatement;
+
+    private static getImportStatementType(statement: ts.Statement): ImportStatementType {
+        const path = Walker.getImportPath(statement);
+        if (path.charAt(0) === ".") {
+            if (path.charAt(1) === ".") {
+                return ImportStatementType.PARENT_DIRECTORY_IMPORT;
+            } else {
+                return ImportStatementType.CURRENT_DIRECTORY_IMPORT;
+            }
+        } else {
+            return ImportStatementType.LIBRARY_IMPORT;
+        }
+    }
+
+    private static getImportPath(statement: ts.Statement): string {
+        const str = statement.getText();
+        let index;
+        let lastIndex;
+        index = str.indexOf("'");
+        if (index > 0) {
+            lastIndex = str.lastIndexOf("'");
+        } else {
+            index = str.indexOf("\"");
+            lastIndex = str.lastIndexOf("\"");
+        }
+        if (index < 0 || lastIndex < 0) {
+            throw new Error(`Unable to extract path from import statement \`${statement.getText()}\``);
+        }
+        return str.substring(index + 1, lastIndex);
+    }
+
+    public walk(sourceFile: ts.SourceFile): void {
+        sourceFile.statements
+            .filter(isImportDeclaration)
+            .forEach((st) => this.checkStatement(st));
+    }
+
+    private toImportStatement(statement: ts.Statement): ImportStatement {
+        return {
+            lineEnd: this.sourceFile.getLineAndCharacterOfPosition(statement.getEnd()).line,
+            lineStart: this.sourceFile.getLineAndCharacterOfPosition(statement.getStart()).line,
+            statement,
+            type: Walker.getImportStatementType(statement),
+        };
+    }
+
+    private checkStatement(statement: ts.Statement): void {
+        const importStatement = this.toImportStatement(statement);
+        if (this.lastImportStatement) {
+            this.checkImportStatement(importStatement);
+        }
+        this.lastImportStatement = importStatement;
+    }
+
+    private checkImportStatement(importStatement: ImportStatement) {
+        if (importStatement.type === this.lastImportStatement.type) {
+            if (importStatement.lineStart !== this.lastImportStatement.lineEnd + 1) {
+                const replacement = Lint.Replacement.deleteFromTo(
+                    this.lastImportStatement.statement.getEnd() + 1, importStatement.statement.getStart());
+                this.addFailureAtNode(importStatement.statement, Rule.IMPORT_SOURCES_SEPARATED, replacement);
+            }
+        } else if (importStatement.type.valueOf() < this.lastImportStatement.type.valueOf()) {
+            this.addFailureAtNode(importStatement.statement, Rule.IMPORT_SOURCES_ORDER, this.getAllImportsFix());
+        } else {
+            if (importStatement.lineStart !== this.lastImportStatement.lineEnd + 2) {
+                const replacement = Lint.Replacement.appendText(importStatement.statement.getStart(), ts.sys.newLine);
+                this.addFailureAtNode(importStatement.statement, Rule.IMPORT_SOURCES_NOT_SEPARATED, replacement);
+            }
+        }
+    }
+
+    private getAllImportsFix(): Lint.Fix {
+        const importStatements = this.sourceFile.statements.filter(isImportDeclaration);
+        const libs = importStatements.filter((st) => Walker.getImportStatementType(st) === ImportStatementType.LIBRARY_IMPORT);
+        const parent = importStatements.filter((st) => Walker.getImportStatementType(st) === ImportStatementType.PARENT_DIRECTORY_IMPORT);
+        const current = importStatements.filter((st) => Walker.getImportStatementType(st) === ImportStatementType.CURRENT_DIRECTORY_IMPORT);
+        let imports: string[] = [];
+        [libs, parent, current].forEach((statements) => {
+            if (statements.length) {
+                imports = imports.concat(statements.map((st) => st.getText()));
+                imports.push("");
+            }
+        });
+        return Lint.Replacement.replaceFromTo(
+            importStatements[0].getStart(),
+            importStatements[importStatements.length - 1].getEnd(),
+            imports.join(ts.sys.newLine),
+        );
+    }
+}

--- a/src/rules/groupedImportsRule.ts
+++ b/src/rules/groupedImportsRule.ts
@@ -34,10 +34,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static IMPORT_SOURCES_SEPARATED = "Import sources within a group must not be separated by blank lines";
-    public static IMPORT_SOURCES_NOT_SEPARATED =
-        "Import sources of different groups must be separated by a single blank line";
-    public static IMPORT_SOURCES_ORDER =
+    public static GROUPED_IMPORTS =
         "Import sources of different groups must be sorted by: libraries, parent directories, current directory";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -52,49 +49,45 @@ enum ImportStatementType {
 }
 
 interface ImportStatement {
-    statement: ts.Statement;
+    statement: ts.ImportDeclaration;
     type: ImportStatementType;
     lineStart: number;
     lineEnd: number;
 }
 
 class Walker extends Lint.AbstractWalker<Lint.IOptions> {
-    private lastImportStatement: ImportStatement;
-    private newLine: string;
-    private allImportsFix: boolean;
+    private previousImportStatement: ImportStatement | undefined;
 
     public walk(sourceFile: ts.SourceFile): void {
-        this.newLine = this.getEofChar(sourceFile);
-        sourceFile.statements
+        const importsStatements = sourceFile.statements
             .filter(isImportDeclaration)
-            .forEach(this.checkStatement);
+            .map(this.toImportStatement);
+        const firstFailure = importsStatements.find(this.isBadlyPositioned);
+        if (firstFailure != null) {
+            const fix = this.createFix(importsStatements);
+            this.addFailureAtNode(firstFailure.statement, Rule.GROUPED_IMPORTS, fix);
+        }
     }
 
-    private getEofChar(sourceFile: ts.SourceFile): string {
-        const lineEnd = sourceFile.getLineEndOfPosition(0);
-        let newLine;
-        if (lineEnd > 0) {
-            if (lineEnd > 1 && sourceFile.text[lineEnd - 1] === "\r") {
-                newLine = "\r\n";
-            } else if (sourceFile.text[lineEnd] === "\n") {
-                newLine = "\n";
+    private isBadlyPositioned = (importStatement: ImportStatement): boolean => {
+        if (this.previousImportStatement != null) {
+            if (importStatement.type === this.previousImportStatement.type) {
+                if (importStatement.lineStart !== this.previousImportStatement.lineEnd + 1) {
+                    return true;
+                }
+            } else {
+                if (importStatement.type < this.previousImportStatement.type) {
+                    return true;
+                } else if (importStatement.lineStart !== this.previousImportStatement.lineEnd + 2) {
+                    return true;
+                }
             }
         }
-        return newLine == null ? ts.sys.newLine : newLine;
+        this.previousImportStatement = importStatement;
+        return false;
     }
 
-    private checkStatement = (statement: ts.ImportDeclaration): void => {
-        if (this.allImportsFix) {
-            return;
-        }
-        const importStatement = this.toImportStatement(statement);
-        if (this.lastImportStatement != null) {
-            this.checkForFailure(importStatement);
-        }
-        this.lastImportStatement = importStatement;
-    }
-
-    private toImportStatement(statement: ts.ImportDeclaration): ImportStatement {
+    private toImportStatement = (statement: ts.ImportDeclaration): ImportStatement => {
         return {
             lineEnd: this.sourceFile.getLineAndCharacterOfPosition(statement.getEnd()).line,
             lineStart: this.sourceFile.getLineAndCharacterOfPosition(statement.getStart()).line,
@@ -123,60 +116,56 @@ class Walker extends Lint.AbstractWalker<Lint.IOptions> {
         return "";
     }
 
-    private checkForFailure(importStatement: ImportStatement): void {
-        if (importStatement.type === this.lastImportStatement.type) {
-            if (importStatement.lineStart !== this.lastImportStatement.lineEnd + 1) {
-                this.addSeparatedImportsFailure(importStatement);
+    private createFix(importStatements: ImportStatement[]): Lint.Fix {
+        const newLine = this.getEofChar(this.sourceFile);
+        const imports = this.getOrderedImports(importStatements);
+        const addition = Lint.Replacement.appendText(0, imports.join(newLine));
+        const deletions = importStatements.map((imp) => {
+            const [start, end] = this.getRangeIncludingWhitespace(imp.statement);
+            return Lint.Replacement.deleteFromTo(start, end);
+        });
+        return [...deletions, addition];
+    }
+
+    private getOrderedImports(importStatements: ImportStatement[]): string[] {
+        const libs = importStatements.filter((imp) => imp.type === ImportStatementType.LIBRARY_IMPORT);
+        const parent = importStatements.filter((imp) => imp.type === ImportStatementType.PARENT_DIRECTORY_IMPORT);
+        const current = importStatements.filter((imp) => imp.type === ImportStatementType.CURRENT_DIRECTORY_IMPORT);
+        return [libs, parent, current].reduce((arr, imps) => {
+            if (imps.length == 0) {
+                return arr;
             }
-        } else {
-            if (importStatement.type < this.lastImportStatement.type) {
-                this.addIncorrectlyOrderedImportsFailure(importStatement);
-            } else if (importStatement.lineStart !== this.lastImportStatement.lineEnd + 2) {
-                this.addNotSeparatedImportsFailure(importStatement);
+            return arr.concat(imps.map((imp) => imp.statement.getText()), "");
+        }, [] as string[]).concat("");
+    }
+
+    private getRangeIncludingWhitespace(statement: ts.ImportDeclaration): [number, number] {
+        const text = this.sourceFile.text;
+        let start = statement.getStart();
+        while (this.isWhiteSpaceChar(text[start - 1])) {
+            start--;
+        }
+        let end = statement.getEnd();
+        while (this.isWhiteSpaceChar(text[end + 1])) {
+            end++;
+        }
+        return [start, end];
+    }
+
+    private isWhiteSpaceChar(char: string | undefined): boolean {
+        return char === undefined ? false : Lint.isWhiteSpace(char.charCodeAt(0));
+    }
+
+    private getEofChar(sourceFile: ts.SourceFile): string {
+        const lineEnd = sourceFile.getLineEndOfPosition(0);
+        let newLine;
+        if (lineEnd > 0) {
+            if (lineEnd > 1 && sourceFile.text[lineEnd - 1] === "\r") {
+                newLine = "\r\n";
+            } else if (sourceFile.text[lineEnd] === "\n") {
+                newLine = "\n";
             }
         }
-    }
-
-    private addSeparatedImportsFailure(importStatement: ImportStatement): void {
-        const text = [this.lastImportStatement, importStatement]
-            .map((st) => st.statement.getText())
-            .join(this.newLine);
-        const replacement = Lint.Replacement.replaceFromTo(
-            this.lastImportStatement.statement.getStart(), importStatement.statement.getEnd(), text);
-        this.addFailureAtNode(importStatement.statement, Rule.IMPORT_SOURCES_SEPARATED, replacement);
-    }
-
-    private addIncorrectlyOrderedImportsFailure(importStatement: ImportStatement): void {
-        this.allImportsFix = true;
-        this.failures.length = 0;
-        this.addFailureAtNode(importStatement.statement, Rule.IMPORT_SOURCES_ORDER, this.getAllImportsFix());
-    }
-
-    private addNotSeparatedImportsFailure(importStatement: ImportStatement): void {
-        const replacement = Lint.Replacement.replaceFromTo(this.lastImportStatement.statement.getEnd(),
-            importStatement.statement.getStart(), this.newLine + this.newLine);
-        this.addFailureAtNode(importStatement.statement, Rule.IMPORT_SOURCES_NOT_SEPARATED, replacement);
-    }
-
-    private getAllImportsFix(): Lint.Fix {
-        const importStatements = this.sourceFile.statements.filter(isImportDeclaration);
-        const libs = importStatements.filter(
-            (st) => this.getImportStatementType(st) === ImportStatementType.LIBRARY_IMPORT);
-        const parent = importStatements.filter(
-            (st) => this.getImportStatementType(st) === ImportStatementType.PARENT_DIRECTORY_IMPORT);
-        const current = importStatements.filter(
-            (st) => this.getImportStatementType(st) === ImportStatementType.CURRENT_DIRECTORY_IMPORT);
-        let imports: string[] = [];
-        [libs, parent, current].forEach((statements) => {
-            if (statements.length > 0) {
-                imports = imports.concat(statements.map((st) => st.getText()));
-                imports.push("");
-            }
-        });
-        return Lint.Replacement.replaceFromTo(
-            importStatements[0].getStart(),
-            importStatements[importStatements.length - 1].getEnd(),
-            imports.join(this.newLine),
-        );
+        return newLine == null ? ts.sys.newLine : newLine;
     }
 }

--- a/test/rules/grouped-imports/bad-order.ts.fix
+++ b/test/rules/grouped-imports/bad-order.ts.fix
@@ -1,0 +1,6 @@
+import {foo} from 'foo';
+
+import {bar} from '../bar';
+
+import './baz';
+

--- a/test/rules/grouped-imports/bad-order.ts.lint
+++ b/test/rules/grouped-imports/bad-order.ts.lint
@@ -1,0 +1,6 @@
+import {bar} from '../bar';
+
+import {foo} from 'foo';
+~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be sorted by: libraries, parent directories, current directory]
+
+import './baz';

--- a/test/rules/grouped-imports/different-groups.ts.fix
+++ b/test/rules/grouped-imports/different-groups.ts.fix
@@ -1,3 +1,5 @@
 import {foo} from 'foo';
 
 import {bar} from '../bar';
+
+

--- a/test/rules/grouped-imports/different-groups.ts.fix
+++ b/test/rules/grouped-imports/different-groups.ts.fix
@@ -1,0 +1,3 @@
+import {foo} from 'foo';
+
+import {bar} from '../bar';

--- a/test/rules/grouped-imports/different-groups.ts.lint
+++ b/test/rules/grouped-imports/different-groups.ts.lint
@@ -1,3 +1,3 @@
 import {foo} from 'foo';
 import {bar} from '../bar';
-~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be separated by a single blank line]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be sorted by: libraries, parent directories, current directory]

--- a/test/rules/grouped-imports/different-groups.ts.lint
+++ b/test/rules/grouped-imports/different-groups.ts.lint
@@ -1,0 +1,3 @@
+import {foo} from 'foo';
+import {bar} from '../bar';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be separated by a single blank line]

--- a/test/rules/grouped-imports/mixed.ts.fix
+++ b/test/rules/grouped-imports/mixed.ts.fix
@@ -1,0 +1,6 @@
+import {foo} from 'foo';
+
+import {bar} from '../bar';
+
+import './baz';
+

--- a/test/rules/grouped-imports/mixed.ts.lint
+++ b/test/rules/grouped-imports/mixed.ts.lint
@@ -1,0 +1,5 @@
+import {bar} from '../bar';
+
+import {foo} from 'foo';
+~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be sorted by: libraries, parent directories, current directory]
+import './baz';

--- a/test/rules/grouped-imports/same-group.ts.fix
+++ b/test/rules/grouped-imports/same-group.ts.fix
@@ -1,0 +1,2 @@
+import {foo} from 'foo';
+import {bar} from 'bar';

--- a/test/rules/grouped-imports/same-group.ts.fix
+++ b/test/rules/grouped-imports/same-group.ts.fix
@@ -1,2 +1,3 @@
 import {foo} from 'foo';
 import {bar} from 'bar';
+

--- a/test/rules/grouped-imports/same-group.ts.lint
+++ b/test/rules/grouped-imports/same-group.ts.lint
@@ -1,4 +1,4 @@
 import {foo} from 'foo';
 
 import {bar} from 'bar';
-~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources within a group must not be separated by blank lines]
+~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be sorted by: libraries, parent directories, current directory]

--- a/test/rules/grouped-imports/same-group.ts.lint
+++ b/test/rules/grouped-imports/same-group.ts.lint
@@ -1,0 +1,4 @@
+import {foo} from 'foo';
+
+import {bar} from 'bar';
+~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources within a group must not be separated by blank lines]

--- a/test/rules/grouped-imports/single-line.ts.fix
+++ b/test/rules/grouped-imports/single-line.ts.fix
@@ -1,0 +1,4 @@
+import bar from "bar";
+import foo from "foo";
+
+import {baz} from "./baz";

--- a/test/rules/grouped-imports/single-line.ts.fix
+++ b/test/rules/grouped-imports/single-line.ts.fix
@@ -2,3 +2,5 @@ import bar from "bar";
 import foo from "foo";
 
 import {baz} from "./baz";
+
+

--- a/test/rules/grouped-imports/single-line.ts.lint
+++ b/test/rules/grouped-imports/single-line.ts.lint
@@ -1,0 +1,3 @@
+import bar from "bar";import foo from "foo";import {baz} from "./baz";
+                      ~~~~~~~~~~~~~~~~~~~~~~                           [Import sources within a group must not be separated by blank lines]
+                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be separated by a single blank line]

--- a/test/rules/grouped-imports/single-line.ts.lint
+++ b/test/rules/grouped-imports/single-line.ts.lint
@@ -1,3 +1,2 @@
 import bar from "bar";import foo from "foo";import {baz} from "./baz";
-                      ~~~~~~~~~~~~~~~~~~~~~~                           [Import sources within a group must not be separated by blank lines]
-                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be separated by a single blank line]
+                      ~~~~~~~~~~~~~~~~~~~~~~                           [Import sources of different groups must be sorted by: libraries, parent directories, current directory]

--- a/test/rules/grouped-imports/statements.ts.fix
+++ b/test/rules/grouped-imports/statements.ts.fix
@@ -1,0 +1,13 @@
+import {foo} from 'foo';
+
+import {bar} from '../bar';
+
+import './baz';
+
+let bar2 = false;
+
+const one = 1; // some comment
+
+const two = 2;
+// another comment
+let q = 'a';

--- a/test/rules/grouped-imports/statements.ts.fix
+++ b/test/rules/grouped-imports/statements.ts.fix
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import {foo} from 'foo';
 
 import {bar} from '../bar';
@@ -10,4 +12,5 @@ const one = 1; // some comment
 
 const two = 2;
 // another comment
+
 let q = 'a';

--- a/test/rules/grouped-imports/statements.ts.lint
+++ b/test/rules/grouped-imports/statements.ts.lint
@@ -1,0 +1,13 @@
+import {bar} from '../bar';let bar2 = false;
+
+const one = 1;
+
+import {foo} from 'foo'; // some comment
+~~~~~~~~~~~~~~~~~~~~~~~~                 [Import sources of different groups must be sorted by: libraries, parent directories, current directory]
+
+const two = 2;
+// another comment
+
+import './baz';
+
+let q = 'a';

--- a/test/rules/grouped-imports/statements.ts.lint
+++ b/test/rules/grouped-imports/statements.ts.lint
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import {bar} from '../bar';let bar2 = false;
 
 const one = 1;

--- a/test/rules/grouped-imports/tslint.json
+++ b/test/rules/grouped-imports/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "grouped-imports": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -32,6 +32,7 @@
 
     // TODO: Enable these
     "completed-docs": false,
+    "grouped-imports": false,
     "no-any": false,
     "no-magic-numbers": false,
     "no-non-null-assertion": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,9 +1502,9 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
+typescript@~2.4.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
 
 uglify-js@^2.6:
   version "2.8.28"


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Adds new rule to verify imports are grouped by libraries, parent directories & current directory.

#### Is there anything you'd like reviewers to focus on?

The fixes for too many/few blank lines fix a single import statement. The fix for changing the order fixes all imports statements completely. I am not sure this is OK.

#### CHANGELOG.md entry:

[new-rule] `grouped-imports`