### PR TITLE
Refine no-unnecessary-type-assertion rule to not flag necessary assertions

### DIFF
--- a/src/rules/noUnnecessaryTypeAssertionRule.ts
+++ b/src/rules/noUnnecessaryTypeAssertionRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { isObjectFlagSet, isTypeFlagSet } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -66,9 +67,9 @@ class Walker extends Lint.AbstractWalker<void> {
         }
 
         if (node.kind !== ts.SyntaxKind.NonNullExpression &&
-            ((castType.flags & ts.TypeFlags.Literal) ||
-                (castType.flags & ts.TypeFlags.Object &&
-                (castType as ts.ObjectType).objectFlags & ts.ObjectFlags.Tuple))) {
+            (isTypeFlagSet(castType, ts.TypeFlags.Literal) ||
+                isTypeFlagSet(castType, ts.TypeFlags.Object) &&
+                isObjectFlagSet(castType as ts.ObjectType, ts.ObjectFlags.Tuple))) {
             // It's not always safe to remove a cast to a literal type or tuple
             // type, as those types are sometimes widened without the cast.
             return;

--- a/src/rules/noUnnecessaryTypeAssertionRule.ts
+++ b/src/rules/noUnnecessaryTypeAssertionRule.ts
@@ -65,6 +65,15 @@ class Walker extends Lint.AbstractWalker<void> {
             return;
         }
 
+        if (node.kind !== ts.SyntaxKind.NonNullExpression &&
+            ((castType.flags & ts.TypeFlags.Literal) ||
+                (castType.flags & ts.TypeFlags.Object &&
+                (castType as ts.ObjectType).objectFlags & ts.ObjectFlags.Tuple))) {
+            // It's not always safe to remove a cast to a literal type or tuple
+            // type, as those types are sometimes widened without the cast.
+            return;
+        }
+
         const uncastType = this.checker.getTypeAtLocation(node.expression);
         if (uncastType === castType) {
             this.addFailureAtNode(node, Rule.FAILURE_STRING, node.kind === ts.SyntaxKind.TypeAssertionExpression

--- a/src/rules/noUnnecessaryTypeAssertionRule.ts
+++ b/src/rules/noUnnecessaryTypeAssertionRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isObjectFlagSet, isTypeFlagSet } from "tsutils";
+import { isObjectFlagSet, isObjectType, isTypeFlagSet } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -68,8 +68,8 @@ class Walker extends Lint.AbstractWalker<void> {
 
         if (node.kind !== ts.SyntaxKind.NonNullExpression &&
             (isTypeFlagSet(castType, ts.TypeFlags.Literal) ||
-                isTypeFlagSet(castType, ts.TypeFlags.Object) &&
-                isObjectFlagSet(castType as ts.ObjectType, ts.ObjectFlags.Tuple))) {
+                isObjectType(castType) &&
+                isObjectFlagSet(castType, ts.ObjectFlags.Tuple))) {
             // It's not always safe to remove a cast to a literal type or tuple
             // type, as those types are sometimes widened without the cast.
             return;

--- a/test/rules/no-unnecessary-type-assertion/test.ts.fix
+++ b/test/rules/no-unnecessary-type-assertion/test.ts.fix
@@ -69,3 +69,13 @@ function func(aOrB: TypeA|TypeB) {
         let z = aOrB;
     }
 }
+
+// Expecting no warning for these assertions as they are not unnecessary.
+
+type Bar = 'bar';
+const data = {
+    x: 'foo' as 'foo',
+    y: 'bar' as Bar,
+}
+
+[1, 2, 3, 4, 5].map(x => [x, 'A' + x] as [number, string]);

--- a/test/rules/no-unnecessary-type-assertion/test.ts.lint
+++ b/test/rules/no-unnecessary-type-assertion/test.ts.lint
@@ -86,3 +86,13 @@ function func(aOrB: TypeA|TypeB) {
                 ~~~~~~~~~~~  [This assertion is unnecessary since it does not change the type of the expression.]
     }
 }
+
+// Expecting no warning for these assertions as they are not unnecessary.
+
+type Bar = 'bar';
+const data = {
+    x: 'foo' as 'foo',
+    y: 'bar' as Bar,
+}
+
+[1, 2, 3, 4, 5].map(x => [x, 'A' + x] as [number, string]);


### PR DESCRIPTION
Type assertions prevent a type from being widened in a couple of
situations, such as in an object literal or the inferred return type of
a function.