### PR TITLE
Update ordered-imports rule: add default grouping

### DIFF
--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -31,7 +31,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "ordered-imports",
-        description: "Requires that import statements be alphabetized.",
+        description: "Requires that import statements be alphabetized and grouped.",
         descriptionDetails: Lint.Utils.dedent`
             Enforce a consistent ordering for ES6 imports:
             - Named imports must be alphabetized (i.e. "import {A, B, C} from "foo";")
@@ -41,7 +41,8 @@ export class Rule extends Lint.Rules.AbstractRule {
                     import * as foo from "a";
                     import * as bar from "b";
             - Groups of imports are delineated by blank lines. You can use these to group imports
-                however you like, e.g. by first- vs. third-party or thematically.`,
+                however you like, e.g. by first- vs. third-party or thematically or can you can
+                enforce a grouping of third-party, parent directories and the current directory.`,
         hasFix: true,
         optionsDescription: Lint.Utils.dedent`
             You may set the \`"import-sources-order"\` option to control the ordering of source
@@ -53,6 +54,14 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`"lowercase-first"\`: Correct order is \`"baz"\`, \`"Bar"\`, \`"Foo"\`.
             * \`"lowercase-last"\`: Correct order is \`"Bar"\`, \`"Foo"\`, \`"baz"\`.
             * \`"any"\`: Allow any order.
+
+            You may set the \`"grouped-imports"\` option to control the grouping of source
+            imports (the \`"foo"\` in \`import {A, B, C} from "foo"\`).
+
+            Possible values for \`"grouped-imports"\` are:
+
+            * \`false\`: Do not enforce grouping. (This is the default.)
+            * \`true\`: Group source imports by \`"bar"\`, \`"../baz"\`, \`"./foo"\`.
 
             You may set the \`"named-imports-order"\` option to control the ordering of named
             imports (the \`{A, B, C}\` in \`import {A, B, C} from "foo"\`).
@@ -68,6 +77,9 @@ export class Rule extends Lint.Rules.AbstractRule {
         options: {
             type: "object",
             properties: {
+                "grouped-imports": {
+                    type: "boolean",
+                },
                 "import-sources-order": {
                     type: "string",
                     enum: ["case-insensitive", "lowercase-first", "lowercase-last", "any"],
@@ -88,6 +100,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
+    public static IMPORT_SOURCES_NOT_GROUPED =
+        "Import sources of different groups must be sorted by: libraries, parent directories, current directory.";
     public static IMPORT_SOURCES_UNORDERED = "Import sources within a group must be alphabetized.";
     public static NAMED_IMPORTS_UNORDERED = "Named imports must be alphabetized.";
 
@@ -106,12 +120,20 @@ const TRANSFORMS = new Map<string, Transform>([
     ["lowercase-last", (x) => x],
 ]);
 
+enum ImportType {
+    LIBRARY_IMPORT = 1,
+    PARENT_DIRECTORY_IMPORT = 2, // starts with "../"
+    CURRENT_DIRECTORY_IMPORT = 3, // starts with "./"
+}
+
 interface Options {
+    groupedImports: boolean;
     importSourcesOrderTransform: Transform;
     namedImportsOrderTransform: Transform;
 }
 
 interface JsonOptions {
+    "grouped-imports"?: boolean;
     "import-sources-order"?: string;
     "named-imports-order"?: string;
 }
@@ -119,25 +141,35 @@ interface JsonOptions {
 function parseOptions(ruleArguments: any[]): Options {
     const optionSet = (ruleArguments as JsonOptions[])[0];
     const {
+        "grouped-imports": isGrouped = false,
         "import-sources-order": sources = "case-insensitive",
         "named-imports-order": named = "case-insensitive",
     } = optionSet === undefined ? {} : optionSet;
     return {
+        groupedImports: isGrouped,
         importSourcesOrderTransform: TRANSFORMS.get(sources)!,
         namedImportsOrderTransform: TRANSFORMS.get(named)!,
     };
 }
 
 class Walker extends Lint.AbstractWalker<Options> {
-    private currentImportsBlock = new ImportsBlock();
+    private importsBlocks = [new ImportsBlock()];
     // keep a reference to the last Fix object so when the entire block is replaced, the replacement can be added
     private lastFix: Lint.Replacement[] | undefined;
+    private nextType = ImportType.LIBRARY_IMPORT;
+
+    private get currentImportsBlock(): ImportsBlock {
+        return this.importsBlocks[this.importsBlocks.length - 1];
+    }
 
     public walk(sourceFile: ts.SourceFile): void {
         for (const statement of sourceFile.statements) {
             this.checkStatement(statement);
         }
         this.endBlock();
+        if (this.options.groupedImports) {
+            this.checkBlocksGrouping();
+        }
     }
 
     private checkStatement(statement: ts.Statement): void {
@@ -213,7 +245,7 @@ class Walker extends Lint.AbstractWalker<Options> {
             }
             this.lastFix = undefined;
         }
-        this.currentImportsBlock = new ImportsBlock();
+        this.importsBlocks.push(new ImportsBlock());
     }
 
     private checkNamedImports(node: ts.NamedImports): void {
@@ -237,6 +269,82 @@ class Walker extends Lint.AbstractWalker<Options> {
             this.addFailure(a.getStart(), b.getEnd(), Rule.NAMED_IMPORTS_UNORDERED, this.lastFix);
         }
     }
+
+    private checkBlocksGrouping(): void {
+        this.importsBlocks.some(this.checkBlockGroups, this);
+    }
+
+    private checkBlockGroups(importsBlock: ImportsBlock): boolean {
+        const oddImportDeclaration = this.getOddImportDeclaration(importsBlock);
+        if (oddImportDeclaration !== undefined) {
+            this.addFailureAtNode(oddImportDeclaration.node, Rule.IMPORT_SOURCES_NOT_GROUPED, this.getReplacements());
+            return true;
+        }
+        return false;
+    }
+
+    private getOddImportDeclaration(importsBlock: ImportsBlock): ImportDeclaration|undefined {
+        const importDeclarations = importsBlock.getImportDeclarations();
+        if (importDeclarations.length === 0) {
+            return undefined;
+        }
+        const type = importDeclarations[0].type;
+        if (type < this.nextType) {
+            return importDeclarations[0];
+        } else {
+            this.nextType = type;
+            return importDeclarations.find((importDeclaration) => importDeclaration.type != type);
+        }
+    }
+
+    private getReplacements(): Lint.Replacement[] {
+        const importDeclarationsList = this.importsBlocks
+            .map((block) => block.getImportDeclarations())
+            .filter((imports) => imports.length > 0);
+        const allImportDeclarations = ([] as ImportDeclaration[]).concat(...importDeclarationsList);
+        const replacements = this.getReplacementsForExistingImports(importDeclarationsList);
+        const startOffset = allImportDeclarations.length === 0 ? 0 : allImportDeclarations[0].nodeStartOffset;
+        replacements.push(Lint.Replacement.appendText(startOffset, this.getGroupedImports(allImportDeclarations)));
+        return replacements;
+    }
+
+    private getReplacementsForExistingImports(importDeclarationsList: ImportDeclaration[][]): Lint.Replacement[] {
+        return importDeclarationsList.map((items, index) => {
+            let start = items[0].nodeStartOffset;
+            if (index > 0) {
+                const prevItems = importDeclarationsList[index - 1];
+                const last = prevItems[prevItems.length - 1];
+                if (/[\r\n]+/.test(this.sourceFile.text.slice(last.nodeEndOffset, start))) {
+                    // remove whitespace between blocks
+                    start = last.nodeEndOffset;
+                }
+            }
+            return Lint.Replacement.deleteFromTo(start, items[items.length - 1].nodeEndOffset);
+        });
+    }
+
+    private getGroupedImports(importDeclarations: ImportDeclaration[]): string {
+        return [ImportType.LIBRARY_IMPORT, ImportType.PARENT_DIRECTORY_IMPORT, ImportType.CURRENT_DIRECTORY_IMPORT]
+            .map((type) => {
+                const imports = importDeclarations.filter((importDeclaration) => importDeclaration.type === type);
+                return getSortedImportDeclarationsAsText(imports);
+            })
+            .filter((text) => text.length > 0)
+            .join(this.getEolChar());
+    }
+
+    private getEolChar(): string {
+        const lineEnd = this.sourceFile.getLineEndOfPosition(0);
+        let newLine;
+        if (lineEnd > 0) {
+            if (lineEnd > 1 && this.sourceFile.text[lineEnd - 1] === "\r") {
+                newLine = "\r\n";
+            } else if (this.sourceFile.text[lineEnd] === "\n") {
+                newLine = "\n";
+            }
+        }
+        return newLine == null ? ts.sys.newLine : newLine;
+    }
 }
 
 interface ImportDeclaration {
@@ -245,6 +353,7 @@ interface ImportDeclaration {
     nodeStartOffset: number;    // start position of node within source file
     text: string;               // initialized with original import text; modified if the named imports are reordered
     sourcePath: string;
+    type: ImportType;
 }
 
 class ImportsBlock {
@@ -254,6 +363,7 @@ class ImportsBlock {
         const start = this.getStartOffset(node);
         const end = this.getEndOffset(sourceFile, node);
         const text = sourceFile.text.substring(start, end);
+        const type = this.getImportType(sourcePath);
 
         if (start > node.getStart() || end === 0) {
             // skip block if any statements don't end with a newline to simplify implementation
@@ -267,7 +377,12 @@ class ImportsBlock {
             nodeStartOffset: start,
             sourcePath,
             text,
+            type,
         });
+    }
+
+    public getImportDeclarations(): ImportDeclaration[] {
+        return this.importDeclarations;
     }
 
     // replaces the named imports on the most recent import declaration
@@ -299,8 +414,7 @@ class ImportsBlock {
         if (this.importDeclarations.length === 0) {
             return undefined;
         }
-        const sortedDeclarations = sortByKey(this.importDeclarations.slice(), (x) => x.sourcePath);
-        const fixedText = sortedDeclarations.map((x) => x.text).join("");
+        const fixedText = getSortedImportDeclarationsAsText(this.importDeclarations);
         const start = this.importDeclarations[0].nodeStartOffset;
         const end = this.getLastImportDeclaration().nodeEndOffset;
         return new Lint.Replacement(start, end - start, fixedText);
@@ -321,6 +435,18 @@ class ImportsBlock {
 
     private getLastImportDeclaration() {
         return this.importDeclarations[this.importDeclarations.length - 1];
+    }
+
+    private getImportType(sourcePath: string): ImportType {
+        if (sourcePath.charAt(0) === ".") {
+            if (sourcePath.charAt(1) === ".") {
+                return ImportType.PARENT_DIRECTORY_IMPORT;
+            } else {
+                return ImportType.CURRENT_DIRECTORY_IMPORT;
+            }
+        } else {
+            return ImportType.LIBRARY_IMPORT;
+        }
     }
 }
 
@@ -370,6 +496,11 @@ function removeQuotes(value: string): string {
         value = value.substr(1, value.length - 2);
     }
     return value;
+}
+
+function getSortedImportDeclarationsAsText(importDeclarations: ImportDeclaration[]): string {
+    const sortedDeclarations = sortByKey(importDeclarations.slice(), (x) => x.sourcePath);
+    return sortedDeclarations.map((x) => x.text).join("");
 }
 
 function sortByKey<T>(xs: ReadonlyArray<T>, getSortKey: (x: T) => string): T[] {

--- a/test/rules/ordered-imports/grouped-imports/test.ts.fix
+++ b/test/rules/ordered-imports/grouped-imports/test.ts.fix
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import {afoo, foo} from 'foo';
+import x = require('y');
+
+import {bar} from '../bar';
+
+import './baa';
+import './baz'; // required
+
+export class Test {}

--- a/test/rules/ordered-imports/grouped-imports/test.ts.lint
+++ b/test/rules/ordered-imports/grouped-imports/test.ts.lint
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import {bar} from '../bar';
+
+import {foo, afoo} from 'foo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of different groups must be sorted by: libraries, parent directories, current directory.]
+        ~~~~~~~~~              [Named imports must be alphabetized.]
+
+import './baz'; // required
+import './baa';
+~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
+
+import x = require('y');
+
+export class Test {}

--- a/test/rules/ordered-imports/grouped-imports/tslint.json
+++ b/test/rules/ordered-imports/grouped-imports/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "ordered-imports": [true, {"import-sources-order": "case-insensitive", "named-imports-order": "case-insensitive", "grouped-imports": true}]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### Overview of change:
Added an extra options to ordered-imports to enforce grouping by libraries, parent directories & the current directory.

#### Is there anything you'd like reviewers to focus on?
Should the grouping fix clear the sorting fixes?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

[new-rule-option] `"grouped-imports"` for `ordered-imports` rule