### PR TITLE
Silence tslint on no output / tslint produces empty lines on successful lint run

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -150,7 +150,9 @@ async function runWorker(options: Options, logger: Logger): Promise<Status> {
     }
 
     const { output, errorCount } = await runLinter(options, logger);
-    logger.log(output);
+    if (output && output.trim()) {
+        logger.log(output);
+    }
     return options.force || errorCount === 0 ? Status.Ok : Status.LintError;
 }
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] ~~New feature, bugfix, or~~ enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

Currently runnting tslint yields two empty lines, e.g.:

```
$ "$(yarn bin)"/tslint .


$
```
e.g. when running this linter via [`run-p`](https://github.com/mysticatea/npm-run-all) for example, the output is:

![tslint empty lines](https://user-images.githubusercontent.com/188038/29256099-fc4380b8-80ea-11e7-8716-b38bc645a330.png)


#### CHANGELOG.md entry:
[enhancement] remove superfluous empty lines on tslint output.
