### PR TITLE
docs update - Add `hasFix` metadata for the indent rule

### DIFF
--- a/src/rules/indentRule.ts
+++ b/src/rules/indentRule.ts
@@ -66,6 +66,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             [true, OPTION_USE_SPACES, OPTION_INDENT_SIZE_4],
             [true, OPTION_USE_TABS, OPTION_INDENT_SIZE_2],
         ],
+        hasFix: true,
         type: "maintainability",
         typescriptOnly: false,
     };

--- a/src/rules/indentRule.ts
+++ b/src/rules/indentRule.ts
@@ -44,7 +44,9 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`${OPTION_INDENT_SIZE_2.toString()}\` enforces 2 space indentation.
             * \`${OPTION_INDENT_SIZE_4.toString()}\` enforces 4 space indentation.
 
-            Indentation size is required for auto-fixing, but not for rule checking.
+            Indentation size is **required** for auto-fixing, but not for rule checking.
+            
+            **NOTE**: auto-fixing will only convert invalid indent whitespace to the desired type, it will not fix invalid whitespace sizes.
             `,
         options: {
             type: "array",

--- a/src/rules/indentRule.ts
+++ b/src/rules/indentRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`${OPTION_INDENT_SIZE_4.toString()}\` enforces 4 space indentation.
 
             Indentation size is **required** for auto-fixing, but not for rule checking.
-            
+
             **NOTE**: auto-fixing will only convert invalid indent whitespace to the desired type, it will not fix invalid whitespace sizes.
             `,
         options: {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

Add the `hasFix` property to the metadata of the `indent` rule.  

The [docs for this rule](https://palantir.github.io/tslint/rules/indent/) mention auto-fixing, but the green "**🔧 Has Fixer**" badge doesn't appear, which could lead people to assume (like I did) that this rule has no fixer.


#### Future Suggestions:
Perhaps make the `hasFix` property required instead of optional so that rule authors are required to correctly set this properly.  Further more, maybe add a check to see if `hasFix: false` is set but the rule contains a call on the `Lint.Replacement`, or `Lint.RuleFailure` has something passed into the 6th parameter for a fix.