### PR TITLE
Add 'dryRun' option to Linter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,12 +39,14 @@ export interface LintResult {
     warningCount: number;
     failures: RuleFailure[];
     fixes?: RuleFailure[];
+    fixedSources: Record<string, string>;
     format: string | FormatterConstructor;
     output: string;
 }
 
 export interface ILinterOptions {
     fix: boolean;
+    dryRun?: boolean;
     formatter?: string | FormatterConstructor;
     formattersDirectory?: string;
     rulesDirectory?: string | string[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export interface LintResult {
     warningCount: number;
     failures: RuleFailure[];
     fixes?: RuleFailure[];
-    fixedSources: Record<string, string>;
+    fixedSources: Map<string, string>;
     format: string | FormatterConstructor;
     output: string;
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -52,7 +52,7 @@ class Linter {
 
     private failures: RuleFailure[] = [];
     private fixes: RuleFailure[] = [];
-    private fixedSources: Record<string, string> = {};
+    private fixedSources = new Map<string, string>();
 
     /**
      * Creates a TypeScript program object from a tsconfig.json file path and optional project directory.
@@ -165,7 +165,7 @@ class Linter {
                 const fixableFailures = updatedFailures.filter((f) => f.hasFix());
                 this.fixes = this.fixes.concat(fixableFailures);
                 source = this.applyFixes(sourceFileName, source, fixableFailures);
-                this.fixedSources[sourceFileName] = source;
+                this.fixedSources.set(sourceFileName, source);
                 sourceFile = this.getSourceFile(sourceFileName, source);
             }
         }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -41,6 +41,11 @@ export interface Options {
     config?: string;
 
     /**
+     * When running with fix: true, do not write files to disk.
+     */
+    dryRun?: boolean;
+
+    /**
      * Exclude globs from path expansion.
      */
     exclude: string[];
@@ -211,6 +216,7 @@ async function doLinting(
     const possibleConfigAbsolutePath = options.config !== undefined ? path.resolve(options.config) : null;
     const linter = new Linter(
         {
+            dryRun: !!options.dryRun,
             fix: !!options.fix,
             formatter: options.format,
             formattersDirectory: options.formattersDirectory,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -41,11 +41,6 @@ export interface Options {
     config?: string;
 
     /**
-     * When running with fix: true, do not write files to disk.
-     */
-    dryRun?: boolean;
-
-    /**
      * Exclude globs from path expansion.
      */
     exclude: string[];
@@ -216,7 +211,7 @@ async function doLinting(
     const possibleConfigAbsolutePath = options.config !== undefined ? path.resolve(options.config) : null;
     const linter = new Linter(
         {
-            dryRun: !!options.dryRun,
+            dryRun: false,
             fix: !!options.fix,
             formatter: options.format,
             formattersDirectory: options.formattersDirectory,

--- a/test/linterTests.ts
+++ b/test/linterTests.ts
@@ -64,4 +64,16 @@ describe("Linter", () => {
         assert.equal(fs.readFileSync(templateFile, "utf-8"), templateDeclarationFixed);
     });
 
+    it("dry run does not write files to disk", () => {
+        const linter = new TestLinter({ fix: true, dryRun: true });
+        const templateFile = createTempFile("ts");
+        fs.writeFileSync(templateFile, templateDeclaration);
+        const sourceFile = createSourceFile(templateFile, `${templateDeclaration}`, ScriptTarget.ES2015);
+        const replacement = new Replacement(6, 9, "");
+        const failure = new RuleFailure(sourceFile, 6, 15, "Declaration doesn't exist", "foo-bar", replacement);
+        const result = linter.applyFixesHelper(templateFile, templateDeclaration, [failure]);
+        assert.equal(fs.readFileSync(templateFile, "utf-8"), templateDeclaration);
+        assert.equal(result, templateDeclarationFixed);
+    });
+
 });


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: Fixes #1760
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update (updated type definitions)

#### Overview of change:

Adds a `dryRun` option to the `Linter` constructor. When set, during the fix process, no files will be written to disk. Instead, the result is returned as `fixedSources` in `linter.getResult()`.

```ts
const linter = new Linter({ fix: true, dryRun: true }, program);
linter.lint(filepath, code, config);
const fixed = linter.getResult().fixedSources[filepath];
```

#### Is there anything you'd like reviewers to focus on?

Supports multiple calls to `lint()`, but fixes in other files are ignored. Is that OK?

#### CHANGELOG.md entry:

[api] add `dryRun` to `Linter`.
