### PR TITLE
stylish-formatter: make filename clickable

### DIFF
--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -62,11 +62,13 @@ export class Formatter extends AbstractFormatter {
 
         for (const failure of failures) {
             const fileName = failure.getFileName();
+            const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
+            let positionTuple = `${lineAndCharacter.line + 1}:${lineAndCharacter.character + 1}`;
 
             // Output the name of each file once
             if (currentFile !== fileName) {
                 outputLines.push("");
-                outputLines.push(fileName);
+                outputLines.push(`${fileName}${chalk.hidden(`:${positionTuple}`)}`);
                 currentFile = fileName;
             }
 
@@ -79,9 +81,6 @@ export class Formatter extends AbstractFormatter {
             ruleName     = chalk.grey(ruleName);
 
             // Lines
-            const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
-
-            let positionTuple = `${lineAndCharacter.line + 1}:${lineAndCharacter.character + 1}`;
             positionTuple = this.pad(positionTuple, positionMaxSize);
 
             positionTuple = failure.getRuleSeverity() === "warning"

--- a/test/formatters/stylishFormatterTests.ts
+++ b/test/formatters/stylishFormatterTests.ts
@@ -47,7 +47,7 @@ describe("Stylish Formatter", () => {
         const maxPositionTuple = `${maxPositionObj.line + 1}:${maxPositionObj.character + 1}`;
 
         const expectedResult = dedent`
-            formatters/stylishFormatter.test.ts
+            formatters/stylishFormatter.test.ts\u001b[8m:1:1\u001b[28m
             \u001b[31mERROR: 1:1\u001b[39m  \u001b[90mfirst-name\u001b[39m  \u001b[33mfirst failure\u001b[39m
             \u001b[31mERROR: 1:1\u001b[39m  \u001b[90mfull-name \u001b[39m  \u001b[33mfull failure\u001b[39m
             \u001b[31mERROR: 1:3\u001b[39m  \u001b[90mescape    \u001b[39m  \u001b[33m&<>'\" should be escaped\u001b[39m


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: https://github.com/palantir/tslint/issues/3460#issuecomment-342396889
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Make the filename clickable in IDE by adding `:line:col` of the first failure at the end of the filename. The line and column information has a transparent color. There will be no transparency in terminals without colors.

#### Is there anything you'd like reviewers to focus on?

Do we need to add a note about this in the docs?

#### CHANGELOG.md entry:

[enhancement] clicking the filename in `stylish`-formatter's output jumps to the first failure in that file.