### PR TITLE
arrow-parens: fix invalid code produced by fixer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,3 @@ insert_final_newline = true
 
 [tslint.json]
 indent_size = 2
-
-[*.{fix,lint}]
-trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [tslint.json]
 indent_size = 2
+
+[*.{fix,lint}]
+trim_trailing_whitespace = false

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -73,7 +73,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
             } else if (ctx.options.banSingleArgParens) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
                 ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
-                    Lint.Replacement.deleteText(openParen.end - 1, 1),
+                    Lint.Replacement.replaceFromTo(openParen.pos, node.parameters[0].getStart(ctx.sourceFile), " "),
                     Lint.Replacement.deleteFromTo(node.parameters[0].end, closeParen.end),
                 ]);
             }

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -74,7 +74,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
                 ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
                     Lint.Replacement.deleteText(openParen.end - 1, 1),
-                    Lint.Replacement.deleteText(closeParen.end - 1, 1),
+                    Lint.Replacement.deleteFromTo(node.parameters[0].end, closeParen.end),
                 ]);
             }
         }

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -25,14 +25,16 @@ var f = ab => {};
 // invalid case
 var a = a => {};
 const invalidAsync = async param => {};
+const invalidAsync = async param => {};
 
 // parens required when return type annotation is present
 const fn = (param): void => {};
 
 let foo = bar => bar;
-let foo = 
-    bar => bar;
 
-let foo = 
-    bar => bar;
+let foo = bar => bar;
+
+let foo = bar => bar;
+
+let foo = async bar => bar;
 

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -28,3 +28,11 @@ const invalidAsync = async param => {};
 
 // parens required when return type annotation is present
 const fn = (param): void => {};
+
+let foo = bar => bar;
+let foo = 
+    bar => bar;
+
+let foo = 
+    bar => bar;
+

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -31,4 +31,16 @@ const invalidAsync = async (param) => {};
 // parens required when return type annotation is present
 const fn = (param): void => {};
 
+let foo = (bar,) => bar;
+           ~~~ [0]
+let foo = (
+    bar
+    ~~~ [0]
+) => bar;
+
+let foo = (
+    bar,
+    ~~~ [0]
+) => bar;
+
 [0]: Parentheses are prohibited around the parameter in this single parameter arrow function

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -27,18 +27,26 @@ var a = (a) => {};
          ~         [0]
 const invalidAsync = async (param) => {};
                             ~~~~~ [0]
+const invalidAsync = async(param) => {};
+                           ~~~~~ [0]
 
 // parens required when return type annotation is present
 const fn = (param): void => {};
 
 let foo = (bar,) => bar;
            ~~~ [0]
+
 let foo = (
     bar
     ~~~ [0]
 ) => bar;
 
 let foo = (
+    bar,
+    ~~~ [0]
+) => bar;
+
+let foo = async (
     bar,
     ~~~ [0]
 ) => bar;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Fixing `avoid-single-arg-parens` could lead to invalid code if there were trailing commas and/or the close paren is on the next line or parameter is on another line than the `async` keyword.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] `arrow-parens` with option `"ban-single-arg-parens"` no longer produces invalid code when fixed

