### PR TITLE
Add check for indent size violations

### DIFF
--- a/test/rules/indent/spaces-2/test.ts.fix
+++ b/test/rules/indent/spaces-2/test.ts.fix
@@ -71,7 +71,7 @@ module TestModule {
 }
 
 function() {
-    var test = 123;
+  var test = 123;
 }
 
 class TestClass {
@@ -135,5 +135,9 @@ var arr2 = [
     a: 3,
     b: 4
   }
+];
+
+var arr3 = [
+  1
 ];
 

--- a/test/rules/indent/spaces-2/test.ts.lint
+++ b/test/rules/indent/spaces-2/test.ts.lint
@@ -159,4 +159,9 @@ var arr2 = [
   }
 ];
 
+var arr3 = [
+    1
+~~~~ [0]
+];
+
 [0]: 2 space indentation expected

--- a/test/rules/indent/spaces-4/test.ts.fix
+++ b/test/rules/indent/spaces-4/test.ts.fix
@@ -71,7 +71,7 @@ module TestModule {
 }
 
 function() {
-        var test = 123;
+    var test = 123;
 }
 
 class TestClass {

--- a/test/rules/indent/tabs-2/test.ts.fix
+++ b/test/rules/indent/tabs-2/test.ts.fix
@@ -72,7 +72,7 @@ module TestModule {
 }
 
 function() {
-		var test = 123;
+	var test = 123;
 }
 
 class TestClass {

--- a/test/rules/indent/tabs-4/test.ts.fix
+++ b/test/rules/indent/tabs-4/test.ts.fix
@@ -72,7 +72,7 @@ module TestModule {
 }
 
 function() {
-		var test = 123;
+	var test = 123;
 }
 
 class TestClass {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2814
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Fixed the #2814 issue.
Updated logic to make it smarter, so now it's able to check/correct indentation even after fixing wrong characters. TSlint 5.7.0 may require a second pass to fix indentation in these cases.

#### Is there anything you'd like reviewers to focus on?
Changed test files, e.g. test/rules/indent/spaces-2/test.ts.fix