### PR TITLE
Ignore npm5's package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules/
 !test/rules/**/node_modules
 tscommand*.txt
 npm-debug.log
+package-lock.json
 # created by grunt-ts for faster compiling
 typings/.basedir.ts
 


### PR DESCRIPTION
As this project uses `yarn` to manage dependencies, `npm5`'s `package-lock.json` should be ignored.
This rule cannot be applied to global `.gitignore,` because in general it should be stored in git repository.