### PR TITLE
deprecate typeof-compare

### DIFF
--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -52,7 +52,7 @@ export function loadRules(ruleOptionsList: IOptions[],
                 rules.push(rule);
             }
 
-            if (Rule.metadata !== undefined && Rule.metadata.deprecationMessage !== undefined) {
+            if (Rule.metadata !== undefined && Boolean(Rule.metadata.deprecationMessage)) {
                 showWarningOnce(`${Rule.metadata.ruleName} is deprecated. ${Rule.metadata.deprecationMessage}`);
             }
         }

--- a/src/rules/typeofCompareRule.ts
+++ b/src/rules/typeofCompareRule.ts
@@ -32,6 +32,9 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         type: "functionality",
         typescriptOnly: false,
+        deprecationMessage: ts.versionMajorMinor as string === "2.1"
+            ? "Starting from TypeScript 2.2 the compiler includes this check which makes this rule redundant."
+            : undefined,
     };
     /* tslint:enable:object-literal-sort-keys */
 

--- a/src/rules/typeofCompareRule.ts
+++ b/src/rules/typeofCompareRule.ts
@@ -34,7 +34,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         typescriptOnly: false,
         deprecationMessage: ts.versionMajorMinor as string === "2.1"
             ? "Starting from TypeScript 2.2 the compiler includes this check which makes this rule redundant."
-            : undefined,
+            : "",
     };
     /* tslint:enable:object-literal-sort-keys */
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2187
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:
Show a deprecation warning if the rule is used with typescript 2.2 or newer.
That allows us to remove this rule when we drop support for typescript@2.1
Fixes: #2187
Closes: #2066

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[deprecation] `typeof-compare` is deprecated because typescript already does that check
