### PR TITLE
no-invalid-template-strings: fix for escaped template expressions

### DIFF
--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -52,6 +52,10 @@ function walk(ctx: Lint.WalkContext<void>) {
     function check(node: ts.StringLiteral): void {
         const idx = node.text.search(/\$\{/);
         if (idx !== -1) {
+            const preceedingCharacter = node.getFullText().substr(node.getFullText().search(/\$\{/) - 1, 1);
+            if (preceedingCharacter === "\\") {
+                return;
+            }
             const textStart = node.getStart() + 1;
             ctx.addFailureAt(textStart + idx, 2, Rule.FAILURE_STRING);
         }

--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -53,7 +53,7 @@ function walk(ctx: Lint.WalkContext<void>) {
         const index = node.text.search(/\$\{/);
         if (index !== -1) {
             /**
-             * Support for ignoring case: '\${binding}'
+             * Support for ignoring case: '\${template-expression}'
              */
             const unescapedText: string = node.getFullText();
             const preceedingCharacter = unescapedText.substr(unescapedText.search(/\$\{/) - 1, 1);

--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -54,6 +54,7 @@ function walk(ctx: Lint.WalkContext<void>) {
          * Finds instances of '${'
          */
         const findTemplateString = new RegExp(/\$\{/);
+            
         const index = node.text.search(findTemplateString);
         if (index !== -1) {
             /**

--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -50,14 +50,19 @@ function walk(ctx: Lint.WalkContext<void>) {
     });
 
     function check(node: ts.StringLiteral): void {
-        const idx = node.text.search(/\$\{/);
-        if (idx !== -1) {
-            const preceedingCharacter = node.getFullText().substr(node.getFullText().search(/\$\{/) - 1, 1);
+        const index = node.text.search(/\$\{/);
+        if (index !== -1) {
+            /**
+             * Support for ignoring case: '\${binding}'
+             */
+            const unescapedText: string = node.getFullText();
+            const preceedingCharacter = unescapedText.substr(unescapedText.search(/\$\{/) - 1, 1);
             if (preceedingCharacter === "\\") {
                 return;
             }
+
             const textStart = node.getStart() + 1;
-            ctx.addFailureAt(textStart + idx, 2, Rule.FAILURE_STRING);
+            ctx.addFailureAt(textStart + index, 2, Rule.FAILURE_STRING);
         }
     }
 }

--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -50,14 +50,18 @@ function walk(ctx: Lint.WalkContext<void>) {
     });
 
     function check(node: ts.StringLiteral): void {
-        const index = node.text.search(/\$\{/);
+        /**
+         * Finds instances of '${'
+         */
+        const findTemplateString = new RegExp(/\$\{/);
+        const index = node.text.search(findTemplateString);
         if (index !== -1) {
             /**
              * Support for ignoring case: '\${template-expression}'
              */
-            const unescapedText: string = node.getFullText();
-            const preceedingCharacter = unescapedText.substr(unescapedText.search(/\$\{/) - 1, 1);
-            if (preceedingCharacter === "\\") {
+            const unescapedText = node.getFullText();
+            const preceedingCharacter = unescapedText.substr(unescapedText.search(findTemplateString) - 1, 1);
+            if (isBackslash(preceedingCharacter)) {
                 return;
             }
 
@@ -65,4 +69,8 @@ function walk(ctx: Lint.WalkContext<void>) {
             ctx.addFailureAt(textStart + index, 2, Rule.FAILURE_STRING);
         }
     }
+}
+
+function isBackslash(character: string): boolean {
+    return character === "\\";
 }

--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -62,10 +62,12 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
     public static FAILURE_STRING_ALPHABETICAL(name: string): string {
         return `The key '${name}' is not sorted alphabetically`;
     }
+    /* tslint:disable:no-shadowed-variable */
     public static FAILURE_STRING_USE_DECLARATION_ORDER(propName: string, typeName: string | undefined): string {
         const type = typeName === undefined ? "its type declaration" : `'${typeName}'`;
         return `The key '${propName}' is not in the same order as it is in ${type}.`;
     }
+    /* tslint:enable:no-shadowed-variable */
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options = parseOptions(this.ruleArguments);

--- a/test/rules/no-invalid-template-strings/test.ts.lint
+++ b/test/rules/no-invalid-template-strings/test.ts.lint
@@ -1,3 +1,9 @@
+new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comment-tab=\${which}></div>',Tab.mixins.AlwaysHasData())))
+
+new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comment-tab=\${which}></div>',Tab.mixins.AlwaysHasData('\${which}'))))
+
+new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comment-tab=\\\\\\${which}></div>',Tab.mixins.AlwaysHasData())))
+
 "One plus one is ${1 + 1}.";
                  ~~ [0]
 


### PR DESCRIPTION
#### PR checklist

- [x ] Addresses an existing issue: #[2738](https://github.com/palantir/tslint/issues/2738)
- [x ] bugfix
  - [x ] Includes tests
- [ ] Documentation update

Checks if ${} sequence is preceeded by backslash. 

