### PR TITLE
[docs] [ban-comma-operator] metadata updates

### DIFF
--- a/src/rules/banCommaOperatorRule.ts
+++ b/src/rules/banCommaOperatorRule.ts
@@ -50,8 +50,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         options: null,
         optionsDescription: "",
         optionExamples: [true],
-        type: "typescript",
-        typescriptOnly: true,
+        type: "functionality",
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys max-line-length */
 


### PR DESCRIPTION
#3611 1001 ### PR checklist   

- [x] Addresses an existing issue: [#3611](https://github.com/palantir/tslint/issues/3611)
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:
correctly lists ban-comma-operator as a non-TS-specific rule; changes "type" from "typescript" to "functionality" (is that right?)

#### Changelog entry

[docs] `ban-comma-operator`: fix metadata, list as "functionality" rule
  