### PR TITLE
[new-rule-option] [object-literal-sort-key] Add shorthand-first option

### DIFF
--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -22,10 +22,12 @@ import * as Lint from "../index";
 
 const OPTION_IGNORE_CASE = "ignore-case";
 const OPTION_MATCH_DECLARATION_ORDER = "match-declaration-order";
+const OPTION_SHORTHAND_FIRST = "shorthand-first";
 
 interface Options {
     ignoreCase: boolean;
     matchDeclarationOrder: boolean;
+    shorthandFirst: boolean;
 }
 
 export class Rule extends Lint.Rules.OptionallyTypedRule {
@@ -43,21 +45,24 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
             By default, this rule checks that keys are in alphabetical order.
             The following may optionally be passed:
 
-            * "${OPTION_IGNORE_CASE}" will to compare keys in a case insensitive way.
+            * "${OPTION_IGNORE_CASE}" will compare keys in a case insensitive way.
             * "${OPTION_MATCH_DECLARATION_ORDER}" will prefer to use the key ordering of the contextual type of the object literal, as in:
 
                 interface I { foo: number; bar: number; }
                 const obj: I = { foo: 1, bar: 2 };
 
             If a contextual type is not found, alphabetical ordering will be used instead.
+            * "${OPTION_SHORTHAND_FIRST}" will enforce shorthand properties to appear first, as in:
+
+                const obj = { a, c, b: true };
             `,
         options: {
             type: "string",
-            enum: [OPTION_IGNORE_CASE, OPTION_MATCH_DECLARATION_ORDER],
+            enum: [OPTION_IGNORE_CASE, OPTION_MATCH_DECLARATION_ORDER, OPTION_SHORTHAND_FIRST],
         },
         optionExamples: [
             true,
-            [true, OPTION_IGNORE_CASE, OPTION_MATCH_DECLARATION_ORDER],
+            [true, OPTION_IGNORE_CASE, OPTION_MATCH_DECLARATION_ORDER, OPTION_SHORTHAND_FIRST],
         ],
         type: "maintainability",
         typescriptOnly: false,
@@ -71,6 +76,10 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
     public static FAILURE_STRING_USE_DECLARATION_ORDER(propName: string, typeName: string | undefined): string {
         const type = typeName === undefined ? "its type declaration" : `'${typeName}'`;
         return `The key '${propName}' is not in the same order as it is in ${type}.`;
+    }
+
+    public static FAILURE_STRING_SHORTHAND_FIRST(name: string): string {
+        return `The shorthand property '${name}' should appear before normal properties`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -95,6 +104,7 @@ function parseOptions(ruleArguments: any[]): Options {
     return {
         ignoreCase: has(OPTION_IGNORE_CASE),
         matchDeclarationOrder: has(OPTION_MATCH_DECLARATION_ORDER),
+        shorthandFirst: has(OPTION_SHORTHAND_FIRST),
     };
 
     function has(name: string) {
@@ -105,7 +115,7 @@ function parseOptions(ruleArguments: any[]): Options {
 function walk(ctx: Lint.WalkContext<Options>, checker?: ts.TypeChecker): void {
     const {
         sourceFile,
-        options: { ignoreCase, matchDeclarationOrder },
+        options: { ignoreCase, matchDeclarationOrder, shorthandFirst },
     } = ctx;
 
     ts.forEachChild(sourceFile, function cb(node): void {
@@ -135,13 +145,32 @@ function walk(ctx: Lint.WalkContext<Options>, checker?: ts.TypeChecker): void {
         }
 
         let lastKey: string | undefined;
+        let lastPropertyWasShorthand: boolean | undefined;
         for (const property of node.properties) {
             switch (property.kind) {
                 case ts.SyntaxKind.SpreadAssignment:
                     lastKey = undefined; // reset at spread
+                    lastPropertyWasShorthand = undefined; // reset at spread
                     break;
                 case ts.SyntaxKind.ShorthandPropertyAssignment:
                 case ts.SyntaxKind.PropertyAssignment:
+                    if (shorthandFirst) {
+                        if (property.kind === ts.SyntaxKind.ShorthandPropertyAssignment) {
+                            if (lastPropertyWasShorthand === false) {
+                                ctx.addFailureAtNode(property.name, Rule.FAILURE_STRING_SHORTHAND_FIRST(property.name.text));
+                                return; // only show warning on first out-of-order property
+                            }
+
+                            lastPropertyWasShorthand = true;
+                        } else {
+                            if (lastPropertyWasShorthand === true) {
+                                lastKey = undefined; // reset on change from shorthand to normal
+                            }
+
+                            lastPropertyWasShorthand = false;
+                        }
+                    }
+
                     if (property.name.kind === ts.SyntaxKind.Identifier ||
                         property.name.kind === ts.SyntaxKind.StringLiteral) {
                         const key = ignoreCase ? property.name.text.toLowerCase() : property.name.text;

--- a/test/rules/object-literal-sort-keys/shorthand-first/test.ts.lint
+++ b/test/rules/object-literal-sort-keys/shorthand-first/test.ts.lint
@@ -1,0 +1,79 @@
+const a = 'a'
+const c = 'c'
+const x = {}
+
+const fail1 = {
+  a,
+  b: 'b',
+  c,
+  ~  [shorthandErr % ('c')]
+  d: 'd',
+}
+
+const fail2 = {
+  c,
+  a,
+  ~  [alphaErr % ('a')]
+  b: 'b',
+  d: 'd',
+}
+
+const fail3 = {
+  a,
+  c,
+  d: 'd',
+  b: 'b',
+  ~       [alphaErr % ('b')]
+}
+
+const fail4 = {
+  c,
+  ...x,
+  a,
+  d: 'd',
+  b: 'b',
+  ~       [alphaErr % ('b')]
+}
+
+const pass1 = {
+  a,
+  c,
+  b: 'b',
+  d: 'd',
+}
+
+const pass2 = {
+  ...x,
+  a,
+  c,
+  b: 'b',
+  d: 'd',
+}
+
+const pass3 = {
+  a,
+  c,
+  ...x,
+  b: 'b',
+  d: 'd',
+}
+
+const pass4 = {
+  c,
+  ...x,
+  a,
+  b: 'b',
+  d: 'd',
+}
+
+const pass5 = {
+  d: 'd',
+  ...x,
+  c,
+  ...x,
+  a,
+  b: 'b',
+}
+
+[alphaErr]: The key '%s' is not sorted alphabetically
+[shorthandErr]: The shorthand property '%s' should appear before normal properties

--- a/test/rules/object-literal-sort-keys/shorthand-first/tslint.json
+++ b/test/rules/object-literal-sort-keys/shorthand-first/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "object-literal-sort-keys": [true, "shorthand-first"]
+  }
+}


### PR DESCRIPTION
Fix #3606

Similar to PR #2831 but different implementation and focused only on shorthand-first

#### PR checklist

- [x] Addresses an existing issue: #3606
- [x] New feature, bugfix and enhancement 🤔
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

[new-rule-option] [object-literal-sort-key] Add shorthand-first option