### PR TITLE
fix condition for deprecation of typeof-compare

### DIFF
--- a/src/rules/typeofCompareRule.ts
+++ b/src/rules/typeofCompareRule.ts
@@ -32,7 +32,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         type: "functionality",
         typescriptOnly: false,
-        deprecationMessage: ts.versionMajorMinor as string === "2.1"
+        deprecationMessage: !/^2\.1\./.test(ts.version)
             ? "Starting from TypeScript 2.2 the compiler includes this check which makes this rule redundant."
             : "",
     };


### PR DESCRIPTION
The condition was off. #3286 actually deprecated the rule only for typescript@2.1.
Well, not really, because `ts.versionMajorMinor` was introduced in a later release.
That means nobody gets a deprecation warning right now.

This PR fixes both issues.