### PR TITLE
applyWithFunction: allow passing TypeChecker or Program directly

### DIFF
--- a/src/language/rule/abstractRule.ts
+++ b/src/language/rule/abstractRule.ts
@@ -51,9 +51,20 @@ export abstract class AbstractRule implements IRule {
 
     protected applyWithFunction(sourceFile: ts.SourceFile, walkFn: (ctx: WalkContext<void>) => void): RuleFailure[];
     protected applyWithFunction<T>(sourceFile: ts.SourceFile, walkFn: (ctx: WalkContext<T>) => void, options: NoInfer<T>): RuleFailure[];
-    protected applyWithFunction<T>(sourceFile: ts.SourceFile, walkFn: (ctx: WalkContext<T | void>) => void, options?: T): RuleFailure[] {
+    protected applyWithFunction<T, U>(
+        sourceFile: ts.SourceFile,
+        walkFn: (ctx: WalkContext<T>, programOrChecker: U) => void,
+        options: NoInfer<T>,
+        checker: NoInfer<U>,
+    ): RuleFailure[];
+    protected applyWithFunction<T, U>(
+        sourceFile: ts.SourceFile,
+        walkFn: (ctx: WalkContext<T | void>, programOrChecker?: U) => void,
+        options?: T,
+        programOrChecker?: U,
+    ): RuleFailure[] {
         const ctx = new WalkContext(sourceFile, this.ruleName, options);
-        walkFn(ctx);
+        walkFn(ctx, programOrChecker);
         return ctx.failures;
     }
 

--- a/src/rules/awaitPromiseRule.ts
+++ b/src/rules/awaitPromiseRule.ts
@@ -45,12 +45,12 @@ export class Rule extends Lint.Rules.TypedRule {
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         const promiseTypes = new Set(["Promise", ...this.ruleArguments as string[]]);
-        const tc = program.getTypeChecker();
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, tc, promiseTypes));
+        return this.applyWithFunction(sourceFile, walk, promiseTypes, program.getTypeChecker());
     }
 }
 
-function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker, promiseTypes: Set<string>) {
+function walk(ctx: Lint.WalkContext<Set<string>>, tc: ts.TypeChecker) {
+    const promiseTypes = ctx.options;
     return ts.forEachChild(ctx.sourceFile, cb);
 
     function cb(node: ts.Node): void {

--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.TypedRule {
     }
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/matchDefaultExportNameRule.ts
+++ b/src/rules/matchDefaultExportNameRule.ts
@@ -41,7 +41,7 @@ export class Rule extends Lint.Rules.TypedRule {
     }
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/noBooleanLiteralCompareRule.ts
+++ b/src/rules/noBooleanLiteralCompareRule.ts
@@ -40,7 +40,7 @@ export class Rule extends Lint.Rules.TypedRule {
     }
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/noFloatingPromisesRule.ts
+++ b/src/rules/noFloatingPromisesRule.ts
@@ -49,8 +49,9 @@ export class Rule extends Lint.Rules.TypedRule {
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         return this.applyWithFunction(
             sourceFile,
-            (ctx) => walk(ctx, program.getTypeChecker()),
+            walk,
             ["Promise", ...this.ruleArguments as string[]],
+            program.getTypeChecker(),
         );
     }
 }

--- a/src/rules/noForInArrayRule.ts
+++ b/src/rules/noForInArrayRule.ts
@@ -50,14 +50,14 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING = "for-in loops over arrays are forbidden. Use for-of or array.forEach instead.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 
-function walk(ctx: Lint.WalkContext<void>, program: ts.Program) {
+function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (node.kind === ts.SyntaxKind.ForInStatement) {
-            const type = program.getTypeChecker().getTypeAtLocation((node as ts.ForInStatement).expression);
+            const type = checker.getTypeAtLocation((node as ts.ForInStatement).expression);
             if (type.symbol !== undefined && type.symbol.name === "Array" ||
                 // tslint:disable-next-line:no-bitwise
                 (type.flags & ts.TypeFlags.StringLike) !== 0) {

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -45,9 +45,14 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING = "Avoid referencing unbound methods which may cause unintentional scoping of 'this'.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()), {
-            ignoreStatic: this.ruleArguments.indexOf(OPTION_IGNORE_STATIC) !== -1,
-        });
+        return this.applyWithFunction(
+            sourceFile,
+            walk,
+            {
+                ignoreStatic: this.ruleArguments.indexOf(OPTION_IGNORE_STATIC) !== -1,
+            },
+            program.getTypeChecker(),
+        );
     }
 }
 

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -40,7 +40,7 @@ export class Rule extends Lint.Rules.TypedRule {
     }
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -40,7 +40,7 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING = "Unsafe use of expression of type 'any'.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -73,7 +73,7 @@ export class Rule extends Lint.Rules.TypedRule {
                 "the 'no-unused-locals' and 'no-unused-parameters' compiler options are enabled.");
         }
 
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program, parseOptions(this.ruleArguments)));
+        return this.applyWithFunction(sourceFile, walk, parseOptions(this.ruleArguments), program);
     }
 }
 
@@ -99,8 +99,8 @@ function parseOptions(options: any[]): Options {
     return { checkParameters, ignorePattern };
 }
 
-function walk(ctx: Lint.WalkContext<void>, program: ts.Program, { checkParameters, ignorePattern }: Options): void {
-    const { sourceFile } = ctx;
+function walk(ctx: Lint.WalkContext<Options>, program: ts.Program): void {
+    const { sourceFile, options: { checkParameters, ignorePattern } } = ctx;
     const unusedCheckedProgram = getUnusedCheckedProgram(program, checkParameters);
     const diagnostics = ts.getPreEmitDiagnostics(unusedCheckedProgram, sourceFile);
     const checker = unusedCheckedProgram.getTypeChecker(); // Doesn't matter which program is used for this.
@@ -151,7 +151,7 @@ function walk(ctx: Lint.WalkContext<void>, program: ts.Program, { checkParameter
  * - If all of the import specifiers in an import are unused, add a combined failure for them all.
  * - Unused imports are fixable.
  */
-function addImportSpecifierFailures(ctx: Lint.WalkContext<void>, failures: Map<ts.Identifier, string>, sourceFile: ts.SourceFile) {
+function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Map<ts.Identifier, string>, sourceFile: ts.SourceFile) {
     forEachImport(sourceFile, (importNode) => {
         if (importNode.kind === ts.SyntaxKind.ImportEqualsDeclaration) {
             tryRemoveAll(importNode.name);

--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -41,7 +41,7 @@ export class Rule extends Lint.Rules.TypedRule {
     }
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/noVoidExpressionRule.ts
+++ b/src/rules/noVoidExpressionRule.ts
@@ -49,8 +49,7 @@ export class Rule extends Lint.Rules.TypedRule {
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         const ignoreArrowFunctionShorthand = this.ruleArguments.indexOf(OPTION_IGNORE_ARROW_FUNCTION_SHORTHAND) !== -1;
-        return this.applyWithFunction(
-            sourceFile, (ctx) => walk(ctx, program.getTypeChecker()), { ignoreArrowFunctionShorthand });
+        return this.applyWithFunction(sourceFile, walk, { ignoreArrowFunctionShorthand }, program.getTypeChecker());
     }
 }
 

--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -79,8 +79,9 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         return this.applyWithFunction(
             sourceFile,
-            (ctx) => walk(ctx, program.getTypeChecker()),
+            walk,
             parseOptions(this.ruleArguments),
+            program.getTypeChecker(),
         );
     }
 }

--- a/src/rules/preferTemplateRule.ts
+++ b/src/rules/preferTemplateRule.ts
@@ -22,6 +22,10 @@ import * as Lint from "../index";
 
 const OPTION_SINGLE_CONCAT = "allow-single-concat";
 
+interface Options {
+    allowSingleConcat: boolean;
+}
+
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
@@ -48,11 +52,12 @@ export class Rule extends Lint.Rules.AbstractRule {
         }
 
         const allowSingleConcat = this.ruleArguments.indexOf(OPTION_SINGLE_CONCAT) !== -1;
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, allowSingleConcat));
+        return this.applyWithFunction(sourceFile, walk, {allowSingleConcat});
     }
 }
 
-function walk(ctx: Lint.WalkContext<void>, allowSingleConcat: boolean): void {
+function walk(ctx: Lint.WalkContext<Options>): void {
+    const allowSingleConcat = ctx.options.allowSingleConcat;
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         const failure = getError(node, allowSingleConcat);
         if (failure !== undefined) {

--- a/src/rules/promiseFunctionAsyncRule.ts
+++ b/src/rules/promiseFunctionAsyncRule.ts
@@ -42,7 +42,7 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING = "functions that return promises must be async";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/restrictPlusOperandsRule.ts
+++ b/src/rules/restrictPlusOperandsRule.ts
@@ -37,14 +37,13 @@ export class Rule extends Lint.Rules.TypedRule {
     public static INVALID_TYPES_ERROR = "Operands of '+' operation must either be both strings or both numbers";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 
-function walk(ctx: Lint.WalkContext<void>, program: ts.Program) {
+function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
-            const tc = program.getTypeChecker();
             const leftType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.left));
             const rightType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.right));
             if (leftType === "invalid" || rightType === "invalid" || leftType !== rightType) {

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -40,7 +40,7 @@ export class Rule extends Lint.Rules.TypedRule {
         "`void` function should use `return;`, not `return undefined;`.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -88,7 +88,7 @@ export class Rule extends Lint.Rules.TypedRule {
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         const options = parseOptions(this.ruleArguments, Lint.isStrictNullChecksEnabled(program.getCompilerOptions()));
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()), options);
+        return this.applyWithFunction(sourceFile, walk, options, program.getTypeChecker());
     }
 }
 

--- a/src/rules/strictTypePredicatesRule.ts
+++ b/src/rules/strictTypePredicatesRule.ts
@@ -59,7 +59,7 @@ export class Rule extends Lint.Rules.TypedRule {
             showWarningOnce("strict-type-predicates does not work without --strictNullChecks");
             return [];
         }
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 

--- a/src/rules/useDefaultTypeParameterRule.ts
+++ b/src/rules/useDefaultTypeParameterRule.ts
@@ -37,7 +37,7 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING = "This is the default value for this type parameter, so it can be omitted.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, (ctx) => walk(ctx, program.getTypeChecker()));
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
     }
 }
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
With this change we no longer need a closure to pass the `TypeChecker` or `Program` to the `walkFn`.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[api] `AbstractRule#applyWithFunction` allows additional parameter that is passed through to `walkFn`