### PR TITLE
Async-ified writing the tslint.json file in --init

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -32,7 +32,7 @@ import {
 import { FatalError } from "./error";
 import { LintResult } from "./index";
 import * as Linter from "./linter";
-import { arrayify, flatMap } from "./utils";
+import { arrayify, flatMap, writeFileAsync } from "./utils";
 
 export interface Options {
     /**
@@ -135,7 +135,7 @@ async function runWorker(options: Options, logger: Logger): Promise<Status> {
             throw new FatalError(`Cannot generate ${CONFIG_FILENAME}: file already exists`);
         }
 
-        fs.writeFileSync(CONFIG_FILENAME, JSON.stringify(DEFAULT_CONFIG, undefined, "    "));
+        await writeFileAsync(CONFIG_FILENAME, JSON.stringify(DEFAULT_CONFIG, undefined, "    "));
         return Status.Ok;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import * as fs from "fs";
+
 /**
  * Enforces the invariant that the input is an array.
  */
@@ -212,4 +214,16 @@ export function detectBufferEncoding(buffer: Buffer, length = buffer.length): En
 // converts Windows normalized paths (with backwards slash `\`) to paths used by TypeScript (with forward slash `/`)
 export function denormalizeWinPath(path: string): string {
     return path.replace(/\\/g, "/");
+}
+
+export async function writeFileAsync(fileName: string, data: string) {
+    await new Promise((resolve, reject) => {
+        fs.writeFile(fileName, data, (error?: Error) => {
+            if (error != null) {
+                reject(error);
+            } else {
+                resolve();
+            }
+        });
+    });
 }


### PR DESCRIPTION
The `runWorker` method is already `async`. Added a general purpose `async` wrapper in utils around `fs.writeFile`.

#### PR checklist

- [x] Addresses an existing issue: #2328 _(indirectly)_ / #3333

#### Overview of change:

Uses `fs.readFile` within an `async` wrapper under `utils` instead of `fs.readFileSync`.