### PR TITLE
return-undefined: various bug fixes

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -93,11 +93,13 @@ export function someAncestor(node: ts.Node, predicate: (n: ts.Node) => boolean):
     return predicate(node) || (node.parent !== undefined && someAncestor(node.parent, predicate));
 }
 
-export function ancestorWhere<T extends ts.Node>(node: ts.Node, predicate: (n: ts.Node) => boolean): ts.Node | undefined {
+export function ancestorWhere<T extends ts.Node>(node: ts.Node, predicate: (n: ts.Node) => n is T): T | undefined;
+export function ancestorWhere(node: ts.Node, predicate: (n: ts.Node) => boolean): ts.Node | undefined;
+export function ancestorWhere<T extends ts.Node>(node: ts.Node, predicate: (n: ts.Node) => n is T): T | undefined {
     let cur: ts.Node | undefined = node;
     do {
         if (predicate(cur)) {
-            return cur as T;
+            return cur;
         }
         cur = cur.parent;
     } while (cur !== undefined);

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -108,10 +108,12 @@ function getReturnKind(node: FunctionLike, checker: ts.TypeChecker): ReturnKind 
             return ReturnKind.Value;
     }
 
-    const contextual = isFunctionExpressionLike(node) ? tryGetReturnType(checker.getContextualType(node), checker) : undefined;
+    const contextual = isFunctionExpressionLike(node) && node.type === undefined
+        ? tryGetReturnType(checker.getContextualType(node), checker)
+        : undefined;
     const returnType = contextual !== undefined ? contextual : tryGetReturnType(checker.getTypeAtLocation(node), checker);
 
-    if (returnType === undefined) {
+    if (returnType === undefined || Lint.isTypeFlagSet(returnType, ts.TypeFlags.Any)) {
         return undefined;
     } else if (isEffectivelyVoid(returnType)) {
         return ReturnKind.Void;
@@ -143,8 +145,7 @@ function tryGetReturnType(fnType: ts.Type | undefined, checker: ts.TypeChecker):
         return undefined;
     }
 
-    const ret = checker.getReturnTypeOfSignature(sigs[0]);
-    return Lint.isTypeFlagSet(ret, ts.TypeFlags.Any) ? undefined : ret;
+    return checker.getReturnTypeOfSignature(sigs[0]);
 }
 
 function isFunctionLike(node: ts.Node): node is FunctionLike {

--- a/test/rules/return-undefined/test.ts.lint
+++ b/test/rules/return-undefined/test.ts.lint
@@ -70,5 +70,13 @@ declare function f<T>(action: () => T | undefined): void;
 f(() => { return undefined; });
           ~~~~~~~~~~~~~~~~~ [VOID]
 
+declare function test(cb: () => Promise<void> | void): void;
+
+test(async () => {
+    if (1 === 2) return;
+    else return undefined;
+         ~~~~~~~~~~~~~~~~~ [VOID]
+});
+
 [VOID]: `void` function should use `return;`, not `return undefined;`.
 [UNDEFINED]: Value-returning function should use `return undefined;`, not just `return;`.

--- a/test/rules/return-undefined/test.ts.lint
+++ b/test/rules/return-undefined/test.ts.lint
@@ -36,17 +36,19 @@ badContextualType(() => {
          ~~~~~~~ [UNDEFINED]
 });
 
-// 'any' doesn't provide a contextual type, so assumes meant to return 'void'.
+// Allow anything in callback taking 'any'.
 function takesAnyCb(cb: () => any): void;
 takesAnyCb(() => { return; });
 takesAnyCb(() => { return undefined; });
-                   ~~~~~~~~~~~~~~~~~ [VOID]
 takesAnyCb(() => {
     if (1 === 2) return;
-                 ~~~~~~~ [UNDEFINED]
     else return 1;
 });
 takesAnyCb(() => {
+    if (1 === 2) return;
+    else return undefined;
+});
+takesAnyCb((): void => {
     if (1 === 2) return;
     else return undefined;
          ~~~~~~~~~~~~~~~~~ [VOID]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3234, #2812
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `return-undefined` fixed regressions: once again allows anything if return type is `any`
Fixes: #2812
[bugfix] `return-undefined` declared return type takes precedence over contextual type
[bugfix] `return-undefined` handles union return types in async functions
Fixes: #3234

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
