### PR TITLE
[WIP] Add plugin support to customize linting (vue support)

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -50,6 +50,11 @@ export interface IConfigurationFile {
     }>;
 
     /**
+     * An array of plugins to use.
+     */
+    plugins: string[];
+
+    /**
      * Directories containing custom rules. Resolved using node module semantics.
      */
     rulesDirectory: string[];
@@ -76,6 +81,7 @@ export const DEFAULT_CONFIG: IConfigurationFile = {
     defaultSeverity: "error",
     extends: ["tslint:recommended"],
     jsRules: new Map<string, Partial<IOptions>>(),
+    plugins: [],
     rules: new Map<string, Partial<IOptions>>(),
     rulesDirectory: [],
 };
@@ -84,6 +90,7 @@ export const EMPTY_CONFIG: IConfigurationFile = {
     defaultSeverity: "error",
     extends: [],
     jsRules: new Map<string, Partial<IOptions>>(),
+    plugins: [],
     rules: new Map<string, Partial<IOptions>>(),
     rulesDirectory: [],
 };
@@ -329,10 +336,14 @@ export function extendConfigurationFile(targetConfig: IConfigurationFile,
     const combinedRulesDirs = targetConfig.rulesDirectory.concat(nextConfigSource.rulesDirectory);
     const dedupedRulesDirs = Array.from(new Set(combinedRulesDirs));
 
+    const combinedPlugins = targetConfig.plugins.concat(nextConfigSource.plugins);
+    const dedupedPlugins = Array.from(new Set(combinedPlugins));
+
     return {
         extends: [],
         jsRules: combineMaps(targetConfig.jsRules, nextConfigSource.jsRules),
         linterOptions: combineProperties(targetConfig.linterOptions, nextConfigSource.linterOptions),
+        plugins: dedupedPlugins,
         rules: combineMaps(targetConfig.rules, nextConfigSource.rules),
         rulesDirectory: dedupedRulesDirs,
     };
@@ -455,6 +466,7 @@ function parseRuleOptions(ruleConfigValue: RawRuleConfig, rawDefaultRuleSeverity
 }
 
 export interface RawConfigFile {
+    plugins?: string | string[];
     extends?: string | string[];
     linterOptions?: IConfigurationFile["linterOptions"];
     rulesDirectory?: string | string[];
@@ -481,6 +493,7 @@ export function parseConfigFile(configFile: RawConfigFile, configFileDir?: strin
         extends: arrayify(configFile.extends),
         jsRules: parseRules(configFile.jsRules),
         linterOptions: parseLinterOptions(configFile.linterOptions),
+        plugins: arrayify(configFile.plugins),
         rules: parseRules(configFile.rules),
         rulesDirectory: getRulesDirectories(configFile.rulesDirectory, configFileDir),
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,3 +49,7 @@ export interface ILinterOptions {
     formattersDirectory?: string;
     rulesDirectory?: string | string[];
 }
+
+export interface ILinterPlugin {
+    lint(linter: Linter, fileName: string, source: string, configFile: Configuration.IConfigurationFile | undefined): boolean;
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "moduleResolution": "node",
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "noImplicitThis": true,
@@ -13,6 +14,9 @@
         "sourceMap": false,
         "target": "es5",
         "lib": ["es6"],
-        "outDir": "../lib"
+        "outDir": "../lib",
+        "types": [
+           "node"
+        ]
     }
 }

--- a/test/configurationTests.ts
+++ b/test/configurationTests.ts
@@ -461,6 +461,7 @@ function getEmptyConfig(): IConfigurationFile {
         extends: [],
         jsRules: new Map<string, Partial<IOptions>>(),
         linterOptions: {},
+        plugins: [],
         rules: new Map<string, Partial<IOptions>>(),
         rulesDirectory: [],
     };


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2099
- [x] New feature, bugfix, or enhancement
- [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

Add plugin support. It's meant to be used with https://github.com/Toilal/tslint-plugin-vue which is a plugin that implements #2099, but it may open other possibilities too ...

This is a work in progress, but feel free to try. You can add the plugin with `npm install git+https://https://github.com/Toilal/tslint-plugin-vue` and enable it by adding `plugins: 'vue'` into `tslint.json`.

Currently it doesn't work with `-p/--project` option, you have to use `-c/--config` option and it doesn't support type checking.

I also plan plugins to be able to yield additional files that are not reported by typescript program. (would be useful for vue plugin to work with `-p/--project`).

#### Is there anything you'd like reviewers to focus on?

I'll add test and docs later.

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
