### PR TITLE
Add the option allow-empty-functions in no-empty

### DIFF
--- a/test/rules/no-empty/allow-empty-functions/test.ts.lint
+++ b/test/rules/no-empty/allow-empty-functions/test.ts.lint
@@ -10,17 +10,14 @@ if (x === 2) {
 ~ [block is empty]
 
 function testFunction1() {
-                         ~
 
-~nil
+
+
 }
-~ [block is empty]
 
 const testFunction2 = () => { };
-                            ~~~  [block is empty]
 
 const testFunction3 = function() {}
-                                 ~~ [block is empty]
 
 for (var x = 0; x < 1; ++x) { }
                             ~~~ [block is empty]
@@ -73,3 +70,4 @@ class PublicClassConstructor {
 try {
     throw new Error();
 } catch (error) {}
+                ~~ [block is empty]

--- a/test/rules/no-empty/allow-empty-functions/tslint.json
+++ b/test/rules/no-empty/allow-empty-functions/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-empty": [true, "allow-empty-functions"]
+  }
+}

--- a/test/rules/no-empty/default/test.ts.lint
+++ b/test/rules/no-empty/default/test.ts.lint
@@ -9,12 +9,18 @@ if (x === 2) {
 }
 ~ [block is empty]
 
-function testFunction() {
-                        ~
+function testFunction1() {
+                         ~
 
 ~nil
 }
 ~ [block is empty]
+
+const testFunction2 = () => { };
+                            ~~~  [block is empty]
+
+const testFunction3 = function() {}
+                                 ~~ [block is empty]
 
 for (var x = 0; x < 1; ++x) { }
                             ~~~ [block is empty]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2107
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Introduces option to allow function declarations to be empty while using `no-empty`.

#### Is there anything you'd like reviewers to focus on?

This is my first PR to tslint, so any feedback is welcome.  
I was a bit unsure if I did the correct setup for the `options` property (an `array` with an `anyOf` of the two strings).

#### CHANGELOG.md entry:

[enhancement] Introduces option to allow function declarations to be empty while using `no-empty`.