### PR TITLE
Enable if-else in test markup, fix build

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -94,9 +94,8 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
         let fileText = isEncodingRule ? readBufferWithDetectedEncoding(fs.readFileSync(fileToLint)) : fs.readFileSync(fileToLint, "utf-8");
         const tsVersionRequirement = parse.getTypescriptVersionRequirement(fileText);
         if (tsVersionRequirement !== undefined) {
-            const tsVersion = new semver.SemVer(ts.version);
             // remove prerelease suffix when matching to allow testing with nightly builds
-            if (!semver.satisfies(`${tsVersion.major}.${tsVersion.minor}.${tsVersion.patch}`, tsVersionRequirement)) {
+            if (!semver.satisfies(parse.getNormalizedTypescriptVersion(), tsVersionRequirement)) {
                 results.results[fileToLint] = {
                     requirement: tsVersionRequirement,
                     skipped: true,
@@ -107,6 +106,7 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
             const lineBreak = fileText.search(/\n/);
             fileText = lineBreak === -1 ? "" : fileText.substr(lineBreak + 1);
         }
+        fileText = parse.preprocessDirectives(fileText);
         const fileTextWithoutMarkup = parse.removeErrorMarkup(fileText);
         const errorsFromMarkup = parse.parseErrorsFromMarkup(fileText);
 

--- a/src/verify/parse.ts
+++ b/src/verify/parse.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as semver from "semver";
 import * as ts from "typescript";
 import { format } from "util";
 
@@ -39,6 +40,57 @@ export function getTypescriptVersionRequirement(text: string): string | undefine
         return firstLine.message;
     }
     return undefined;
+}
+
+export function getNormalizedTypescriptVersion(): string {
+    const tsVersion = new semver.SemVer(ts.version);
+    // remove prerelease suffix when matching to allow testing with nightly builds
+    return `${tsVersion.major}.${tsVersion.minor}.${tsVersion.patch}`;
+}
+
+export function preprocessDirectives(text: string): string {
+    if (!/^#(?:if|else|endif)\b/m.test(text)) {
+        return text; // If there are no directives, just return the input unchanged
+    }
+    const tsVersion = getNormalizedTypescriptVersion();
+    const enum State {
+        Initial,
+        If,
+        Else,
+    }
+    const lines = text.split(/\n/);
+    const result = [];
+    let collecting = true;
+    let state = State.Initial;
+    for (const line of lines) {
+        if (line.startsWith("#if typescript")) {
+            if (state !== State.Initial) {
+                throw lintSyntaxError("#if directives cannot be nested");
+            }
+            state = State.If;
+            collecting = semver.satisfies(tsVersion, line.slice(14).trim());
+        } else if (/^#else\s*$/.test(line)) {
+            if (state !== State.If) {
+                throw lintSyntaxError("unexpected #else");
+            }
+            state = State.Else;
+            collecting = !collecting;
+        } else if (/^#endif\s*$/.test(line)) {
+            if (state === State.Initial) {
+                throw lintSyntaxError("unexpected #endif");
+            }
+            state = State.Initial;
+            collecting = true;
+        } else if (collecting) {
+            result.push(line);
+        }
+    }
+
+    if (state !== State.Initial) {
+        throw lintSyntaxError("expected #endif");
+    }
+
+    return result.join("\n");
 }
 
 /**

--- a/src/verify/parse.ts
+++ b/src/verify/parse.ts
@@ -68,7 +68,7 @@ export function preprocessDirectives(text: string): string {
                 throw lintSyntaxError("#if directives cannot be nested");
             }
             state = State.If;
-            collecting = semver.satisfies(tsVersion, line.slice(14).trim());
+            collecting = semver.satisfies(tsVersion, line.slice("#if typescript".length).trim());
         } else if (/^#else\s*$/.test(line)) {
             if (state !== State.If) {
                 throw lintSyntaxError("unexpected #else");

--- a/test/rules/_integration/typescript-version/if-else.ts.lint
+++ b/test/rules/_integration/typescript-version/if-else.ts.lint
@@ -1,0 +1,21 @@
+'foo';
+~~~~~ [' should be "]
+#if typescript 0.0.0
+'bar'
+#else
+"bar"
+#endif
+
+#if typescript >= 2.0.0
+'baz'
+#else
+"baz"
+#endif
+~~~~~ [err]
+
+'bas'
+~~~~~ [err]
+
+#if typescript >= 2.0.0
+[err]: ' should be "
+#endif

--- a/test/rules/no-unused-variable/check-parameters/test.ts.lint
+++ b/test/rules/no-unused-variable/check-parameters/test.ts.lint
@@ -1,15 +1,15 @@
 export function func1(x: number, y: number, ...args: number[]) {
-                                               ~~~~              ['args' is declared but never used.]
+                                               ~~~~              [err % ('args')]
     return x + y;
 }
 
 export function func2(x: number, y: number, ...args: number[]) {
-                                 ~                               ['y' is declared but never used.]
+                                 ~                               [err % ('y')]
     return x + args[0];
 }
 
 export function func3(x?: number, y?: number) {
-                                  ~             ['y' is declared but never used.]
+                                  ~             [err % ('y')]
     return x;
 }
 
@@ -19,7 +19,7 @@ export interface ITestInterface {
 
 export class ABCD {
     constructor(private x: number, public y: number, private z: number) {
-                        ~                                                 [Property 'x' is declared but never used.]
+                        ~                                                 [prop % ('x')]
     }
 
     func5() {
@@ -40,7 +40,7 @@ export function func7(f: (x: number) => number) {
 }
 
 export function func8([x, y]: [number, number]) {
-                          ~                       ['y' is declared but never used.]
+                          ~                       [err % ('y')]
     return x;
 }
 
@@ -49,23 +49,31 @@ export class DestructuringTests {
     }
 
     public func9({a, b}) {
-                     ~     ['b' is declared but never used.]
+                     ~     [err % ('b')]
         return a;
     }
 
     public func10([a, b]) {
-                      ~     ['b' is declared but never used.]
+                      ~     [err % ('b')]
         return [a];
     }
 
     // destructuring with default value
     public func11([x = 0]) {
-                   ~         ['x' is declared but never used.]
+                   ~         [err % ('x')]
         return;
     }
 }
 
 abstract class AbstractTest {
-               ~~~~~~~~~~~~ ['AbstractTest' is declared but never used.]
+               ~~~~~~~~~~~~ [err % ('AbstractTest')]
     abstract foo(x);
 }
+
+#if typescript >= 2.6.0
+[err]: '%s' is declared but its value is never read.
+[prop]: Property '%s' is declared but its value is never read.
+#else
+[err]: '%s' is declared but never used.
+[prop]: Property '%s' is declared but never used.
+#endif

--- a/test/rules/no-unused-variable/default/class.ts.lint
+++ b/test/rules/no-unused-variable/default/class.ts.lint
@@ -1,6 +1,6 @@
 class ABCD {
     private z2: number;
-            ~~          ['z2' is declared but never used.]
+            ~~          [err % ('z2')]
     constructor() {
     }
 
@@ -17,8 +17,14 @@ class ABCD {
     }
 
     private mfunc4() {
-            ~~~~~~     ['mfunc4' is declared but never used.]
+            ~~~~~~     [err % ('mfunc4')]
         //
     }
     static stillPublic: number;
 }
+
+#if typescript >= 2.6.0
+[err]: '%s' is declared but its value is never read.
+#else
+[err]: '%s' is declared but never used.
+#endif

--- a/test/rules/no-unused-variable/default/false-positives.ts.lint
+++ b/test/rules/no-unused-variable/default/false-positives.ts.lint
@@ -2,7 +2,7 @@
 const fs = require("fs");
 
 module Foo {
-       ~~~   ['Foo' is declared but never used.]
+       ~~~   [err % ('Foo')]
     const path = require("path");
 
     console.log(fs);
@@ -24,7 +24,7 @@ hello.sayHello();
 import Bar = whatever.that.Foo;
 
 module some.module.blah {
-       ~~~~               ['some' is declared but never used.]
+       ~~~~               [err % ('some')]
     export class bar {
         private bar: Bar;
         constructor() {
@@ -52,3 +52,9 @@ myFunc(bar);
 
 import a from "a";
 export { a };
+
+#if typescript >= 2.6.0
+[err]: '%s' is declared but its value is never read.
+#else
+[err]: '%s' is declared but never used.
+#endif

--- a/test/rules/no-unused-variable/default/function.ts.lint
+++ b/test/rules/no-unused-variable/default/function.ts.lint
@@ -3,12 +3,12 @@ function func1(x: number, y: number) {
 }
 
 var func2 = () => {
-    ~~~~~           ['func2' is declared but never used.]
+    ~~~~~           [err % ('func2')]
     //
 };
 
 function func3() {
-         ~~~~~     ['func3' is declared but never used.]
+         ~~~~~     [err % ('func3')]
     return func1(1, 2);
 }
 
@@ -17,8 +17,14 @@ export function func4() {
 }
 
 declare function func5(): any;
-                 ~~~~~ ['func5' is declared but never used.]
+                 ~~~~~ [err % ('func5')]
 
 export default function () {
     return 0;
 }
+
+#if typescript >= 2.6.0
+[err]: '%s' is declared but its value is never read.
+#else
+[err]: '%s' is declared but never used.
+#endif

--- a/test/rules/no-unused-variable/default/import.ts.fix
+++ b/test/rules/no-unused-variable/default/import.ts.fix
@@ -49,3 +49,4 @@ import "a";
 import abc = require('a');
 import def = abc.someVar;
 console.log(def);
+

--- a/test/rules/no-unused-variable/default/import.ts.lint
+++ b/test/rules/no-unused-variable/default/import.ts.lint
@@ -3,14 +3,14 @@
  * This text will not be deleted.
  */
 import xyz = require("a");
-       ~~~                   ['xyz' is declared but never used.]
+       ~~~                   [err % ('xyz')]
 import  $ = require("a");
 import  _ = require("a");
 import {a1 as aa1, a2 as aa2} from "a";
-              ~~~             ['aa1' is declared but never used.]
+              ~~~             [err % ('aa1')]
 aa2;
 import {a3 as aa3, a4 as aa4} from "a";
-                         ~~~  ['aa4' is declared but never used.]
+                         ~~~  [err % ('aa4')]
 aa3;
 // This import statement is unused and will be deleted along with this comment.
 import {a5, a6} from "a";
@@ -18,15 +18,15 @@ import {a5, a6} from "a";
 import {a7} from "a";
 ~~~~~~~~~~~~~~~~~~~~~      [All imports are unused.]
 import {a8, a9, a10} from "a";
-            ~~                ['a9' is declared but never used.]
-                ~~~           ['a10' is declared but never used.]
+            ~~                [err % ('a9')]
+                ~~~           [err % ('a10')]
 a8;
 import {a11, a12, a13} from "a";
-        ~~~                   ['a11' is declared but never used.]
-             ~~~              ['a12' is declared but never used.]
+        ~~~                   [err % ('a11')]
+             ~~~              [err % ('a12')]
 a13;
 import {a14, a15, a16} from "a";
-             ~~~              ['a15' is declared but never used.]
+             ~~~              [err % ('a15')]
 a14;
 a16;
 
@@ -42,17 +42,17 @@ $(_.xyz());
 /// <reference path="../externalFormatter.test.ts" />
 
 module S {
-       ~ ['S' is declared but never used.]
+       ~ [err % ('S')]
   var template = "";
-      ~~~~~~~~       ['template' is declared but never used.]
+      ~~~~~~~~       [err % ('template')]
 }
 
 import * as foo from "a";
-            ~~~              ['foo' is declared but never used.]
+            ~~~              [err % ('foo')]
 import * as bar from "a";
 import baz from "a";
 import defaultExport, { namedExport } from "a";
-       ~~~~~~~~~~~~~                               ['defaultExport' is declared but never used.]
+       ~~~~~~~~~~~~~                               [err % ('defaultExport')]
 import d1, { d2 } from "a";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~                     [All imports are unused.]
 import d3, { d4 } from "a";
@@ -75,3 +75,9 @@ import "a";
 import abc = require('a');
 import def = abc.someVar;
 console.log(def);
+
+#if typescript >= 2.6.0
+[err]: '%s' is declared but its value is never read.
+#else
+[err]: '%s' is declared but never used.
+#endif

--- a/test/rules/no-unused-variable/default/react-addons3.tsx.lint
+++ b/test/rules/no-unused-variable/default/react-addons3.tsx.lint
@@ -1,2 +1,6 @@
 import * as React from "react/addons";
-            ~~~~~                      ['React' is declared but never used.]
+#if typescript >= 2.6.0
+            ~~~~~               ['React' is declared but its value is never read.]
+#else
+            ~~~~~               ['React' is declared but never used.]
+#endif

--- a/test/rules/no-unused-variable/default/react3.tsx.lint
+++ b/test/rules/no-unused-variable/default/react3.tsx.lint
@@ -1,2 +1,6 @@
 import * as React from "react";
+#if typescript >= 2.6.0
+            ~~~~~               ['React' is declared but its value is never read.]
+#else
             ~~~~~               ['React' is declared but never used.]
+#endif

--- a/test/rules/no-unused-variable/default/react4.tsx.lint
+++ b/test/rules/no-unused-variable/default/react4.tsx.lint
@@ -1,2 +1,6 @@
 import * as React from "react";
+#if typescript >= 2.6.0
+            ~~~~~               ['React' is declared but its value is never read.]
+#else
             ~~~~~               ['React' is declared but never used.]
+#endif

--- a/test/rules/no-unused-variable/default/var.ts.lint
+++ b/test/rules/no-unused-variable/default/var.ts.lint
@@ -1,13 +1,16 @@
 var x = 3;
 
 var y = x;
-    ~      ['y' is declared but never used.]
+    ~      [err % ('y')]
 var z;
+#if typescript >= 2.6.0
+    ~ [err % ('z')]
+#endif
 
 export var abcd = 3;
 
 class ABCD {
-      ~~~~ ['ABCD' is declared but never used.]
+      ~~~~ [err % ('ABCD')]
     constructor() {
         z = 3;
     }
@@ -20,17 +23,17 @@ try {
 }
 
 declare var tmp: any;
-            ~~~ ['tmp' is declared but never used.]
+            ~~~ [err % ('tmp')]
 
 export function testDestructuring() {
     var [a, b] = [1, 2];
-         ~               ['a' is declared but never used.]
-            ~            ['b' is declared but never used.]
+         ~               [err % ('a')]
+            ~            [err % ('b')]
     var [c] = [3];
 
     var {d, e} = { d: 1, e: 2 };
-         ~                       ['d' is declared but never used.]
-            ~                    ['e' is declared but never used.]
+         ~                       [err % ('d')]
+            ~                    [err % ('e')]
     var {f} = { f: 3 };
 
     return c * f;
@@ -40,7 +43,7 @@ export var [foo, bar] = [1, 2];
 
 export function testUnusedSpread() {
   var a = [1, 2];
-      ~           ['a' is declared but never used.]
+      ~           [err % ('a')]
   var b = [3, 4];
   var c = [...b, 5]; // make sure we see that b is being used
 
@@ -49,14 +52,20 @@ export function testUnusedSpread() {
 }
 
 for(let e of [1,2,3]) {
-        ~               ['e' is declared but never used.]
+        ~               [err % ('e')]
 
 }
 
 export function testRenamingDestructure() {
   var a = 2;
   let {a: b} = {a: 4};
-          ~            ['b' is declared but never used.]
+          ~            [err % ('b')]
   let {x: y} = {x: 7}; // false positive
   return a + y;
 }
+
+#if typescript >= 2.6.0
+[err]: '%s' is declared but its value is never read.
+#else
+[err]: '%s' is declared but never used.
+#endif

--- a/test/rules/no-unused-variable/ignore-pattern/var.ts.lint
+++ b/test/rules/no-unused-variable/ignore-pattern/var.ts.lint
@@ -1,14 +1,17 @@
 var x = 3;
 
 var y = x;
-    ~      ['y' is declared but never used.]
+    ~      [err % ('y')]
 var _y = x;
 var z;
+#if typescript >= 2.6.0
+    ~ [err % ('z')]
+#endif
 
 export var abcd = 3;
 
 class ABCD {
-      ~~~~   ['ABCD' is declared but never used.]
+      ~~~~   [err % ('ABCD')]
     constructor() {
         z = 3;
     }
@@ -21,18 +24,18 @@ try {
 }
 
 declare var tmp: any;
-            ~~~       ['tmp' is declared but never used.]
+            ~~~       [err % ('tmp')]
 
 export function testDestructuring() {
     var [a, b] = [1, 2];
-         ~               ['a' is declared but never used.]
-            ~            ['b' is declared but never used.]
+         ~               [err % ('a')]
+            ~            [err % ('b')]
     var [_a, _b] = [1, 2];
     var [c] = [3];
 
     var {d, e} = { d: 1, e: 2 };
-         ~                       ['d' is declared but never used.]
-            ~                    ['e' is declared but never used.]
+         ~                       [err % ('d')]
+            ~                    [err % ('e')]
     var {d: _d, e: _e} = { d: 1, e: 2 };
     var {f} = { f: 3 };
 
@@ -43,7 +46,7 @@ export var [foo, bar] = [1, 2];
 
 export function testUnusedSpread() {
   var a = [1, 2];
-      ~           ['a' is declared but never used.]
+      ~           [err % ('a')]
   var _a = [1, 2];
   var b = [3, 4];
   var c = [...b, 5]; // make sure we see that b is being used
@@ -53,7 +56,7 @@ export function testUnusedSpread() {
 }
 
 for(let e of [1,2,3]) {
-        ~               ['e' is declared but never used.]
+        ~               [err % ('e')]
 
 }
 
@@ -64,8 +67,14 @@ for(let _e of [1,2,3]) {
 export function testRenamingDestructure() {
   var a = 2;
   let {a: b} = {a: 4};
-          ~            ['b' is declared but never used.]
+          ~            [err % ('b')]
   let {a: _b} = {a: 4};
   let {x: y} = {x: 7}; // false positive
   return a + y;
 }
+
+#if typescript >= 2.6.0
+[err]: '%s' is declared but its value is never read.
+#else
+[err]: '%s' is declared but never used.
+#endif

--- a/test/rules/no-unused-variable/type-checked/destructuring.ts.lint
+++ b/test/rules/no-unused-variable/type-checked/destructuring.ts.lint
@@ -1,6 +1,10 @@
 import { SomeClass, someVar } from "./some.test";
 const person = { name: "alice" };
 const { name } = person;
+#if typescript >= 2.6.0
+        ~~~~ ['name' is declared but its value is never read.]
+#else
         ~~~~ ['name' is declared but never used.]
+#endif
 
 export const {prop} = someVar;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Fixes build failures with typescript@next

Instead of duplicating all tests that have different output between typescript versions, I chose to add support for #if #else and #endif directives to the test markup. The syntax is inspired by C/C++.
The directives are processed before the file is actually parsed. Therefore it can be used to conditionally set the text of a message substitution.
Currently you can only test the typescript version.

#### Is there anything you'd like reviewers to focus on?
I'll update the docs afterwards.

#### CHANGELOG.md entry:

[no-log] will add a changelog entry to the docs PR
