### PR TITLE
Fix lint error in no-invalid-template-strings

### DIFF
--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -54,7 +54,7 @@ function walk(ctx: Lint.WalkContext<void>) {
          * Finds instances of '${'
          */
         const findTemplateString = new RegExp(/\$\{/);
-            
+
         const index = node.text.search(findTemplateString);
         if (index !== -1) {
             /**


### PR DESCRIPTION
[no-log] removed trailing whitespace