### PR TITLE
no-unbound-method: add another exception

### DIFF
--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -86,8 +86,9 @@ function isSafeUse(node: ts.Node): boolean {
             return (parent as ts.CallExpression).expression === node;
         case ts.SyntaxKind.TaggedTemplateExpression:
             return (parent as ts.TaggedTemplateExpression).tag === node;
-        // E.g. `obj.method.bind(obj)`.
+        // E.g. `obj.method.bind(obj) or obj.method["prop"]`.
         case ts.SyntaxKind.PropertyAccessExpression:
+        case ts.SyntaxKind.ElementAccessExpression:
             return true;
         // Allow most binary operators, but don't allow e.g. `myArray.forEach(obj.method || otherObj.otherMethod)`.
         case ts.SyntaxKind.BinaryExpression:

--- a/test/rules/no-unbound-method/default/test.ts.lint
+++ b/test/rules/no-unbound-method/default/test.ts.lint
@@ -6,6 +6,7 @@ function f(i: I) {
     i.m ? 1 : 2;
     if (i.m) {}
     !i.m;
+    i.m["length"];
     return i.m!;
            ~~~ [0]
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Reading a property of the unbound method with square brackets, though rare, should be allowed because it's not related to whether `this` is bound.

#### Is there anything you'd like reviewers to focus on?
No, but I'm happy to provide more details about where I needed this irl if necessary.

#### CHANGELOG.md entry:
[bugfix] `no-unbound-method`: allow square bracket property access