### PR TITLE
Update to typescript@2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "resolve": "^1.3.2",
     "semver": "^5.3.0",
     "tslib": "^1.7.1",
-    "tsutils": "^2.7.1"
+    "tsutils": "^2.8.0"
   },
   "peerDependencies": {
-    "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev"
+    "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev"
   },
   "devDependencies": {
     "@types/babel-code-frame": "^6.20.0",
@@ -72,9 +72,9 @@
     "npm-run-all": "^4.0.2",
     "nyc": "^10.2.0",
     "rimraf": "^2.5.4",
-    "tslint": "^5.5.0",
+    "tslint": "^5.6.0",
     "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
-    "typescript": "~2.4.1"
+    "typescript": "~2.5.0"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rimraf": "^2.5.4",
     "tslint": "^5.6.0",
     "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
-    "typescript": "~2.5.0"
+    "typescript": "~2.5.1"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "resolve": "^1.3.2",
     "semver": "^5.3.0",
     "tslib": "^1.7.1",
-    "tsutils": "^2.8.0"
+    "tsutils": "^2.8.1"
   },
   "peerDependencies": {
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev"

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -221,7 +221,7 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
         return ts.forEachChild(sourceFile, cb);
     }
 
-    private checkMembers(members: Member[]) {
+    private checkMembers(members: ts.NodeArray<Member>) {
         let prevRank = -1;
         let prevName: string | undefined;
         for (const member of members) {

--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -89,7 +89,10 @@ class NoInferrableTypesWalker extends Lint.AbstractWalker<Options> {
     }
 }
 
-function shouldCheck(node: ts.Node, { ignoreParameters, ignoreProperties }: Options): node is ts.VariableLikeDeclaration {
+function shouldCheck(
+    node: ts.Node,
+    { ignoreParameters, ignoreProperties }: Options,
+): node is ts.ParameterDeclaration | ts.PropertyDeclaration | ts.VariableDeclaration {
     switch (node.kind) {
         case ts.SyntaxKind.Parameter:
             return !ignoreParameters &&

--- a/src/rules/noSubmoduleImportsRule.ts
+++ b/src/rules/noSubmoduleImportsRule.ts
@@ -81,6 +81,7 @@ class NoSubmoduleImportsWalker extends Lint.AbstractWalker<string[]> {
 
     private checkForBannedImport(expression: ts.Expression) {
         if (isTextualLiteral(expression) &&
+            // TODO remove assertion on upgrade to typescript@2.5.2
             !(ts as any as {isExternalModuleNameRelative(m: string): boolean}).isExternalModuleNameRelative(expression.text) &&
             isSubmodulePath(expression.text)) {
             /*

--- a/src/rules/noSubmoduleImportsRule.ts
+++ b/src/rules/noSubmoduleImportsRule.ts
@@ -81,7 +81,7 @@ class NoSubmoduleImportsWalker extends Lint.AbstractWalker<string[]> {
 
     private checkForBannedImport(expression: ts.Expression) {
         if (isTextualLiteral(expression) &&
-            (ts as any as {moduleHasNonRelativeName(m: string): boolean}).moduleHasNonRelativeName(expression.text) &&
+            !(ts as any as {isExternalModuleNameRelative(m: string): boolean}).isExternalModuleNameRelative(expression.text) &&
             isSubmodulePath(expression.text)) {
             /*
              * A submodule is being imported.

--- a/src/rules/noSubmoduleImportsRule.ts
+++ b/src/rules/noSubmoduleImportsRule.ts
@@ -81,7 +81,7 @@ class NoSubmoduleImportsWalker extends Lint.AbstractWalker<string[]> {
 
     private checkForBannedImport(expression: ts.Expression) {
         if (isTextualLiteral(expression) &&
-            ts.moduleHasNonRelativeName(expression.text) &&
+            (ts as any as {moduleHasNonRelativeName(m: string): boolean}).moduleHasNonRelativeName(expression.text) &&
             isSubmodulePath(expression.text)) {
             /*
              * A submodule is being imported.

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -167,10 +167,12 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
             if (node.kind === ts.SyntaxKind.VariableDeclarationList) {
                 this.handleVariableDeclaration(node as ts.VariableDeclarationList);
             } else if (node.kind === ts.SyntaxKind.CatchClause) {
-                this.handleBindingName((node as ts.CatchClause).variableDeclaration.name, {
-                    canBeConst: false,
-                    isBlockScoped: true,
-                });
+                if ((node as ts.CatchClause).variableDeclaration !== undefined) {
+                    this.handleBindingName((node as ts.CatchClause).variableDeclaration!.name, {
+                        canBeConst: false,
+                        isBlockScoped: true,
+                    });
+                }
             } else if (node.kind === ts.SyntaxKind.Parameter) {
                 this.handleBindingName((node as ts.ParameterDeclaration).name, {
                     canBeConst: false,

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -200,7 +200,7 @@ class TypedefWalker extends Lint.AbstractWalker<Options> {
             name?: ts.Node): void {
         if (this.options[option] === true && typeAnnotation === undefined) {
             const failure = `expected ${option}${name === undefined ? "" : `: '${name.getText()}'`} to have a typedef`;
-            if (Array.isArray(location)) {
+            if (isNodeArray(location)) {
                 this.addFailure(location.pos - 1, location.end + 1, failure);
             } else {
                 this.addFailureAtNode(location, failure);
@@ -211,4 +211,8 @@ class TypedefWalker extends Lint.AbstractWalker<Options> {
 
 function isTypedPropertyDeclaration(node: ts.Node): boolean {
     return utils.isPropertyDeclaration(node) && node.type !== undefined;
+}
+
+export function isNodeArray(nodeOrArray: ts.Node | ts.NodeArray<ts.Node>): nodeOrArray is ts.NodeArray<ts.Node> {
+    return Array.isArray(nodeOrArray);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,7 +148,7 @@ export function flatMap<T, U>(inputs: ReadonlyArray<T>, getOutputs: (input: T, i
 }
 
 /** Returns an array of all outputs that are not `undefined`. */
-export function mapDefined<T, U>(inputs: T[], getOutput: (input: T) => U | undefined): U[] {
+export function mapDefined<T, U>(inputs: ReadonlyArray<T>, getOutput: (input: T) => U | undefined): U[] {
     const out = [];
     for (const input of inputs) {
         const output = getOutput(input);

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -463,7 +463,7 @@ function execCli(args: string[], options: cp.ExecFileOptions | ExecFileCallback,
     }
 
     if (isFunction(options)) {
-        cb = options as ExecFileCallback;
+        cb = options;
         options = {};
     }
 
@@ -475,7 +475,7 @@ function execCli(args: string[], options: cp.ExecFileOptions | ExecFileCallback,
     });
 }
 
-function isFunction(fn: any): boolean {
+function isFunction(fn: any): fn is (...args: any[]) => any {
     return ({}).toString.call(fn) === "[object Function]";
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,9 +1473,9 @@ tslib@^1.7.1:
 "tslint-test-config-non-relative@file:test/external/tslint-test-config-non-relative":
   version "0.0.1"
 
-tslint@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.5.0.tgz#10e8dab3e3061fa61e9442e8cee3982acf20a6aa"
+tslint@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.6.0.tgz#088aa6c6026623338650b2900828ab3edf59f6cf"
   dependencies:
     babel-code-frame "^6.22.0"
     colors "^1.1.2"
@@ -1486,11 +1486,11 @@ tslint@^5.5.0:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.7.1"
-    tsutils "^2.5.1"
+    tsutils "^2.7.1"
 
-tsutils@^2.5.1, tsutils@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.7.1.tgz#411a0e9466525a2b2869260a55620d7292155e24"
+tsutils@^2.7.1, tsutils@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
   dependencies:
     tslib "^1.7.1"
 
@@ -1502,9 +1502,9 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@~2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+typescript@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.0.tgz#60989e74cad93c28fe35f7f7b41fe9b205a25701"
 
 uglify-js@^2.6:
   version "2.8.28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,9 +1502,9 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.0.tgz#60989e74cad93c28fe35f7f7b41fe9b205a25701"
+typescript@~2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
 
 uglify-js@^2.6:
   version "2.8.28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,9 +1488,9 @@ tslint@^5.6.0:
     tslib "^1.7.1"
     tsutils "^2.7.1"
 
-tsutils@^2.7.1, tsutils@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
+tsutils@^2.7.1, tsutils@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.1.tgz#3771404e7ca9f0bedf5d919a47a4b1890a68efff"
   dependencies:
     tslib "^1.7.1"
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Update to the new version of typescript and fix all new errors.
Unfortunately `moduleNameHasNonRelativeName` is no longer exposed which would break the build. We can either wait for https://github.com/Microsoft/TypeScript/issues/17890 to be fixed in the next patch release or merge as is and remove the assertion in `noSubmoduleImportsRule` later. 

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[bugfix] `prefer-const` correctly handle `catch` without binding parameter introduced in `typescript@2.5.1`
Fixes #3154
