### PR TITLE
Fix 'space-before-function-paren' for anonymous/arrow generic functions

### DIFF
--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -110,7 +110,10 @@ function walk(ctx: Lint.WalkContext<Options>): void {
 function getOption(node: ts.Node, options: Options): Option | undefined {
     switch (node.kind) {
         case ts.SyntaxKind.ArrowFunction:
-            return Lint.hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword) ? options.asyncArrow : undefined;
+            return (node as ts.SignatureDeclaration).typeParameters === undefined
+                && Lint.hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword)
+                    ? options.asyncArrow
+                    : undefined;
 
         case ts.SyntaxKind.Constructor:
             return options.constructor;
@@ -119,7 +122,12 @@ function getOption(node: ts.Node, options: Options): Option | undefined {
             // name is optional for function declaration which is default export (TS will emit error in other cases).
             // Can be handled in the same way as function expression.
         case ts.SyntaxKind.FunctionExpression:
-            return (node as ts.FunctionExpression).name !== undefined ? options.named : options.anonymous;
+            const functionName = (node as ts.FunctionExpression).name;
+            return functionName !== undefined && functionName.text !== ""
+                ? options.named
+                : (node as ts.SignatureDeclaration).typeParameters === undefined
+                    ? options.anonymous
+                    : undefined;
 
         case ts.SyntaxKind.MethodDeclaration:
         case ts.SyntaxKind.MethodSignature:

--- a/src/rules/spaceBeforeFunctionParenRule.ts
+++ b/src/rules/spaceBeforeFunctionParenRule.ts
@@ -110,10 +110,8 @@ function walk(ctx: Lint.WalkContext<Options>): void {
 function getOption(node: ts.Node, options: Options): Option | undefined {
     switch (node.kind) {
         case ts.SyntaxKind.ArrowFunction:
-            return (node as ts.SignatureDeclaration).typeParameters === undefined
-                && Lint.hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword)
-                    ? options.asyncArrow
-                    : undefined;
+            return !hasTypeParameters(node) && Lint.hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword)
+                ? options.asyncArrow : undefined;
 
         case ts.SyntaxKind.Constructor:
             return options.constructor;
@@ -121,13 +119,12 @@ function getOption(node: ts.Node, options: Options): Option | undefined {
         case ts.SyntaxKind.FunctionDeclaration:
             // name is optional for function declaration which is default export (TS will emit error in other cases).
             // Can be handled in the same way as function expression.
-        case ts.SyntaxKind.FunctionExpression:
+        case ts.SyntaxKind.FunctionExpression: {
             const functionName = (node as ts.FunctionExpression).name;
-            return functionName !== undefined && functionName.text !== ""
-                ? options.named
-                : (node as ts.SignatureDeclaration).typeParameters === undefined
-                    ? options.anonymous
-                    : undefined;
+            const hasName = functionName !== undefined && functionName.text !== "";
+
+            return hasName ? options.named : !hasTypeParameters(node) ? options.anonymous : undefined;
+        }
 
         case ts.SyntaxKind.MethodDeclaration:
         case ts.SyntaxKind.MethodSignature:
@@ -138,4 +135,8 @@ function getOption(node: ts.Node, options: Options): Option | undefined {
         default:
             return undefined;
     }
+}
+
+function hasTypeParameters(node: ts.Node): boolean {
+    return (node as ts.SignatureDeclaration).typeParameters !== undefined;
 }

--- a/test/rules/space-before-function-paren/always/test.ts.fix
+++ b/test/rules/space-before-function-paren/always/test.ts.fix
@@ -9,6 +9,8 @@ var f = function (): void {
 };
 var f = function (a: string, cb: ()=>{}): void {};
 
+function <T>() {}
+var f = function <T>() {};
 
 // Named
 function foobar (){}
@@ -21,6 +23,8 @@ var f = function foobar (): void{
 };
 var f = function foobar (a: string, cb: ()=>{}): void{};
 
+function foobar<T> () {}
+var f = function foobar<T> () {}
 
 // Default export (name ommited)
 export default function () {}
@@ -35,17 +39,25 @@ var arrow = async () => {};
 
 async x => x;
 
+<T>() => {};
+var arrow = <T>() => {};
+
+async <T>() => {};
+var arrow = async <T>() => {};
+
 // Method
 interface IMyInterface {
         one ();
         two (): void;
         three (a: string, cb: ()=>{}): void;
+        four<T> ();
 }
 class MyClass {
         one () {}
         two (): void {
         }
         three (a: string, cb: ()=>{}): void {}
+        four<T> () {}
 }
 
 

--- a/test/rules/space-before-function-paren/always/test.ts.lint
+++ b/test/rules/space-before-function-paren/always/test.ts.lint
@@ -15,6 +15,8 @@ var f = function(): void {
 var f = function(a: string, cb: ()=>{}): void {};
                 ~  [space-before-function-paren]
 
+function <T>() {}
+var f = function <T>() {};
 
 // Named
 function foobar(){}
@@ -33,6 +35,10 @@ var f = function foobar(): void{
 var f = function foobar(a: string, cb: ()=>{}): void{};
                        ~  [space-before-function-paren]
 
+function foobar<T>() {}
+                  ~  [space-before-function-paren]
+var f = function foobar<T>() {}
+                          ~  [space-before-function-paren]
 
 // Default export (name ommited)
 export default function() {}
@@ -50,6 +56,12 @@ var arrow = async() => {};
 
 async x => x;
 
+<T>() => {};
+var arrow = <T>() => {};
+
+async <T>() => {};
+var arrow = async <T>() => {};
+
 // Method
 interface IMyInterface {
         one();
@@ -58,6 +70,8 @@ interface IMyInterface {
            ~  [space-before-function-paren]
         three(a: string, cb: ()=>{}): void;
              ~  [space-before-function-paren]
+        four<T>();
+               ~  [space-before-function-paren]
 }
 class MyClass {
         one() {}
@@ -67,6 +81,8 @@ class MyClass {
         }
         three(a: string, cb: ()=>{}): void {}
              ~  [space-before-function-paren]
+        four<T>() {}
+               ~  [space-before-function-paren]
 }
 
 

--- a/test/rules/space-before-function-paren/mixed/test.ts.fix
+++ b/test/rules/space-before-function-paren/mixed/test.ts.fix
@@ -4,6 +4,8 @@ var f = function (): void {
 };
 var f = function (a: string, cb: ()=>{}): void {};
 
+function <T>() {}
+var f = function <T>() {};
 
 // Named
 function foobar(){}
@@ -16,6 +18,9 @@ var f = function foobar(): void{
 };
 var f = function foobar(a: string, cb: ()=>{}): void{};
 
+function foobar<T>() {}
+var f = function foobar<T>() {}
+
 // Default export (name ommited)
 export default function () {}
 
@@ -27,18 +32,25 @@ var arrow = () => {};
 async () => {};
 var arrow = async () => {};
 
+<T>() => {};
+var arrow = <T>() => {};
+
+async <T>() => {};
+var arrow = async <T>() => {};
 
 // Method
 interface IMyInterface {
         one();
         two(): void;
         three(a: string, cb: ()=>{}): void;
+        four<T>();
 }
 class MyClass {
         one() {}
         two(): void {
         }
         three(a: string, cb: ()=>{}): void {}
+        four<T>() {}
 }
 
 

--- a/test/rules/space-before-function-paren/mixed/test.ts.lint
+++ b/test/rules/space-before-function-paren/mixed/test.ts.lint
@@ -7,6 +7,8 @@ var f = function(): void {
 var f = function(a: string, cb: ()=>{}): void {};
                 ~  [missing-space]
 
+function <T>() {}
+var f = function <T>() {};
 
 // Named
 function foobar (){}
@@ -25,6 +27,11 @@ var f = function foobar (): void{
 var f = function foobar (a: string, cb: ()=>{}): void{};
                        ~  [invalid-space]
 
+function foobar<T> () {}
+                  ~  [invalid-space]
+var f = function foobar<T> () {}
+                          ~  [invalid-space]
+
 // Default export (name ommited)
 export default function() {}
                        ~  [missing-space]
@@ -39,6 +46,11 @@ async() => {};
 var arrow = async() => {};
                  ~  [missing-space]
 
+<T>() => {};
+var arrow = <T>() => {};
+
+async <T>() => {};
+var arrow = async <T>() => {};
 
 // Method
 interface IMyInterface {
@@ -48,6 +60,8 @@ interface IMyInterface {
            ~  [invalid-space]
         three (a: string, cb: ()=>{}): void;
              ~  [invalid-space]
+        four<T> ();
+               ~  [invalid-space]
 }
 class MyClass {
         one () {}
@@ -57,6 +71,8 @@ class MyClass {
         }
         three (a: string, cb: ()=>{}): void {}
              ~  [invalid-space]
+        four<T> () {}
+               ~  [invalid-space]
 }
 
 

--- a/test/rules/space-before-function-paren/never/test.ts.fix
+++ b/test/rules/space-before-function-paren/never/test.ts.fix
@@ -9,6 +9,8 @@ var f = function(): void {
 };
 var f = function(a: string, cb: ()=>{}): void {};
 
+function <T>() {}
+var f = function <T>() {};
 
 // Named
 function foobar(){}
@@ -21,6 +23,9 @@ var f = function foobar(): void{
 };
 var f = function foobar(a: string, cb: ()=>{}): void{};
 
+function foobar<T>() {}
+var f = function foobar<T>() {}
+
 // Default export (name ommited)
 export default function() {}
 
@@ -32,18 +37,25 @@ var arrow = () => {};
 async() => {};
 var arrow = async() => {};
 
+<T>() => {};
+var arrow = <T>() => {};
+
+async <T>() => {};
+var arrow = async <T>() => {};
 
 // Method
 interface IMyInterface {
         one();
         two(): void;
         three(a: string, cb: ()=>{}): void;
+        four<T>();
 }
 class MyClass {
         one() {}
         two(): void {
         }
         three(a: string, cb: ()=>{}): void {}
+        four<T>() {}
 
         get a() {}
         set a() {}

--- a/test/rules/space-before-function-paren/never/test.ts.lint
+++ b/test/rules/space-before-function-paren/never/test.ts.lint
@@ -15,6 +15,8 @@ var f = function (): void {
 var f = function (a: string, cb: ()=>{}): void {};
                 ~ [0]
 
+function <T>() {}
+var f = function <T>() {};
 
 // Named
 function foobar (){}
@@ -33,6 +35,11 @@ var f = function foobar (): void{
 var f = function foobar (a: string, cb: ()=>{}): void{};
                        ~ [0]
 
+function foobar<T> () {}
+                  ~  [0]
+var f = function foobar<T> () {}
+                          ~  [0]
+
 // Default export (name ommited)
 export default function () {}
                        ~ [0]
@@ -47,6 +54,11 @@ async () => {};
 var arrow = async () => {};
                  ~ [0]
 
+<T>() => {};
+var arrow = <T>() => {};
+
+async <T>() => {};
+var arrow = async <T>() => {};
 
 // Method
 interface IMyInterface {
@@ -56,6 +68,8 @@ interface IMyInterface {
            ~ [0]
         three (a: string, cb: ()=>{}): void;
              ~ [0]
+        four<T> ();
+               ~  [0]
 }
 class MyClass {
         one () {}
@@ -65,6 +79,8 @@ class MyClass {
         }
         three (a: string, cb: ()=>{}): void {}
              ~ [0]
+        four<T> () {}
+               ~  [0]
 
         get a () {}
              ~ [0]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2308
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

Fix considers the following cases as exceptions and skips whitespace check:
- arrow function with type parameters
- anonymous functions with type parameters