### PR TITLE
no-implicit-dependencies: strip BOM before parsing JSON

### DIFF
--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -115,7 +115,8 @@ function getDependencies(fileName: string, options: Options): Set<string> {
     const packageJsonPath = findPackageJson(path.resolve(path.dirname(fileName)));
     if (packageJsonPath !== undefined) {
         // don't use require here to avoid caching
-        const content = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as PackageJson;
+        // remove BOM from file content before parsing
+        const content = JSON.parse(fs.readFileSync(packageJsonPath, "utf8").replace(/^\uFEFF/, "")) as PackageJson;
         if (content.dependencies !== undefined) {
             addDependencies(result, content.dependencies);
         }

--- a/test/rules/no-implicit-dependencies/default/bom/package.json
+++ b/test/rules/no-implicit-dependencies/default/bom/package.json
@@ -1,0 +1,5 @@
+﻿{
+    "name": "bom",
+    "version": "1.0.0",
+    "dependencies": {}
+}

--- a/test/rules/no-implicit-dependencies/default/bom/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/bom/test.ts.lint
@@ -1,0 +1,2 @@
+import * as ts from "typescript";
+                    ~~~~~~~~~~~~ [Module 'typescript' is not listed as dependency in package.json]

--- a/test/rules/no-implicit-dependencies/default/subdir/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/subdir/test.ts.lint
@@ -2,6 +2,9 @@ import {assert} from 'chai';
                      ~~~~~~ [err % ('chai')]
 import foo from 'foo';
 
+import Foo from 'Foo';
+                ~~~~~ [err % ('Foo')]
+
 if (foo) {
     const common = require('common');
                            ~~~~~~~~ [err % ('common')]


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Strip BOM from the contents of `package.json` to avoid `JSON.parse` throwing an error.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
[no-log]

