### PR TITLE
Add "check-type-operator" option for whitespace rule

### DIFF
--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -112,3 +112,9 @@ const foo = [ ...bar ];
 function foo (bar, ...baz) {}
 
 const { foo, ...bar } = baz;
+
+type A = number | string;
+
+type B = number | string | {result: string};
+
+type C = {result: string} & {type: "A" | "B"};

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -173,3 +173,19 @@ function foo (bar, ... baz) {}
 
 const { foo, ... bar } = baz;
                 ~ [invalid whitespace]
+
+type A = number|string;
+               ~        [missing whitespace]
+                ~       [missing whitespace]
+
+type B = number|string|{result: string};
+               ~                         [missing whitespace]
+                ~                        [missing whitespace]
+                      ~                  [missing whitespace]
+                       ~                 [missing whitespace]
+
+type C = {result: string}&{type: "A"|"B"};
+                         ~                 [missing whitespace]
+                          ~                [missing whitespace]
+                                    ~      [missing whitespace]
+                                     ~     [missing whitespace]

--- a/test/rules/whitespace/all/tslint.json
+++ b/test/rules/whitespace/all/tslint.json
@@ -9,7 +9,8 @@
       "check-separator",
       "check-rest-spread",
       "check-type",
-      "check-typecast"
+      "check-typecast",
+      "check-type-operator"
     ]
   }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #488, #2818
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
This PR adds the "check-type-operator" option to the whitespace rule. The implementation is very similar to the binary operator one.


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[new-rule-option] `check-type-operator` for `whitepace` rule

