### PR TITLE
deprecation: check correct constructor overload

### DIFF
--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-    getDeclarationOfBindingElement, isBindingElement, isCallExpression, isIdentifier, isJsDoc,
+    getDeclarationOfBindingElement, isBindingElement, isCallExpression, isIdentifier, isJsDoc, isNewExpression,
     isPropertyAccessExpression, isTaggedTemplateExpression, isVariableDeclaration, isVariableDeclarationList,
 } from "tsutils";
 import * as ts from "typescript";
@@ -113,7 +113,8 @@ function getCallExpresion(node: ts.Expression): ts.CallLikeExpression | undefine
         node = parent;
         parent = node.parent!;
     }
-    return isTaggedTemplateExpression(parent) || isCallExpression(parent) && parent.expression === node ? parent : undefined;
+    return isTaggedTemplateExpression(parent) ||
+        (isCallExpression(parent) || isNewExpression(parent)) && parent.expression === node ? parent : undefined;
 }
 
 function getDeprecation(node: ts.Identifier, tc: ts.TypeChecker): string | undefined {

--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -16,8 +16,16 @@
  */
 
 import {
-    getDeclarationOfBindingElement, isBindingElement, isCallExpression, isIdentifier, isJsDoc, isNewExpression,
-    isPropertyAccessExpression, isTaggedTemplateExpression, isVariableDeclaration, isVariableDeclarationList,
+    getDeclarationOfBindingElement,
+    isBindingElement,
+    isCallExpression,
+    isIdentifier,
+    isJsDoc,
+    isNewExpression,
+    isPropertyAccessExpression,
+    isTaggedTemplateExpression,
+    isVariableDeclaration,
+    isVariableDeclarationList,
 } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
@@ -113,8 +121,9 @@ function getCallExpresion(node: ts.Expression): ts.CallLikeExpression | undefine
         node = parent;
         parent = node.parent!;
     }
-    return isTaggedTemplateExpression(parent) ||
-        (isCallExpression(parent) || isNewExpression(parent)) && parent.expression === node ? parent : undefined;
+    return isTaggedTemplateExpression(parent) || (isCallExpression(parent) || isNewExpression(parent)) && parent.expression === node
+        ? parent
+        : undefined;
 }
 
 function getDeprecation(node: ts.Identifier, tc: ts.TypeChecker): string | undefined {

--- a/test/rules/deprecation/other.test.ts
+++ b/test/rules/deprecation/other.test.ts
@@ -15,3 +15,20 @@ export let notDeprecated2: any;
 /** @deprecated deprecated default export */
 let def = "";
 export default def;
+
+/** @deprecated */
+export class DeprecatedClass {
+    constructor() {}
+}
+
+export class DeprecatedConstructorClass {
+    /** @deprecated */
+    constructor() {}
+}
+
+export class PartiallyDeprecatedClass {
+    constructor();
+    /** @deprecated */
+    constructor(foo: number);
+    constructor(_foo?: number) {}
+}

--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -131,6 +131,18 @@ dedent`${1}`;
 dedent`${[]}`;
 ~~~~~~ [err % ('dedent')]
 
+import {DeprecatedClass, DeprecatedConstructorClass, PartiallyDeprecatedClass} from "./other.test"
+{
+    const a: DeprecatedClass = new DeprecatedClass();
+             ~~~~~~~~~~~~~~~ [err % ('DeprecatedClass')]
+                                   ~~~~~~~~~~~~~~~ [err % ('DeprecatedClass')]
+    const b: DeprecatedConstructorClass = new DeprecatedConstructorClass();
+                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ('DeprecatedConstructorClass')]
+    const c: PartiallyDeprecatedClass = new PartiallyDeprecatedClass();
+    const d: PartiallyDeprecatedClass = new PartiallyDeprecatedClass(1);
+                                            ~~~~~~~~~~~~~~~~~~~~~~~~ [err % ('PartiallyDeprecatedClass')]
+}
+
 // TODO: those should be an error
 let {f, g, h} = p;
 (function ({f, g}: I) {})


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Basically the same change I did to resolve the correct call signature. I forgot `NewExpression` back then.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] `deprecation` checks correct constructor overload
<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
