### PR TITLE
remove test for plain test output

### DIFF
--- a/test/formatters/codeFrameFormatterTests.ts
+++ b/test/formatters/codeFrameFormatterTests.ts
@@ -26,15 +26,20 @@ describe("CodeFrame Formatter", () => {
     const TEST_FILE = "formatters/codeFrameFormatter.test.ts";
     let sourceFile: ts.SourceFile;
     let formatter: IFormatter;
-
+    let colorsEnabled: boolean;
     before(() => {
-        (chalk as any).enabled = true;
+        colorsEnabled = chalk.enabled;
         const Formatter = TestUtils.getFormatter("codeFrame");
         sourceFile = TestUtils.getSourceFile(TEST_FILE);
         formatter = new Formatter();
     });
 
-    it("formats failures", () => {
+    after(() => {
+        (chalk as any).enabled = colorsEnabled;
+    });
+
+    it("formats failures with colors", () => {
+        (chalk as any).enabled = true;
         const maxPosition = sourceFile.getFullWidth();
 
         const failures = [
@@ -44,36 +49,6 @@ describe("CodeFrame Formatter", () => {
             createFailure(sourceFile, 0, maxPosition, "full failure", "full-name", undefined, "error"),
             createFailure(sourceFile, 0, maxPosition, "warning failure", "warning-name", undefined, "warning"),
         ];
-
-        const expectedResultPlain =
-            `formatters/codeFrameFormatter.test.ts
-            first failure (first-name)
-            > 1 | module CodeFrameModule {
-            2 |     export class CodeFrameClass {
-            3 |         private name: string;
-            4 |
-
-            &<>'" should be escaped (escape)
-            > 1 | module CodeFrameModule {
-                |  ^
-            2 |     export class CodeFrameClass {
-            3 |         private name: string;
-            4 |
-
-            last failure (last-name)
-            7 |         }
-            8 |     }
-            >  9 | }
-                | ^
-            10 |
-
-            full failure (full-name)
-            > 1 | module CodeFrameModule {
-            2 |     export class CodeFrameClass {
-            3 |         private name: string;
-            4 |
-
-        `;
 
         const expectedResultColored =
             `formatters/codeFrameFormatter.test.ts
@@ -116,7 +91,7 @@ describe("CodeFrame Formatter", () => {
             return lines.split("\n").map((line) => line.trim());
         }
 
-        const expectedResult = toTrimmedLines(chalk.enabled ? expectedResultColored : expectedResultPlain);
+        const expectedResult = toTrimmedLines(expectedResultColored);
         const result = toTrimmedLines(formatter.format(failures));
 
         assert.deepEqual(result, expectedResult);


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
While reviewing #3402 I notices that it contains two different expected results depending on the value of `chalk.enabled`. Before running the test `chalk.enabled` is set to true anyway. That makes it dead code. The expected plain text output was already outdated.
This PR removes the unused the plain text assertion.

#### Is there anything you'd like reviewers to focus on?

I tried running running the test completely without colors. That didn't work for some reason.

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
