### PR TITLE
no-unsafe-any: allow object spread

### DIFF
--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -119,6 +119,12 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
                 return initializer !== undefined &&
                     this.visitNode(initializer, isPropertyAny(node as ts.PropertyDeclaration, this.checker));
             }
+            case ts.SyntaxKind.SpreadAssignment:
+                return this.visitNode(
+                    (node as ts.SpreadAssignment).expression,
+                    // allow any in object spread, but not in object rest
+                    !isReassignmentTarget(node.parent as ts.ObjectLiteralExpression),
+                );
             case ts.SyntaxKind.ComputedPropertyName:
                 return this.visitNode((node as ts.ComputedPropertyName).expression, true);
             case ts.SyntaxKind.TaggedTemplateExpression: {

--- a/test/rules/no-unsafe-any/test.ts.lint
+++ b/test/rules/no-unsafe-any/test.ts.lint
@@ -309,4 +309,14 @@ function hasThisParameter(this: any) {
            ~ [0]
 })
 
+{
+    let obj = {...x};
+    ({...obj} = x);
+         ~~~ [0]
+    let arr = [...x];
+                  ~ [0]
+    predicate(...x);
+                 ~ [0]
+}
+
 [0]: Unsafe use of expression of type 'any'.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
You can basically use everything in object spread. Therefore it should not be an error when spreading `any`.
The tests make sure we only allow object spread, not object rest.
`any` in array spread is not allowed. You need an `Iterable` there. I also added tests for this.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:


[bugfix] `no-unsafe-any` allows spreading an `any`-value into an object
