### PR TITLE
one-line: Check block in case clause

### DIFF
--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -81,7 +81,8 @@ class OneLineWalker extends Lint.AbstractWalker<Options> {
         const cb = (node: ts.Node): void => {
             switch (node.kind) {
                 case ts.SyntaxKind.Block:
-                    if (!isBlockLike(node.parent!)) {
+                    if (!isBlockLike(node.parent!)
+                        || node.parent!.kind === ts.SyntaxKind.CaseClause && (node.parent as ts.CaseClause).statements.length === 1) {
                         this.check({pos: node.pos, end: (node as ts.Block).statements.pos});
                     }
                     break;

--- a/test/rules/one-line/all/test.ts.fix
+++ b/test/rules/one-line/all/test.ts.fix
@@ -30,9 +30,10 @@ for(var x= 0; x < 1; ++x) {
 }
 
 switch(y) {
-    case 0:
+    case 0: {
         x--;
         break;
+    }
     default:
         x++;
         break;

--- a/test/rules/one-line/all/test.ts.lint
+++ b/test/rules/one-line/all/test.ts.lint
@@ -49,8 +49,11 @@ switch(y)
 {
 ~ [misplaced opening brace]
     case 0:
+    {
+    ~ [misplaced opening brace]
         x--;
         break;
+    }
     default:
         x++;
         break;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

This rule previously did not check the block in `case 0: { ... }` because `isBlockLike` returns true for `CaseClause`s.

#### CHANGELOG.md entry:

[bugfix] `one-line`: Check block in a case clause
