### PR TITLE
one-line: avoid crash on parse error

### DIFF
--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -97,7 +97,10 @@ class OneLineWalker extends Lint.AbstractWalker<Options> {
                 case ts.SyntaxKind.InterfaceDeclaration:
                 case ts.SyntaxKind.ClassDeclaration:
                 case ts.SyntaxKind.ClassExpression: {
-                    this.check(getChildOfKind(node, ts.SyntaxKind.OpenBraceToken, sourceFile)!);
+                    const openBrace = getChildOfKind(node, ts.SyntaxKind.OpenBraceToken, sourceFile);
+                    if (openBrace !== undefined) {
+                        this.check(openBrace);
+                    }
                     break;
                 }
                 case ts.SyntaxKind.IfStatement: {

--- a/test/rules/one-line/all/test.ts.fix
+++ b/test/rules/one-line/all/test.ts.fix
@@ -136,3 +136,16 @@ if (true) {
 } else {
     false;
 }
+
+// don't crash on parse error
+interface InvalidInterface = {
+  foo: string,
+}
+
+class InvalidClass = {
+  foo: string,
+}
+
+foo = class InvalidClassExpression = {
+  foo: string,
+}

--- a/test/rules/one-line/all/test.ts.lint
+++ b/test/rules/one-line/all/test.ts.lint
@@ -179,3 +179,16 @@ if (true) {
  ~~~~   [missing whitespace]
     false;
 }
+
+// don't crash on parse error
+interface InvalidInterface = {
+  foo: string,
+}
+
+class InvalidClass = {
+  foo: string,
+}
+
+foo = class InvalidClassExpression = {
+  foo: string,
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3537
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
[bugfix] `one-line` fixed crash on syntax error in class or interface
Fixes: #3537

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
