### PR TITLE
object-literal-shorthand: various optimizations

### DIFF
--- a/test/rules/object-literal-shorthand/always/test.ts.fix
+++ b/test/rules/object-literal-shorthand/always/test.ts.fix
@@ -39,3 +39,5 @@ const asyncFn = {
   async foo() {},
   async *bar() {}
 }
+
+({foo} = {foo});

--- a/test/rules/object-literal-shorthand/always/test.ts.lint
+++ b/test/rules/object-literal-shorthand/always/test.ts.lint
@@ -1,10 +1,10 @@
 const bad = {
   w: function() {},
-  ~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{w() {...}}').]
+  ~~~~~~~~~~~ [Expected method shorthand in object literal ('{w() {...}}').]
   x: function *() {},
-  ~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{*x() {...}}').]
+  ~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{*x() {...}}').]
   [y]: function() {},
-  ~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{[y]() {...}}').]
+  ~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{[y]() {...}}').]
   z: z
   ~~~~  [Expected property shorthand in object literal ('{z}').]
 };
@@ -26,7 +26,7 @@ const namedFunctions = {
 
 const quotes = {
   "foo-bar": function() {},
-  ~~~~~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{"foo-bar"() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{"foo-bar"() {...}}').]
   "foo-bar"() {}
 };
 
@@ -43,7 +43,11 @@ const extraCases = {
 
 const asyncFn = {
   foo: async function() {},
-  ~~~~~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{async foo() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{async foo() {...}}').]
   bar: async function*() {}
-  ~~~~~~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{async *bar() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{async *bar() {...}}').]
 }
+
+({foo: foo} = {foo: foo});
+  ~~~~~~~~ [Expected property shorthand in object literal ('{foo}').]
+               ~~~~~~~~ [Expected property shorthand in object literal ('{foo}').]

--- a/test/rules/object-literal-shorthand/never/test.ts.fix
+++ b/test/rules/object-literal-shorthand/never/test.ts.fix
@@ -8,7 +8,11 @@ const asyncFn = {
 };
 
 const bad = {
-  w: function() {},
+  w: function() {
+    const alsoBad = {
+        bad: bad,
+    };
+  },
   x: function*() {},
   [y]: function() {},
   z: z,
@@ -50,3 +54,6 @@ const extraCases = {
 export class ClassA extends ClassZ {
   testMethod() {}
 }
+
+({foo: foo} = {foo: foo});
+

--- a/test/rules/object-literal-shorthand/never/test.ts.lint
+++ b/test/rules/object-literal-shorthand/never/test.ts.lint
@@ -10,8 +10,13 @@ const asyncFn = {
 };
 
 const bad = {
-  w() {},
+  w() {
   ~ [OBJECT_LITERAL_DISALLOWED]
+    const alsoBad = {
+        bad,
+        ~~~ [OBJECT_LITERAL_DISALLOWED]
+    };
+  },
   *x() {},
    ~ [OBJECT_LITERAL_DISALLOWED]
   [y]() {},
@@ -59,4 +64,9 @@ const extraCases = {
 export class ClassA extends ClassZ {
   testMethod() {}
 }
+
+({foo} = {foo});
+  ~~~ [OBJECT_LITERAL_DISALLOWED]
+          ~~~ [OBJECT_LITERAL_DISALLOWED]
+
 [OBJECT_LITERAL_DISALLOWED]: Shorthand property assignments have been disallowed.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: follow-up on #3268
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
I didn't want to occupy @aervin even more with my optimization ideas. So I made a follow-up to address certain things:
* removed a `return` in `disallowShorthandWalker` that shouldn't be there and I missed during review, added a test case
* simplified the fix for shorthand -> longhand method
* narrowed the error location of longhand method
* added a test case for destructuring assignment

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[no-log]
