### PR TITLE
object-literal-shorthand: check destructuring

### DIFF
--- a/test/rules/object-literal-shorthand/always/test.ts.fix
+++ b/test/rules/object-literal-shorthand/always/test.ts.fix
@@ -41,3 +41,6 @@ const asyncFn = {
 }
 
 ({foo} = {foo});
+
+let {foo, bar = foo, "baz": baz, bas = baz, foobar: barfoo} = {};
+let {foo: {foo}} = {};

--- a/test/rules/object-literal-shorthand/always/test.ts.lint
+++ b/test/rules/object-literal-shorthand/always/test.ts.lint
@@ -51,3 +51,7 @@ const asyncFn = {
 ({foo: foo} = {foo: foo});
   ~~~~~~~~ [Expected property shorthand in object literal ('{foo}').]
                ~~~~~~~~ [Expected property shorthand in object literal ('{foo}').]
+
+let {foo, bar = foo, "baz": baz, bas: bas = baz, foobar: barfoo} = {};
+                                 ~~~~~~~~ [Expected property shorthand in object literal ('{bas}').]
+let {foo: {foo}} = {};

--- a/test/rules/object-literal-shorthand/never/test.ts.fix
+++ b/test/rules/object-literal-shorthand/never/test.ts.fix
@@ -57,3 +57,6 @@ export class ClassA extends ClassZ {
 
 ({foo: foo} = {foo: foo});
 
+let {foo: foo = 1, baz: baz, bar: {bar: bar}, ...bas} = {};
+let [bar, ...foobar] = [];
+

--- a/test/rules/object-literal-shorthand/never/test.ts.lint
+++ b/test/rules/object-literal-shorthand/never/test.ts.lint
@@ -69,4 +69,9 @@ export class ClassA extends ClassZ {
   ~~~ [OBJECT_LITERAL_DISALLOWED]
           ~~~ [OBJECT_LITERAL_DISALLOWED]
 
+let {foo = 1, baz: baz, bar: {bar}, ...bas} = {};
+     ~~~ [OBJECT_LITERAL_DISALLOWED]
+                              ~~~ [OBJECT_LITERAL_DISALLOWED]
+let [bar, ...foobar] = [];
+
 [OBJECT_LITERAL_DISALLOWED]: Shorthand property assignments have been disallowed.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3272
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[enhancement] `object-literal-destructuring` added check for object destructuring
Fixes: #3272

#### Is there anything you'd like reviewers to focus on?
Do we need another error message specifically for object destructuring?

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
