### PR TITLE
Add test for no-unnecesary-type-assertion

### DIFF
--- a/test/rules/no-unnecessary-type-assertion/test.ts.fix
+++ b/test/rules/no-unnecessary-type-assertion/test.ts.fix
@@ -103,3 +103,4 @@ function foo() {
     f();
     xx as 1 | 2 === 2; // xx is inferred as 1, assertion is necessary to avoid compile error
 }
+

--- a/test/rules/no-unnecessary-type-assertion/test.ts.fix
+++ b/test/rules/no-unnecessary-type-assertion/test.ts.fix
@@ -83,3 +83,10 @@ const data = {
 
 [1, 2, 3, 4, 5].map(x => [x, 'A' + x] as [number, string]);
 let x: Array<[number, string]> = [1, 2, 3, 4, 5].map(x => [x, 'A' + x] as [number, string]);
+
+function foo() {
+    let xx: 1 | 2 = 1;
+    const f = () => xx = 2;
+    f();
+    xx as 1 | 2 === 2; // xx is inferred as 1, assertion is necessary to avoid compile error
+}

--- a/test/rules/no-unnecessary-type-assertion/test.ts.lint
+++ b/test/rules/no-unnecessary-type-assertion/test.ts.lint
@@ -100,3 +100,10 @@ const data = {
 
 [1, 2, 3, 4, 5].map(x => [x, 'A' + x] as [number, string]);
 let x: Array<[number, string]> = [1, 2, 3, 4, 5].map(x => [x, 'A' + x] as [number, string]);
+
+function foo() {
+    let xx: 1 | 2 = 1;
+    const f = () => xx = 2;
+    f();
+    xx as 1 | 2 === 2; // xx is inferred as 1, assertion is necessary to avoid compile error
+}


### PR DESCRIPTION
Adds a test where type inference narrows a type and an assertion is needed.
It's already handled correctly. I just want to make sure this remains correct.

[no-log]