### PR TITLE
whitespace: add option check-postblock-prekeyword

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -32,6 +32,7 @@ const OPTION_TYPE = "check-type";
 const OPTION_TYPECAST = "check-typecast";
 const OPTION_TYPE_OPERATOR = "check-type-operator";
 const OPTION_PREBLOCK = "check-preblock";
+const OPTION_POSTBLOCK_PREKEYWORD = "check-postblock-prekeyword";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
@@ -39,7 +40,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Enforces whitespace style conventions.",
         rationale: "Helps maintain a readable, consistent style in your codebase.",
         optionsDescription: Lint.Utils.dedent`
-            Ten arguments may be optionally provided:
+            Eleven arguments may be optionally provided:
 
             * \`"check-branch"\` checks branching statements (\`if\`/\`else\`/\`for\`/\`while\`) are followed by whitespace.
             * \`"check-decl"\`checks that variable declarations have whitespace around the equals token.
@@ -50,7 +51,9 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`"check-type"\` checks for whitespace before a variable type specification.
             * \`"check-typecast"\` checks for whitespace between a typecast and its target.
             * \`"check-type-operator"\` checks for whitespace between type operators \`|\` and \`&\`.
-            * \`"check-preblock"\` checks for whitespace before the opening brace of a block`,
+            * \`"check-preblock"\` checks for whitespace before the opening brace of a block.
+            * \`"check-postblock-prekeyword"\` checks for whitespace between the closing brace of a block
+            and the following keyword (\`} else\` / \`} catch\` / \`} while\`).`,
         options: {
             type: "array",
             items: {
@@ -58,6 +61,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 enum: [
                     "check-branch", "check-decl", "check-operator", "check-module", "check-separator",
                     "check-rest-spread", "check-type", "check-typecast", "check-type-operator", "check-preblock",
+                    "check-postblock-prekeyword",
                 ],
             },
             minLength: 0,
@@ -77,7 +81,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 type Options = Record<
-    "branch" | "decl" | "operator" | "module" | "separator" | "restSpread" | "type" | "typecast" | "typeOperator" | "preblock",
+    "branch" | "decl" | "operator" | "module" | "separator" | "restSpread" | "type" | "typecast" | "typeOperator" | "preblock"
+    | "postblockPrekeyword",
     boolean>;
 
 function parseOptions(ruleArguments: string[]): Options {
@@ -92,6 +97,7 @@ function parseOptions(ruleArguments: string[]): Options {
         typecast: has(OPTION_TYPECAST),
         typeOperator: has(OPTION_TYPE_OPERATOR),
         preblock: has(OPTION_PREBLOCK),
+        postblockPrekeyword: has(OPTION_POSTBLOCK_PREKEYWORD),
     };
 
     function has(option: string): boolean {
@@ -121,6 +127,21 @@ function walk(ctx: Lint.WalkContext<Options>) {
             case ts.SyntaxKind.Block:
                 if (options.preblock) {
                     checkForTrailingWhitespace(node.getFullStart());
+                }
+                if (options.postblockPrekeyword) {
+                    const nextToken = utils.getNextToken(node as ts.Block)!;
+                    if (!utils.isSameLine(sourceFile, node.end, nextToken.getStart())) {
+                        break;
+                    }
+                    switch (nextToken.kind) {
+                        case ts.SyntaxKind.WhileKeyword:
+                        case ts.SyntaxKind.ElseKeyword:
+                        case ts.SyntaxKind.CatchKeyword:
+                        case ts.SyntaxKind.FinallyKeyword:
+                            if (node.end === nextToken.getStart()) {
+                                addMissingWhitespaceErrorAt(node.end);
+                            }
+                    }
                 }
                 break;
 

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -129,11 +129,11 @@ if () {
 }
 
 try {
-
+// try111
 } catch (e) {
-
+// 111
 } finally {
-
+// finally111
 }
 
 if () {
@@ -153,7 +153,7 @@ if () {
 try {
 
 } catch (e) {
-
+// 222
 } finally {
 
 }
@@ -161,3 +161,9 @@ try {
 do {
 
 } while ()
+
+try {
+
+} finally {
+
+}

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -121,3 +121,43 @@ type A = number | string;
 type B = number | string | {result: string};
 
 type C = {result: string} & {type: "A" | "B"};
+
+if () {
+  console.info()
+} else {
+  console.info()
+}
+
+try {
+
+} catch (e) {
+
+} finally {
+
+}
+
+if () {
+
+} else {
+
+}
+
+if () {
+
+}//xxx
+
+if () {
+
+}/*xxx*/
+
+try {
+
+} catch (e) {
+
+} finally {
+
+}
+
+do {
+
+} while ()

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -192,3 +192,60 @@ type C = {result: string}&{type: "A"|"B"};
                           ~                [missing whitespace]
                                     ~      [missing whitespace]
                                      ~     [missing whitespace]
+
+if () {
+  console.info()
+} else {
+  console.info()
+}
+
+try {
+
+} catch (e) {
+
+} finally {
+
+}
+
+if(){
+  ~     [missing whitespace]
+    ~     [missing whitespace]
+
+}else{
+ ~     [missing whitespace]
+     ~     [missing whitespace]
+
+}
+
+if(){
+  ~     [missing whitespace]
+    ~     [missing whitespace]
+
+}//xxx
+
+if(){
+  ~     [missing whitespace]
+    ~     [missing whitespace]
+
+}/*xxx*/
+
+try{
+   ~     [missing whitespace]
+
+}catch(e){
+ ~     [missing whitespace]
+      ~     [missing whitespace]
+         ~     [missing whitespace]
+
+}finally{
+ ~     [missing whitespace]
+        ~     [missing whitespace]
+
+}
+
+do{
+  ~     [missing whitespace]
+
+}while()
+ ~     [missing whitespace]
+      ~     [missing whitespace]

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -200,11 +200,11 @@ if () {
 }
 
 try {
-
+// try111
 } catch (e) {
-
+// 111
 } finally {
-
+// finally111
 }
 
 if(){
@@ -236,7 +236,7 @@ try{
  ~     [missing whitespace]
       ~     [missing whitespace]
          ~     [missing whitespace]
-
+// 222
 }finally{
  ~     [missing whitespace]
         ~     [missing whitespace]
@@ -249,3 +249,11 @@ do{
 }while()
  ~     [missing whitespace]
       ~     [missing whitespace]
+
+try {
+
+}finally{
+ ~     [missing whitespace]
+        ~     [missing whitespace]
+
+}

--- a/test/rules/whitespace/all/tslint.json
+++ b/test/rules/whitespace/all/tslint.json
@@ -10,7 +10,8 @@
       "check-rest-spread",
       "check-type",
       "check-typecast",
-      "check-type-operator"
+      "check-type-operator",
+      "check-postblock-prekeyword"
     ]
   }
 }


### PR DESCRIPTION
check-postblock-prekeyword

#### Example:

before lint:
```
try {
}catch {
}finally {
}

if () {
}else {
}
```
after lint:
```
try {
} catch {
} finally {
}


if () {
} else {
}
```

#### PR checklist

- [x] Addresses an existing issue: #746
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[new-rule] `check-postblock-prekeyword`
[new-rule]
