### PR TITLE
Added test names to VS Code console logs for ruleTestRunner

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,7 @@
             "request": "launch",
             "program": "${workspaceRoot}/test/ruleTestRunner.ts",
             "stopOnEntry": false,
-            "args": ["run", "test"],
+            "args": ["--verboseResultHandler"],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "tsc",
             "runtimeExecutable": null,

--- a/src/test.ts
+++ b/src/test.ts
@@ -207,7 +207,7 @@ export function consoleTestResultsHandler(testResults: TestResult[]): boolean {
     return didAllTestsPass;
 }
 
-export function consoleTestResultHandler(testResult: TestResult): boolean {
+export function consoleTestResultHandler(testResult: TestResult, rootTestDirectory?: string): boolean {
     // needed to get colors to show up when passing through Grunt
     (chalk as any).enabled = true;
 
@@ -225,11 +225,14 @@ export function consoleTestResultHandler(testResult: TestResult): boolean {
             const fixesDiffResults = diff.diffLines(results.fixesFromLinter, results.fixesFromMarkup);
             const didMarkupTestPass = !markupDiffResults.some((hunk) => hunk.added === true || hunk.removed === true);
             const didFixesTestPass = !fixesDiffResults.some((hunk) => hunk.added === true || hunk.removed === true);
+            const testDescriptor = rootTestDirectory === undefined
+                ? ""
+                : ` ${testResult.directory.substring(rootTestDirectory.length).replace(/\//g, " > ")}`;
 
             if (didMarkupTestPass && didFixesTestPass) {
-                console.log(chalk.green(" Passed"));
+                console.log(chalk.green(` Passed${testDescriptor}`));
             } else {
-                console.log(chalk.red(" Failed!"));
+                console.log(chalk.red(` Failed${testDescriptor}!`));
                 didAllTestsPass = false;
                 if (!didMarkupTestPass) {
                     displayDiffResults(markupDiffResults, MARKUP_FILE_EXTENSION);

--- a/test/ruleTestRunner.ts
+++ b/test/ruleTestRunner.ts
@@ -25,11 +25,15 @@ console.log();
 console.log(chalk.underline("Testing Lint Rules:"));
 /* tslint:enable:no-console */
 
-const testDirectories = glob.sync("test/rules/**/tslint.json").map(path.dirname);
+const verboseResultHandler = process.argv.indexOf("--verboseResultHandler") !== -1;
+const rootTestDirectory = "test/rules/";
+const testDirectories = glob.sync(`${rootTestDirectory}**/tslint.json`).map(path.dirname);
 
 for (const testDirectory of testDirectories) {
     const results = runTest(testDirectory);
-    const didAllTestsPass = consoleTestResultHandler(results);
+    const didAllTestsPass = verboseResultHandler
+        ? consoleTestResultHandler(results, rootTestDirectory)
+        : consoleTestResultHandler(results);
     if (!didAllTestsPass) {
         process.exit(1);
     }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3457

#### Overview of change:

Because some of the logs are to `process.stdout`, the VS Code F5 test running just shows a lot of "Passed" messages. Not very informative. This adds a `folder > folder`-style descriptor for the test if running with `--verboseResultHandler`, which is passed by `launch.json`.

#### Is there anything you'd like reviewers to focus on?

Alternately, it could just print everything using the console instead of `process.stdout`...?