### PR TITLE
restrict-plus-operands: Minor error message change.

### DIFF
--- a/src/rules/restrictPlusOperandsRule.ts
+++ b/src/rules/restrictPlusOperandsRule.ts
@@ -35,6 +35,7 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static INVALID_TYPES_ERROR = "Operands of '+' operation must either be both strings or both numbers";
+    public static SUGGEST_TEMPLATE_LITERALS = ", consider using template literals";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
@@ -47,7 +48,11 @@ function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker) {
             const leftType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.left));
             const rightType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.right));
             if (leftType === "invalid" || rightType === "invalid" || leftType !== rightType) {
-                return ctx.addFailureAtNode(node, Rule.INVALID_TYPES_ERROR);
+                if (leftType === "string" || rightType === "string") {
+                    return ctx.addFailureAtNode(node, Rule.INVALID_TYPES_ERROR + Rule.SUGGEST_TEMPLATE_LITERALS);
+                } else {
+                    return ctx.addFailureAtNode(node, Rule.INVALID_TYPES_ERROR);
+                }
             }
         }
         return ts.forEachChild(node, cb);

--- a/test/rules/restrict-plus-operands/test.ts.lint
+++ b/test/rules/restrict-plus-operands/test.ts.lint
@@ -17,7 +17,7 @@ var pair: NumberStringPair = {
 
 // bad
 var bad1  = 5 + "10";
-            ~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad2  = [] + 5;
             ~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
 var bad3  = [] + {};
@@ -27,23 +27,23 @@ var bad4  = [] + [];
 var bad4  = 5 + [];
             ~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
 var bad5  = "5" + {};
-            ~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad6  = 5.5 + "5";
-            ~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad7  = "5.5" + 5;
-            ~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad8  = x + y;
-            ~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad9  = y + x;
-            ~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad10 = x + {};
             ~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
 var bad11 = [] + y;
-            ~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad12 = pair.first + "10";
-            ~~~~~~~~~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~~~~~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad13 = 5 + pair.second;
-            ~~~~~~~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
+            ~~~~~~~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers, consider using template literals]
 var bad14 = pair + pair;
             ~~~~~~~~~~~  [Operands of '+' operation must either be both strings or both numbers]
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Suggest template literals when an operand is a string.
Most violations in Google code base is "string + number". Users might do `.toString()` to pass this check if they didn't know about template literals.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[enhancement] `restrict-plus-operands`: More specific error message when arguments include strings

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
