### PR TITLE
quotemark-rule: single/double options can be at any index in arg list

### DIFF
--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Palantir Technologies, Inc.
+ * Copyright 2013 Palantir Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,10 +72,6 @@ export class Rule extends Lint.Rules.AbstractRule {
         return `${actual} should be ${expected}`;
     }
 
-    public isEnabled(): boolean {
-        return super.isEnabled() && hasSingleDoublePreference(this.ruleArguments);
-    }
-
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const args = this.ruleArguments;
         const quoteMark = getQuotemarkPreference(args) === OPTION_SINGLE ? "'" : '"';
@@ -134,19 +130,10 @@ function walk(ctx: Lint.WalkContext<Options>) {
     });
 }
 
-function hasSingleDoublePreference(args: any[]): boolean {
-    for (const arg of args) {
-        if (arg === OPTION_SINGLE || arg === OPTION_DOUBLE) {
-            return true;
-        }
-    }
-    return false;
-}
-
 function getQuotemarkPreference(args: any[]): string | undefined {
     for (const arg of args) {
         if (arg === OPTION_SINGLE || arg === OPTION_DOUBLE) {
-            return (arg === OPTION_SINGLE) ? OPTION_SINGLE : OPTION_DOUBLE;
+            return arg as string;
         }
     }
     return undefined;

--- a/test/rules/quotemark/avoid-template/tslint.json
+++ b/test/rules/quotemark/avoid-template/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "quotemark": [true, "double", "avoid-escape", "avoid-template"]
+    "quotemark": [true, "avoid-escape", "double", "avoid-template"]
   }
 }

--- a/test/rules/quotemark/jsx-double/tslint.json
+++ b/test/rules/quotemark/jsx-double/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "quotemark": [true, "single", "jsx-double"]
+    "quotemark": [true,"jsx-double",  "single"]
   }
 }

--- a/test/rules/quotemark/single-avoid-escape/tslint.json
+++ b/test/rules/quotemark/single-avoid-escape/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "quotemark": [true, "single", "avoid-escape"]
+    "quotemark": [true, "avoid-escape", "single"]
   }
 }


### PR DESCRIPTION
- [x] Addresses an existing issue: [#3063](https://github.com/palantir/tslint/issues/3063)
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

Added a couple util functions to quotemark rule. Checks argument list for OPTION_SINGLE or OPTION_DOUBLE in such a way that argument order doesn't matter. Currently, isEnabled() will return false if no single/double option is specified. Maybe defaulting to double quotes makes more sense?
