### PR TITLE
object-literal-sort-keys: Allow grouping of object properties via additional blank lines

### DIFF
--- a/test/rules/object-literal-sort-keys/default/test.ts.lint
+++ b/test/rules/object-literal-sort-keys/default/test.ts.lint
@@ -191,4 +191,129 @@ const b = {
   ~~~~~~~ [err % ('objList')]
 }
 
+var blankLineGroupingPassA = {
+    a: 1,
+    b: 2,
+    d: 4,
+
+    c: 3,
+    e: 5,
+};
+
+var blankLineGroupingFailA = {
+    a: 1,
+    b: 2,
+    d: 4,
+    // non-empty line not counted as a new line
+    c: 3,
+    ~     [err % ('c')]
+    e: 5,
+};
+
+var blankLineGroupingPassB = {
+    a: 1,
+    b: 2,
+    d: 4,
+    // a comment
+
+    c: 3,
+    e: 5,
+};
+
+var blankLineGroupingFailB = {
+    a: 1,
+    b: 2,
+    c: 3,
+
+    f: 6,
+    e: 5,
+    ~     [err % ('e')]
+    d: 4
+};
+
+var blankLineGroupingPassC = {
+    b: 1,
+
+    // a single line comment before the group
+    a: 2,
+    c: 3,
+};
+
+var blankLineGroupingFailC = {
+    b: 1,
+    /* a multiline comment with
+
+    an extra new line in the middle */
+    a: 2,
+    ~     [err % ('a')]
+    c: 3,
+};
+
+var blankLineGroupingPassD = {
+    b: 1,
+
+    /* a multiline comment with a new line before and
+
+    an extra new line in the middle, before a group */
+    a: 2,
+    c: 3,
+};
+
+var blankLineGroupingFailD = {
+    b: 1,
+    // a single-line comments
+    /* a multiline comment with
+
+    an extra new line in the middle */
+    a: 2,
+    ~     [err % ('a')]
+    c: 3,
+};
+
+var blankLineGroupingPassE = {
+    b: 1,
+    /* a multiline comment with a new line after and
+
+    an extra new line in the middle */
+
+    a: 2,
+    c: 3,
+};
+
+var blankLineGroupingFailE = {
+    a: 1,
+    c: `3 is a
+
+    multiline string`,
+    b: 2,
+    ~     [err % ('b')]
+    d: 4
+}
+
+var blankLineGroupingPassF = {
+    b: 1,
+    /* double multiline comments
+
+    and a space between */
+
+    /* more talking
+
+    here */
+    a: 2,
+    c: 3,
+};
+
+var blankLineGroupingFailF = {
+    b: 1,
+    /* double multiline comments
+
+    with no space between */
+    /* more talking
+
+    here */
+    a: 2,
+    ~     [err % ('a')]
+    c: 3,
+};
+
 [err]: The key '%s' is not sorted alphabetically


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3190  
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Changes the behaviour of `object-literal-sort-keys` when using alphabetical ordering, and allows object keys to be grouped together separated with blank lines.

#### CHANGELOG.md entry:

[enhancement] [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): allow grouping of object properties via additional blank lines when using alphabetical ordering.