### PR TITLE
launch.json: show stdout in debug console

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,7 @@
                 "NODE_ENV": "development"
             },
             "console": "internalConsole",
+            "outputCapture": "std",
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/build/**/*.js"]
         },
@@ -38,6 +39,7 @@
                 "NODE_ENV": "development"
             },
             "console": "internalConsole",
+            "outputCapture": "std",
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/build/**/*.js"]
         },
@@ -58,6 +60,7 @@
                 "NODE_ENV": "development"
             },
             "console": "internalConsole",
+            "outputCapture": "std",
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/build/**/*.js"]
         },
@@ -78,6 +81,7 @@
                 "NODE_ENV": "development"
             },
             "console": "internalConsole",
+            "outputCapture": "std",
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/build/**/*/js"]
         }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: Fixes: #3457, Supersedes: #3458

#### Overview of change:

Show stdout in VSCode's debug console instead of only `console.log`.
https://github.com/Microsoft/vscode/issues/19750#issuecomment-332924834

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[no-log]
