### PR TITLE
Fix CI failures with updated yarn.lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,35 +20,36 @@ jobs:
           paths:
             - lib
             - build
+            - yarn.lock
   lint:
     docker:
       - image: circleci/node:latest
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
       - attach_workspace:
           at: '.'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn lint
   test:
     docker:
       - image: circleci/node:8
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
       - attach_workspace:
           at: '.'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn test
   test2.1:
     docker:
       - image: circleci/node:4
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
       - attach_workspace:
           at: '.'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn add typescript@2.1
       - run: yarn test
   test2.4:
@@ -56,10 +57,10 @@ jobs:
       - image: circleci/node:6
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
       - attach_workspace:
           at: '.'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn add typescript@2.4
       - run: yarn test
   testNext:
@@ -67,10 +68,10 @@ jobs:
       - image: circleci/node:latest
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
       - attach_workspace:
           at: '.'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
       - run: yarn add typescript@next
       - run: yarn test
 


### PR DESCRIPTION
#### Overview of change:
CI fails on master because dependencies are not found in later jobs. That's because we cache dependencies by the checksum of yarn.lock.
If `yarn install` changes yarn.lock, all following jobs won't find the cache, because they use yarn.lock from git.

This change saves yarn.lock to the workspace and attaches the workspace before loading the dependency cache.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[no-log]
