### PR TITLE
[no-unnecessary-type-assertion]: adds an option to ignore whitelisted type assertions.

### DIFF
--- a/test/rules/no-unnecessary-type-assertion/test.ts.fix
+++ b/test/rules/no-unnecessary-type-assertion/test.ts.fix
@@ -1,6 +1,8 @@
 const nonNullStringLiteral: 'test';
 const nonNullString: string;
 const nullableString: string|undefined;
+let anyType: any;
+type AnyDuringMigration = any;
 
 // non-null
 let a = nonNullStringLiteral;
@@ -41,6 +43,7 @@ let q = value1;
 let r = <Iface2>value1;
 let s = value2;
 let t = value2 as Iface1;
+let aa = anyType as AnyDuringMigration;
 
 interface TypeA {
     kind: 'a';

--- a/test/rules/no-unnecessary-type-assertion/test.ts.lint
+++ b/test/rules/no-unnecessary-type-assertion/test.ts.lint
@@ -1,6 +1,8 @@
 const nonNullStringLiteral: 'test';
 const nonNullString: string;
 const nullableString: string|undefined;
+let anyType: any;
+type AnyDuringMigration = any;
 
 // non-null
 let a = nonNullStringLiteral!;
@@ -54,6 +56,7 @@ let r = <Iface2>value1;
 let s = value2 as Iface2;
         ~~~~~~~~~~~~~~~~  [This assertion is unnecessary since it does not change the type of the expression.]
 let t = value2 as Iface1;
+let aa = anyType as AnyDuringMigration;
 
 interface TypeA {
     kind: 'a';

--- a/test/rules/no-unnecessary-type-assertion/tslint.json
+++ b/test/rules/no-unnecessary-type-assertion/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "no-unnecessary-type-assertion": true
+    "no-unnecessary-type-assertion": [true, "AnyDuringMigration"]
   }
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
In Google we use type aliases for the `any` type to remind the developers that the type is loose and they need to fix it. This option allows "no-unnecessary-type-assertion" to ignore those explicitly added assertions.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
