### PR TITLE
allow functions as first argument to Object.assign

### DIFF
--- a/src/rules/preferObjectSpreadRule.ts
+++ b/src/rules/preferObjectSpreadRule.ts
@@ -51,6 +51,7 @@ function walk(ctx: Lint.WalkContext<void>) {
             isPropertyAccessExpression(node.expression) && node.expression.name.text === "assign" &&
             isIdentifier(node.expression.expression) && node.expression.expression.text === "Object" &&
             // Object.assign(...someArray) cannot be written as object spread
+            !ts.isFunctionLike(node.arguments[0]) &&
             !node.arguments.some(isSpreadElement)) {
             if (node.arguments[0].kind === ts.SyntaxKind.ObjectLiteralExpression) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING, createFix(node, ctx.sourceFile));

--- a/src/rules/preferObjectSpreadRule.ts
+++ b/src/rules/preferObjectSpreadRule.ts
@@ -50,8 +50,8 @@ function walk(ctx: Lint.WalkContext<void>) {
         if (isCallExpression(node) && node.arguments.length !== 0 &&
             isPropertyAccessExpression(node.expression) && node.expression.name.text === "assign" &&
             isIdentifier(node.expression.expression) && node.expression.expression.text === "Object" &&
-            // Object.assign(...someArray) cannot be written as object spread
             !ts.isFunctionLike(node.arguments[0]) &&
+            // Object.assign(...someArray) cannot be written as object spread
             !node.arguments.some(isSpreadElement)) {
             if (node.arguments[0].kind === ts.SyntaxKind.ObjectLiteralExpression) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING, createFix(node, ctx.sourceFile));

--- a/test/rules/prefer-object-spread/test.ts.fix
+++ b/test/rules/prefer-object-spread/test.ts.fix
@@ -21,3 +21,5 @@ foo({...original, c: 3});
 // allowed
 result = Object.assign(new Foo(), {});
 result = Object.assign(createFoo(), {});
+result = Object.assign(function() {}, {});
+result = Object.assign(() => {}, {});

--- a/test/rules/prefer-object-spread/test.ts.lint
+++ b/test/rules/prefer-object-spread/test.ts.lint
@@ -34,6 +34,8 @@ Object.assign({}, {},);
 // allowed
 result = Object.assign(new Foo(), {});
 result = Object.assign(createFoo(), {});
+result = Object.assign(function() {}, {});
+result = Object.assign(() => {}, {});
 
 [0]: Use the object spread operator instead.
 [1]: 'Object.assign' returns the first argument. Prefer object spread if you want a new object.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3055
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Permits functions as first argument to Object.assign

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

- [bugfix] [`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) Permit functions as first argument to Object.assign
