### PR TITLE
no-redundant-jsdoc: handle class tag

### DIFF
--- a/src/rules/noRedundantJsdocRule.ts
+++ b/src/rules/noRedundantJsdocRule.ts
@@ -107,6 +107,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
 const redundantTags = new Set([
     "abstract",
     "access",
+    "class",
     "constant",
     "constructs",
     "default",

--- a/src/rules/noRedundantJsdocRule.ts
+++ b/src/rules/noRedundantJsdocRule.ts
@@ -75,6 +75,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
                 // OK
                 break;
 
+            case ts.SyntaxKind.JSDocClassTag:
+            case ts.SyntaxKind.JSDocTypeLiteral:
             case ts.SyntaxKind.JSDocTemplateTag:
             case ts.SyntaxKind.JSDocTypeTag:
             case ts.SyntaxKind.JSDocTypedefTag:
@@ -105,7 +107,6 @@ function walk(ctx: Lint.WalkContext<void>): void {
 const redundantTags = new Set([
     "abstract",
     "access",
-    "class",
     "constant",
     "constructs",
     "default",

--- a/src/rules/noRedundantJsdocRule.ts
+++ b/src/rules/noRedundantJsdocRule.ts
@@ -76,7 +76,6 @@ function walk(ctx: Lint.WalkContext<void>): void {
                 break;
 
             case ts.SyntaxKind.JSDocClassTag:
-            case ts.SyntaxKind.JSDocTypeLiteral:
             case ts.SyntaxKind.JSDocTemplateTag:
             case ts.SyntaxKind.JSDocTypeTag:
             case ts.SyntaxKind.JSDocTypedefTag:

--- a/test/rules/no-redundant-jsdoc/test.ts.lint
+++ b/test/rules/no-redundant-jsdoc/test.ts.lint
@@ -10,6 +10,8 @@ function f() {}
 const x = 0;
 
 /**
+ * @class
+    ~~~~~ [tag % ('class')]
  * @param {number} x Is a number
           ~~~~~~~~ [type]
  * @param y


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3413 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `no-redundant-jsdoc` fixed crash on unhandled tag
Fixes: #3413

#### Is there anything you'd like reviewers to focus on?
@andy-ms I also added `JSDocTypeLiteral` to the always redundant tags. Unfortunately I don't even know what exactly that is. Can you confirm that it is expected to always show an error on this tag?

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
