### PR TITLE
Updated version of commander.js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-code-frame": "^6.22.0",
     "builtin-modules": "^1.1.1",
     "chalk": "^2.3.0",
-    "commander": "^2.9.0",
+    "commander": "^2.12.1",
     "diff": "^3.2.0",
     "glob": "^7.1.1",
     "js-yaml": "^3.7.0",
@@ -56,7 +56,6 @@
   "devDependencies": {
     "@types/babel-code-frame": "^6.20.0",
     "@types/chai": "^3.5.0",
-    "@types/commander": "^2.9.0",
     "@types/diff": "^3.2.0",
     "@types/glob": "^5.0.30",
     "@types/js-yaml": "^3.5.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,12 +10,6 @@
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.5.2.tgz#c11cd2817d3a401b7ba0f5a420f35c56139b1c1e"
 
-"@types/commander@^2.9.0":
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.9.1.tgz#d4e464425baf4685bd49dd233be11de9c00c0784"
-  dependencies:
-    "@types/node" "*"
-
 "@types/diff@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-3.2.0.tgz#2cf019a98b4cca072102cb48af5675502b5a831f"
@@ -301,7 +295,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.3.0:
+chalk@^2.1.0, chalk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -344,6 +338,10 @@ commander@2.9.0, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.12.1:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
 commondir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3509

#### Changelog

[bugfix] Update commander.js dependency to prevent users from transitively installing a buggy 2.12.0 release
