### PR TITLE
await-promise: correctly unwrap ReferenceTypes

### DIFF
--- a/src/rules/awaitPromiseRule.ts
+++ b/src/rules/awaitPromiseRule.ts
@@ -70,14 +70,18 @@ function walk(ctx: Lint.WalkContext<Set<string>>, tc: ts.TypeChecker) {
 }
 
 function containsType(type: ts.Type, predicate: (name: string) => boolean): boolean {
-    if (Lint.isTypeFlagSet(type, ts.TypeFlags.Any) ||
-        isTypeReference(type) && type.target.symbol !== undefined && predicate(type.target.symbol.name)) {
+    if (Lint.isTypeFlagSet(type, ts.TypeFlags.Any)) {
+        return true;
+    }
+    if (isTypeReference(type)) {
+        type = type.target;
+    }
+    if (type.symbol !== undefined && predicate(type.symbol.name)) {
         return true;
     }
     if (isUnionOrIntersectionType(type)) {
         return type.types.some((t) => containsType(t, predicate));
     }
-
     const bases = type.getBaseTypes();
     return bases !== undefined && bases.some((t) => containsType(t, predicate));
 }

--- a/test/rules/await-promise/es6-promise/test.ts.lint
+++ b/test/rules/await-promise/es6-promise/test.ts.lint
@@ -1,51 +1,8 @@
-async function fAny() {
-    const isAny: any = 1;
+type AxiosResponse<T> = T;
+interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {}
 
-    // any type
-    await isAny;
-
-    // union type with any type
-    await (Math.random() > 0.5 ? isAny : 0);
-}
-
-async function fNonPromise() {
-    // number type
-    await 0;
-    ~~~~~~~ [0]
-
-    // union type without Promise
-    await (Math.random() > 0.5 ? "" : 0);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
-
-    // non Promise type
-    class NonPromise extends Array {}
-    await new NonPromise();
-    ~~~~~~~~~~~~~~~~~~~~~~ [0]
-}
-
-async function fPromise() {
-    // direct type
-    const numberPromise: Promise<number>;
-    await numberPromise;
-
-    // 1st level base type
-    class Foo extends Promise<number> {}
-    const foo: Foo = Foo.resolve(2);
-    await foo;
-
-    // 2nd level base type
-    class Bar extends Foo {}
-    const bar: Bar = Bar.resolve(2);
-    await bar;
-
-    // union type
-    await (Math.random() > 0.5 ? numberPromise : 0);
-    await (Math.random() > 0.5 ? foo : 0);
-    await (Math.random() > 0.5 ? bar : 0);
-
-    // intersection type
-    const intersectionPromise: Promise<number> & number;
-    await intersectionPromise;
+async function extendsPromise(v: AxiosPromise<any>) {
+    await v;
 }
 
 [0]: Invalid 'await' of a non-Promise value.

--- a/test/rules/await-promise/es6-promise/test.ts.lint
+++ b/test/rules/await-promise/es6-promise/test.ts.lint
@@ -1,3 +1,53 @@
+async function fAny() {
+    const isAny: any = 1;
+
+    // any type
+    await isAny;
+
+    // union type with any type
+    await (Math.random() > 0.5 ? isAny : 0);
+}
+
+async function fNonPromise() {
+    // number type
+    await 0;
+    ~~~~~~~ [0]
+
+    // union type without Promise
+    await (Math.random() > 0.5 ? "" : 0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+    // non Promise type
+    class NonPromise extends Array {}
+    await new NonPromise();
+    ~~~~~~~~~~~~~~~~~~~~~~ [0]
+}
+
+async function fPromise() {
+    // direct type
+    const numberPromise: Promise<number>;
+    await numberPromise;
+
+    // 1st level base type
+    class Foo extends Promise<number> {}
+    const foo: Foo = Foo.resolve(2);
+    await foo;
+
+    // 2nd level base type
+    class Bar extends Foo {}
+    const bar: Bar = Bar.resolve(2);
+    await bar;
+
+    // union type
+    await (Math.random() > 0.5 ? numberPromise : 0);
+    await (Math.random() > 0.5 ? foo : 0);
+    await (Math.random() > 0.5 ? bar : 0);
+
+    // intersection type
+    const intersectionPromise: Promise<number> & number;
+    await intersectionPromise;
+}
+
 type AxiosResponse<T> = T;
 interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {}
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3381
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `await-promise` correctly recognises classes extending Promise
Fixes: #3381
#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
