### PR TITLE
Fix CI - use newer versions of node

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 dependencies:
   pre:
     - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
-    - case $CIRCLE_NODE_INDEX in 0) nvm use 4.1.2 ;; 1) nvm use 5.7 ;; [2-3]) nvm use 6.1 ;; esac
+    - case $CIRCLE_NODE_INDEX in 0) nvm use 4.8 ;; 1) nvm use 5.7 ;; 2) nvm use 6 ;; 3) nvm use 8 ;; esac
   override:
     - yarn
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 dependencies:
   pre:
     - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
-    - case $CIRCLE_NODE_INDEX in 0) nvm install 4.8.5; NODE_VERSION=4.8.5 ;; 1) NODE_VERSION=5 ;; 2) NODE_VERSION=6 ;; 3) NODE_VERSION=8 ;; esac; nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
+    - case $CIRCLE_NODE_INDEX in 0) nvm install 4.8.5; NODE_VERSION=4.8.5 ;; 1) NODE_VERSION=5 ;; 2) NODE_VERSION=6 ;; 3) NODE_VERSION=8 ;; esac; nvm use $NODE_VERSION && nvm alias default $NODE_VERSION
   override:
     - yarn
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 dependencies:
   pre:
     - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
-    - case $CIRCLE_NODE_INDEX in 0) nvm install 4.8.5 ;; 1) nvm use 5 ;; 2) nvm use 6 ;; 3) nvm use 8 ;; esac
+    - case $CIRCLE_NODE_INDEX in 0) nvm install 4.8.5; nvm alias default 4.8.5 ;; 1) nvm use 5; nvm alias default 5 ;; 2) nvm use 6; nvm alias default 6 ;; 3) nvm use 8 nvm alias default 8 ;; esac
   override:
     - yarn
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 dependencies:
   pre:
     - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
-    - case $CIRCLE_NODE_INDEX in 0) nvm use 4 ;; 1) nvm use 5 ;; 2) nvm use 6 ;; 3) nvm use 8 ;; esac
+    - case $CIRCLE_NODE_INDEX in 0) nvm install 4.8.5 ;; 1) nvm use 5 ;; 2) nvm use 6 ;; 3) nvm use 8 ;; esac
   override:
     - yarn
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 dependencies:
   pre:
     - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
-    - case $CIRCLE_NODE_INDEX in 0) nvm use 4.8 ;; 1) nvm use 5.7 ;; 2) nvm use 6 ;; 3) nvm use 8 ;; esac
+    - case $CIRCLE_NODE_INDEX in 0) nvm use 4 ;; 1) nvm use 5 ;; 2) nvm use 6 ;; 3) nvm use 8 ;; esac
   override:
     - yarn
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ general:
 dependencies:
   pre:
     - node ./scripts/assertMinCircleNodes.js $CIRCLE_NODE_TOTAL
-    - case $CIRCLE_NODE_INDEX in 0) nvm install 4.8.5; nvm alias default 4.8.5 ;; 1) nvm use 5; nvm alias default 5 ;; 2) nvm use 6; nvm alias default 6 ;; 3) nvm use 8 nvm alias default 8 ;; esac
+    - case $CIRCLE_NODE_INDEX in 0) nvm install 4.8.5; NODE_VERSION=4.8.5 ;; 1) NODE_VERSION=5 ;; 2) NODE_VERSION=6 ;; 3) NODE_VERSION=8 ;; esac; nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
   override:
     - yarn
 test:

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.1.2"
+    "node": ">=4.8.0"
   }
 }


### PR DESCRIPTION
CircleCI updated to yarn 1.x.x. This caused our builds to fail because we tested with node versions that didn't support the `shell` option in `child_process.spawn`.
To fix this we need to use at least 4.8.0, 5.7.0 or 6.0.0 and above. See https://github.com/yarnpkg/yarn/issues/4337 for more details.

While fixing this I noticed that we always used node 4.2.6 on every node. Even executing `nvm use <version>` didn't change this, see https://discuss.circleci.com/t/node-npm-version-build-issues/11471. I fixed that by using `nvm alias default <version>`

[no-log]