### PR TITLE
Escape code in no-reference-import documentation metadata

### DIFF
--- a/src/rules/noReferenceImportRule.ts
+++ b/src/rules/noReferenceImportRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-reference-import",
-        description: 'Don\'t <reference types="foo" /> if you import "foo" anyway.',
+        description: 'Don\'t `<reference types="foo" />` if you import `foo` anyway.',
         optionsDescription: "Not configurable.",
         options: null,
         type: "style",


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2511
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:
This should fix the documentation for the for the `no-reference-import` rule to actually be readable and understood.  Right now it makes no sense.
currently: http://palantir.github.io/tslint/rules/no-reference-import
