### PR TITLE
fix CI failures with typescript@next

### DIFF
--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -58,7 +58,9 @@ const A = 1, B = 2;
 
 A + B;
 ~     [err % ('A')]
+#if typescript < 2.7.0
     ~ [err % ('B')]
+#endif
 
 export default A;
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: https://github.com/palantir/tslint/pull/3346#issuecomment-338125279
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
typescript@next changes how JSDoc is associated with variable declarations if there are 2 or more variables in the VariableDeclarationStatement.
I don't know if this is a bug or intended. However, it breaks our tests on CI.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[no-log]
