### PR TITLE
callable-types: add parens inside ArrayType

### DIFF
--- a/src/rules/callableTypesRule.ts
+++ b/src/rules/callableTypesRule.ts
@@ -104,6 +104,7 @@ function shouldWrapSuggestion(parent: ts.Node) {
     switch (parent.kind) {
         case ts.SyntaxKind.UnionType:
         case ts.SyntaxKind.IntersectionType:
+        case ts.SyntaxKind.ArrayType:
             return true;
         default:
             return false;

--- a/test/rules/callable-types/test.ts.fix
+++ b/test/rules/callable-types/test.ts.fix
@@ -17,6 +17,7 @@ function f(x: string | (() => void)): void;
 function f(x: (() => string) | (() => number)): void;
 function f(x: string & (() => void)): void;
 function f(x: (() => string) & (() => number)): void;
+function f(x: (() => string)[]): void;
 
 // Overloads OK
 interface K {
@@ -28,3 +29,4 @@ interface K {
 export type I = () => void;
 
 export type T = () => void
+

--- a/test/rules/callable-types/test.ts.lint
+++ b/test/rules/callable-types/test.ts.lint
@@ -44,6 +44,8 @@ function f(x: string & { (): void }): void;
 function f(x: { (): string } & { (): number }): void;
                 ~~~~~~~~~~ [type % ('(() => string)')]
                                  ~~~~~~~~~~ [type % ('(() => number)')]
+function f(x: { (): string }[]): void;
+                ~~~~~~~~~~ [type % ('(() => string)')]
 
 // Overloads OK
 interface K {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `callable-types` adds parentheses when fixing a type literal inside an array type

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
