### PR TITLE
Implement new rule no-duplicate-imports

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -145,6 +145,7 @@ export const rules = {
     "max-file-line-count": [true, 1000],
     "max-line-length": [true, 120],
     "no-default-export": true,
+    "no-duplicate-imports": true,
     "no-irregular-whitespace": true,
     "no-mergeable-namespace": true,
     "no-require-imports": true,

--- a/src/configs/latest.ts
+++ b/src/configs/latest.ts
@@ -43,6 +43,9 @@ export const rules = {
     ],
     "no-this-assignment": true,
     "space-within-parens": [true, 0],
+
+    // added in v5.6
+    "no-duplicate-imports": true,
 };
 // tslint:enable object-literal-sort-keys
 

--- a/src/rules/noDuplicateImportsRule.ts
+++ b/src/rules/noDuplicateImportsRule.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isImportDeclaration, isModuleDeclaration, isTextualLiteral } from "tsutils";
+import * as ts from "typescript";
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-duplicate-imports",
+        description: Lint.Utils.dedent`
+            Disallows multiple import statements from the same module.`,
+        rationale: Lint.Utils.dedent`
+            Using a single import statement per module will make the code clearer because you can see everything being imported
+            from that module on one line.`,
+        optionsDescription: "Not configurable",
+        options: null,
+        optionExamples: [true],
+        type: "maintainability",
+        typescriptOnly: false,
+    };
+
+    public static FAILURE_STRING(module: string) {
+        return `Multiple imports from '${module}' can be combined into one.`;
+    }
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoDuplicateImportsWalker(sourceFile, this.ruleName, undefined));
+    }
+}
+
+class NoDuplicateImportsWalker extends Lint.AbstractWalker<void> {
+    private seenImports = new Set<string>();
+
+    public walk(sourceFile: ts.SourceFile) {
+        this.checkStatements(sourceFile.statements);
+    }
+
+    private checkStatements(statements: ts.NodeArray<ts.Statement>) {
+        for (const statement of statements) {
+            if (isImportDeclaration(statement)) {
+                this.checkImport(statement);
+            } else if (this.sourceFile.isDeclarationFile && isModuleDeclaration(statement) &&
+                statement.body !== undefined && statement.name.kind === ts.SyntaxKind.StringLiteral) {
+                // module augmentations in declaration files can contain imports
+                this.checkStatements((statement.body as ts.ModuleBlock).statements);
+            }
+        }
+    }
+
+    private checkImport(statement: ts.ImportDeclaration) {
+        if (isTextualLiteral(statement.moduleSpecifier)) {
+            if (this.seenImports.has(statement.moduleSpecifier.text)) {
+                return this.addFailureAtNode(statement, Rule.FAILURE_STRING(statement.moduleSpecifier.text));
+            }
+            this.seenImports.add(statement.moduleSpecifier.text);
+        }
+    }
+}

--- a/test/rules/no-duplicate-imports/test.d.ts.lint
+++ b/test/rules/no-duplicate-imports/test.d.ts.lint
@@ -1,0 +1,7 @@
+import * as fs from 'fs';
+declare module "foo" {
+    import {readFile} from 'fs';
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Multiple imports from 'fs' can be combined into one.]
+}
+
+declare module "*";

--- a/test/rules/no-duplicate-imports/test.ts.lint
+++ b/test/rules/no-duplicate-imports/test.ts.lint
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+import {readFile} from 'fs';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ('fs')]
+
+import * as path from 'path';
+
+import {writeFileSync as wfs} from 'fs';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ('fs')]
+
+import {parse} from 'url';
+import {format} from 'url';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ('url')]
+
+import foo from './foo';
+import {bar} from './foo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ('./foo')]
+
+import {writeFile} from './fs';
+
+[err]: Multiple imports from '%s' can be combined into one.

--- a/test/rules/no-duplicate-imports/tslint.json
+++ b/test/rules/no-duplicate-imports/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-duplicate-imports": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2869
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
[new-rule] `no-duplicate-imports`
Fixes: #2869

#### Is there anything you'd like reviewers to focus on?

Some thoughts about the current implemenation:
* There no option `includeExports` like in the ESLint rule. Do we want this?
* ImportEqualsDeclarations are ignored
* There's no fixer. That can be added later.
* In some cases you cannot simply merge imports. The rule will still complain about them (maybe the error message should be changed?):

```ts
import foo from 'foo';
import foo2 from 'foo'; // cannot be combined with preceding import

import * as bar from 'bar';
import {baz} from 'bar'; // cannot be combined with preceding import
```

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
