### PR TITLE
no-empty-interface: allow providing type arguments for extended type

### DIFF
--- a/test/rules/no-empty-interface/test.ts.lint
+++ b/test/rules/no-empty-interface/test.ts.lint
@@ -10,3 +10,5 @@ interface L extends J, K {} // extending more than one interface is ok, as it ca
 
 interface M extends {} // don't crash on empty extends list
           ~               [An interface declaring no members is equivalent to its supertype.]
+
+interface N extends Promise<string|number> {}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3256
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `no-empty-interface` allows providing type arguments for extended type
Fixes: #3256

#### Is there anything you'd like reviewers to focus on?
The rule now ignores every interface whose parent has type arguments. That leads to some false-negatives:
```ts
interface Base<T> {
    prop: T;
}

interface Good extends Base<string> {}
interface Bad<T> extends Base<T> {}
interface ProbablyGood<T extends string> extends Base<T> {}
interface ProbablyGood2<T = string> extends Base<T> {}

interface Base2<T, U = void> {
    prop: T,
    prop2: U;
}

interface Bad2<T, U> extends Base2<T, U> {}
interface Good2<U, T> extends Base2<T, U> {}
interface Good3<T> extends Base2<T> {} // looks like `Bad`, but isn't ... would require the type checker
```

There will be no error on any of these declarations. One might expect errors on `Bad` and `Bad2` (and maybe even on `ProbablyGood`, `ProbablyGood2` if the base type has the same default and/or constraint) but that requires the type checker to find out about all type parameters of the base type.

I don't know if these rare cases are worth the effort. Anyways, that should be done in a separate PR.

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
