### PR TITLE
--test: allow target other than default

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -119,13 +119,13 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
                 getDefaultLibFileName: () => ts.getDefaultLibFileName(compilerOptions),
                 getDirectories: (dir) => fs.readdirSync(dir),
                 getNewLine: () => "\n",
-                getSourceFile(filenameToGet) {
-                    const target = compilerOptions.target === undefined ? ts.ScriptTarget.ES5 : compilerOptions.target;
-                    if (filenameToGet === ts.getDefaultLibFileName(compilerOptions)) {
-                        const fileContent = fs.readFileSync(ts.getDefaultLibFilePath(compilerOptions), "utf8");
-                        return ts.createSourceFile(filenameToGet, fileContent, target);
-                    } else if (denormalizeWinPath(filenameToGet) === fileCompileName) {
+                getSourceFile(filenameToGet, target) {
+                    if (denormalizeWinPath(filenameToGet) === fileCompileName) {
                         return ts.createSourceFile(filenameToGet, fileTextWithoutMarkup, target, true);
+                    }
+                    if (path.basename(filenameToGet) === filenameToGet) {
+                        // resolve path of lib.xxx.d.ts
+                        filenameToGet = path.join(path.dirname(ts.getDefaultLibFilePath(compilerOptions)), filenameToGet);
                     }
                     const text = fs.readFileSync(filenameToGet, "utf8");
                     return ts.createSourceFile(filenameToGet, text, target, true);

--- a/src/verify/lintError.ts
+++ b/src/verify/lintError.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { Error } from "../error";
-
 export interface PositionInFile {
    line: number;
    col: number;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Removed unnecessary import of `Error` which caused a crash at runtime if there was an error in a `.lint` file.
`CompilerHost` used for rule tests can now handle any `lib.xxx.d.ts` file, not just the default.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] `--test` works correctly with any `compilerOptions.target`
