### PR TITLE
fix(ruleLoader): resolve rule files using node path resolution

### DIFF
--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -107,14 +107,28 @@ function transformName(name: string): string {
  * @param ruleName - A name of a rule in filename format. ex) "someLintRule"
  */
 function loadRule(directory: string, ruleName: string): RuleConstructor | "not-found" {
-    const fullPath = path.join(directory, ruleName);
-    if (fs.existsSync(`${fullPath}.js`)) {
-        const ruleModule = require(fullPath) as { Rule: RuleConstructor } | undefined;
+    const ruleFullPath = getRuleFullPath(directory, ruleName);
+    if (ruleFullPath !== undefined) {
+        const ruleModule = require(ruleFullPath) as { Rule: RuleConstructor } | undefined;
         if (ruleModule !== undefined) {
             return ruleModule.Rule;
         }
     }
     return "not-found";
+}
+
+/**
+ * Returns the full path to a rule file. Path to rules are resolved using nodes path resolution.
+ * This allows developers to write custom rules in TypeScript, which then can be loaded by TS-Node.
+ * @param directory - An absolute path to a directory of rules
+ * @param ruleName - A name of a rule in filename format. ex) "someLintRule"
+ */
+function getRuleFullPath(directory: string, ruleName: string): string | undefined {
+    try {
+        return require.resolve(path.join(directory, ruleName));
+    } catch (e) {
+        return undefined;
+    }
 }
 
 function loadCachedRule(directory: string, ruleName: string, isCustomPath?: boolean): RuleConstructor | undefined {


### PR DESCRIPTION
Custom rule files are no longer being loaded with a hardcoded/fixed extenson (`.js`).

With this change all rule files will be resolved using Nodes path resolution. This means that the extension will be detected automatically and other extension loaders like `ts-node` can be used.

This means that rules can be also written in TypeScript and loaded through TS-Node.

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [ ] Includes tests (Not sure if it's worth testing with TS-node etc. Might be a better follow-up)
- [ ] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[no-log] custom lint rules will be resolved using node's path resolution