### PR TITLE
prefer-object-spread: ignore Object.assign({}, this)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,7 @@
             "request": "launch",
             "program": "${workspaceRoot}/test/ruleTestRunner.ts",
             "stopOnEntry": false,
-            "args": [],
+            "args": ["run", "test"],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "tsc",
             "runtimeExecutable": null,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,7 @@
             "request": "launch",
             "program": "${workspaceRoot}/test/ruleTestRunner.ts",
             "stopOnEntry": false,
-            "args": ["run", "test"],
+            "args": [],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "tsc",
             "runtimeExecutable": null,

--- a/src/rules/preferObjectSpreadRule.ts
+++ b/src/rules/preferObjectSpreadRule.ts
@@ -16,8 +16,14 @@
  */
 
 import {
-    hasSideEffects, isCallExpression, isExpressionValueUsed, isIdentifier, isObjectLiteralExpression,
-    isPropertyAccessExpression, isSpreadElement, SideEffectOptions,
+    hasSideEffects,
+    isCallExpression,
+    isExpressionValueUsed,
+    isIdentifier,
+    isObjectLiteralExpression,
+    isPropertyAccessExpression,
+    isSpreadElement,
+    SideEffectOptions,
 } from "tsutils";
 import * as ts from "typescript";
 
@@ -56,14 +62,17 @@ function walk(ctx: Lint.WalkContext<void>) {
             if (node.arguments[0].kind === ts.SyntaxKind.ObjectLiteralExpression) {
 
                 /**
+                 * @TODO
+                 * Remove this when typescript get's support for spread types.
+                 * PR: https://github.com/Microsoft/TypeScript/issues/10727
+                 *
                  * @url https://github.com/palantir/tslint/issues/3117
                  * Per TS2698, "spread types may only be created from
                  * object types."
+                 *
                  */
-                if (node.arguments[1] !== undefined) {
-                    if (node.arguments[1].kind === ts.SyntaxKind.ThisKeyword) {
-                        return;
-                    }
+                if (node.arguments.some((arg) => arg.kind === ts.SyntaxKind.ThisKeyword)) {
+                    return;
                 }
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING, createFix(node, ctx.sourceFile));
             } else if (isExpressionValueUsed(node) && !hasSideEffects(node.arguments[0], SideEffectOptions.Constructor)) {

--- a/src/rules/preferObjectSpreadRule.ts
+++ b/src/rules/preferObjectSpreadRule.ts
@@ -54,6 +54,17 @@ function walk(ctx: Lint.WalkContext<void>) {
             // Object.assign(...someArray) cannot be written as object spread
             !node.arguments.some(isSpreadElement)) {
             if (node.arguments[0].kind === ts.SyntaxKind.ObjectLiteralExpression) {
+
+                /**
+                 * @url https://github.com/palantir/tslint/issues/3117
+                 * Per TS2698, "spread types may only be created from
+                 * object types."
+                 */
+                if (node.arguments[1] !== undefined) {
+                    if (node.arguments[1].kind === ts.SyntaxKind.ThisKeyword) {
+                        return;
+                    }
+                }
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING, createFix(node, ctx.sourceFile));
             } else if (isExpressionValueUsed(node) && !hasSideEffects(node.arguments[0], SideEffectOptions.Constructor)) {
                 ctx.addFailureAtNode(node, Rule.ASSIGNMENT_FAILURE_STRING, createFix(node, ctx.sourceFile));

--- a/src/rules/preferObjectSpreadRule.ts
+++ b/src/rules/preferObjectSpreadRule.ts
@@ -58,26 +58,20 @@ function walk(ctx: Lint.WalkContext<void>) {
             isIdentifier(node.expression.expression) && node.expression.expression.text === "Object" &&
             !ts.isFunctionLike(node.arguments[0]) &&
             // Object.assign(...someArray) cannot be written as object spread
-            !node.arguments.some(isSpreadElement)) {
+            !node.arguments.some(isSpreadElement) &&
+            /**
+             * @TODO
+             * Remove !node.arguments.some(isThisKeyword) when typescript get's
+             * support for spread types.
+             * PR: https://github.com/Microsoft/TypeScript/issues/10727
+             */
+            !node.arguments.some(isThisKeyword)) {
             if (node.arguments[0].kind === ts.SyntaxKind.ObjectLiteralExpression) {
-
-                /**
-                 * @TODO
-                 * Remove this when typescript get's support for spread types.
-                 * PR: https://github.com/Microsoft/TypeScript/issues/10727
-                 *
-                 * @url https://github.com/palantir/tslint/issues/3117
-                 * Per TS2698, "spread types may only be created from
-                 * object types."
-                 *
-                 */
-                if (node.arguments.some((arg) => arg.kind === ts.SyntaxKind.ThisKeyword)) {
-                    return;
-                }
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING, createFix(node, ctx.sourceFile));
             } else if (isExpressionValueUsed(node) && !hasSideEffects(node.arguments[0], SideEffectOptions.Constructor)) {
                 ctx.addFailureAtNode(node, Rule.ASSIGNMENT_FAILURE_STRING, createFix(node, ctx.sourceFile));
             }
+
         }
         return ts.forEachChild(node, cb);
     });
@@ -120,6 +114,10 @@ function createFix(node: ts.CallExpression, sourceFile: ts.SourceFile): Lint.Fix
     }
 
     return fix;
+}
+
+function isThisKeyword(node: ts.Expression): boolean {
+    return node.kind === ts.SyntaxKind.ThisKeyword;
 }
 
 function needsParens(node: ts.Node): boolean {

--- a/test/rules/prefer-object-spread/test.ts.fix
+++ b/test/rules/prefer-object-spread/test.ts.fix
@@ -1,5 +1,5 @@
 const form = Object.assign({}, this);
-
+const foo = Object.assign({}, bar, baz, this);
 const original = {a: 1, b:2};
 {...original, c: 3};
 {a: 1, b: 2, c: 3};

--- a/test/rules/prefer-object-spread/test.ts.fix
+++ b/test/rules/prefer-object-spread/test.ts.fix
@@ -1,4 +1,5 @@
 const form = Object.assign({}, this);
+const foo = Object.assign(bar, this);
 const foo = Object.assign({}, bar, baz, this);
 const original = {a: 1, b:2};
 {...original, c: 3};

--- a/test/rules/prefer-object-spread/test.ts.fix
+++ b/test/rules/prefer-object-spread/test.ts.fix
@@ -1,3 +1,5 @@
+const form = Object.assign({}, this);
+
 const original = {a: 1, b:2};
 {...original, c: 3};
 {a: 1, b: 2, c: 3};

--- a/test/rules/prefer-object-spread/test.ts.lint
+++ b/test/rules/prefer-object-spread/test.ts.lint
@@ -1,4 +1,5 @@
 const form = Object.assign({}, this);
+const foo = Object.assign(bar, this);
 const foo = Object.assign({}, bar, baz, this);
 const original = {a: 1, b:2};
 Object.assign({}, original, {c: 3});

--- a/test/rules/prefer-object-spread/test.ts.lint
+++ b/test/rules/prefer-object-spread/test.ts.lint
@@ -1,3 +1,5 @@
+const form = Object.assign({}, this);
+
 const original = {a: 1, b:2};
 Object.assign({}, original, {c: 3});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]

--- a/test/rules/prefer-object-spread/test.ts.lint
+++ b/test/rules/prefer-object-spread/test.ts.lint
@@ -1,5 +1,5 @@
 const form = Object.assign({}, this);
-
+const foo = Object.assign({}, bar, baz, this);
 const original = {a: 1, b:2};
 Object.assign({}, original, {c: 3});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]


### PR DESCRIPTION
- [x] Addresses an existing issue: #[3117](https://github.com/palantir/tslint/issues/3117)
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Allows for Object.assign(obj, this)
