### PR TITLE
[enhancement] max-classes-per-file / config to exclude class expressions

### DIFF
--- a/src/rules/maxClassesPerFileRule.ts
+++ b/src/rules/maxClassesPerFileRule.ts
@@ -15,9 +15,16 @@
  * limitations under the License.
  */
 
-import { hasModifier, isClassLikeDeclaration } from "tsutils";
+import { isClassExpression, isClassLikeDeclaration } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
+
+interface Options {
+    includeClassExpressions: boolean;
+    maxClasses: number;
+}
+
+const OPTION_INCLUDE_CLASS_EXPRESSIONS = "include-class-expressions";
 
 export class Rule extends Lint.Rules.AbstractRule {
 
@@ -29,7 +36,9 @@ export class Rule extends Lint.Rules.AbstractRule {
         rationale: Lint.Utils.dedent`
             Ensures that files have a single responsibility so that that classes each exist in their own files`,
         optionsDescription: Lint.Utils.dedent`
-            The one required argument is an integer indicating the maximum number of classes that can appear in a file.`,
+            The one required argument is an integer indicating the maximum number of classes that can appear in a
+            file. An optional argument \`"include-class-expressions"\` can be provided to include class expressions
+            in the overall class count.`,
         options: {
             type: "array",
             items: [
@@ -37,12 +46,15 @@ export class Rule extends Lint.Rules.AbstractRule {
                     type: "number",
                     minimum: 1,
                 },
+                {
+                    type: "string",
+                },
             ],
             additionalItems: false,
-            minLength: 1,
-            maxLength: 2,
+            minLength: 2,
+            maxLength: 3,
         },
-        optionExamples: [[true, 1], [true, 5]],
+        optionExamples: [[true, 1], [true, 5, "include-class-expressions"]],
         type: "maintainability",
         typescriptOnly: false,
     };
@@ -56,19 +68,23 @@ export class Rule extends Lint.Rules.AbstractRule {
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const argument = this.ruleArguments[0] as number;
         const maxClasses = isNaN(argument) || argument > 0 ? argument : 1;
-        return this.applyWithFunction(sourceFile, walk, { maxClasses });
+        return this.applyWithFunction(sourceFile, walk, {
+            includeClassExpressions: this.ruleArguments.indexOf(OPTION_INCLUDE_CLASS_EXPRESSIONS) !== -1,
+            maxClasses,
+        });
     }
 }
 
-interface Options {
-    maxClasses: number;
-}
-
 function walk(ctx: Lint.WalkContext<Options>): void {
-    const { sourceFile, options: { maxClasses } } = ctx;
+    const { sourceFile, options: { maxClasses, includeClassExpressions } } = ctx;
     let classes = 0;
     return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
-        if (isClassLikeDeclaration(node) && !hasDeclareLikeModifier(node)) {
+        if (
+            isClassLikeDeclaration(node) &&
+            (includeClassExpressions
+                ? true
+                : !isClassExpression(node))
+        ) {
             classes++;
             if (classes > maxClasses) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING(maxClasses));
@@ -76,11 +92,4 @@ function walk(ctx: Lint.WalkContext<Options>): void {
         }
         return ts.forEachChild(node, cb);
     });
-}
-
-function hasDeclareLikeModifier(node: ts.Node): boolean {
-    return (
-        hasModifier(node.modifiers, ts.SyntaxKind.AbstractKeyword) ||
-        hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
-    );
 }

--- a/src/rules/maxClassesPerFileRule.ts
+++ b/src/rules/maxClassesPerFileRule.ts
@@ -20,11 +20,11 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 
 interface Options {
-    includeClassExpressions: boolean;
+    excludeClassExpressions: boolean;
     maxClasses: number;
 }
 
-const OPTION_INCLUDE_CLASS_EXPRESSIONS = "include-class-expressions";
+const OPTION_INCLUDE_CLASS_EXPRESSIONS = "exclude-class-expressions";
 
 export class Rule extends Lint.Rules.AbstractRule {
 
@@ -48,13 +48,14 @@ export class Rule extends Lint.Rules.AbstractRule {
                 },
                 {
                     type: "string",
+                    enum: OPTION_INCLUDE_CLASS_EXPRESSIONS,
                 },
             ],
             additionalItems: false,
-            minLength: 2,
-            maxLength: 3,
+            minLength: 1,
+            maxLength: 2,
         },
-        optionExamples: [[true, 1], [true, 5, "include-class-expressions"]],
+        optionExamples: [[true, 1], [true, 5, "exclude-class-expressions"]],
         type: "maintainability",
         typescriptOnly: false,
     };
@@ -69,21 +70,21 @@ export class Rule extends Lint.Rules.AbstractRule {
         const argument = this.ruleArguments[0] as number;
         const maxClasses = isNaN(argument) || argument > 0 ? argument : 1;
         return this.applyWithFunction(sourceFile, walk, {
-            includeClassExpressions: this.ruleArguments.indexOf(OPTION_INCLUDE_CLASS_EXPRESSIONS) !== -1,
+            excludeClassExpressions: this.ruleArguments.indexOf(OPTION_INCLUDE_CLASS_EXPRESSIONS) !== -1,
             maxClasses,
         });
     }
 }
 
 function walk(ctx: Lint.WalkContext<Options>): void {
-    const { sourceFile, options: { maxClasses, includeClassExpressions } } = ctx;
+    const { sourceFile, options: { maxClasses, excludeClassExpressions } } = ctx;
     let classes = 0;
     return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
         if (
             isClassLikeDeclaration(node) &&
-            (includeClassExpressions
-                ? true
-                : !isClassExpression(node))
+            (excludeClassExpressions
+                ? !isClassExpression(node)
+                : true)
         ) {
             classes++;
             if (classes > maxClasses) {

--- a/src/rules/maxClassesPerFileRule.ts
+++ b/src/rules/maxClassesPerFileRule.ts
@@ -37,8 +37,8 @@ export class Rule extends Lint.Rules.AbstractRule {
             Ensures that files have a single responsibility so that that classes each exist in their own files`,
         optionsDescription: Lint.Utils.dedent`
             The one required argument is an integer indicating the maximum number of classes that can appear in a
-            file. An optional argument \`"include-class-expressions"\` can be provided to include class expressions
-            in the overall class count.`,
+            file. An optional argument \`"exclude-class-expressions"\` can be provided to exclude class expressions
+            from the overall class count.`,
         options: {
             type: "array",
             items: [

--- a/src/rules/maxClassesPerFileRule.ts
+++ b/src/rules/maxClassesPerFileRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isClassLikeDeclaration } from "tsutils";
+import { hasModifier, isClassLikeDeclaration } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -68,7 +68,7 @@ function walk(ctx: Lint.WalkContext<Options>): void {
     const { sourceFile, options: { maxClasses } } = ctx;
     let classes = 0;
     return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
-        if (isClassLikeDeclaration(node)) {
+        if (isClassLikeDeclaration(node) && !hasDeclareLikeModifier(node)) {
             classes++;
             if (classes > maxClasses) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING(maxClasses));
@@ -76,4 +76,11 @@ function walk(ctx: Lint.WalkContext<Options>): void {
         }
         return ts.forEachChild(node, cb);
     });
+}
+
+function hasDeclareLikeModifier(node: ts.Node): boolean {
+    return (
+        hasModifier(node.modifiers, ts.SyntaxKind.AbstractKeyword) ||
+        hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
+    );
 }

--- a/test/rules/max-classes-per-file/one/test.ts.lint
+++ b/test/rules/max-classes-per-file/one/test.ts.lint
@@ -18,4 +18,25 @@ let three = class {
 }
 ~ [0]
 
+export abstract class UnsupportedVisitor extends NodeVisitor {
+    public static withDescriptor(descriptor: string): typeof UnsupportedVisitor {
+        return class extends UnsupportedVisitor {
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            protected descriptor = descriptor;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        };
+~~~~~~~~~ [0]
+    }
+
+    protected abstract descriptor: string;
+
+    public visit(node: Node): undefined {
+        return `${this.descriptor} is not supported.`;
+    }
+}
+
+declare class HelloClass {
+    private helloMom: string = "hello mom!";
+}
+
 [0]: A maximum of 1 class per file is allowed.

--- a/test/rules/max-classes-per-file/one/test.ts.lint
+++ b/test/rules/max-classes-per-file/one/test.ts.lint
@@ -1,6 +1,23 @@
-class one {
-    public foo = "bar";
+export abstract class UnsupportedVisitor extends NodeVisitor {
+    public static withDescriptor(descriptor: string): typeof UnsupportedVisitor {
+        return class extends UnsupportedVisitor {   // ignores this class b/c it's an expression
+            protected descriptor = descriptor;
+        };
+    }
+
+    protected abstract descriptor: string;
+
+    public visit(node: Node): undefined {
+        return `${this.descriptor} is not supported.`;
+    }
 }
+
+class one {
+~~~~~~~~~~~
+    public foo = "bar";
+~~~~~~~~~~~~~~~~~~~~~~~
+}
+~ [0]
 
 class two {
 ~~~~~~~~~~~
@@ -12,31 +29,7 @@ class two {
 ~ [0]
 
 let three = class {
-            ~~~~~~~
     public foo = "bar";
-~~~~~~~~~~~~~~~~~~~~~~~
-}
-~ [0]
-
-export abstract class UnsupportedVisitor extends NodeVisitor {
-    public static withDescriptor(descriptor: string): typeof UnsupportedVisitor {
-        return class extends UnsupportedVisitor {
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            protected descriptor = descriptor;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        };
-~~~~~~~~~ [0]
-    }
-
-    protected abstract descriptor: string;
-
-    public visit(node: Node): undefined {
-        return `${this.descriptor} is not supported.`;
-    }
-}
-
-declare class HelloClass {
-    private helloMom: string = "hello mom!";
 }
 
 [0]: A maximum of 1 class per file is allowed.

--- a/test/rules/max-classes-per-file/one/test.ts.lint
+++ b/test/rules/max-classes-per-file/one/test.ts.lint
@@ -1,6 +1,6 @@
 export abstract class UnsupportedVisitor extends NodeVisitor {
     public static withDescriptor(descriptor: string): typeof UnsupportedVisitor {
-        return class extends UnsupportedVisitor {   // ignores this class b/c it's an expression
+        return class extends UnsupportedVisitor {
             protected descriptor = descriptor;
         };
     }

--- a/test/rules/max-classes-per-file/one/tslint.json
+++ b/test/rules/max-classes-per-file/one/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "max-classes-per-file": [true, 1]
+    "max-classes-per-file": [true, 1, "exclude-class-expressions"]
   }
 }

--- a/test/rules/max-classes-per-file/two/tslint.json
+++ b/test/rules/max-classes-per-file/two/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "max-classes-per-file": [true, 2]
+    "max-classes-per-file": [true, 2, "include-class-expressions"]
   }
 }

--- a/test/rules/max-classes-per-file/two/tslint.json
+++ b/test/rules/max-classes-per-file/two/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "max-classes-per-file": [true, 2, "include-class-expressions"]
+    "max-classes-per-file": [true, 2]
   }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: [#3270](https://github.com/palantir/tslint/issues/3270)
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Rule accepts an optional `"include-class-expressions"` argument. If arg is provided, class expressions count toward the file's overall class count, otherwise they are ignored.
