### PR TITLE
no-unnecessary-qualifier: better fix for ts@2.5

### DIFF
--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -120,7 +120,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
     }
 
     function symbolsAreEqual(accessed: ts.Symbol, inScope: ts.Symbol): boolean {
-        // TODO remove type assertion on update to typescript@2.5.0
+        // TODO remove type assertion on update to typescript@2.6.0
         if ((checker as any as {getExportSymbolOfSymbol(s: ts.Symbol): ts.Symbol}).getExportSymbolOfSymbol !== undefined) {
             inScope = (checker as any as {getExportSymbolOfSymbol(s: ts.Symbol): ts.Symbol}).getExportSymbolOfSymbol(inScope);
         }

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -125,7 +125,9 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
             inScope = (checker as any as {getExportSymbolOfSymbol(s: ts.Symbol): ts.Symbol}).getExportSymbolOfSymbol(inScope);
             return accessed === inScope;
         }
-        return accessed === inScope || Lint.Utils.arraysAreEqual(accessed.declarations, inScope.declarations, (a, b) => a === b);
+        return accessed === inScope ||
+            // For compatibility with typescript@2.5: compare declarations because the symbols don't have the same reference
+            Lint.Utils.arraysAreEqual(accessed.declarations, inScope.declarations, (a, b) => a === b);
     }
 }
 

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -123,8 +123,9 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
         // TODO remove type assertion on update to typescript@2.6.0
         if ((checker as any as {getExportSymbolOfSymbol(s: ts.Symbol): ts.Symbol}).getExportSymbolOfSymbol !== undefined) {
             inScope = (checker as any as {getExportSymbolOfSymbol(s: ts.Symbol): ts.Symbol}).getExportSymbolOfSymbol(inScope);
+            return accessed === inScope;
         }
-        return accessed === inScope;
+        return accessed === inScope || Lint.Utils.arraysAreEqual(accessed.declarations, inScope.declarations, (a, b) => a === b);
     }
 }
 

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -98,7 +98,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
 
         // If the symbol in scope is different, the qualifier is necessary.
         const fromScope = getSymbolInScope(qualifier, accessedSymbol.flags, name.text);
-        return fromScope === undefined || Lint.Utils.arraysAreEqual(fromScope.declarations, accessedSymbol.declarations, (a, b) => a === b);
+        return fromScope === undefined || symbolsAreEqual(accessedSymbol, fromScope);
     }
 
     function getSymbolInScope(node: ts.Node, flags: ts.SymbolFlags, name: string): ts.Symbol | undefined {
@@ -117,6 +117,14 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
 
         const alias = tryGetAliasedSymbol(symbol, checker);
         return alias !== undefined && symbolIsNamespaceInScope(alias);
+    }
+
+    function symbolsAreEqual(accessed: ts.Symbol, inScope: ts.Symbol): boolean {
+        // TODO remove type assertion on update to typescript@2.5.0
+        if ((checker as any as {getExportSymbolOfSymbol(s: ts.Symbol): ts.Symbol}).getExportSymbolOfSymbol !== undefined) {
+            inScope = (checker as any as {getExportSymbolOfSymbol(s: ts.Symbol): ts.Symbol}).getExportSymbolOfSymbol(inScope);
+        }
+        return accessed === inScope;
     }
 }
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
#3052 made `no-unnecessary-qualifier` work with upcoming changes in typescript@2.5
In the meantime typescript added a new API to do this in a more correct way: https://github.com/Microsoft/TypeScript/pull/17457
/cc @andy-ms 

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[no-log]
