### PR TITLE
fix whitespace rule with 'check-decl' also lint property declarations

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -201,6 +201,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 break;
 
             case ts.SyntaxKind.VariableDeclaration:
+            case ts.SyntaxKind.PropertyDeclaration:
                 const { name, type, initializer } = node as ts.VariableDeclaration;
                 if (options.decl && initializer !== undefined) {
                     checkForTrailingWhitespace((type !== undefined ? type : name).getEnd());

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -121,3 +121,9 @@ type A = number | string;
 type B = number | string | {result: string};
 
 type C = {result: string} & {type: "A" | "B"};
+
+class a {
+    private x = 1;
+    y = 1;
+    public z = 0;
+}

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -192,3 +192,13 @@ type C = {result: string}&{type: "A"|"B"};
                           ~                [missing whitespace]
                                     ~      [missing whitespace]
                                      ~     [missing whitespace]
+
+class a {
+    private x= 1;
+             ~     [missing whitespace]
+    y= 1;
+     ~     [missing whitespace]
+    public z=0;
+            ~     [missing whitespace]
+             ~     [missing whitespace]
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #3199
- [x ] New feature, bugfix, or enhancement
  - [x ] Includes tests
- [ ] Documentation update

#### Overview of change:
Added PropertyDeclaration to the whitespace rule walker.

#### CHANGELOG.md entry:

[bugfix] 'whitespace' rule checks property declarations if 'check-decl' is enabled