### PR TITLE
typeCheck ignored when project is unset

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -173,15 +173,15 @@ async function runLinter(options: Options, logger: Logger): Promise<LintResult> 
     return doLinting(options, files, program, logger);
 }
 
-function resolveFilesAndProgram({ files, project, exclude, outputAbsolutePaths }: Options): { files: string[]; program?: ts.Program } {
+function resolveFilesAndProgram({ files, typeCheck, project, exclude, outputAbsolutePaths }: Options): { files: string[]; program?: ts.Program } {
     // remove single quotes which break matching on Windows when glob is passed in single quotes
     const ignore = arrayify(exclude).map(trimSingleQuotes);
 
-    if (project === undefined) {
+    if (!typeCheck && project === undefined) {
         return { files: resolveGlobs(files, ignore, outputAbsolutePaths) };
     }
 
-    const projectPath = findTsconfig(project);
+    const projectPath = findTsconfig(project || ".");
     if (projectPath === undefined) {
         throw new FatalError(`Invalid option for project: ${project}`);
     }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -173,7 +173,9 @@ async function runLinter(options: Options, logger: Logger): Promise<LintResult> 
     return doLinting(options, files, program, logger);
 }
 
-function resolveFilesAndProgram({ files, typeCheck, project, exclude, outputAbsolutePaths }: Options): { files: string[]; program?: ts.Program } {
+function resolveFilesAndProgram(
+        { files, typeCheck, project, exclude, outputAbsolutePaths }: Options
+    ): { files: string[]; program?: ts.Program } {
     // remove single quotes which break matching on Windows when glob is passed in single quotes
     const ignore = arrayify(exclude).map(trimSingleQuotes);
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -175,7 +175,7 @@ async function runLinter(options: Options, logger: Logger): Promise<LintResult> 
 
 function resolveFilesAndProgram(
         { files, typeCheck, project, exclude, outputAbsolutePaths }: Options
-    ): { files: string[]; program?: ts.Program } {
+    ): { files: string[], program?: ts.Program } {
     // remove single quotes which break matching on Windows when glob is passed in single quotes
     const ignore = arrayify(exclude).map(trimSingleQuotes);
 


### PR DESCRIPTION
`typeCheck: true` is ignored if `project` is undefined. This fix sets a reasonable default `project` value.

Made with: @markuskeunecke

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update
