### PR TITLE
no-string-literal: correctly fix property names with leading underscores

### DIFF
--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -52,11 +52,13 @@ function walk(ctx: Lint.WalkContext<void>) {
         if (isElementAccessExpression(node)) {
             const argument = node.argumentExpression;
             if (argument !== undefined && isStringLiteral(argument) && isValidPropertyAccess(argument.text)) {
+                // for compatibility with typescript@<2.5.0 to avoid fixing expr['__foo'] to expr.___foo
+                const propertyName = ts.unescapeIdentifier(argument.text); // tslint:disable-line:deprecation
                 ctx.addFailureAtNode(
                     argument,
                     Rule.FAILURE_STRING,
                     // expr['foo'] -> expr.foo
-                    Lint.Replacement.replaceFromTo(node.expression.end, node.end, `.${argument.text}`),
+                    Lint.Replacement.replaceFromTo(node.expression.end, node.end, `.${propertyName}`),
                 );
             }
         }

--- a/test/rules/no-string-literal/test.ts.fix
+++ b/test/rules/no-string-literal/test.ts.fix
@@ -24,3 +24,6 @@ obj["?a#$!$^&%&"];
 // invalid accessor - no crash
 obj[]
 
+// that underscrore escaping thing typescript does
+obj.__foo__;
+

--- a/test/rules/no-string-literal/test.ts.lint
+++ b/test/rules/no-string-literal/test.ts.lint
@@ -29,4 +29,8 @@ obj["?a#$!$^&%&"];
 // invalid accessor - no crash
 obj[]
 
+// that underscrore escaping thing typescript does
+obj['__foo__'];
+    ~~~~~~~~~ [0]
+
 [0]: object access via string literals is disallowed


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2965
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
The AST contains the escaped name. That bug is fixed in typescript@2.5.0. This adds a fix for older versions.
Fixes: #2965

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] `no-string-literal` correctly fix property names with leading underscores
