### PR TITLE
variable-name: don't crash on syntax errors

### DIFF
--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -151,7 +151,7 @@ function walk(ctx: Lint.WalkContext<Options>): void {
             return;
         }
 
-        if (!isCamelCase(text, options) && !isUpperCase(text)) {
+        if (text.length !== 0 && !isCamelCase(text, options) && !isUpperCase(text)) {
             ctx.addFailureAtNode(name, formatFailure());
         }
     }

--- a/test/rules/variable-name/allow-pascal-case/test.ts.lint
+++ b/test/rules/variable-name/allow-pascal-case/test.ts.lint
@@ -43,3 +43,8 @@ let optionallyValid_ = "bar";
     ~~~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
 let _$httpBackend_ = "leading and trailing";
     ~~~~~~~~~~~~~~          [variable name must be in lowerCamelCase, PascalCase or UPPER_CASE]
+
+// don't crash on syntax errors
+
+class {}
+let {bar:} = foo;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3288
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `variable-name` fixed crash on empty variable name
Fixes: #3288

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
