### PR TITLE
Ordered-Imports Rule: Allow sorting by the trailing end of the module path

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -216,7 +216,7 @@ export const rules = {
     "ordered-imports": [true, {
         "import-sources-order": "case-insensitive",
         "named-imports-order": "case-insensitive",
-        "module-source-path": "full-path",
+        "module-source-path": "full",
     }],
     "prefer-function-over-method": true,
     "prefer-method-signature": true,

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -216,6 +216,7 @@ export const rules = {
     "ordered-imports": [true, {
         "import-sources-order": "case-insensitive",
         "named-imports-order": "case-insensitive",
+        "module-source-path": "full-path",
     }],
     "prefer-function-over-method": true,
     "prefer-method-signature": true,

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -129,6 +129,7 @@ export const rules = {
         options: {
             "import-sources-order": "case-insensitive",
             "named-imports-order": "case-insensitive",
+            "module-source-path": "full-path",
         },
     },
     "prefer-const": true,

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -128,7 +128,7 @@ export const rules = {
     "ordered-imports": {
         options: {
             "import-sources-order": "case-insensitive",
-            "module-source-path": "full-path",
+            "module-source-path": "full",
             "named-imports-order": "case-insensitive",
         },
     },

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -128,8 +128,8 @@ export const rules = {
     "ordered-imports": {
         options: {
             "import-sources-order": "case-insensitive",
-            "named-imports-order": "case-insensitive",
             "module-source-path": "full-path",
+            "named-imports-order": "case-insensitive",
         },
     },
     "prefer-const": true,

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -118,18 +118,18 @@ const TRANSFORMS = new Map<string, Transform>([
     ["lowercase-last", (x) => x],
     ["full-path", (x) => x],
     ["module-name", (x) => {
-        const splitIndex = x.lastIndexOf('/');
+        const splitIndex = x.lastIndexOf("/");
         if (splitIndex === -1) {
             return x;
         }
         return x.substr(splitIndex + 1);
-    }]
+    }],
 ]);
 
 interface Options {
     importSourcesOrderTransform: Transform;
+    moduleSourcePath: Transform;
     namedImportsOrderTransform: Transform;
-    moduleSourcePath: Transform
 }
 
 interface JsonOptions {

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -118,6 +118,10 @@ const TRANSFORMS = new Map<string, Transform>([
     ["lowercase-last", (x) => x],
     ["full-path", (x) => x],
     ["module-name", (x) => {
+        if (!(ts as any as {isExternalModuleNameRelative(m: string): boolean}).isExternalModuleNameRelative(x)) {
+            return x;
+        }
+
         const splitIndex = x.lastIndexOf("/");
         if (splitIndex === -1) {
             return x;
@@ -147,8 +151,8 @@ function parseOptions(ruleArguments: any[]): Options {
     } = optionSet === undefined ? {} : optionSet;
     return {
         importSourcesOrderTransform: TRANSFORMS.get(sources)!,
-        namedImportsOrderTransform: TRANSFORMS.get(named)!,
         moduleSourcePath: TRANSFORMS.get(path)!,
+        namedImportsOrderTransform: TRANSFORMS.get(named)!,
     };
 }
 

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -116,7 +116,7 @@ const TRANSFORMS = new Map<string, Transform>([
     ["case-insensitive", (x) => x.toLowerCase()],
     ["lowercase-first", flipCase],
     ["lowercase-last", (x) => x],
-    ["full-path", () => ""],
+    ["full-path", (x) => x],
     ["module-name", (x) => {
         const splitIndex = x.lastIndexOf('/');
         if (splitIndex === -1) {

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -69,8 +69,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
             Possible values for \`"module-source-path"\` are:
 
-            * \`"full-path'\`: Correct order is  \`"./a/Foo"\`, \`"./b/baz"\`, \`"./c/Bar"\`. (This is the default.)
-            * \`"module-name"\`: Correct order is \`"./c/Bar"\`, \`"./b/baz"\`, \`"./a/Foo"\`.
+            * \`"full'\`: Correct order is  \`"./a/Foo"\`, \`"./b/baz"\`, \`"./c/Bar"\`. (This is the default.)
+            * \`"basename"\`: Correct order is \`"./c/Bar"\`, \`"./b/baz"\`, \`"./a/Foo"\`.
 
         `,
         options: {
@@ -86,7 +86,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 },
                 "module-source-path": {
                     type: "string",
-                    enum: ["full-path", "module-name"],
+                    enum: ["full", "basename"],
                 },
             },
             additionalProperties: false,
@@ -116,8 +116,8 @@ const TRANSFORMS = new Map<string, Transform>([
     ["case-insensitive", (x) => x.toLowerCase()],
     ["lowercase-first", flipCase],
     ["lowercase-last", (x) => x],
-    ["full-path", (x) => x],
-    ["module-name", (x) => {
+    ["full", (x) => x],
+    ["basename", (x) => {
         if (!(ts as any as {isExternalModuleNameRelative(m: string): boolean}).isExternalModuleNameRelative(x)) {
             return x;
         }
@@ -147,7 +147,7 @@ function parseOptions(ruleArguments: any[]): Options {
     const {
         "import-sources-order": sources = "case-insensitive",
         "named-imports-order": named = "case-insensitive",
-        "module-source-path": path = "full-path",
+        "module-source-path": path = "full",
     } = optionSet === undefined ? {} : optionSet;
     return {
         importSourcesOrderTransform: TRANSFORMS.get(sources)!,

--- a/test/rules/ordered-imports/module-source-path/test.ts.fix
+++ b/test/rules/ordered-imports/module-source-path/test.ts.fix
@@ -12,3 +12,8 @@ import c = require('./baz/c');
 import a from '../../foo/a';
 import b from './bar/b';
 import c = require('./baz/c');
+
+// contains scoped import
+import a from 'foo/a';
+import b = require('foo/b');
+import c from 'foo/c';

--- a/test/rules/ordered-imports/module-source-path/test.ts.fix
+++ b/test/rules/ordered-imports/module-source-path/test.ts.fix
@@ -1,0 +1,14 @@
+// Other styles of import statements.
+import someDefault from "module";
+import "something";
+import someDefault, {nameA, nameBReallyLong as anotherName} from "./wherever";
+
+// contains relative path & ImportEqualsDeclaration
+import a from './foo/a';
+import b from './bar/b';
+import c = require('./baz/c');
+
+// contains relative path & ImportEqualsDeclaration
+import a from '../../foo/a';
+import b from './bar/b';
+import c = require('./baz/c');

--- a/test/rules/ordered-imports/module-source-path/test.ts.lint
+++ b/test/rules/ordered-imports/module-source-path/test.ts.lint
@@ -1,0 +1,17 @@
+// Other styles of import statements.
+import someDefault, {nameA, nameBReallyLong as anotherName} from "./wherever";
+import someDefault from "module";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
+import "something";
+
+// contains relative path & ImportEqualsDeclaration
+import c = require('./baz/c');
+import a from './foo/a';
+~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
+import b from './bar/b';
+
+// contains relative path & ImportEqualsDeclaration
+import c = require('./baz/c');
+import a from '../../foo/a';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
+import b from './bar/b';

--- a/test/rules/ordered-imports/module-source-path/test.ts.lint
+++ b/test/rules/ordered-imports/module-source-path/test.ts.lint
@@ -15,3 +15,9 @@ import c = require('./baz/c');
 import a from '../../foo/a';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
 import b from './bar/b';
+
+// contains scoped import
+import b = require('foo/b');
+import a from 'foo/a';
+~~~~~~~~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
+import c from 'foo/c';

--- a/test/rules/ordered-imports/module-source-path/tslint.json
+++ b/test/rules/ordered-imports/module-source-path/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "ordered-imports": [true, {"module-source-path": "module-name"}]
+  }
+}

--- a/test/rules/ordered-imports/module-source-path/tslint.json
+++ b/test/rules/ordered-imports/module-source-path/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "ordered-imports": [true, {"module-source-path": "module-name"}]
+    "ordered-imports": [true, {"module-source-path": "basename"}]
   }
 }


### PR DESCRIPTION


#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Add an additional argument to ordered-import rule allowing sorting by trailing end of path.  This allows sorting modules with relative path by filename

#### CHANGELOG.md entry:
[enhancement] Allow sorting imports by trailing end of path