### PR TITLE
fix 'no-magic-number' ignores parseInt radix parameter

### DIFF
--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -72,7 +72,7 @@ class NoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
             if (isCallExpression(node) && isIdentifier(node.expression) && node.expression.text === "parseInt") {
-                return;
+                return node.arguments.length === 0 ? undefined : cb(node.arguments[0]);
             }
 
             if (node.kind === ts.SyntaxKind.NumericLiteral) {

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -17,6 +17,7 @@
 
 import * as ts from "typescript";
 
+import { isCallExpression, isIdentifier } from "tsutils";
 import * as Lint from "../index";
 import { isNegativeNumberLiteral } from "../language/utils";
 
@@ -70,6 +71,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
+            if (isCallExpression(node) && isIdentifier(node.expression) && node.expression.text === "parseInt") {
+                return;
+            }
+
             if (node.kind === ts.SyntaxKind.NumericLiteral) {
                 return this.checkNumericLiteral(node, (node as ts.NumericLiteral).text);
             }

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -1,4 +1,8 @@
+parseInt();
+parseInt('123', 2);
+parseInt('123', 8);
 parseInt('123', 10);
+parseInt('123', 16);
 console.log(1337);
 console.log(-1337);
 console.log(- 1337);
@@ -7,6 +11,8 @@ console.log(1338);
             ~~~~                      ['magic numbers' are not allowed]
 console.log(-1338)
             ~~~~~                     ['magic numbers' are not allowed]
+parseInt(foo === 4711 ? bar : baz, 10);
+                 ~~~~                 ['magic numbers' are not allowed]
 export let x = 1337;
 export let x = -1337;
 export let x = 1337.7;

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -1,3 +1,4 @@
+parseInt('123', 10);
 console.log(1337);
 console.log(-1337);
 console.log(- 1337);


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x ] New feature, bugfix, or enhancement
  - [x ] Includes tests
- [ ] Documentation update

#### Overview of change:
Enhancement of 'no-magic-number' based on issue #3514

#### CHANGELOG.md entry:
[enhancement]: 'no-magic-numbers' ignores parseInt radix parameter
