### PR TITLE
semicolon: add "strict-bound-class-methods" option

### DIFF
--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -23,10 +23,17 @@ import * as Lint from "../index";
 const OPTION_ALWAYS = "always";
 const OPTION_NEVER = "never";
 const OPTION_IGNORE_BOUND_CLASS_METHODS = "ignore-bound-class-methods";
+const OPTION_STRICT_BOUND_CLASS_METHODS = "strict-bound-class-methods";
 const OPTION_IGNORE_INTERFACES = "ignore-interfaces";
 
+const enum BoundClassMethodOption {
+    Default,
+    Ignore,
+    Strict,
+}
+
 interface Options {
-    boundClassMethods: boolean;
+    boundClassMethods: BoundClassMethodOption;
     interfaces: boolean;
 }
 
@@ -45,7 +52,10 @@ export class Rule extends Lint.Rules.AbstractRule {
             The following arguments may be optionally provided:
 
             * \`"${OPTION_IGNORE_INTERFACES}"\` skips checking semicolons at the end of interface members.
-            * \`"${OPTION_IGNORE_BOUND_CLASS_METHODS}"\` skips checking semicolons at the end of bound class methods.`,
+            * \`"${OPTION_IGNORE_BOUND_CLASS_METHODS}"\` skips checking semicolons at the end of bound class methods.
+            * \`"${OPTION_STRICT_BOUND_CLASS_METHODS}"\` disables any special handling of bound class methods and treats them as any
+            other assignment. This option overrides \`"${OPTION_IGNORE_BOUND_CLASS_METHODS}"\`.
+        `,
         options: {
             type: "array",
             items: [
@@ -77,7 +87,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options: Options = {
-            boundClassMethods: this.ruleArguments.indexOf(OPTION_IGNORE_BOUND_CLASS_METHODS) === -1,
+            boundClassMethods: this.ruleArguments.indexOf(OPTION_STRICT_BOUND_CLASS_METHODS) !== -1
+                ? BoundClassMethodOption.Strict
+                : this.ruleArguments.indexOf(OPTION_IGNORE_BOUND_CLASS_METHODS) !== -1
+                    ? BoundClassMethodOption.Ignore
+                    : BoundClassMethodOption.Default,
             interfaces: this.ruleArguments.indexOf(OPTION_IGNORE_INTERFACES) === -1,
         };
         const Walker = this.ruleArguments.indexOf(OPTION_NEVER) === -1 ? SemicolonAlwaysWalker : SemicolonNeverWalker;
@@ -175,10 +189,11 @@ abstract class SemicolonWalker extends Lint.AbstractWalker<Options> {
 
     private visitPropertyDeclaration(node: ts.PropertyDeclaration) {
         // check if this is a multi-line arrow function
-        if (node.initializer !== undefined &&
+        if (this.options.boundClassMethods !== BoundClassMethodOption.Strict &&
+            node.initializer !== undefined &&
             node.initializer.kind === ts.SyntaxKind.ArrowFunction &&
             !utils.isSameLine(this.sourceFile, node.getStart(this.sourceFile), node.end)) {
-            if (this.options.boundClassMethods) {
+            if (this.options.boundClassMethods === BoundClassMethodOption.Default) {
                 this.checkUnnecessary(node);
             }
         } else {

--- a/test/rules/semicolon/strict-bound-class-methods/test.ts.fix
+++ b/test/rules/semicolon/strict-bound-class-methods/test.ts.fix
@@ -1,0 +1,22 @@
+class MyClass {
+    public name : string;
+    private index : number;
+    private email : string;
+
+    public initializedProperty = 6;
+    public initializedMethodProperty = () => {
+        return "hi";
+    };
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again";
+    };
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; };
+    public realMethod() {}
+    public multilineRealMethod() {
+        return "foo";
+    }
+}

--- a/test/rules/semicolon/strict-bound-class-methods/test.ts.lint
+++ b/test/rules/semicolon/strict-bound-class-methods/test.ts.lint
@@ -1,0 +1,27 @@
+class MyClass {
+    public name : string
+                        ~nil [Missing semicolon]
+    private index : number
+                          ~nil [Missing semicolon]
+    private email : string;
+
+    public initializedProperty = 6
+                                  ~nil [Missing semicolon]
+    public initializedMethodProperty = () => {
+        return "hi";
+    };
+
+    public initializedMethodPropertyWithoutSemicolon = () => {
+        return "hi again";
+    }
+     ~nil [Missing semicolon]
+
+    public initializedMethodProperty1Line = () => { return "hi"; };
+
+    public initializedMethodPropertyWithoutSemicolon1Line = () => { return "hi again"; }
+                                                                                        ~nil [Missing semicolon]
+    public realMethod() {}
+    public multilineRealMethod() {
+        return "foo";
+    }
+}

--- a/test/rules/semicolon/strict-bound-class-methods/tslint.json
+++ b/test/rules/semicolon/strict-bound-class-methods/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "semicolon": [true, "always", "strict-bound-class-methods"]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3216
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
[new-rule-option] `semicolon` adds `"strict-bound-class-methods"`
Fixes: #3216

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
