### PR TITLE
relativizes file names if 'rootDir' is provided in tsconfig.json

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -131,6 +131,15 @@ class Linter {
             throw new Error(`formatter '${formatterName}' not found`);
         }
 
+        if (this.program) {
+            const rootDir = this.program.getCompilerOptions().rootDir;
+            if (rootDir) {
+                for (const f of this.failures) {
+                    f["fileName"] = path.relative(rootDir, f.getFileName());
+                }
+            }
+        }
+
         const output = formatter.format(this.failures, this.fixes);
 
         const errorCount = this.failures.filter((failure) => failure.getRuleSeverity() === "error").length;

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -131,10 +131,11 @@ class Linter {
             throw new Error(`formatter '${formatterName}' not found`);
         }
 
-        if (this.program) {
+        if (this.program !== undefined) {
             const rootDir = this.program.getCompilerOptions().rootDir;
-            if (rootDir) {
+            if (rootDir !== undefined) {
                 for (const f of this.failures) {
+                    // tslint:disable-next-line:no-string-literal fileName is private
                     f["fileName"] = path.relative(rootDir, f.getFileName());
                 }
             }


### PR DESCRIPTION
Run TSLint without "-p" makes file names in failures relative. Run TSLint with a tsconfig.json and "rootDir" makes file names in failures absolute. (I think it's because of this bug fix https://github.com/palantir/tslint/pull/2688)

To reproduce the problem:
```
~/workspace/tslint: cat repro/repro.ts 
let a = 1
~/workspace/tslint: cat repro/tslint.json 
{
    "rules": {
        "semicolon": [true, "always"]
    }
}
~/workspace/tslint: cat repro/tsconfig.json 
{
    "compilerOptions": {
        "rootDir": "/usr/local/home/bowenni/workspace/tslint",
        "outDir": "/usr/local/home/bowenni/workspace/tslint"
    },
    "files": [
        "repro.ts"
    ]
}
~/workspace/tslint: ./bin/tslint -c repro/tslint.json repro/repro.ts
ERROR: repro/repro.ts[1, 10]: Missing semicolon
~/workspace/tslint: ./bin/tslint -c repro/tslint.json -p repro/tsconfig.json
ERROR: /usr/local/home/bowenni/workspace/tslint/repro/repro.ts[1, 10]: Missing semicolon
```

This relativizes the file names in failures.
```
~/workspace/tslint: ./bin/tslint -c repro/tslint.json -p repro/tsconfig.json
ERROR: repro/repro.ts[1, 10]: Missing semicolon
```

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
