### PR TITLE
ban-comma-operator: ignore for-loop incrementors

### DIFF
--- a/src/rules/banCommaOperatorRule.ts
+++ b/src/rules/banCommaOperatorRule.ts
@@ -64,9 +64,14 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.CommaToken) {
+        if (isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.CommaToken && !isForLoopIncrementor(node)) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);
     });
+}
+
+function isForLoopIncrementor(node: ts.Node) {
+    const parent = node.parent;
+    return parent && parent.kind === ts.SyntaxKind.ForStatement && (parent as ts.ForStatement).incrementor === node;
 }

--- a/src/rules/banCommaOperatorRule.ts
+++ b/src/rules/banCommaOperatorRule.ts
@@ -72,6 +72,6 @@ function walk(ctx: Lint.WalkContext<void>) {
 }
 
 function isForLoopIncrementor(node: ts.Node) {
-    const parent = node.parent;
-    return parent && parent.kind === ts.SyntaxKind.ForStatement && (parent as ts.ForStatement).incrementor === node;
+    const parent = node.parent!;
+    return parent.kind === ts.SyntaxKind.ForStatement && (parent as ts.ForStatement).incrementor === node;
 }

--- a/test/rules/ban-comma-operator/test.ts.lint
+++ b/test/rules/ban-comma-operator/test.ts.lint
@@ -16,5 +16,8 @@ switch (blah) {
         return false;
 }
 
+for(let i = 0, j = 0; i < 10, j < 10; i++, j++) {
+                      ~~~~~~~~~~~~~~ [0]
+}
 
 [0]: Do not use comma operator here because it can be easily misunderstood or lead to unintended bugs.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Rule `ban-comma-operator` raises an issue on every usage of comma operator, while using it inside for-loop incrementor IMO should be authorised. 
```typescript
for (let i = 0, j = 0; i < 10; i++, j++) {
}
```
<!-- optional -->

#### CHANGELOG.md entry:
[enhancement] `ban-comma-operator` ignores comma operator inside for-loop incrementor
