### PR TITLE
fix no unnecessary space before parameter from arrow-parens fixer

### DIFF
--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -19,6 +19,7 @@ import { getChildOfKind, isArrowFunction } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { isCallExpression } from 'typescript';
 
 const BAN_SINGLE_ARG_PARENS = "ban-single-arg-parens";
 
@@ -72,8 +73,10 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 }
             } else if (ctx.options.banSingleArgParens) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
+                const parentNode = node.parent!;
+                const replaceValue = isCallExpression(parentNode) ? "" : " ";
                 ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
-                    Lint.Replacement.replaceFromTo(openParen.pos, node.parameters[0].getStart(ctx.sourceFile), " "),
+                    Lint.Replacement.replaceFromTo(openParen.pos, node.parameters[0].getStart(ctx.sourceFile), replaceValue),
                     Lint.Replacement.deleteFromTo(node.parameters[0].end, closeParen.end),
                 ]);
             }

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -73,7 +73,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
             } else if (ctx.options.banSingleArgParens) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
                 const charBeforeOpenParen = ctx.sourceFile.text.substring(openParen.pos - 1, openParen.pos);
-                const replaceValue = charBeforeOpenParen.match(/[a-z=]/i) ? " " : "";
+                const replaceValue = charBeforeOpenParen.match(/[a-z=]/i) !== null ? " " : "";
                 ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
                     Lint.Replacement.replaceFromTo(openParen.pos, node.parameters[0].getStart(ctx.sourceFile), replaceValue),
                     Lint.Replacement.deleteFromTo(node.parameters[0].end, closeParen.end),

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -73,7 +73,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
             } else if (ctx.options.banSingleArgParens) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
                 const charBeforeOpenParen = ctx.sourceFile.text.substring(openParen.pos - 1, openParen.pos);
-                const replaceValue = charBeforeOpenParen.match(/[a-z=]/i) !== null ? " " : "";
+                const replaceValue = charBeforeOpenParen.match(/[a-z]/i) !== null ? " " : "";
                 ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
                     Lint.Replacement.replaceFromTo(openParen.pos, node.parameters[0].getStart(ctx.sourceFile), replaceValue),
                     Lint.Replacement.deleteFromTo(node.parameters[0].end, closeParen.end),

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -72,8 +72,8 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 }
             } else if (ctx.options.banSingleArgParens) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
-                const parentNode = node.parent!;
-                const replaceValue = ts.isCallExpression(parentNode) ? "" : " ";
+                const charBeforeOpenParen = ctx.sourceFile.text.substring(openParen.pos - 1, openParen.pos);
+                const replaceValue = charBeforeOpenParen.match(/[a-z=]/i) ? " " : "";
                 ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
                     Lint.Replacement.replaceFromTo(openParen.pos, node.parameters[0].getStart(ctx.sourceFile), replaceValue),
                     Lint.Replacement.deleteFromTo(node.parameters[0].end, closeParen.end),

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -19,7 +19,6 @@ import { getChildOfKind, isArrowFunction } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { isCallExpression } from 'typescript';
 
 const BAN_SINGLE_ARG_PARENS = "ban-single-arg-parens";
 
@@ -74,7 +73,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
             } else if (ctx.options.banSingleArgParens) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
                 const parentNode = node.parent!;
-                const replaceValue = isCallExpression(parentNode) ? "" : " ";
+                const replaceValue = ts.isCallExpression(parentNode) ? "" : " ";
                 ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
                     Lint.Replacement.replaceFromTo(openParen.pos, node.parameters[0].getStart(ctx.sourceFile), replaceValue),
                     Lint.Replacement.deleteFromTo(node.parameters[0].end, closeParen.end),

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -41,3 +41,5 @@ let foo = bar => bar;
 let foo = async bar => bar;
 
 arr.map(a => b);
+
+foo(async a => b)

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -22,6 +22,8 @@ const validAsync = async (param: any) => {};
 var e = (a => {})(1);
 var f = ab => {};
 
+arr.map(a => b);
+
 // invalid case
 var a = a => {};
 const invalidAsync = async param => {};
@@ -38,3 +40,4 @@ let foo = bar => bar;
 
 let foo = async bar => bar;
 
+arr.map(a => b);

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.fix
@@ -25,21 +25,27 @@ var f = ab => {};
 arr.map(a => b);
 
 // invalid case
-var a = a => {};
+var a =a => {};
 const invalidAsync = async param => {};
 const invalidAsync = async param => {};
 
 // parens required when return type annotation is present
 const fn = (param): void => {};
 
-let foo = bar => bar;
+let foo =bar => bar;
 
-let foo = bar => bar;
+let foo =bar => bar;
 
-let foo = bar => bar;
+let foo =bar => bar;
 
 let foo = async bar => bar;
 
 arr.map(a => b);
 
-foo(async a => b)
+foo(async a => b);
+
+function *gen() { yield a => b; }
+
+export default a => b;
+
+throw a => b;

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -22,6 +22,8 @@ const validAsync = async (param: any) => {};
 var e = (a => {})(1);
 var f = ab => {};
 
+arr.map(a => b);
+
 // invalid case
 var a = (a) => {};
          ~         [0]
@@ -51,4 +53,6 @@ let foo = async (
     ~~~ [0]
 ) => bar;
 
+arr.map((a) => b);
+         ~ [0]
 [0]: Parentheses are prohibited around the parameter in this single parameter arrow function

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -55,4 +55,7 @@ let foo = async (
 
 arr.map((a) => b);
          ~ [0]
+
+foo(async (a) => b)
+           ~ [0]
 [0]: Parentheses are prohibited around the parameter in this single parameter arrow function

--- a/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
+++ b/test/rules/arrow-parens/ban-single-arg-parens/test.ts.lint
@@ -56,6 +56,15 @@ let foo = async (
 arr.map((a) => b);
          ~ [0]
 
-foo(async (a) => b)
+foo(async (a) => b);
            ~ [0]
+
+function *gen() { yield (a) => b; }
+                         ~ [0]
+
+export default (a) => b;
+                ~ [0]
+
+throw (a) => b;
+       ~ [0]
 [0]: Parentheses are prohibited around the parameter in this single parameter arrow function


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3563
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Fixer for ban-single-arg-parens doesn't add unnecessary whitespace before argument if parent node is a call expresion.

#### CHANGELOG.md entry:
[bugfix] no unnecessary whitespace before argument in callback functions fixed with arrow-parens fixer
