### PR TITLE
New rule option: 'check-rest-spread' for 'whitespace' rule

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -64,8 +64,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         typescriptOnly: false,
     };
 
-    public static FAILURE_STRING = "missing whitespace";
-    public static FAILURE_STRING_2 = "invalid whitespace";
+    public static FAILURE_STRING_MISSING = "missing whitespace";
+    public static FAILURE_STRING_INVALID = "invalid whitespace";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, parseOptions(this.ruleArguments));
@@ -289,7 +289,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
             return;
         }
         const fix = Lint.Replacement.appendText(position, " ");
-        ctx.addFailureAt(position, 1, Rule.FAILURE_STRING, fix);
+        ctx.addFailureAt(position, 1, Rule.FAILURE_STRING_MISSING, fix);
     }
 
     function checkForExcessiveWhitespace(position: number): void {
@@ -300,6 +300,6 @@ function walk(ctx: Lint.WalkContext<Options>) {
 
     function addInvalidWhitespaceErrorAt(position: number): void {
         const fix = Lint.Replacement.deleteText(position, 1);
-        ctx.addFailureAt(position, 1, Rule.FAILURE_STRING_2, fix);
+        ctx.addFailureAt(position, 1, Rule.FAILURE_STRING_INVALID, fix);
     }
 }

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -27,6 +27,7 @@ const OPTION_DECL = "check-decl";
 const OPTION_OPERATOR = "check-operator";
 const OPTION_MODULE = "check-module";
 const OPTION_SEPARATOR = "check-separator";
+const OPTION_SPREAD = "check-spread";
 const OPTION_TYPE = "check-type";
 const OPTION_TYPECAST = "check-typecast";
 const OPTION_PREBLOCK = "check-preblock";
@@ -37,13 +38,14 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Enforces whitespace style conventions.",
         rationale: "Helps maintain a readable, consistent style in your codebase.",
         optionsDescription: Lint.Utils.dedent`
-            Eight arguments may be optionally provided:
+            Nine arguments may be optionally provided:
 
             * \`"check-branch"\` checks branching statements (\`if\`/\`else\`/\`for\`/\`while\`) are followed by whitespace.
             * \`"check-decl"\`checks that variable declarations have whitespace around the equals token.
             * \`"check-operator"\` checks for whitespace around operator tokens.
             * \`"check-module"\` checks for whitespace in import & export statements.
             * \`"check-separator"\` checks for whitespace after separator tokens (\`,\`/\`;\`).
+            * \`"check-spread"\` checks that there is no whitespace after spread operator (\`...\`).
             * \`"check-type"\` checks for whitespace before a variable type specification.
             * \`"check-typecast"\` checks for whitespace between a typecast and its target.
             * \`"check-preblock"\` checks for whitespace before the opening brace of a block`,
@@ -52,10 +54,10 @@ export class Rule extends Lint.Rules.AbstractRule {
             items: {
                 type: "string",
                 enum: ["check-branch", "check-decl", "check-operator", "check-module",
-                       "check-separator", "check-type", "check-typecast", "check-preblock"],
+                       "check-separator", "check-spread", "check-type", "check-typecast", "check-preblock"],
             },
             minLength: 0,
-            maxLength: 7,
+            maxLength: 9,
         },
         optionExamples: [[true, "check-branch", "check-operator", "check-typecast"]],
         type: "style",
@@ -63,13 +65,14 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
 
     public static FAILURE_STRING = "missing whitespace";
+    public static FAILURE_STRING_2 = "invalid whitespace";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, parseOptions(this.ruleArguments));
     }
 }
 
-type Options = Record<"branch" | "decl" | "operator" | "module" | "separator" | "type" | "typecast" | "preblock", boolean>;
+type Options = Record<"branch" | "decl" | "operator" | "module" | "separator" | "spread" | "type" | "typecast" | "preblock", boolean>;
 function parseOptions(ruleArguments: string[]): Options {
     return {
         branch: has(OPTION_BRANCH),
@@ -77,6 +80,7 @@ function parseOptions(ruleArguments: string[]): Options {
         operator: has(OPTION_OPERATOR),
         module: has(OPTION_MODULE),
         separator: has(OPTION_SEPARATOR),
+        spread: has(OPTION_SPREAD),
         type: has(OPTION_TYPE),
         typecast: has(OPTION_TYPECAST),
         preblock: has(OPTION_PREBLOCK),

--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -196,6 +196,13 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 if (options.decl && initializer !== undefined) {
                     checkForTrailingWhitespace((type !== undefined ? type :  name).getEnd());
                 }
+                break;
+
+            case ts.SyntaxKind.SpreadAssignment:
+                if (options.spread) {
+                    const position = (node as ts.SpreadAssignment).expression.getFullStart();
+                    checkForExcessiveWhitespace(position);
+                }
         }
 
         ts.forEachChild(node, cb);
@@ -283,5 +290,16 @@ function walk(ctx: Lint.WalkContext<Options>) {
         }
         const fix = Lint.Replacement.appendText(position, " ");
         ctx.addFailureAt(position, 1, Rule.FAILURE_STRING, fix);
+    }
+
+    function checkForExcessiveWhitespace(position: number): void {
+        if (position !== sourceFile.end && Lint.isWhiteSpace(sourceFile.text.charCodeAt(position))) {
+            addInvalidWhitespaceErrorAt(position);
+        }
+    }
+
+    function addInvalidWhitespaceErrorAt(position: number): void {
+        const fix = Lint.Replacement.deleteText(position, 1);
+        ctx.addFailureAt(position, 1, Rule.FAILURE_STRING_2, fix);
     }
 }

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -105,6 +105,10 @@ else
     // code that just wants to be encapsulated in a block scope
 }
 
-const foo = {
-    ...bar
-};
+const foo = { ...bar };
+
+const foo = [ ...bar ];
+
+function foo (bar, ...baz) {}
+
+const { foo, ...bar } = baz;

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -104,3 +104,7 @@ else
     const foo = 123;
     // code that just wants to be encapsulated in a block scope
 }
+
+const foo = {
+    ...bar
+};

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -161,3 +161,8 @@ else
     const foo = 123;
     // code that just wants to be encapsulated in a block scope
 }
+
+const foo = {
+    ... bar
+       ~ [invalid whitespace]
+};

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -162,7 +162,14 @@ else
     // code that just wants to be encapsulated in a block scope
 }
 
-const foo = {
-    ... bar
-       ~ [invalid whitespace]
-};
+const foo = { ... bar };
+                 ~ [invalid whitespace]
+
+const foo = [ ... bar ];
+                 ~ [invalid whitespace]
+
+function foo (bar, ... baz) {}
+                      ~ [invalid whitespace]
+
+const { foo, ... bar } = baz;
+                ~ [invalid whitespace]

--- a/test/rules/whitespace/all/tslint.json
+++ b/test/rules/whitespace/all/tslint.json
@@ -7,6 +7,7 @@
       "check-module",
       "check-preblock",
       "check-separator",
+      "check-spread",
       "check-type",
       "check-typecast"
     ]

--- a/test/rules/whitespace/all/tslint.json
+++ b/test/rules/whitespace/all/tslint.json
@@ -7,7 +7,7 @@
       "check-module",
       "check-preblock",
       "check-separator",
-      "check-spread",
+      "check-rest-spread",
       "check-type",
       "check-typecast"
     ]

--- a/test/rules/whitespace/none/test.ts.lint
+++ b/test/rules/whitespace/none/test.ts.lint
@@ -92,3 +92,7 @@ else
     const foo = 123;
     // code that just wants to be encapsulated in a block scope
 }
+
+const foo = {
+    ... bar
+};

--- a/test/rules/whitespace/none/test.ts.lint
+++ b/test/rules/whitespace/none/test.ts.lint
@@ -93,6 +93,10 @@ else
     // code that just wants to be encapsulated in a block scope
 }
 
-const foo = {
-    ... bar
-};
+const foo = { ... bar };
+
+const foo = [ ... bar ];
+
+function foo (bar, ... baz) {}
+
+const { foo, ... bar } = baz;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2122
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### CHANGELOG.md entry:

[new-rule-option] `whitespace`: Add `check-rest-spread` option (#2122)
