### PR TITLE
object-literal-sort-keys: don't consider \r\n as two line breaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 /test/rules/linebreak-style/**/CRLF/*.lint text eol=crlf
 /test/rules/linebreak-style/**/LF/*.fix text eol=crlf
 /test/rules/jsdoc-format/**/jsdoc-windows.ts.lint text eol=crlf
+/test/rules/object-literal-sort-keys/default/crlf.ts.lint eol=crlf

--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -208,7 +208,7 @@ function hasBlankLineBefore(sourceFile: ts.SourceFile, element: ts.ObjectLiteral
 }
 
 function hasDoubleNewLine(sourceFile: ts.SourceFile, position: number) {
-    return /(\r\n|\r|\n){2}/.test(sourceFile.text.slice(position, position + 4));
+    return /(\r?\n){2}/.test(sourceFile.text.slice(position, position + 4));
 }
 
 function getTypeName(t: TypeLike): string | undefined {

--- a/test/rules/object-literal-sort-keys/default/crlf.ts.lint
+++ b/test/rules/object-literal-sort-keys/default/crlf.ts.lint
@@ -1,0 +1,6 @@
+// ensure that we don't treat \r\n as two line breaks
+let obj = {
+    foo: 1,
+    bar: 2,
+    ~~~ [The key 'bar' is not sorted alphabetically]
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3426 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `object-literal-sort-keys` fixed regression that effectively disabled the rule with `\r\n` line breaks
Fixes: #3426

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
