### PR TITLE
[new-fixer] file-header rule

### DIFF
--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -57,19 +57,19 @@ export class Rule extends Lint.Rules.AbstractRule {
 
         // ignore shebang if it exists
         let offset = text.startsWith("#!") ? text.indexOf("\n") : 0;
-        // returns details about the first comment or undefined
-        const commentText  = ts.forEachLeadingCommentRange(
+        // returns the text of the first comment or undefined
+        const commentText = ts.forEachLeadingCommentRange(
             text,
             offset,
             (pos, end, kind) => text.substring(pos + 2, kind === ts.SyntaxKind.SingleLineCommentTrivia ? end : end - 2));
 
         if (commentText === undefined || !headerFormat.test(commentText)) {
-            const errorAtStart = offset === 0;
-            if (!errorAtStart) {
+            const isErrorAtStart = offset === 0;
+            if (!isErrorAtStart) {
                 ++offset; // show warning in next line after shebang
             }
-            const leadingNewlines = errorAtStart ? 0 : 1;
-            const trailingNewlines = errorAtStart ? 2 : 1;
+            const leadingNewlines = isErrorAtStart ? 0 : 1;
+            const trailingNewlines = isErrorAtStart ? 2 : 1;
 
             const fix = textToInsert !== undefined
                 ? Lint.Replacement.appendText(offset, this.createComment(sourceFile, textToInsert, leadingNewlines, trailingNewlines))

--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -18,6 +18,8 @@
 import * as ts from "typescript";
 import * as Lint from "../index";
 
+const ONLY_WHITESPACE = /^\s*$/;
+
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
@@ -25,7 +27,18 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Enforces a certain header comment for all files, matched by a regular expression.",
         optionsDescription: "Regular expression to match the header.",
         options: {
-            type: "string",
+            type: "array",
+            items: [
+                {
+                    type: "string",
+                },
+                {
+                    type: "string",
+                },
+            ],
+            additionalItems: false,
+            minLength: 1,
+            maxLength: 2,
         },
         optionExamples: [[true, "Copyright \\d{4}"]],
         type: "style",
@@ -37,19 +50,50 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const { text } = sourceFile;
+        const testRegex = new RegExp(this.ruleArguments[0] as string);
+        const insertText = this.ruleArguments[1] as string | undefined;
+
         // ignore shebang if it exists
         let offset = text.startsWith("#!") ? text.indexOf("\n") : 0;
         // returns the text of the first comment or undefined
-        const commentText = ts.forEachLeadingCommentRange(
+        const commentDetails  = ts.forEachLeadingCommentRange(
             text,
             offset,
-            (pos, end, kind) => text.substring(pos + 2, kind === ts.SyntaxKind.SingleLineCommentTrivia ? end : end - 2));
-        if (commentText === undefined || !new RegExp(this.ruleArguments[0] as string).test(commentText)) {
-            if (offset !== 0) {
-                ++offset; // show warning in next line after shebang
+            (pos, end, kind) => ({pos, end, kind}));
+
+        if (offset !== 0) {
+            ++offset; // show warning in next line after shebang
+        }
+        if (commentDetails === undefined) {
+            const fix = insertText !== undefined
+                ? Lint.Replacement.appendText(offset, this.createComment(sourceFile, insertText))
+                : undefined;
+            return [new Lint.RuleFailure(sourceFile, offset, offset, Rule.FAILURE_STRING, this.ruleName, fix)];
+        } else {
+            const { pos, end, kind } = commentDetails;
+            const commentText = text.substring(pos, kind === ts.SyntaxKind.SingleLineCommentTrivia ? end : end - 2);
+            if (!testRegex.test(commentText)) {
+                const hasContentBeforeComment = !ONLY_WHITESPACE.test(text.substring(offset, pos));
+                const fix = insertText !== undefined
+                    ? hasContentBeforeComment
+                        ? Lint.Replacement.appendText(offset, this.createComment(sourceFile, insertText))
+                        : Lint.Replacement.replaceFromTo(pos, end, this.createComment(sourceFile, insertText, false))
+                    : undefined;
+                return [new Lint.RuleFailure(sourceFile, offset, offset, Rule.FAILURE_STRING, this.ruleName, fix)];
             }
-            return [new Lint.RuleFailure(sourceFile, offset, offset, Rule.FAILURE_STRING, this.ruleName)];
         }
         return [];
     }
+
+    private createComment(sourceFile: ts.SourceFile, commentText: string, trailingNewline=true) {
+        const maybeCarriageReturn = sourceFile.text[sourceFile.getLineEndOfPosition(0)] === "\r" ? "\r" : "";
+        const lineEnding = `${maybeCarriageReturn}\n`;
+        return [
+            '/*',
+            ...commentText.split(lineEnding).map(l => ` * ${l}`),
+            ' */',
+            ...(trailingNewline ? [''] : []),
+        ].join(lineEnding);
+    }
 }
+

--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -44,6 +44,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             maxLength: 2,
         },
         optionExamples: [[true, "Copyright \\d{4}", "Copyright 2017"]],
+        hasFix: true,
         type: "style",
         typescriptOnly: false,
     };

--- a/test/rules/file-header/bad-shebang/test.ts.fix
+++ b/test/rules/file-header/bad-shebang/test.ts.fix
@@ -4,6 +4,10 @@
  * Good header 2
  */
 
+/*
+ * Bad header 3
+ */
+
 export class A {
     public x = 1;
 

--- a/test/rules/file-header/bad-shebang/test.ts.fix
+++ b/test/rules/file-header/bad-shebang/test.ts.fix
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+/*
+ * Good header 2
+ */
+
+export class A {
+    public x = 1;
+
+    public B() {
+        return 2;
+    }
+}
+
+/*
+ * Good header 4
+ */

--- a/test/rules/file-header/bad-shebang/tslint.json
+++ b/test/rules/file-header/bad-shebang/tslint.json
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "file-header": [true, "Good header \\d"]
+        "file-header": [true, "Good header \\d", "Good header 2"]
     }
 }

--- a/test/rules/file-header/bad-single-line/test.ts.fix
+++ b/test/rules/file-header/bad-single-line/test.ts.fix
@@ -1,0 +1,15 @@
+/*
+ * Good header 2
+ */
+
+export class A {
+    public x = 1;
+
+    public B() {
+        return 2;
+    }
+}
+
+/*
+ * Good header 2
+ */

--- a/test/rules/file-header/bad-single-line/test.ts.fix
+++ b/test/rules/file-header/bad-single-line/test.ts.fix
@@ -2,6 +2,8 @@
  * Good header 2
  */
 
+// Bad header 1
+
 export class A {
     public x = 1;
 

--- a/test/rules/file-header/bad-single-line/tslint.json
+++ b/test/rules/file-header/bad-single-line/tslint.json
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "file-header": [true, "Good header \\d"]
+        "file-header": [true, "Good header \\d", "Good header 2"]
     }
 }

--- a/test/rules/file-header/bad-use-strict/test.ts.fix
+++ b/test/rules/file-header/bad-use-strict/test.ts.fix
@@ -1,0 +1,21 @@
+/*
+ * Good header 2
+ */
+
+"use strict";
+
+/*
+ * Bad header 5
+ */
+
+export class A {
+    public x = 1;
+
+    public B() {
+        return 2;
+    }
+}
+
+/*
+ * Good header 6
+ */

--- a/test/rules/file-header/bad-use-strict/tslint.json
+++ b/test/rules/file-header/bad-use-strict/tslint.json
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "file-header": [true, "Good header \\d"]
+        "file-header": [true, "Good header \\d", "Good header 2"]
     }
 }

--- a/test/rules/file-header/bad/test.ts.fix
+++ b/test/rules/file-header/bad/test.ts.fix
@@ -2,6 +2,10 @@
  * Good header 2
  */
 
+/*
+ * Bad header 1
+ */
+
 export class A {
     public x = 1;
 

--- a/test/rules/file-header/bad/test.ts.fix
+++ b/test/rules/file-header/bad/test.ts.fix
@@ -1,0 +1,15 @@
+/*
+ * Good header 2
+ */
+
+export class A {
+    public x = 1;
+
+    public B() {
+        return 2;
+    }
+}
+
+/*
+ * Good header 2
+ */

--- a/test/rules/file-header/bad/tslint.json
+++ b/test/rules/file-header/bad/tslint.json
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "file-header": [true, "Good header \\d"]
+        "file-header": [true, "Good header \\d", "Good header 2"]
     }
 }

--- a/test/rules/file-header/good/test.ts.fix
+++ b/test/rules/file-header/good/test.ts.fix
@@ -1,0 +1,12 @@
+
+/*
+ * Good header 1
+ */
+
+export class A {
+    public x = 1;
+
+    public B() {
+        return 2;
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Overview of change:

Adds a fixer to `file-header`. The rule will now insert text from a new second option as the header of your file if that option is provided and `--fix` is enabled. 

If the rule finds a header comment that's incorrect, it's replaced with the specified header. If the rule doesn't find a header comment at all, the specified header is inserted at the top of the document.

#### Is there anything you'd like reviewers to focus on?

Is the newline handling legit? 

#### CHANGELOG.md entry:

[new-fixer] `file-header`