### PR TITLE
completed-docs: corrected example config for tags

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -269,11 +269,13 @@ export class Rule extends Lint.Rules.TypedRule {
                         [DESCRIPTOR_LOCATIONS]: LOCATION_INSTANCE,
                         [DESCRIPTOR_PRIVACIES]: [PRIVACY_PUBLIC, PRIVACY_PROTECTED],
                     },
-                    [DESCRIPTOR_TAGS]: {
-                        [TAGS_FOR_CONTENT]: {
-                            see: ["#.*"],
+                    [ARGUMENT_PROPERTIES]: {
+                        [DESCRIPTOR_TAGS]: {
+                            [TAGS_FOR_CONTENT]: {
+                                see: ["#.*"],
+                            },
+                            [TAGS_FOR_EXISTENCE]: ["inheritdoc"],
                         },
-                        [TAGS_FOR_EXISTENCE]: ["inheritdoc"],
                     },
                 },
             ],


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3576
- [x] Documentation update

#### Overview of change:

Corrected the example config that uses `tags`.

Also, the published documentation says (incorrectly) that there is an "exists" property, but the committed docs correctly states that it's called "existence", so I guess the latest documentation just hasn't been pushed to the website yet.

#### CHANGELOG.md entry:

[no-log] completed-docs: fixed example config for tags
