### PR TITLE
strict-type-predicates: allow comparing typeof with expression

### DIFF
--- a/src/rules/strictTypePredicatesRule.ts
+++ b/src/rules/strictTypePredicatesRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isBinaryExpression, isTypeFlagSet, isUnionType } from "tsutils";
+import { isBinaryExpression, isIdentifier, isLiteralExpression, isTypeFlagSet, isUnionType } from "tsutils";
 
 import * as ts from "typescript";
 import { showWarningOnce } from "../error";
@@ -130,11 +130,19 @@ function getTypePredicateOneWay(left: ts.Expression, right: ts.Expression, isStr
     switch (right.kind) {
         case ts.SyntaxKind.TypeOfExpression:
             const expression = (right as ts.TypeOfExpression).expression;
-            const kind = left.kind === ts.SyntaxKind.StringLiteral ? (left as ts.StringLiteral).text : "";
-            const predicate = getTypePredicateForKind(kind);
+            if (!isLiteralExpression(left)) {
+                if (isIdentifier(left) && left.text === "undefined" ||
+                    left.kind === ts.SyntaxKind.NullKeyword ||
+                    left.kind === ts.SyntaxKind.TrueKeyword ||
+                    left.kind === ts.SyntaxKind.FalseKeyword) {
+                    return {kind: TypePredicateKind.TypeofTypo};
+                }
+                return undefined;
+            }
+            const predicate = getTypePredicateForKind(left.text);
             return predicate === undefined
                 ? { kind: TypePredicateKind.TypeofTypo }
-                : { kind: TypePredicateKind.Plain, expression, predicate, isNullOrUndefined: kind === "undefined" };
+                : { kind: TypePredicateKind.Plain, expression, predicate, isNullOrUndefined: left.text === "undefined" };
 
         case ts.SyntaxKind.NullKeyword:
             return nullOrUndefined(ts.TypeFlags.Null);

--- a/test/rules/strict-type-predicates/strict-null-checks/test.ts.lint
+++ b/test/rules/strict-type-predicates/strict-null-checks/test.ts.lint
@@ -191,6 +191,18 @@ declare function get<T>(): T;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [typeof]
 }
 
+let a: string, b: string;
+typeof a === typeof b;
+typeof a === b;
+a === typeof b;
+typeof a === undefined;
+~~~~~~~~~~~~~~~~~~~~~~ [F]
+
+undefined === typeof a;
+~~~~~~~~~~~~~~~~~~~~~~ [typeof]
+null === typeof b;
+~~~~~~~~~~~~~~~~~ [typeof]
+
 [T]: Expression is always true.
 [F]: Expression is always false.
 [typeof]: Bad comparison for 'typeof'.

--- a/test/rules/strict-type-predicates/strict-null-checks/test.ts.lint
+++ b/test/rules/strict-type-predicates/strict-null-checks/test.ts.lint
@@ -189,19 +189,23 @@ declare function get<T>(): T;
 
     typeof get<any>() === "orbject";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [typeof]
+
+    typeof get<string | number>() === `string`;
+    typeof get<string | number>() === `stirng`;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [typeof]
+
+    let a: string, b: string;
+    typeof a === typeof b;
+    typeof a === b;
+    a === typeof b;
+    typeof a === undefined;
+    ~~~~~~~~~~~~~~~~~~~~~~ [F]
+
+    undefined === typeof a;
+    ~~~~~~~~~~~~~~~~~~~~~~ [typeof]
+    null === typeof b;
+    ~~~~~~~~~~~~~~~~~ [typeof]
 }
-
-let a: string, b: string;
-typeof a === typeof b;
-typeof a === b;
-a === typeof b;
-typeof a === undefined;
-~~~~~~~~~~~~~~~~~~~~~~ [F]
-
-undefined === typeof a;
-~~~~~~~~~~~~~~~~~~~~~~ [typeof]
-null === typeof b;
-~~~~~~~~~~~~~~~~~ [typeof]
 
 [T]: Expression is always true.
 [F]: Expression is always false.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3508
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
The rule didn't allow comparing `typeof foo` to anything but a string literal. Even NonSubstitutionTemplateLiteral was not allowed. This PR makes the rule less strict, but this doesn't really matter since the compiler already catches most errors.
[bugfix] `strict-type-predicates` allows comparing typeof result with non-literals
Fixes: #3508

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
