### PR TITLE
no-duplicate-imports: Allow duplicate imports from separate ambient module declarations

### DIFF
--- a/src/rules/noDuplicateImportsRule.ts
+++ b/src/rules/noDuplicateImportsRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { findImports, ImportKind } from "tsutils";
+import { isLiteralExpression, isModuleBlock, isModuleDeclaration } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -44,13 +44,38 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
-function walk(ctx: Lint.WalkContext<void>) {
-    const seen = new Set<string>();
-    for (const {text, parent} of findImports(ctx.sourceFile, ImportKind.ImportDeclaration)) {
-        if (seen.has(text)) {
-            ctx.addFailureAtNode(parent!, Rule.FAILURE_STRING(text));
-        } else {
+function walk(ctx: Lint.WalkContext<void>): void {
+    walkWorker(ctx, ctx.sourceFile.statements, new Set());
+}
+
+function walkWorker(ctx: Lint.WalkContext<void>, statements: ReadonlyArray<ts.Statement>, seen: Set<string>): void {
+    for (const statement of statements) {
+        const im = tryGetImportSpecifier(statement);
+        if (im !== undefined && isLiteralExpression(im)) {
+            const { text } = im;
+            if (seen.has(text)) {
+                ctx.addFailureAtNode(im.parent!, Rule.FAILURE_STRING(text));
+            }
             seen.add(text);
         }
+
+        if (isModuleDeclaration(statement) && statement.body !== undefined && isModuleBlock(statement.body)) {
+            // If this is a module augmentation, re-use `seen` since those imports could be moved outside.
+            // If this is an ambient module, create a fresh `seen`
+            // because they should have separate imports to avoid becoming augmentations.
+            walkWorker(ctx, statement.body.statements, ts.isExternalModule(ctx.sourceFile) ? seen : new Set());
+        }
+    }
+}
+
+function tryGetImportSpecifier(statement: ts.Statement): ts.Expression | undefined {
+    switch (statement.kind) {
+        case ts.SyntaxKind.ImportDeclaration:
+            return (statement as ts.ImportDeclaration).moduleSpecifier;
+        case ts.SyntaxKind.ImportEqualsDeclaration:
+            const ref = (statement as ts.ImportEqualsDeclaration).moduleReference;
+            return ref.kind === ts.SyntaxKind.ExternalModuleReference ? ref.expression : undefined;
+        default:
+            return undefined;
     }
 }

--- a/test/rules/no-duplicate-imports/test2.d.ts.lint
+++ b/test/rules/no-duplicate-imports/test2.d.ts.lint
@@ -1,0 +1,8 @@
+declare module 'a' {
+    import foo from 'foo';
+}
+
+declare module 'b' {
+    // No error -- this is a separate ambient module declaration.
+    import foo from 'foo';
+}

--- a/test/rules/no-duplicate-imports/test3.d.ts.lint
+++ b/test/rules/no-duplicate-imports/test3.d.ts.lint
@@ -1,0 +1,11 @@
+export {};
+
+declare module 'a' {
+    import foo from 'foo';
+}
+
+declare module 'b' {
+    // Error because these imports could be combined in an outer scope.
+    import foo from 'foo';
+    ~~~~~~~~~~~~~~~~~~~~~~ [Multiple imports from 'foo' can be combined into one.]
+}


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: Microsoft/dtslint/issues/79
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Allows two *ambient* modules to have separate imports:
```ts
declare module "a" {
    import foo from "foo";
}
declare module "b" {
    import foo from "foo";
}
```
Preserves existing behavior for module augmentations.

@ajafff It would be nice to reuse more code from `findImports` in tsutils but it doesn't seem possible given that it currently takes the whole source file as input, so I can't run it on a single `declare module`.

#### CHANGELOG.md entry:

[bugfix] no-duplicate-imports: Allow duplicate imports from separate ambient module declarations