### PR TITLE
completed-docs: Added option to check get and set accessors.

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -356,11 +356,8 @@ function walk(context: Lint.WalkContext<ExclusionsMap>, typeChecker: ts.TypeChec
                 break;
 
             case ts.SyntaxKind.GetAccessor:
-                checkNode(node as ts.GetAccessorDeclaration, ARGUMENT_PROPERTIES);
-                break;
-
             case ts.SyntaxKind.SetAccessor:
-                checkNode(node as ts.SetAccessorDeclaration, ARGUMENT_PROPERTIES);
+                checkAccessor(node as ts.NamedDeclaration);
         }
 
         return ts.forEachChild(node, cb);
@@ -411,6 +408,14 @@ function walk(context: Lint.WalkContext<ExclusionsMap>, typeChecker: ts.TypeChec
             case ts.SyntaxKind.SourceFile:
             case ts.SyntaxKind.ModuleBlock:
                 checkNode(node, ARGUMENT_VARIABLES, statement);
+        }
+    }
+
+    function checkAccessor(node: ts.NamedDeclaration): void {
+        // Properties in object literal expressions do not
+        // require documentation, so neither do accessors.
+        if (node.parent!.kind !== ts.SyntaxKind.ObjectLiteralExpression) {
+            checkNode(node, ARGUMENT_PROPERTIES);
         }
     }
 

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -353,6 +353,14 @@ function walk(context: Lint.WalkContext<ExclusionsMap>, typeChecker: ts.TypeChec
 
             case ts.SyntaxKind.VariableDeclaration:
                 checkVariable(node as ts.VariableDeclaration);
+                break;
+
+            case ts.SyntaxKind.GetAccessor:
+                checkNode(node as ts.GetAccessorDeclaration, ARGUMENT_PROPERTIES);
+                break;
+
+            case ts.SyntaxKind.SetAccessor:
+                checkNode(node as ts.SetAccessorDeclaration, ARGUMENT_PROPERTIES);
         }
 
         return ts.forEachChild(node, cb);

--- a/test/rules/completed-docs/accessors-public/test.ts.lint
+++ b/test/rules/completed-docs/accessors-public/test.ts.lint
@@ -1,0 +1,16 @@
+export class Foo {
+
+    private myField: string;
+
+    public get myAccessor(): string { return this.myField; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for public properties.]
+
+
+    public set myAccessor(value: string) { this.myField = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for public properties.]
+
+    private hiddenField: string;
+    private get hiddenAccessor(): string { return this.hiddenField; }
+    private set hiddenAccessor(value: string) { this.hiddenField = value; }
+
+}

--- a/test/rules/completed-docs/accessors-public/tsconfig.json
+++ b/test/rules/completed-docs/accessors-public/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/completed-docs/accessors-public/tslint.json
+++ b/test/rules/completed-docs/accessors-public/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+      "properties": {
+        "privacies": ["public"]
+      }
+    }]
+  }
+}

--- a/test/rules/completed-docs/accessors/test.ts.lint
+++ b/test/rules/completed-docs/accessors/test.ts.lint
@@ -1,0 +1,118 @@
+export class Bad {
+
+    /**
+     * ...
+     */
+    private myField: string;
+
+    get myAccessor(): string { return this.myField; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for properties.]
+
+
+    set myAccessor(value: string) { this.myField = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for properties.]
+
+}
+
+export class Good {
+
+    /**
+     * ...
+     */
+    private myField: string;
+
+    /**
+     * The get accessor.
+     */
+    get myAccessor(): string { return this.myField; }
+
+    /**
+     * The set accessor.
+     */
+    set myAccessor(value: string) { this.myField = value; }
+
+}
+
+export class CommentsOnGetOnly {
+
+    /**
+     * ...
+     */
+    private myField: string;
+
+    /**
+     * The get accessor.
+     */
+    get myAccessor(): string { return this.myField; }
+
+    set myAccessor(value: string) { this.myField = value; } // Comments for the setter are inherited from the getter.
+
+}
+
+export class CommentsOnSetOnly {
+
+    /**
+     * ...
+     */
+    private myField: string;
+
+    get myAccessor(): string { return this.myField; }   // Comments from the getter are inherited from the setter.
+
+    /**
+     * The set accessor.
+     */
+    set myAccessor(value: string) { this.myField = value; }
+
+}
+
+export class OnlyHasGetAccessorWithComments {
+
+    /**
+     * ...
+     */
+    private myField: string;
+
+    /**
+     * The get accessor.
+     */
+    get myAccessor(): string { return this.myField; }
+
+}
+
+export class OnlyHasGetAccessorWithNoComments {
+
+    /**
+     * ...
+     */
+    private myField: string;
+
+    get myAccessor(): string { return this.myField; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for properties.]
+
+}
+
+export class OnlyHasSetAccessorWithComments {
+
+    /**
+     * ...
+     */
+    private myField: string;
+
+    /**
+     * The set accessor.
+     */
+    set myAccessor(value: string) { this.myField = value; }
+
+}
+
+export class OnlyHasSetAccessorWithNoComments {
+
+    /**
+     * ...
+     */
+    private myField: string;
+
+     set myAccessor(value: string) { this.myField = value; }
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for properties.]
+
+}

--- a/test/rules/completed-docs/accessors/tsconfig.json
+++ b/test/rules/completed-docs/accessors/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/completed-docs/accessors/tslint.json
+++ b/test/rules/completed-docs/accessors/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "completed-docs": [
+      true,
+      "properties"
+    ]
+  }
+}

--- a/test/rules/completed-docs/defaults/test.ts.lint
+++ b/test/rules/completed-docs/defaults/test.ts.lint
@@ -6,6 +6,12 @@ export class Aaa {
     public ccc() { }
     ~~~~~~~~~~~~~~~~       [Documentation must exist for public methods.]
 
+    public get prop() { return this.bbb; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for public properties.]
+
+    public set prop(value) { this.bbb = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for public properties.]
+
     // TODO: TypeScript API doesn't give us a symbol for this, so we must ignore it.
     // https://github.com/Microsoft/TypeScript/issues/14257
     [Symbol.iterator]() {}

--- a/test/rules/completed-docs/types/test.ts.lint
+++ b/test/rules/completed-docs/types/test.ts.lint
@@ -346,3 +346,12 @@ const EmptyVariable = 1;
  * ...
  */
 const GoodVariable = 1;
+
+/**
+ * Properties and accessors in object literals should not require documentation.
+ */
+let literal = {
+    prop: 1,
+    get accessor() { return literal.prop; },
+    set accessor(value) { literal.prop = value; }
+}

--- a/test/rules/completed-docs/types/test.ts.lint
+++ b/test/rules/completed-docs/types/test.ts.lint
@@ -23,6 +23,30 @@ class BadClass {
 
     private badPrivateMethod() { }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for private methods.]
+
+    get badDefaultAccessor() { return this.badDefaultProperty; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for properties.]
+
+    set badDefaultAccessor(value) { this.badDefaultProperty = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for properties.]
+
+    public get badPublicAccessor() { return this.badPublicProperty; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for public properties.]
+
+    public set badPublicAccessor(value) { this.badPublicProperty = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for public properties.]
+
+    protected get badProtectedAccessor() { return this.badProtectedProperty; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for protected properties.]
+
+    protected set badProtectedAccessor(value) { this.badProtectedProperty = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for protected properties.]
+
+    private get badPrivateAccessor() { return this.badPrivateProperty; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for private properties.]
+
+    private set badPrivateAccessor(value) { this.badPrivateProperty = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for private properties.]
 }
 
 /**
@@ -77,6 +101,54 @@ class EmptyClass {
      */
     private emptyPrivateMethod() { }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for private methods.]
+
+    /**
+     *
+     */
+    get emptyDefaultAccessor() { return this.emptyDefaultProperty; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for properties.]
+
+    /**
+     *
+     */
+    set emptyDefaultAccessor(value) { this.emptyDefaultProperty = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for properties.]
+
+    /**
+     *
+     */
+    public get emptyPublicAccessor() { return this.emptyPublicProperty; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for public properties.]
+
+    /**
+     *
+     */
+    public set emptyPublicAccessor(value) { this.emptyPublicProperty = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for public properties.]
+
+    /**
+     *
+     */
+    protected get emptyProtectedAccessor() { return this.emptyProtectedProperty; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for protected properties.]
+
+    /**
+     *
+     */
+    protected set emptyProtectedAccessor(value) { this.emptyProtectedProperty = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for protected properties.]
+
+    /**
+     *
+     */
+    private get emptyPrivateAccessor() { return this.emptyPrivateProperty; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        [Documentation must exist for private properties.]
+
+    /**
+     *
+     */
+    private set emptyPrivateAccessor(value) { this.emptyPrivateProperty = value; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Documentation must exist for private properties.]
 }
 
 /**
@@ -122,6 +194,46 @@ class GoodClass {
      * ...
      */
     private goodPrivateMethod() { }
+
+    /**
+     * ...
+     */
+    get goodDefaultAccessor() { return this.goodDefaultProperty; }
+
+    /**
+     * ...
+     */
+    set goodDefaultAccessor(value) { this.goodDefaultProperty = value; }
+
+    /**
+     * ...
+     */
+    public get goodPublicAccessor() { return this.goodPublicProperty; }
+
+    /**
+     * ...
+     */
+    public set goodPublicAccessor(value) { this.goodPublicProperty = value; }
+
+    /**
+     * ...
+     */
+    protected get goodProtectedAccessor() { return this.goodProtectedProperty; }
+
+    /**
+     * ...
+     */
+    protected set goodProtectedAccessor(value) { this.goodProtectedProperty = value; }
+
+    /**
+     * ...
+     */
+    private get goodPrivateAccessor() { return this.goodPrivateProperty; }
+
+    /**
+     * ...
+     */
+    private set goodPrivateAccessor(value) { this.goodPrivateProperty = value; }
 }
 
 enum BadEnum { }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3479
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
The `"properties"` for the `completed-docs` rule now checks `GetAccessor` and `SetAccessor` node types.

#### CHANGELOG.md entry:

[enhancement] `"properties"` option for `completed-docs` rule now checks getter and setter accessors.