### PR TITLE
no-angle-bracket-type-assertion: fixed replacement order and add parens

### DIFF
--- a/test/rules/no-angle-bracket-type-assertion/test.ts.fix
+++ b/test/rules/no-angle-bracket-type-assertion/test.ts.fix
@@ -7,3 +7,11 @@ var c = (5 as any) as number;
 var d = 5 as any as number;
 
 var e = 5 as any as number;
+
+let f = (flag as any as number) & value;
+f = (flag as any as number) | value;
+
+let g = a as any as A;
+
+let h = a as any as AsyncIterableIterator;
+

--- a/test/rules/no-angle-bracket-type-assertion/test.ts.lint
+++ b/test/rules/no-angle-bracket-type-assertion/test.ts.lint
@@ -1,14 +1,26 @@
 var a = <any>5;
-        ~~~~~~  [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+        ~~~~~~ [0]
 
 var b = <number><any>5;
-        ~~~~~~~~~~~~~~  [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
-                ~~~~~~  [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+        ~~~~~~~~~~~~~~ [0]
 
 var c = <number>(5 as any);
-        ~~~~~~~~~~~~~~~~~~  [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+        ~~~~~~~~~~~~~~~~~~ [0]
 
 var d = <any> 5 as number;
-        ~~~~~~~            [Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.]
+        ~~~~~~~ [0]
 
 var e = 5 as any as number;
+
+let f = <number><any>flag & value;
+        ~~~~~~~~~~~~~~~~~ [0]
+f = <number><any>flag | value;
+    ~~~~~~~~~~~~~~~~~ [0]
+
+let g = <A><any>a;
+        ~~~~~~~~~ [0]
+
+let h = <AsyncIterableIterator><any>a;
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+[0]: Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2957, #2955
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Only add one failure for nested assertions and fix them all together.
[bugfix] `no-angle-bracket-type-assertion` fixed order when autofixing consecutive assertions
Fixes: #2957 
[bugfix] `no-angle-bracket-type-assertion` fixer adds parentheses when necessary
Fixes: #2955

#### Is there anything you'd like reviewers to focus on?
It's very weird that the tests didn't fail all the time.
```ts
var b = <number><any>5;
// before it was fixed to
var b = 5 as number as any;
// now it is fixed to
var b = 5 as any as number; // this line was always in the `.fix` file
```
Only some specific changes to `test.ts.lint` caused the test to fail at this line. The offending line stayed unchanged all the time ...
https://github.com/palantir/tslint/issues/2957#issuecomment-311175391
#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
