### PR TITLE
update chalk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "babel-code-frame": "^6.22.0",
     "builtin-modules": "^1.1.1",
-    "chalk": "^2.1.0",
+    "chalk": "^2.3.0",
     "commander": "^2.9.0",
     "diff": "^3.2.0",
     "glob": "^7.1.1",
@@ -55,7 +55,6 @@
   "devDependencies": {
     "@types/babel-code-frame": "^6.20.0",
     "@types/chai": "^3.5.0",
-    "@types/chalk": "^0.4.31",
     "@types/commander": "^2.9.0",
     "@types/diff": "^3.2.0",
     "@types/glob": "^5.0.30",

--- a/src/formatters/codeFrameFormatter.ts
+++ b/src/formatters/codeFrameFormatter.ts
@@ -20,7 +20,7 @@ import { IFormatterMetadata } from "../language/formatter/formatter";
 import { RuleFailure } from "../language/rule/rule";
 
 import codeFrame = require("babel-code-frame");
-import * as chalk from "chalk";
+import chalk from "chalk";
 
 import * as Utils from "../utils";
 

--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -19,7 +19,7 @@ import { AbstractFormatter } from "../language/formatter/abstractFormatter";
 import { IFormatterMetadata } from "../language/formatter/formatter";
 import { RuleFailure } from "../language/rule/rule";
 
-import * as chalk from "chalk";
+import chalk from "chalk";
 
 import * as Utils from "../utils";
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as chalk from "chalk";
+import chalk from "chalk";
 import * as diff from "diff";
 import * as fs from "fs";
 import * as glob from "glob";

--- a/test/formatters/codeFrameFormatterTests.ts
+++ b/test/formatters/codeFrameFormatterTests.ts
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import * as chalk from "chalk";
+import chalk from "chalk";
 
 import * as ts from "typescript";
 

--- a/test/ruleTestRunner.ts
+++ b/test/ruleTestRunner.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as chalk from "chalk";
+import chalk from "chalk";
 import * as glob from "glob";
 import * as path from "path";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,6 @@
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.5.2.tgz#c11cd2817d3a401b7ba0f5a420f35c56139b1c1e"
 
-"@types/chalk@^0.4.31":
-  version "0.4.31"
-  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-0.4.31.tgz#a31d74241a6b1edbb973cf36d97a2896834a51f9"
-
 "@types/commander@^2.9.0":
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.9.1.tgz#d4e464425baf4685bd49dd233be11de9c00c0784"
@@ -297,9 +293,17 @@ chalk@^1.1.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0:
+chalk@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+chalk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3431
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Latest version of chalk comes with type definitions. This breaks all namespace imports. Fortunately they only need to be converted to default imports.


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

[no-log]