### PR TITLE
prefer-const: don't treat index signatures as parameters

### DIFF
--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -175,10 +175,12 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
                     });
                 }
             } else if (node.kind === ts.SyntaxKind.Parameter) {
-                this.handleBindingName((node as ts.ParameterDeclaration).name, {
-                    canBeConst: false,
-                    isBlockScoped: true,
-                });
+                if (node.parent!.kind !== ts.SyntaxKind.IndexSignature) {
+                    this.handleBindingName((node as ts.ParameterDeclaration).name, {
+                        canBeConst: false,
+                        isBlockScoped: true,
+                    });
+                }
             } else if (utils.isPostfixUnaryExpression(node) ||
                        utils.isPrefixUnaryExpression(node) &&
                        (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)) {

--- a/test/rules/prefer-const/default/test.ts.fix
+++ b/test/rules/prefer-const/default/test.ts.fix
@@ -219,3 +219,10 @@ for (let {var1, var2} of someArr) {
     var2 = null;
 }
 
+{
+    let k: any = 0;
+    function foo(param: {[k: string]: string}) {
+        k = param;
+    }
+}
+

--- a/test/rules/prefer-const/default/test.ts.lint
+++ b/test/rules/prefer-const/default/test.ts.lint
@@ -258,6 +258,13 @@ for (let {var1, var2} of someArr) {
     var2 = null;
 }
 
+{
+    let k: any = 0;
+    function foo(param: {[k: string]: string}) {
+        k = param;
+    }
+}
+
 [_base]: Identifier '%%s' is never reassigned; use 'const' instead of '%s'.
 [let]: _base % ('let')
 [var]: _base % ('var')


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
The `k` in `{[k: string]: string}` is a `ts.ParameterDeclaration`. It must not be treated like a parameter in the value domain.
IIRC I fixed a similar bug while rewriting `no-shadowed-variable`.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[bugfix] `prefer-const` false negative with index signature named like a variable
