### PR TITLE
deprecation: Don't show errors on imports and exports

### DIFF
--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -59,6 +59,13 @@ function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker) {
                 }
             }
         } else {
+            switch (node.kind) {
+                case ts.SyntaxKind.ImportDeclaration:
+                case ts.SyntaxKind.ImportEqualsDeclaration:
+                case ts.SyntaxKind.ExportDeclaration:
+                case ts.SyntaxKind.ExportAssignment:
+                    return;
+            }
             return ts.forEachChild(node, cb);
         }
     });
@@ -82,10 +89,6 @@ function isDeclaration(identifier: ts.Identifier): boolean {
         case ts.SyntaxKind.GetAccessor:
         case ts.SyntaxKind.SetAccessor:
         case ts.SyntaxKind.EnumDeclaration:
-        case ts.SyntaxKind.ExportSpecifier:
-        case ts.SyntaxKind.ImportSpecifier:
-        case ts.SyntaxKind.ImportClause:
-        case ts.SyntaxKind.NamespaceImport:
             return true;
         case ts.SyntaxKind.VariableDeclaration:
         case ts.SyntaxKind.TypeAliasDeclaration:

--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -82,6 +82,10 @@ function isDeclaration(identifier: ts.Identifier): boolean {
         case ts.SyntaxKind.GetAccessor:
         case ts.SyntaxKind.SetAccessor:
         case ts.SyntaxKind.EnumDeclaration:
+        case ts.SyntaxKind.ExportSpecifier:
+        case ts.SyntaxKind.ImportSpecifier:
+        case ts.SyntaxKind.ImportClause:
+        case ts.SyntaxKind.NamespaceImport:
             return true;
         case ts.SyntaxKind.VariableDeclaration:
         case ts.SyntaxKind.TypeAliasDeclaration:
@@ -90,13 +94,12 @@ function isDeclaration(identifier: ts.Identifier): boolean {
         case ts.SyntaxKind.PropertyDeclaration:
         case ts.SyntaxKind.PropertyAssignment:
         case ts.SyntaxKind.EnumMember:
+        case ts.SyntaxKind.ImportEqualsDeclaration:
             return (parent as ts.NamedDeclaration).name === identifier;
         case ts.SyntaxKind.BindingElement:
-        case ts.SyntaxKind.ExportSpecifier:
-        case ts.SyntaxKind.ImportSpecifier:
-            // return true for `b` in `import {a as b} from "foo"`
-            return (parent as ts.ImportOrExportSpecifier | ts.BindingElement).name === identifier &&
-                (parent as ts.ImportOrExportSpecifier | ts.BindingElement).propertyName !== undefined;
+            // return true for `b` in `const {a: b} = obj"`
+            return (parent as ts.BindingElement).name === identifier &&
+                (parent as ts.BindingElement).propertyName !== undefined;
         default:
             return false;
     }

--- a/test/rules/deprecation/other.test.ts
+++ b/test/rules/deprecation/other.test.ts
@@ -1,5 +1,8 @@
 /** @deprecated reason */
-export function other() {}
+export function other(): void;
+/** not deprecated */
+export function other(num: number);
+export function other(_num?: number) {}
 
 /** @deprecated */
 export let other2: Function;

--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -12,7 +12,9 @@ other2;
 ~~~~~~ [err % ('other2')]
 
 import tmp = namespaceImport.other;
-                             ~~~~~ [errmsg % ('other', 'reason')]
+
+tmp;
+~~~ [errmsg % ('tmp', 'reason')]
 
 declare interface D {
     /** @deprecated */ m: () => void;
@@ -57,6 +59,8 @@ const A = 1, B = 2;
 A + B;
 ~     [err % ('A')]
     ~ [err % ('B')]
+
+export default A;
 
 declarationIsMissing();
 

--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -1,17 +1,23 @@
+// don't show an error on imports, because they don't do any harm if not used
 import def, {other, other2 as foobar, notDeprecated, notDeprecated2} from './other.test';
-       ~~~ [errmsg % ('def', 'deprecated default export')]
-             ~~~~~          [errmsg % ('other', 'reason')]
-                    ~~~~~~  [err % ('other2')]
+import * as namespaceImport from './other.test';
 import * as other2 from './other2.test';
-            ~~~~~~ [err % ('other2')]
+
 other();
 ~~~~~ [errmsg % ('other', 'reason')]
+other(1);
 foobar();
 ~~~~~~ [err % ('foobar')]
+other2;
+~~~~~~ [err % ('other2')]
+
+import tmp = namespaceImport.other;
+                             ~~~~~ [errmsg % ('other', 'reason')]
 
 declare interface D {
     /** @deprecated */ m: () => void;
 }
+
 
 declare let d: D;
 d.m();


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Imports and exports don't do any harm. We now only show errors at deprecated usage to correctly handle deprecated overload signatures. So this is basically a followup on #2883.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[bugfix] `deprecation` no longer shows errors on imports and exports
