### PR TITLE
Fix compile errors on TS 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "minimatch": "^3.0.4",
     "resolve": "^1.3.2",
     "semver": "^5.3.0",
-    "tslib": "^1.7.1",
+    "tslib": "^1.8",
     "tsutils": "^2.12.1"
   },
   "peerDependencies": {

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -49,7 +49,7 @@ export const PRIVACY_PROTECTED = "protected";
 export const PRIVACY_PUBLIC = "public";
 
 export const TAGS_FOR_CONTENT = "content";
-export const TAGS_FOR_EXISTENCE = "exists";
+export const TAGS_FOR_EXISTENCE = "existence";
 
 export const VISIBILITY_EXPORTED = "exported";
 export const VISIBILITY_INTERNAL = "internal";


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3396

#### Overview of change:
1. [tslib needs to be updated](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript) for the new emit helper `__makeTemplateObject`, used for template literals.
2. 2.6's improved checking of computed property names in object literals found a typo in a constant in completedDocsRule.ts.



#### Is there anything you'd like reviewers to focus on?


1. Did completedDocsRule *ever* work? Why doesn't `src/rules/completed-docs/tagExclusion.ts` contain the `TAGS_FOR_*` constants instead of completedDocsRule.ts? I made the smallest fix possible, but the right thing might be to move those constants.
1. tslib 1.8 works fine on TS 2.5 and 2.6. I haven't tried it on earlier versions, but the additional helpers shouldn't change anything.