### PR TITLE
fix no-duplicate-super rule with ternary operator

### DIFF
--- a/src/rules/noDuplicateSuperRule.ts
+++ b/src/rules/noDuplicateSuperRule.ts
@@ -80,6 +80,11 @@ function walk(ctx: Lint.WalkContext<void>): void {
                     ? { node: node.parent! as ts.CallExpression, break: false }
                     : Kind.NoSuper;
 
+            case ts.SyntaxKind.ConditionalExpression: {
+                const { whenTrue, whenFalse } = node as ts.ConditionalExpression;
+                return worse(getSuperForNode(whenTrue), whenFalse !== undefined ? getSuperForNode(whenFalse) : Kind.NoSuper);
+            }
+
             case ts.SyntaxKind.IfStatement: {
                 const { thenStatement, elseStatement } = node as ts.IfStatement;
                 return worse(getSuperForNode(thenStatement), elseStatement !== undefined ? getSuperForNode(elseStatement) : Kind.NoSuper);

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -72,7 +72,7 @@ class NoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
             if (isCallExpression(node) && isIdentifier(node.expression) && node.expression.text === "parseInt") {
-                return;
+                return node.arguments.length === 0 ? undefined : cb(node.arguments[0]);
             }
 
             if (node.kind === ts.SyntaxKind.NumericLiteral) {

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -17,6 +17,7 @@
 
 import * as ts from "typescript";
 
+import { isCallExpression, isIdentifier } from "tsutils";
 import * as Lint from "../index";
 import { isNegativeNumberLiteral } from "../language/utils";
 
@@ -70,6 +71,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
+            if (isCallExpression(node) && isIdentifier(node.expression) && node.expression.text === "parseInt") {
+                return;
+            }
+
             if (node.kind === ts.SyntaxKind.NumericLiteral) {
                 return this.checkNumericLiteral(node, (node as ts.NumericLiteral).text);
             }

--- a/test/rules/no-duplicate-super/test.ts.lint
+++ b/test/rules/no-duplicate-super/test.ts.lint
@@ -259,5 +259,14 @@ declare const n: number;
     }
 }
 
+// With ternary operator
+{
+    class {
+        constructor(props?: any) {
+            props ? super(props) : super();
+        }
+    }
+}
+
 [0]: Multiple calls to 'super()' found. It must be called only once.
 [1]: 'super()' called in a loop. It must be called only once.

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -1,4 +1,8 @@
+parseInt();
+parseInt('123', 2);
+parseInt('123', 8);
 parseInt('123', 10);
+parseInt('123', 16);
 console.log(1337);
 console.log(-1337);
 console.log(- 1337);
@@ -7,6 +11,8 @@ console.log(1338);
             ~~~~                      ['magic numbers' are not allowed]
 console.log(-1338)
             ~~~~~                     ['magic numbers' are not allowed]
+parseInt(foo === 4711 ? bar : baz, 10);
+                 ~~~~                 ['magic numbers' are not allowed]
 export let x = 1337;
 export let x = -1337;
 export let x = 1337.7;

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -1,3 +1,4 @@
+parseInt('123', 10);
 console.log(1337);
 console.log(-1337);
 console.log(- 1337);


### PR DESCRIPTION
#### PR checklist

- [x ] Addresses an existing issue: #3275
- [x ] New feature, bugfix, or enhancement
  - [x ] Includes tests
- [ ] Documentation update

#### Overview of change:
Added case for ternary operator in no-duplicate-super rule.

#### CHANGELOG.md entry:

[bugfix] using ternary operator for calling super() now passes no-duplicate-super rule.
