### PR TITLE
Only import ./test when needed

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -32,7 +32,6 @@ import {
 import { FatalError } from "./error";
 import { LintResult } from "./index";
 import * as Linter from "./linter";
-import { consoleTestResultsHandler, runTests } from "./test";
 import { arrayify, flatMap } from "./utils";
 
 export interface Options {
@@ -141,8 +140,9 @@ async function runWorker(options: Options, logger: Logger): Promise<Status> {
     }
 
     if (options.test) {
-        const results = runTests((options.files || []).map(trimSingleQuotes), options.rulesDirectory);
-        return consoleTestResultsHandler(results) ? Status.Ok : Status.FatalError;
+        const test = await import("./test");
+        const results = test.runTests((options.files || []).map(trimSingleQuotes), options.rulesDirectory);
+        return test.consoleTestResultsHandler(results) ? Status.Ok : Status.FatalError;
     }
 
     if (options.config && !fs.existsSync(options.config)) {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3072
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Only import the sources needed for rule tests if the `--test` option is used. ~That fixes #3072 for our standard users. Developers using the `--test` feature might still have trouble with the missing `./test` directory caused by `yarn clean`.~
That avoid loading unnecessary modules like `colors`, `diff`, `semver` and everything in `src/test/`

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
