### PR TITLE
don't remove failure that starts at end of disabled range

### DIFF
--- a/src/enableDisableRules.ts
+++ b/src/enableDisableRules.ts
@@ -43,7 +43,7 @@ export function removeDisabledFailures(sourceFile: ts.SourceFile, failures: Rule
         return disabledIntervals === undefined || !disabledIntervals.some(({ pos, end }) => {
             const failPos = failure.getStartPosition().getPosition();
             const failEnd = failure.getEndPosition().getPosition();
-            return failEnd >= pos && (end === -1 || failPos <= end);
+            return failEnd >= pos && (end === -1 || failPos < end);
         });
     });
 }

--- a/test/rules/_integration/enable-disable/test.ts.lint
+++ b/test/rules/_integration/enable-disable/test.ts.lint
@@ -126,3 +126,21 @@ var AAAaA = 'test'; //tslint:enable-line quotemark all
     ~~~~~          [variable name must be in lowerCamelCase or UPPER_CASE]
             ~~~~~~ [' should be "]
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [comment must start with a space]
+
+// ensure line switches only switch the next line
+//tslint:enable-next-line:quotemark
+'foo';
+~~~~~ [' should be "]
+'bar';
+'baz'; // tslint:enable-line:quotemark
+~~~~~ [' should be "]
+'bas';
+
+//tslint:enable:quotemark
+//tslint:disable-next-line:quotemark
+'foo';
+'bar';
+~~~~~ [' should be "]
+'baz'; // tslint:disable-line:quotemark
+'bas';
+~~~~~ [' should be "]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3174
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Don't remove failures that start at the end of a disabled range.
The bug caused line switches to disable failures that started at the beginning of the line following the disabled line.
Fixes: #3174

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[bugfix] Fixed line switches to not disable failures in the next line following the disabled line
