### PR TITLE
vsoFormatter: don't duplicate output for fixed failures

### DIFF
--- a/src/formatters/vsoFormatter.ts
+++ b/src/formatters/vsoFormatter.ts
@@ -34,10 +34,8 @@ export class Formatter extends AbstractFormatter {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public format(failures: RuleFailure[], warnings: RuleFailure[] = []): string {
-        const all = failures.concat(warnings);
-
-        const outputLines = all.map((failure: RuleFailure) => {
+    public format(failures: RuleFailure[]): string {
+        const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();
             const failureString = failure.getFailure();
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();

--- a/test/formatters/vsoFormatterTests.ts
+++ b/test/formatters/vsoFormatterTests.ts
@@ -45,7 +45,27 @@ describe("VSO Formatter", () => {
             getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
             getFailureString(TEST_FILE, 9,  2,  "last failure", "last-name");
 
-        const actualResult = formatter.format(failures, failures);
+        const actualResult = formatter.format(failures);
+        assert.equal(actualResult, expectedResult);
+    });
+
+    it("does not duplicate output for fixed failures", () => {
+        const maxPosition = sourceFile.getFullWidth();
+
+        const failures = [
+            createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
+            createFailure(sourceFile, 32, 36, "mid failure", "mid-name", undefined, "error"),
+            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
+        ];
+
+        const expectedResult =
+            getFailureString(TEST_FILE, 1,  1, "first failure", "first-name") +
+            getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
+            getFailureString(TEST_FILE, 9,  2,  "last failure", "last-name");
+
+        const fixed = failures.slice();
+
+        const actualResult = formatter.format(failures, fixed);
         assert.equal(actualResult, expectedResult);
     });
 

--- a/test/formatters/vsoFormatterTests.ts
+++ b/test/formatters/vsoFormatterTests.ts
@@ -45,7 +45,7 @@ describe("VSO Formatter", () => {
             getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
             getFailureString(TEST_FILE, 9,  2,  "last failure", "last-name");
 
-        const actualResult = formatter.format(failures);
+        const actualResult = formatter.format(failures, failures);
         assert.equal(actualResult, expectedResult);
     });
 


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `vso` formatter no longer duplicates output for fixed failures

I noticed this while looking through the formatters to find out how the `fixes` parameter is used. Obviously this formatter got it wrong...

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
