### PR TITLE
Speed up test for --project --fix

### DIFF
--- a/test/files/project-multiple-fixes/before.test.ts
+++ b/test/files/project-multiple-fixes/before.test.ts
@@ -5,15 +5,15 @@ const DefaultOptions = {
     new winston.transports.Console({
         json: true,
         colorize: true,
-        stringify:true
+        stringify: true
     })],
-    rewriters:[
-        (level,message,meta)=>{
-            if(meta)
+    rewriters: [
+        (level, message, meta) => {
+            if (meta)
             {
                 meta.timeStamp = new Date();
             }
-            return meta;            
+            return meta;
         }
     ]
 

--- a/test/files/project-multiple-fixes/tslint.json
+++ b/test/files/project-multiple-fixes/tslint.json
@@ -2,17 +2,6 @@
   "rules": {
     "no-consecutive-blank-lines": true,
     "no-trailing-whitespace": true,
-    "whitespace": [
-        true,
-        "check-branch",
-        "check-operator",
-        "check-preblock",
-        "check-separator",
-        "check-decl",
-        "check-module",
-        "check-type",
-        "check-typecast"
-    ],
     "trailing-comma": [
         true, {
             "multiline": "always"


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3127
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
We don't need to execute and fix that many rules to ensure everything works as expected. By removing `whitespace` from the test's `tslint.json` the execution time is reduced from 4.7s to 2.7s on my computer.
That's enough to not run into a timeout even if CI is really slow.
Fixes: #3127

#### Is there anything you'd like reviewers to focus on?

Rewriting the test to not spawn a new process only reduces the execution time by 0.2s - 0.5s

#### CHANGELOG.md entry:
[no-log]