### PR TITLE
noUnusedVariableRule should apply the ignorePattern to imports

### DIFF
--- a/test/rules/no-unused-variable/ignore-pattern/a.test.ts
+++ b/test/rules/no-unused-variable/ignore-pattern/a.test.ts
@@ -1,0 +1,1 @@
+export class _A {}

--- a/test/rules/no-unused-variable/ignore-pattern/var.ts.lint
+++ b/test/rules/no-unused-variable/ignore-pattern/var.ts.lint
@@ -1,3 +1,5 @@
+import { _A } from './a.test';
+
 var x = 3;
 
 var y = x;


### PR DESCRIPTION
I have a import that I need to ignore (custom reactNamespace), however ignore-pattern is not applied to imports.

#### PR checklist

- [x] Addresses an existing issue: #3186
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
applies the importPattern to importNames (in addition to the existing behavior)

#### Is there anything you'd like reviewers to focus on?
not sure if importName.text is the correct thing to test against, but it seems to work.
