### PR TITLE
feat(cli): add --color and --no-color flags to force coloring behaviour

### DIFF
--- a/docs/usage/cli/index.md
+++ b/docs/usage/cli/index.md
@@ -47,6 +47,8 @@ Options:
 -t, --format          output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)  [default: "prose"]
 --test                test that tslint produces the correct output for the specified directory
 --type-check          enable type checking when linting a project
+--color               force enabling of colors
+--no-color            force disabling of colors
 -v, --version         current version
 ```
 
@@ -130,6 +132,16 @@ tslint accepts the following command-line options:
 --type-check
     Enables the type checker when running linting rules. --project must be
     specified in order to enable type checking.
+
+--color:
+    Built-in formatters adjust to the terminal window, and disable
+    ANSI-escape coloring when the stdio streams are not associated
+    with a TTY. This flag allows you to force coloring, which might be
+    useful, when you have to run tslint in a forked process.
+
+--no-color:
+    Some built-in formatters enable ANSI-escape coloring when possible.
+    Pass this flag to disable coloring and output only text.
 
 -v, --version:
     The current version of tslint.

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -45,7 +45,7 @@ interface Argv {
 interface Option {
     short?: string;
     // Commander will camelCase option names.
-    name: keyof Argv | "rules-dir" | "formatters-dir" | "type-check";
+    name: keyof Argv | "rules-dir" | "formatters-dir" | "type-check" | "color" | "no-color";
     type: "string" | "boolean" | "array";
     describe: string; // Short, used for usage message
     description: string; // Long, used for `--help`
@@ -185,6 +185,24 @@ const options: Option[] = [
         description: dedent`
             Checks for type errors before linting a project. --project must be
             specified in order to enable type checking.`,
+    },
+    {
+        name: "color",
+        type: "boolean",
+        describe: "force enabling of colors",
+        description: dedent`
+            Built-in formatters adjust to the terminal window, and disable
+            ANSI-escape coloring when the stdio streams are not associated
+            with a TTY. This flag allows you to force coloring, which might be
+            useful, when you have to run tslint in a forked process.`,
+    },
+    {
+        name: "no-color",
+        type: "boolean",
+        describe: "force disabling of colors",
+        description: dedent`
+            Some built-in formatters enable ANSI-escape coloring when possible.
+            Pass this flag to disable coloring and output only text.`,
     },
 ];
 


### PR DESCRIPTION
Add `--color` and `--no-color` CLI flags to force enabling/disabling of ANSI-escape coloring in formatters using [colors.js](https://github.com/Marak/colors.js)

#### PR checklist

- [ ] Addresses an existing issue
- [x] New feature
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

This PR just tells to `commander.js` to support mentioned flags, and the rest is [handled by `colors.js`](https://github.com/Marak/colors.js/blob/master/lib/system/supports-colors.js#L29-L37) library. 

I've actually came from [npm-run-all#7](https://github.com/mysticatea/npm-run-all/issues/7), and surprised that no one had similar issue with colors in `tslint`. 

#### Is there anything you'd like reviewers to focus on?

Note, there can be another fix. As [colors.js](https://github.com/Marak/colors.js) seem to be an abandoned library, `tslint` can replace it with [`chulk`](https://github.com/chalk/chalk#origin-story). Which [appears to be a common thing](https://www.google.com/search?q=site%3Agithub.com+from+colors%7Ccolors.js+to+chalk&oq=site%3Agithub.com+from+colors%7Ccolors.js+to+chalk) here, on github. In such case, no any extra flags are needed, as there is a way to [force colors using env variables](https://github.com/chalk/supports-color/blob/master/index.js#L111-L113).

#### CHANGELOG.md entry:

[cli] Add `--color` and `--no-color` flags to force coloring behaviour