### PR TITLE
Joined descriptors in completed-docs with spaces, not commas.

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -436,7 +436,7 @@ class CompletedDocsWalker extends Lint.ProgramAwareRuleWalker {
         let description = Rule.FAILURE_STRING_EXIST;
 
         if (node.modifiers !== undefined) {
-            description += `${node.modifiers.map((modifier) => this.describeModifier(modifier.kind)).join(",")} `;
+            description += `${node.modifiers.map((modifier) => this.describeModifier(modifier.kind)).join(" ")} `;
         }
 
         return `${description}${nodeType}.`;

--- a/test/rules/completed-docs/locations/test.ts.lint
+++ b/test/rules/completed-docs/locations/test.ts.lint
@@ -28,4 +28,20 @@ class Class {
      * ...
      */
     static goodStaticMethod() { }
+
+    /**
+     * ...
+     */
+    async goodAsyncMethod() { }
+
+    async badAsyncMethod() { }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for async methods.]
+
+    /**
+     * ...
+     */
+    private async goodPrivateAsyncMethod() { }
+
+    private async badPrivateAsyncMethod() { }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for private async methods.]
 }


### PR DESCRIPTION
Added a test case for async methods and private async to ensure modifiers are joined correctly.

#### PR checklist

- [x] Addresses an existing issue: #3378
- [x] Bugfix
  - [x] Includes tests

#### Overview of change:

The descriptors for nodes were joined by `","`, which made ugly things like `public,async`.
