### PR TITLE
Added no-dynamic-delete rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -106,6 +106,7 @@ export const rules = {
         true,
         "check-parameters",
     ],
+    "no-dynamic-delete": true,
     "no-empty": true,
     "no-eval": true,
     "no-floating-promises": true,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -242,6 +242,7 @@ export function loadConfigurationFromPath(configFilePath?: string, originalFileP
             }
         } else {
             rawConfigFile = require(resolvedConfigFilePath) as RawConfigFile;
+            // tslint:disable-next-line:no-dynamic-delete
             delete (require.cache as { [key: string]: any })[resolvedConfigFilePath];
         }
 

--- a/src/rules/noDynamicDeleteRule.ts
+++ b/src/rules/noDynamicDeleteRule.ts
@@ -41,7 +41,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(context: Lint.WalkContext<void>) {
     function checkDeleteAccessExpression(node: ts.Expression | undefined): void {
-        if (node === undefined || !ts.isElementAccessExpression(node)) {
+        if (node === undefined || !tsutils.isElementAccessExpression(node)) {
             return;
         }
 
@@ -54,12 +54,12 @@ function walk(context: Lint.WalkContext<void>) {
         const width = argumentExpression.getWidth() + 2;
         let fix: Lint.Replacement | undefined;
 
-        if (ts.isPrefixUnaryExpression(argumentExpression)) {
+        if (tsutils.isPrefixUnaryExpression(argumentExpression)) {
             const convertedOperand = convertUnaryOperand(argumentExpression);
             if (convertedOperand !== undefined) {
                 fix = Lint.Replacement.replaceFromTo(start, start + width, `[${convertedOperand}]`);
             }
-        } else if (ts.isStringLiteral(argumentExpression)) {
+        } else if (tsutils.isStringLiteral(argumentExpression)) {
             fix = Lint.Replacement.replaceFromTo(start, start + width, `.${argumentExpression.text}`);
         }
 
@@ -76,7 +76,7 @@ function walk(context: Lint.WalkContext<void>) {
 }
 
 function convertUnaryOperand(node: ts.PrefixUnaryExpression) {
-    return ts.isNumericLiteral(node.operand)
+    return tsutils.isNumericLiteral(node.operand)
         ? node.operand.text
         : undefined;
 }
@@ -86,11 +86,11 @@ function isDeleteExpression(node: ts.Node): node is ts.DeleteExpression {
 }
 
 function isNumberLike(node: ts.Node): boolean {
-    if (ts.isPrefixUnaryExpression(node)) {
-        return ts.isNumericLiteral(node.operand) && node.operator === ts.SyntaxKind.MinusToken;
+    if (tsutils.isPrefixUnaryExpression(node)) {
+        return tsutils.isNumericLiteral(node.operand) && node.operator === ts.SyntaxKind.MinusToken;
     }
 
-    return ts.isNumericLiteral(node);
+    return tsutils.isNumericLiteral(node);
 }
 
 function isNecessaryDynamicAccess(argumentExpression: ts.Expression): boolean {
@@ -98,5 +98,5 @@ function isNecessaryDynamicAccess(argumentExpression: ts.Expression): boolean {
         return true;
     }
 
-    return ts.isStringLiteral(argumentExpression) && !tsutils.isValidPropertyAccess(argumentExpression.text);
+    return tsutils.isStringLiteral(argumentExpression) && !tsutils.isValidPropertyAccess(argumentExpression.text);
 }

--- a/src/rules/noDynamicDeleteRule.ts
+++ b/src/rules/noDynamicDeleteRule.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as tsutils from "tsutils";
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static metadata: Lint.IRuleMetadata = {
+        description: "Enforces not deleting computed expressions.",
+        optionExamples: [true],
+        options: null,
+        optionsDescription: "Not configurable.",
+        rationale: "Deleting dynamically computed keys is dangerous and not well optimized.",
+        ruleName: "no-dynamic-delete",
+        type: "functionality",
+        typescriptOnly: false,
+    };
+
+    public static FAILURE_STRING = "Do not delete dynamically computed property keys.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(context: Lint.WalkContext<void>) {
+    function checkDeleteAccessExpression(node: ts.Expression | undefined): void {
+        if (node === undefined || !ts.isElementAccessExpression(node)) {
+            return;
+        }
+
+        const { argumentExpression } = node;
+        if (argumentExpression === undefined || isNecessaryDynamicAccess(argumentExpression)) {
+            return;
+        }
+
+        const start = argumentExpression.getStart(context.sourceFile) - 1;
+        const width = argumentExpression.getWidth() + 2;
+        let fix: Lint.Replacement | undefined;
+
+        if (ts.isPrefixUnaryExpression(argumentExpression)) {
+            const convertedOperand = convertUnaryOperand(argumentExpression);
+            if (convertedOperand !== undefined) {
+                fix = Lint.Replacement.replaceFromTo(start, start + width, `[${convertedOperand}]`);
+            }
+        } else if (ts.isStringLiteral(argumentExpression)) {
+            fix = Lint.Replacement.replaceFromTo(start, start + width, `.${argumentExpression.text}`);
+        }
+
+        context.addFailureAt(start, width, Rule.FAILURE_STRING, fix);
+    }
+
+    return ts.forEachChild(context.sourceFile, function callback(node: ts.Node): void {
+        if (ts.isDeleteExpression(node)) {
+            checkDeleteAccessExpression(node.expression);
+        }
+
+        return ts.forEachChild(node, callback);
+    });
+}
+
+function convertUnaryOperand(node: ts.PrefixUnaryExpression) {
+    return ts.isNumericLiteral(node.operand)
+        ? node.operand.text
+        : undefined;
+}
+
+function isNumberLike(node: ts.Node): boolean {
+    if (ts.isPrefixUnaryExpression(node)) {
+        return ts.isNumericLiteral(node.operand) && node.operator === ts.SyntaxKind.MinusToken;
+    }
+
+    return ts.isNumericLiteral(node);
+}
+
+function isNecessaryDynamicAccess(argumentExpression: ts.Expression): boolean {
+    if (isNumberLike(argumentExpression)) {
+        return true;
+    }
+
+    return ts.isStringLiteral(argumentExpression) && !tsutils.isValidPropertyAccess(argumentExpression.text);
+}

--- a/src/rules/noDynamicDeleteRule.ts
+++ b/src/rules/noDynamicDeleteRule.ts
@@ -22,7 +22,7 @@ import * as Lint from "../index";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
-        description: "Enforces not deleting computed expressions.",
+        description: "Bans usage of the delete operator with computed key expressions.",
         optionExamples: [true],
         options: null,
         optionsDescription: "Not configurable.",

--- a/src/rules/noDynamicDeleteRule.ts
+++ b/src/rules/noDynamicDeleteRule.ts
@@ -67,7 +67,7 @@ function walk(context: Lint.WalkContext<void>) {
     }
 
     return ts.forEachChild(context.sourceFile, function callback(node: ts.Node): void {
-        if (ts.isDeleteExpression(node)) {
+        if (isDeleteExpression(node)) {
             checkDeleteAccessExpression(node.expression);
         }
 
@@ -79,6 +79,10 @@ function convertUnaryOperand(node: ts.PrefixUnaryExpression) {
     return ts.isNumericLiteral(node.operand)
         ? node.operand.text
         : undefined;
+}
+
+function isDeleteExpression(node: ts.Node): node is ts.DeleteExpression {
+    return node.kind === ts.SyntaxKind.DeleteExpression;
 }
 
 function isNumberLike(node: ts.Node): boolean {

--- a/test/rules/no-dynamic-delete/test.ts.fix
+++ b/test/rules/no-dynamic-delete/test.ts.fix
@@ -1,0 +1,19 @@
+const container: { [i: string]: 0 } = {};
+
+const getName = () => "";
+
+delete container.aaa;
+delete container["bb" + "b"];
+delete container.ccc;
+delete container.delete;
+delete container.delete;
+delete container[7];
+delete container[-7];
+delete container[7];
+delete container[-Infinity];
+delete container["-Infinity"];
+delete container[+Infinity];
+delete container["+Infinity"];
+delete container[NaN];
+delete container.NaN;
+delete container[getName()];

--- a/test/rules/no-dynamic-delete/test.ts.lint
+++ b/test/rules/no-dynamic-delete/test.ts.lint
@@ -1,0 +1,29 @@
+const container: { [i: string]: 0 } = {};
+
+const getName = () => "";
+
+delete container.aaa;
+delete container["bb" + "b"];
+                ~~~~~~~~~~~~       [0]
+delete container["ccc"];
+                ~~~~~~~       [0]
+delete container.delete;
+delete container["delete"];
+                ~~~~~~~~~~       [0]
+delete container[7];
+delete container[-7];
+delete container[+7];
+                ~~~~       [0]
+delete container[-Infinity];
+                ~~~~~~~~~~~       [0]
+delete container["-Infinity"];
+delete container[+Infinity];
+                ~~~~~~~~~~~       [0]
+delete container["+Infinity"];
+delete container[NaN];
+                ~~~~~       [0]
+delete container["NaN"];
+                ~~~~~~~       [0]
+delete container[getName()];
+                ~~~~~~~~~~~       [0]
+[0]: Do not delete dynamically computed property keys.

--- a/test/rules/no-dynamic-delete/tslint.json
+++ b/test/rules/no-dynamic-delete/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-dynamic-delete": true
+  }
+}


### PR DESCRIPTION
Equivalent to tslint-microsoft-contrib's no-delete-expression. Renamed because all deletes are technically of node kind DeleteExpression, though they may sometimes contain an expression as the argumentExpression.

Allowed string literals of invalid property accesses, numeric literals, and negative numeric literals because those can't be simplified.
Suggested fixes for converting valid string literals to direct lookups and simplified unnecessarily positive numbers (like `+7` to `7`).

Fixes #3553.

#### CHANGELOG.md entry:

[new-rule] `no-dynamic-delete`
