### PR TITLE
New rule dead-type-branch

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -89,6 +89,7 @@ export const rules = {
     "await-promise": true,
     // "ban": no sensible default
     "curly": true,
+    "dead-type-branch": true,
     "forin": true,
     // "import-blacklist": no sensible default
     "label-position": true,

--- a/src/rules/deadTypeBranchRule.ts
+++ b/src/rules/deadTypeBranchRule.ts
@@ -1,0 +1,232 @@
+import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
+import * as ts from 'typescript';
+
+type PerProgramConfig = {
+  tc: ts.TypeChecker,
+  ctx: Lint.WalkContext<void>,
+  // Format: filename|startPosition|endPosition
+  // We use this Map to flag only the highest-level block / expressions.
+  flaggedRanges: Set<string>,
+};
+
+/**
+ * This linter rule tries to find dead branches in programs by looking for
+ * unsatisfiable typing constraints.
+ */
+export class Rule extends Lint.Rules.TypedRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'dead-type-branch',
+    description: 'This linter rule tries to find dead branches in programs ' +
+        'by looking for unsatisfiable typing constraints.',
+    rationale: 'Unsatisfiable type constraits indicate unreachable code.',
+    options: null,
+    optionsDescription: '',
+    type: 'typescript',
+    typescriptOnly: true,
+  };
+
+  applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program):
+      Lint.RuleFailure[] {
+    return this.applyWithFunction(sourceFile, (ctx) => this.walk(ctx, program));
+  }
+
+  /**
+   * Looks for if statements to analyze for dead branches.
+   */
+  private static searchForIfStatements(
+      node: ts.Node, config: PerProgramConfig,
+      previouslyTaggedExprs?: Set<string>): void {
+    const taggedExpr = Rule.copyOrInit(previouslyTaggedExprs);
+
+    if (!tsutils.isIfStatement(node)) {
+      return node.forEachChild(
+          n => Rule.searchForIfStatements(n, config, taggedExpr));
+    }
+
+    const ifNode: ts.IfStatement = node;
+    Rule.searchForTypeGuardsInCondition(ifNode.expression, config)
+        .forEach(g => taggedExpr.add(g));
+
+    if (taggedExpr.size !== 0) {
+      Rule.searchForExpressionsTypedAsNever(
+          ifNode.thenStatement, config, taggedExpr);
+      if (ifNode.elseStatement &&
+          !tsutils.isIfStatement(ifNode.elseStatement)) {
+        Rule.searchForExpressionsTypedAsNever(
+            ifNode.elseStatement, config, taggedExpr);
+      }
+    }
+
+    Rule.searchForIfStatements(ifNode.thenStatement, config, taggedExpr);
+    if (ifNode.elseStatement) {
+      Rule.searchForIfStatements(ifNode.elseStatement, config, taggedExpr);
+    }
+  }
+
+  /**
+   * Searches for expressions that are part of type-based conditions under
+   * `node`, and returns a set of these, stringified. This recurses.
+   * @param node Should come from inside a condition
+   */
+  private static searchForTypeGuardsInCondition(
+      node: ts.Node, config: PerProgramConfig,
+      previoustaggedExpr?: Set<string>): Set<string> {
+    const taggedExpr = Rule.copyOrInit(previoustaggedExpr);
+
+    if (tsutils.isBinaryExpression(node)) {
+      const expr = node;
+      const tokenKind = expr.operatorToken.kind;
+      // This flags `x instanceof *`
+      if (tokenKind === ts.SyntaxKind.InstanceOfKeyword) {
+        taggedExpr.add(expr.left.getFullText().trim());
+        return taggedExpr;
+      }
+      // This flags `typeof x === *` / `* === typeof x` and the == version
+      if (tokenKind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+          tokenKind === ts.SyntaxKind.EqualsEqualsToken) {
+        if (tsutils.isTypeOfExpression(expr.left) &&
+            !tsutils.isTypeOfExpression(expr.right)) {
+          taggedExpr.add(expr.left.expression.getFullText().trim());
+          return taggedExpr;
+        } else if (
+            !tsutils.isTypeOfExpression(expr.left) &&
+            tsutils.isTypeOfExpression(expr.right)) {
+          taggedExpr.add(expr.right.expression.getFullText().trim());
+          return taggedExpr;
+        } else {
+          return taggedExpr;
+        }
+      }
+    }
+
+    if (tsutils.isCallExpression(node)) {
+      // This flags functions that formalize a type guard. Note that the results
+      // with those can be weird as of TS 2.4.2: TS will use structural typing
+      // here and for the resulting type inference later on for that symbol,
+      // unlike for instanceof (which relies on type names).
+
+      const callNode = node;
+      const signature = config.tc.getResolvedSignature(callNode);
+      if (signature && signature.declaration.type &&
+          tsutils.isTypePredicateNode(signature.declaration.type)) {
+        // We have either a ts.IdentifierTypePredicate or a
+        // ts.ThisTypePredicate, but details are not accessible and they're
+        // complex, so instead just flag arguments of the call as
+        // needing investigation. This could be refined if needed.
+        callNode.arguments.forEach(a => taggedExpr.add(a.getFullText().trim()));
+        return taggedExpr;
+      }
+    }
+
+    // Default is to recurse under this node.
+    node.forEachChild(n => {
+      Rule.searchForTypeGuardsInCondition(n, config).forEach(
+          g => taggedExpr.add(g));
+    });
+    return taggedExpr;
+  }
+
+
+  /**
+   * Looks for branches that use expressions amongst the flagged ones, and if
+   * they are typed as never, flags them.
+   */
+  private static searchForExpressionsTypedAsNever(
+      node: ts.Node, config: PerProgramConfig, taggedExprs: Set<string>): void {
+    if (taggedExprs.has(node.getFullText().trim()) &&
+        tsutils.isExpression(node)) {
+      Rule.checkTypedAsNeverAndFlag(node, config);
+    }
+    return node.forEachChild(
+        n => Rule.searchForExpressionsTypedAsNever(n, config, taggedExprs));
+  }
+
+
+  /**
+   * Flags the block containing `checkedExpression` if it's both typed as never,
+   * and not flagged as part of a larger block.
+   */
+  private static checkTypedAsNeverAndFlag(
+      expr: ts.Expression, config: PerProgramConfig) {
+    const exprType = config.tc.getTypeAtLocation(expr);
+    if (exprType && (exprType.getFlags() & ts.TypeFlags.Never)) {
+      const whereToFlag = Rule.findClosestBlockOrThenStatement(expr);
+      Rule.flagIfNotAlready(whereToFlag, expr.getFullText().trim(), config);
+    }
+  }
+
+  /**
+   * Turns a node into a string identifying it in the context of current run.
+   */
+  private static nodeToRange(n: ts.Node): string {
+    return `${n.getSourceFile().fileName}|${n.getStart()}|${n.getEnd()}`;
+  }
+
+  /**
+   * Given a `PerRunConfig` and a node to flag as dead, flags it if a
+   * larger node hasn't been flagged.
+   */
+  private static flagIfNotAlready(
+      flagLocation: ts.Node, expression: string, config: PerProgramConfig) {
+    if (Rule.parents(flagLocation)
+            .every(n => !config.flaggedRanges.has(Rule.nodeToRange(n)))) {
+      config.flaggedRanges.add(Rule.nodeToRange(flagLocation));
+      config.ctx.addFailureAtNode(
+          flagLocation,
+          `This block is unreachable: TypeScript infers the type of ` +
+              `'${expression}' as 'never' at this location, which means the ` +
+              `previous type guard is always false.`);
+    }
+  }
+
+  /**
+   * Assuming `node` is a proof that a branch is dead, this function searches
+   * above it in the AST to find the right level to tag as dead. That is either
+   * the closest ts.Block, or the node in our path just below the closest
+   * ts.IfStatement.
+   */
+  private static findClosestBlockOrThenStatement(node: ts.Node): ts.Node {
+    while (node.parent) {
+      const old = node;
+      node = node.parent;
+      if (tsutils.isBlock(node)) {
+        return node;
+      } else if (tsutils.isIfStatement(node) && old !== node.expression) {
+        return old;  // condition to avoid tagging conditions
+      }
+    }
+    throw new Error('AST appears malformed.');
+  }
+
+  /**
+   * Either copies `previous`, or returns a new empty Set if `previous` is
+   * undefined.
+   */
+  private static copyOrInit<T>(previous: Set<T>|undefined) {
+    return previous ? new Set(previous) : new Set();
+  }
+
+  /**
+   * Returns an ordered Array of the parents of `node`, sorted by increasing
+   * distance.
+   */
+  private static parents(node: ts.Node): ts.Node[] {
+    const parents = new Array<ts.Node>(node);
+    while (node.parent) {
+      parents.push(node.parent);
+      node = node.parent;
+    }
+    return parents;
+  }
+
+  /**
+   * Looks for dead branches due to typing constraints in `program`.
+   */
+  public walk(ctx: Lint.WalkContext<void>, program: ts.Program) {
+    const tc = program.getTypeChecker();
+    const config = {tc, ctx, flaggedRanges: new Set()};
+    ctx.sourceFile.statements.forEach(
+        n => Rule.searchForIfStatements(n, config));
+  }
+}

--- a/test/rules/dead-type-branch/function-type-guards/test.ts.lint
+++ b/test/rules/dead-type-branch/function-type-guards/test.ts.lint
@@ -1,0 +1,40 @@
+class A {private a(){}};  // implicitly declares a type, and methods for
+class B {private b(){}};  // incompatibility. This behaves weirdly when types
+class C {private c(){}};  // are compatible.
+
+const ab: A|B = Math.random() > .5 ? new A() : new B();
+
+function isA(x:any): x is A { return Math.random() > .5; }
+function isB(x:any): x is B { return  Math.random() > .5; }
+function isC(x:any): x is C { return  Math.random() > .5; }
+
+
+if (isA(ab)) { ab; }
+
+
+if (isA(ab) || isB(ab)) { ab; }
+
+
+if (isC(ab)) { ab; } // Could be A & C | B & C
+
+
+if (isA(ab) || isB(ab)) { ab; }
+else { ab; }
+     ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+
+
+// Interesting case: the first condition leaves B & !A, which gets rounded
+// up into B for the next condition since TS doesn't subtract. We lost the !A
+// along the way, which then gets turned into B & !A, and so on.
+if (isA(ab)) { ab; }
+else if (isA(ab)) { ab; }
+else if (isA(ab)) { ab; }
+
+
+if (isA(ab)) { ab; }
+else if (isB(ab)) { ab; }
+else if (isC(ab)) { ab; }
+                  ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+else { ab; }
+     ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+

--- a/test/rules/dead-type-branch/function-type-guards/tsconfig.json
+++ b/test/rules/dead-type-branch/function-type-guards/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/dead-type-branch/function-type-guards/tslint.json
+++ b/test/rules/dead-type-branch/function-type-guards/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "dead-type-branch": true
+    }
+  }

--- a/test/rules/dead-type-branch/instanceof/test.ts.lint
+++ b/test/rules/dead-type-branch/instanceof/test.ts.lint
@@ -1,0 +1,35 @@
+class A {private a(){}};
+class B {private b(){}};
+class C {private c(){}};
+
+const ab: A|B = Math.random() > .5 ? new A() : new B();
+
+
+if (ab instanceof A) { ab; }
+
+
+if (ab instanceof A || ab instanceof B) { ab; }
+
+
+if (ab instanceof C) { ab; } // A & C | B & C
+
+
+if (ab instanceof A || ab instanceof B) { ab; }
+else { ab; }
+     ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+
+
+// Interesting case: the first condition leaves B & !A, which gets rounded
+// up into B for the next condition since TS doesn't subtract. We lost the !A
+// along the way, which then gets turned into B & !A, and so on.
+if (ab instanceof A) { ab; }
+else if (ab instanceof A) { ab; }
+
+
+if (ab instanceof A) { ab; }
+else if (ab instanceof B) { ab; }
+else if (ab instanceof C) { ab; }
+                          ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+else { ab; }
+     ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+

--- a/test/rules/dead-type-branch/instanceof/tsconfig.json
+++ b/test/rules/dead-type-branch/instanceof/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/dead-type-branch/instanceof/tslint.json
+++ b/test/rules/dead-type-branch/instanceof/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "dead-type-branch": true
+    }
+  }

--- a/test/rules/dead-type-branch/mixed-tests/test.ts.lint
+++ b/test/rules/dead-type-branch/mixed-tests/test.ts.lint
@@ -1,0 +1,49 @@
+
+class A {private a(){}};
+class B {private b(){}};
+
+function isA(x:any): x is A { return Math.random() > .5; }
+function isB(x:any): x is B { return  Math.random() > .5; }
+
+const sna: string|number|A =
+  Math.random() > .5 ? (Math.random() > .5 ? "a" : new A()) : 1;
+
+let getSNA = ():string|number|A => {
+  return Math.random() > .5 ? (Math.random() > .5 ? "a" : new A()) : 1;
+}
+let sna2 = getSNA();
+
+
+if (sna instanceof A) {
+  if (typeof sna === "object") { sna; }
+  else {
+       ~
+    if (typeof sna === "number") { sna; }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else { if (typeof sna === "string") { sna; } }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  }
+~~~ [This block is unreachable: TypeScript infers the type of 'sna' as 'never' at this location, which means the previous type guard is always false.]
+}
+
+
+if (sna2 instanceof A) {
+  if (typeof sna2 === "object") { sna2; }
+  else {
+       ~
+    if (typeof sna2 === "number") { sna2; }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    else { if (typeof sna2 === "string") { sna2; } }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  }
+~~~ [This block is unreachable: TypeScript infers the type of 'sna2' as 'never' at this location, which means the previous type guard is always false.]
+}
+
+// Not tagged, since not deterministic
+if (getSNA() instanceof A) {
+  if (typeof getSNA() === "object") { getSNA(); }
+  else {
+    if (typeof getSNA() === "number") { getSNA(); }
+    else { if (typeof getSNA() === "string") { getSNA(); } }
+  }
+}

--- a/test/rules/dead-type-branch/mixed-tests/tsconfig.json
+++ b/test/rules/dead-type-branch/mixed-tests/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/dead-type-branch/mixed-tests/tslint.json
+++ b/test/rules/dead-type-branch/mixed-tests/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "dead-type-branch": true
+    }
+  }

--- a/test/rules/dead-type-branch/nested-conditions/test.ts.lint
+++ b/test/rules/dead-type-branch/nested-conditions/test.ts.lint
@@ -1,0 +1,57 @@
+class A {private a(){}};
+class B {private b(){}};
+class C {private c(){}};
+
+const ab: A|B = Math.random() > .5 ? new A() : new B();
+
+
+if (ab instanceof A) {
+  if (ab instanceof B) { ab; }
+}
+
+
+if (ab instanceof A) {
+  if (!(ab instanceof A)) { ab; }
+                          ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+}
+
+
+// more complex structure to smoke test
+if (ab instanceof A) {
+  if (ab instanceof B) {
+    ab;
+    if (!(ab instanceof A)) { ab; }
+                            ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+    ab;
+  }
+  if (ab instanceof C || !(ab instanceof A)) {
+    ab; // A & C here
+    if (!(ab instanceof C && ab instanceof A)) { ab; }
+                                               ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+  }
+}
+
+// Check that we never double-flag the same code
+if (ab instanceof A) {
+  if (!(ab instanceof A)) {
+                          ~
+    ab;
+~~~~~~~
+  }
+~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+  if (!(ab instanceof A)) {
+                          ~
+    ab;
+~~~~~~~
+  }
+~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+  if (!(ab instanceof A)) {
+                          ~
+    if (!(ab instanceof A))
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      if (!(ab instanceof A)) { ab; }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  }
+~~~ [This block is unreachable: TypeScript infers the type of 'ab' as 'never' at this location, which means the previous type guard is always false.]
+  ab;
+}

--- a/test/rules/dead-type-branch/nested-conditions/tsconfig.json
+++ b/test/rules/dead-type-branch/nested-conditions/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/dead-type-branch/nested-conditions/tslint.json
+++ b/test/rules/dead-type-branch/nested-conditions/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "dead-type-branch": true
+    }
+  }

--- a/test/rules/dead-type-branch/typeof/test.ts.lint
+++ b/test/rules/dead-type-branch/typeof/test.ts.lint
@@ -1,0 +1,40 @@
+const sn: string|number = Math.random() > .5 ? "a" : 1;
+
+
+if (typeof sn === 'string') { sn; }
+
+
+if (typeof sn === 'string' || typeof sn === 'number') { sn; }
+
+
+if (typeof sn === 'object') { sn; }
+                            ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'sn' as 'never' at this location, which means the previous type guard is always false.]
+
+
+if ('object' === typeof sn) { sn; }
+                            ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'sn' as 'never' at this location, which means the previous type guard is always false.]
+
+
+if (typeof sn === 'foo') { sn; }
+                         ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'sn' as 'never' at this location, which means the previous type guard is always false.]
+
+
+if (typeof sn === 'string' || typeof sn === 'number') { sn; }
+else { sn; }
+     ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'sn' as 'never' at this location, which means the previous type guard is always false.]
+
+
+// There's no structural typing there, so this behaves as intuitively expected.
+if (typeof sn === 'string') { sn; }
+else if (typeof sn === 'string') { sn; }
+                                 ~~~~~~~ [This block is unreachable: TypeScript infers the type of 'sn' as 'never' at this location, which means the previous type guard is always false.]
+
+// Slightly tricky error message positioning, since we locate expressions typed
+// as never.
+if (typeof sn === 'foo') {
+                         ~
+    if (sn) { 0; }
+~~~~~~~~~~~~~~~~~~
+}
+~ [This block is unreachable: TypeScript infers the type of 'sn' as 'never' at this location, which means the previous type guard is always false.]
+

--- a/test/rules/dead-type-branch/typeof/tsconfig.json
+++ b/test/rules/dead-type-branch/typeof/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/dead-type-branch/typeof/tslint.json
+++ b/test/rules/dead-type-branch/typeof/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "dead-type-branch": true
+    }
+  }

--- a/test/rules/dead-type-branch/unrelated-never/test.ts.lint
+++ b/test/rules/dead-type-branch/unrelated-never/test.ts.lint
@@ -1,0 +1,28 @@
+const x:never;
+const s:string = 'a';
+
+if (s) {
+    x;
+    s; // Don't flag, since there's no type testing intention that we can find
+}
+
+if (typeof s === 'string') {
+    x;
+    s; // same, x isn't tested
+}
+
+if (typeof s === 'string' && x) {
+    x; s;
+}
+
+// x should be flagged in that if, but not after
+if (typeof x === 'foo') {
+  if (typeof s === 'string') { x; s; }
+                             ~~~~~~~~~ [This block is unreachable: TypeScript infers the type of 'x' as 'never' at this location, which means the previous type guard is always false.]
+} else { x; }
+       ~~~~~~ [This block is unreachable: TypeScript infers the type of 'x' as 'never' at this location, which means the previous type guard is always false.]
+
+
+if (typeof s === 'string') {
+    x; s;
+}

--- a/test/rules/dead-type-branch/unrelated-never/tsconfig.json
+++ b/test/rules/dead-type-branch/unrelated-never/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/dead-type-branch/unrelated-never/tslint.json
+++ b/test/rules/dead-type-branch/unrelated-never/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "dead-type-branch": true
+    }
+  }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

That rule looks at if-blocks and tries to flag dead branches. More specifically, this searches conditions of if for some type-based tests (typeof, instanceof, type guards in functions), and remembers which variables are looked at, as we consider it a strong signal for type-based tests. We then look for its usage under that condition and the following else / else if statements, and if in there, an occurence of the expression is typed as `never` (per the typechecker), then flag the branch as it's likely to be dead.

To be clear, the rule itself does none of the type arithmetic. Most of the complexity is there to ensure we only flag things typed as never when that is likely to be a result of type tests. 

#### Is there anything you'd like reviewers to focus on?

First of all, that's my first PR into TSLint, so I probably missed a lot of conventions and so on: if so, let me know. This is still a bit rough around the edges too (especially documentation), but I wanted to start the conversation early, to know if you'd be interested in this rule.

Areas that should probably be improved:
- User-facing documentation (my first idea was to use this internally at Google, I haven't looked at your conventions there yet)
- Performance, especially around the way I pass `taggedExpr` around, recursively copying it. It might or might not matter, I'm not sure.
- The error message and the rule name aren't that great, I welcome any suggestion there.
- The code is not trivial, so there might be more bugs in there.
- I uncovered very surprising behaviors around type inference and structural typing (though it's not yet clear whether that's a bug or not or what causes that), see https://github.com/Microsoft/TypeScript/issues/18560. That could result in false-positives.
- It conflicts in principle with some patterns of exhaustiveness checks for enums. Let's say you use string literal types, then you could write a series of `if`/`else if` for each value, then a final `else throw("unexpected enum value" + v);` in case the enum evolves: that's going to be flagged as dead code.

cc @bowenni @mprobst 

#### CHANGELOG.md entry:

[new-rule] `dead-type-branch`
