### PR TITLE
no-submodule-imports: consider exact matches as whitelisted

### DIFF
--- a/test/rules/no-submodule-imports/static-imports/test.ts.lint
+++ b/test/rules/no-submodule-imports/static-imports/test.ts.lint
@@ -27,6 +27,11 @@ import { submodule } from "@angular/core/a/b/c/sub-module";
 import submodule = require("@angular/core");
 import submodule = require("@angular/core/a/b/c/sub-module");
 
+import { submodule } from "@angular/platform-browser";
+import { submodule } from "@angular/platform-browser/animations";
+import { submodule } from "@angular/platform-browser/animations/foo";
+import { submodule } from "@angular/platform-browser/bar";
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 
 import { submodule } from "lodash";
 

--- a/test/rules/no-submodule-imports/static-imports/tslint.json
+++ b/test/rules/no-submodule-imports/static-imports/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "no-submodule-imports": [true, "@angular/core", "rxjs"]
+    "no-submodule-imports": [true, "@angular/core", "rxjs", "@angular/platform-browser/animations"]
   }
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Today I wanted to use the new `no-submodule-imports` rule. I need to whitelist `@angular/core/testing` for example, but doing that will check if the import starts with `@angular/core/testing/` (note the trailing slash).
This PR also tests for exact matches, allowing me to whitelist `@angular/core/testing` instead of `@angular/core`

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[enhancement] `no-submodule-imports` allows whitelisting of submodules like `@angular/core/testing`
