### PR TITLE
deprecate --type-check

### DIFF
--- a/docs/usage/cli/index.md
+++ b/docs/usage/cli/index.md
@@ -46,7 +46,7 @@ Options:
 -s, --formatters-dir  formatters directory
 -t, --format          output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)  [default: "prose"]
 --test                test that tslint produces the correct output for the specified directory
---type-check          enable type checking when linting a project
+--type-check          (deprecated) enable type checking when linting a project
 -v, --version         current version
 ```
 
@@ -128,8 +128,8 @@ tslint accepts the following command-line options:
     files will be linted.
 
 --type-check
-    Enables the type checker when running linting rules. --project must be
-    specified in order to enable type checking.
+    (deprecated) Enables the type checker when running linting rules.
+    --project must be specified in order to enable type checking.
 
 -v, --version:
     The current version of tslint.

--- a/docs/usage/type-checking/index.md
+++ b/docs/usage/type-checking/index.md
@@ -19,8 +19,6 @@ tslint -p tsconfig.json --exclude '**/*.d.ts' # lint all files in the project ex
 tslint -p tsconfig.json **/*.ts # ignores files in tsconfig.json and uses the provided glob instead
 ```
 
-Use the `--type-check` flag to make sure your program has no type errors. TSLint will check for any errors before linting. This flag requires `--project` to be specified.
-
 ##### Library
 
 To enable rules that work with the type checker, a TypeScript program object must be passed to the linter when using the programmatic API. Helper functions are provided to create a program from a `tsconfig.json` file. A project directory can be specified if project files do not lie in the same directory as the `tsconfig.json` file.

--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -181,10 +181,10 @@ const options: Option[] = [
     {
         name: "type-check",
         type: "boolean",
-        describe: "check for type errors before linting the project",
+        describe: "(deprecated) check for type errors before linting the project",
         description: dedent`
-            Checks for type errors before linting a project. --project must be
-            specified in order to enable type checking.`,
+            (deprecated) Checks for type errors before linting a project.
+            --project must be specified in order to enable type checking.`,
     },
 ];
 
@@ -236,9 +236,12 @@ if (!(argv.init || argv.test !== undefined || argv.project !== undefined || comm
     process.exit(1);
 }
 
-if (argv.typeCheck && argv.project === undefined) {
-    console.error("--project must be specified in order to enable type checking.");
-    process.exit(1);
+if (argv.typeCheck) {
+    console.warn("--type-check is deprecated. You only need --project to enable rule which need type information.");
+    if (argv.project === undefined) {
+        console.error("--project must be specified in order to enable type checking.");
+        process.exit(1);
+    }
 }
 
 let log: (message: string) => void;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:
Deprecated `--type-check`. It's no longer necessary. Most users don't read the changelog and may not have noticed it.
It breaks consumers that expect a certain output format. And it confuses users, because `--exclude` does not work as expected.

We should remove it in v6.0

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[deprecation] CLI argument `--type-check` is no longer necessary and will be removed in the next major version
