### PR TITLE
inherit defaultSeverity onto child configurations

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -224,8 +224,8 @@ export function loadConfigurationFromPath(configFilePath?: string, originalFileP
             delete (require.cache as { [key: string]: any })[resolvedConfigFilePath];
         }
         
-        // assign defaultSeverity of parent if no underlying default is set:
-        rawConfigFile.defaultSeverity = rawConfigFile.defaultSeverity | parentConfig.defaultSeverity;
+        // assign defaultSeverity of parent if child configuration has no defaultSeverity set:
+        rawConfigFile.defaultSeverity = rawConfigFile.defaultSeverity || (parentConfig ? parentConfig.defaultSeverity : undefined);
 
         const configFileDir = path.dirname(resolvedConfigFilePath);
         const configFile = parseConfigFile(rawConfigFile, configFileDir);


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2569
- [X] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
As reported in #2569 setting the defaultSeverity in a configuration that extends another configuration (e.g. `tslint:recommended`) leaves the severity of the extended rules unchanged.

The changes in this pull-request make the defaultSeverity inherited from the top-most configuration to all underlying ones (by `extends` & `ruleDirectory`).

#### Is there anything you'd like reviewers to focus on?

This is mainly a quick for me personally but I'm open to improvement.
E.g. this could be activated only by a flag (e.g. `--inheritDefaultSeverity`).
Also some people in #2569 mentioned they'd like to completely override all defaults. This could also be added as a 2nd flag (e.g. `--forceDefaultSeverity`).

Depending on the feedback I can adjust the code and I'll also create new unit tests if necessary.

#### CHANGELOG.md entry:

[enhancement] `inherit defaultSeverity onto child configurations`
