### PR TITLE
only-arrow-functions: also find uses of `this` in parameters

### DIFF
--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -94,15 +94,11 @@ function walk(ctx: Lint.WalkContext<Options>): void {
 
 /** Generator functions and functions using `this` are allowed. */
 function functionIsExempt(node: ts.FunctionLikeDeclaration): boolean {
-    return node.asteriskToken !== undefined || hasThisParameter(node) || node.body !== undefined && usesThisInBody(node.body) === true;
+    return node.asteriskToken !== undefined ||
+        node.parameters.length !== 0 && utils.isThisParameter(node.parameters[0]) ||
+        node.body !== undefined && ts.forEachChild(node, usesThis) === true;
 }
 
-function hasThisParameter(node: ts.FunctionLikeDeclaration): boolean {
-    const first = node.parameters[0];
-    return first !== undefined && first.name.kind === ts.SyntaxKind.Identifier &&
-        first.name.originalKeywordKind === ts.SyntaxKind.ThisKeyword;
-}
-
-function usesThisInBody(node: ts.Node): boolean | undefined {
-    return node.kind === ts.SyntaxKind.ThisKeyword || !utils.hasOwnThisReference(node) && ts.forEachChild(node, usesThisInBody);
+function usesThis(node: ts.Node): boolean | undefined {
+    return node.kind === ts.SyntaxKind.ThisKeyword || !utils.hasOwnThisReference(node) && ts.forEachChild(node, usesThis);
 }

--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -74,7 +74,7 @@ function parseOptions(ruleArguments: string[]): Options {
 
 function walk(ctx: Lint.WalkContext<Options>): void {
     const { sourceFile, options: { allowDeclarations, allowNamedFunctions } } = ctx;
-    return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
+    return ts.forEachChild(sourceFile, function cb(node): void {
         switch (node.kind) {
             case ts.SyntaxKind.FunctionDeclaration:
                 if (allowDeclarations) {

--- a/test/rules/only-arrow-functions/default/test.ts.lint
+++ b/test/rules/only-arrow-functions/default/test.ts.lint
@@ -27,6 +27,7 @@ function hasThisParameter(this) {}
 let hasThisParameter = function(this) {}
 
 let usesThis = function() { this; }
+let usesThis2 = function(foo = this) {}
 
 let notUsesThis = function() {
                   ~~~~~~~~ [0]


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `only-arrow-function` allow function if `this` is used in parameter initializer

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
