### PR TITLE
await-promise: check for-await-of

### DIFF
--- a/src/rules/awaitPromiseRule.ts
+++ b/src/rules/awaitPromiseRule.ts
@@ -41,8 +41,8 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "'await' of non-Promise.";
-    public static FAILURE_FOR_AWAIT_OF = "'for-await-of' of non-AsyncIterable.";
+    public static FAILURE_STRING = "Invalid 'await' of a non-Promise value.";
+    public static FAILURE_FOR_AWAIT_OF = "Invalid 'for-await-of' of a non-AsyncIterable value.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         const promiseTypes = new Set(["Promise", ...this.ruleArguments as string[]]);

--- a/src/rules/awaitPromiseRule.ts
+++ b/src/rules/awaitPromiseRule.ts
@@ -42,7 +42,7 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING = "'await' of non-Promise.";
-    public static FAILURE_FOR_AWAIT_OF = "'for-await-of' expects AsyncIterableIterator.";
+    public static FAILURE_FOR_AWAIT_OF = "'for-await-of' of non-AsyncIterable.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         const promiseTypes = new Set(["Promise", ...this.ruleArguments as string[]]);
@@ -58,7 +58,7 @@ function walk(ctx: Lint.WalkContext<Set<string>>, tc: ts.TypeChecker) {
         if (isAwaitExpression(node) && !containsType(tc.getTypeAtLocation(node.expression), isPromiseType)) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         } else if (isForOfStatement(node) && node.awaitModifier !== undefined &&
-                   !containsType(tc.getTypeAtLocation(node.expression), isAsyncIterableIterator)) {
+                   !containsType(tc.getTypeAtLocation(node.expression), isAsyncIterable)) {
             ctx.addFailureAtNode(node.expression, Rule.FAILURE_FOR_AWAIT_OF);
         }
         return ts.forEachChild(node, cb);
@@ -82,6 +82,6 @@ function containsType(type: ts.Type, predicate: (name: string) => boolean): bool
     return bases !== undefined && bases.some((t) => containsType(t, predicate));
 }
 
-function isAsyncIterableIterator(name: string) {
-    return name === "AsyncIterableIterator";
+function isAsyncIterable(name: string) {
+    return name === "AsyncIterable" || name === "AsyncIterableIterator";
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -119,13 +119,13 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
                 getDefaultLibFileName: () => ts.getDefaultLibFileName(compilerOptions),
                 getDirectories: (dir) => fs.readdirSync(dir),
                 getNewLine: () => "\n",
-                getSourceFile(filenameToGet) {
-                    const target = compilerOptions.target === undefined ? ts.ScriptTarget.ES5 : compilerOptions.target;
-                    if (filenameToGet === ts.getDefaultLibFileName(compilerOptions)) {
-                        const fileContent = fs.readFileSync(ts.getDefaultLibFilePath(compilerOptions), "utf8");
-                        return ts.createSourceFile(filenameToGet, fileContent, target);
-                    } else if (denormalizeWinPath(filenameToGet) === fileCompileName) {
+                getSourceFile(filenameToGet, target) {
+                    if (denormalizeWinPath(filenameToGet) === fileCompileName) {
                         return ts.createSourceFile(filenameToGet, fileTextWithoutMarkup, target, true);
+                    }
+                    if (path.basename(filenameToGet) === filenameToGet) {
+                        // resolve path of lib.xxx.d.ts
+                        filenameToGet = path.join(path.dirname(ts.getDefaultLibFilePath(compilerOptions)), filenameToGet);
                     }
                     const text = fs.readFileSync(filenameToGet, "utf8");
                     return ts.createSourceFile(filenameToGet, text, target, true);

--- a/src/verify/lintError.ts
+++ b/src/verify/lintError.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { Error } from "../error";
-
 export interface PositionInFile {
    line: number;
    col: number;

--- a/test/rules/await-promise/custom-promise/test.ts.lint
+++ b/test/rules/await-promise/custom-promise/test.ts.lint
@@ -75,4 +75,4 @@ async function fCustomPromise() {
     await intersectionPromise;
 }
 
-[0]: 'await' of non-Promise.
+[0]: Invalid 'await' of a non-Promise value.

--- a/test/rules/await-promise/es6-promise/test.ts.lint
+++ b/test/rules/await-promise/es6-promise/test.ts.lint
@@ -48,4 +48,4 @@ async function fPromise() {
     await intersectionPromise;
 }
 
-[0]: 'await' of non-Promise.
+[0]: Invalid 'await' of a non-Promise value.

--- a/test/rules/await-promise/for-await-of/test.ts.lint
+++ b/test/rules/await-promise/for-await-of/test.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: >= 2.3.0
 async function correct(foo: AsyncIterableIterator<string>) {
     for await (const element of foo) {}
 }

--- a/test/rules/await-promise/for-await-of/test.ts.lint
+++ b/test/rules/await-promise/for-await-of/test.ts.lint
@@ -48,4 +48,4 @@ function* generator() {
     yield 1;
 }
 
-[0]: 'for-await-of' of non-AsyncIterable.
+[0]: Invalid 'for-await-of' of a non-AsyncIterable value.

--- a/test/rules/await-promise/for-await-of/test.ts.lint
+++ b/test/rules/await-promise/for-await-of/test.ts.lint
@@ -4,7 +4,7 @@ async function correct(foo: AsyncIterableIterator<string>) {
 }
 
 async function correct2() {
-    for await (const element of generator()) {}
+    for await (const element of asyncGenerator()) {}
 }
 
 async function correct(foo: AsyncIterable<string>) {
@@ -26,11 +26,25 @@ async function incorrect2(foo: IterableIterator<Promise<string>>) {
 }
 
 async function incorrect3() {
-    for await (const element of generator) {}
-                                ~~~~~~~~~ [0]
+    for await (const element of asyncGenerator) {}
+                                ~~~~~~~~~~~~~~ [0]
 }
 
-async function* generator() {
+async function incorrect4() {
+    for await (const element of generator()) {}
+                                ~~~~~~~~~~~ [0]
+}
+
+async function incorrect5(foo: Iterable<string>) {
+    for await (const element of foo) {}
+                                ~~~ [0]
+}
+
+async function* asyncGenerator() {
+    yield 1;
+}
+
+function* generator() {
     yield 1;
 }
 

--- a/test/rules/await-promise/for-await-of/test.ts.lint
+++ b/test/rules/await-promise/for-await-of/test.ts.lint
@@ -1,0 +1,32 @@
+async function correct(foo: AsyncIterableIterator<string>) {
+    for await (const element of foo) {}
+}
+
+async function correct2() {
+    for await (const element of generator()) {}
+}
+
+async function correct3(foo: AsyncIterableIterator<string> | AsyncIterableIterator<number>) {
+    for await (const element of foo) {}
+}
+
+async function incorrect(foo: <Array<Promise<string>>) {
+    for await (const element of foo) {}
+                                ~~~ [0]
+}
+
+async function incorrect2(foo: IterableIterator<Promise<string>>) {
+    for await (const element of foo) {}
+                                ~~~ [0]
+}
+
+async function incorrect3() {
+    for await (const element of generator) {}
+                                ~~~~~~~~~ [0]
+}
+
+async function* generator() {
+    yield 1;
+}
+
+[0]: 'for-await-of' expects AsyncIterableIterator.

--- a/test/rules/await-promise/for-await-of/test.ts.lint
+++ b/test/rules/await-promise/for-await-of/test.ts.lint
@@ -7,6 +7,10 @@ async function correct2() {
     for await (const element of generator()) {}
 }
 
+async function correct(foo: AsyncIterable<string>) {
+    for await (const element of foo) {}
+}
+
 async function correct3(foo: AsyncIterableIterator<string> | AsyncIterableIterator<number>) {
     for await (const element of foo) {}
 }
@@ -30,4 +34,4 @@ async function* generator() {
     yield 1;
 }
 
-[0]: 'for-await-of' expects AsyncIterableIterator.
+[0]: 'for-await-of' of non-AsyncIterable.

--- a/test/rules/await-promise/for-await-of/tsconfig.json
+++ b/test/rules/await-promise/for-await-of/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "target": "esnext"
+    }
+}

--- a/test/rules/await-promise/for-await-of/tslint.json
+++ b/test/rules/await-promise/for-await-of/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "await-promise": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3232
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[enhancement] `await-promise` enforces that `for-await-of` is only used with `AsyncIterableIterator`
Fixes: #3232



#### Is there anything you'd like reviewers to focus on?

Depends on: #3296

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
