### PR TITLE
no-unused-variable: Also delete trailing comments for imports.

### DIFF
--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -227,6 +227,12 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Ma
         function removeAll(errorNode: ts.Node, failure: string): void {
             const start = importNode.getStart();
             let end = importNode.getEnd();
+            utils.forEachToken(importNode, (token) => {
+                ts.forEachTrailingCommentRange(
+                    ctx.sourceFile.text, token.end, (_, commentEnd, __) => {
+                        end = commentEnd;
+                    });
+            }, ctx.sourceFile);
             if (isEntireLine(start, end)) {
                 end = getNextLineStart(end);
             }

--- a/test/rules/no-unused-variable/default/import.ts.fix
+++ b/test/rules/no-unused-variable/default/import.ts.fix
@@ -17,6 +17,9 @@ import {a14, a16} from "a";
 a14;
 a16;
 
+// Leading comment will not be deleted
+// Next comment will not be deleted
+
 export import a = require("a");
 
 $(_.xyz());

--- a/test/rules/no-unused-variable/default/import.ts.lint
+++ b/test/rules/no-unused-variable/default/import.ts.lint
@@ -30,6 +30,11 @@ import {a14, a15, a16} from "a";
 a14;
 a16;
 
+// Leading comment will not be deleted
+import {unusedFunction} from "legacyDependency"; // Import unusedFunction because ....
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                       [All imports are unused.]
+// Next comment will not be deleted
+
 export import a = require("a");
 
 $(_.xyz());


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Enhancement for "no-unused-variable" fixer: Delete trailing comments when deleting an import declaration. Keep the leading comments to prevent deleting licenses.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->