### PR TITLE
Improve CLI error message when no files are specified

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -232,7 +232,7 @@ if (parsed.unknown.length !== 0) {
 const argv = commander.opts() as any as Argv;
 
 if (!(argv.init || argv.test !== undefined || argv.project !== undefined || commander.args.length > 0)) {
-    console.error("Missing files");
+    console.error("No files specified. Use --project to lint a project folder.");
     process.exit(1);
 }
 

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -37,7 +37,9 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
                 assert.isNotNull(err, "process should exit with error");
                 assert.strictEqual(err.code, 1, "error code should be 1");
 
-                assert.include(stderr, "Missing files", "stderr should contain notification about missing files");
+                assert.include(stderr,
+                    "No files specified. Use --project to lint a project folder.",
+                    "stderr should contain notification about ");
                 assert.strictEqual(stdout, "", "shouldn't contain any output in stdout");
                 done();
             });

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -39,7 +39,7 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
                 assert.include(stderr,
                     "No files specified. Use --project to lint a project folder.",
-                    "stderr should contain notification about ");
+                    "stderr should contain notification about missing files");
                 assert.strictEqual(stdout, "", "shouldn't contain any output in stdout");
                 done();
             });


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1664 
- [x] Includes tests

#### Overview of change:

The `tslint` CLI now gives an unhelpful `Missing files ` error when you do not specify any files to lint or the --project argument.

![tslint-err1](https://user-images.githubusercontent.com/8173903/28487367-e131c59c-6ee2-11e7-9693-0dd7f1c07ef2.png)

This PR improves the error message so future people won't have to google it like I did :)...

![tslint-err2](https://user-images.githubusercontent.com/8173903/28487374-f349c446-6ee2-11e7-9549-b47e3dc13256.png)

I have updated and run the tests.

#### CHANGELOG.md entry:

[enhancement] Improved CLI error message when no filenames are specified
