### PR TITLE
Clarify description of no-non-null-assertion

### DIFF
--- a/src/rules/noNonNullAssertionRule.ts
+++ b/src/rules/noNonNullAssertionRule.ts
@@ -23,7 +23,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-non-null-assertion",
-        description: "Disallows non-null assertions.",
+        description: "Disallows non-null assertions using the `!` postfix operator.",
         rationale: "Using non-null assertion cancels the benefits of the strict null checking mode.",
         optionsDescription: "Not configurable.",
         options: null,


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

This commit clarifies that the `non-null-assertion` is the `!` postfix operator.
Even if the description was already correct, clearly stating what this rule is about `!` makes it easier to understand.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->
N/A

#### CHANGELOG.md entry:

**[docs]** `no-non-null-assertion` description clarifies that it relates to the `!` postfix operator

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
