### PR TITLE
member-access: fix insertion position of fixer

### DIFF
--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { getChildOfKind, getModifier, getNextToken, isClassLikeDeclaration } from "tsutils";
+import { getChildOfKind, getModifier, getNextToken, getTokenAtPosition, isClassLikeDeclaration } from "tsutils";
 import * as ts from "typescript";
 
 import { showWarningOnce } from "../error";
@@ -136,10 +136,15 @@ function walk(ctx: Lint.WalkContext<Options>) {
             ctx.addFailureAtNode(
                 nameNode,
                 Rule.FAILURE_STRING_FACTORY(typeToString(node), memberName),
-                Lint.Replacement.appendText(node.getStart(ctx.sourceFile), "public "),
+                Lint.Replacement.appendText(getInsertionPosition(node, ctx.sourceFile), "public "),
             );
         }
     }
+}
+
+function getInsertionPosition(member: ts.ClassElement, sourceFile: ts.SourceFile): number {
+    const node = member.decorators === undefined ? member : getTokenAtPosition(member, member.decorators.end, sourceFile)!;
+    return node.getStart(sourceFile);
 }
 
 function typeToString(node: ts.ClassElement): string {

--- a/test/rules/member-access/default/test.ts.fix
+++ b/test/rules/member-access/default/test.ts.fix
@@ -46,3 +46,9 @@ function main() {
         public n: number;
     }
 }
+
+abstract class Decorated {
+    @decorator public prop;
+    @decorator public abstract method() {}
+    @decorator @moreDecorator({}) public readonly static PROP = 'FOO';
+}

--- a/test/rules/member-access/default/test.ts.lint
+++ b/test/rules/member-access/default/test.ts.lint
@@ -56,3 +56,12 @@ function main() {
         public n: number;
     }
 }
+
+abstract class Decorated {
+    @decorator prop;
+               ~~~~ [The class property 'prop' must be marked either 'private', 'public', or 'protected']
+    @decorator abstract method() {}
+                        ~~~~~~ [The class method 'method' must be marked either 'private', 'public', or 'protected']
+    @decorator @moreDecorator({}) readonly static PROP = 'FOO';
+                                                  ~~~~ [The class property 'PROP' must be marked either 'private', 'public', or 'protected']
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3158 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `member-access` autofix now correcly inserts `public` keyword after decorators
Fixes: #3158

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
