### PR TITLE
Ban rule identifies types in JSX now.

### DIFF
--- a/src/rules/banTypesRule.ts
+++ b/src/rules/banTypesRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isTypeReferenceNode } from "tsutils";
+import { isJsxOpeningElement, isJsxSelfClosingElement, isTypeReferenceNode } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -65,8 +65,17 @@ function parseOption([pattern, message]: [string, string | undefined]): Option {
 
 function walk(ctx: Lint.WalkContext<Option[]>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+
+        let typeName: string | null =  null;
         if (isTypeReferenceNode(node)) {
-            const typeName = node.getText(ctx.sourceFile);
+            typeName = node.getText(ctx.sourceFile);
+        }
+
+        if (isJsxOpeningElement(node) || isJsxSelfClosingElement(node)) {
+            typeName = node.tagName.getText();
+        }
+
+        if (typeName !== null) {
             for (const ban of ctx.options) {
                 if (ban.pattern.test(typeName)) {
                     ctx.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(typeName, ban.message));

--- a/test/rules/ban-types/test.tsx.lint
+++ b/test/rules/ban-types/test.tsx.lint
@@ -11,6 +11,17 @@ let c: F;
 let d: Foooooo;
        ~~~~~~~ [Don't use 'Foooooo' as a type.]
 
+render(): {
+    return (
+        <h/>
+        ~~~~ [Don't use 'h' as a type. Use 'div' instead.]
+        <h>test</h>
+        ~~~ [Don't use 'h' as a type. Use 'div' instead.]
+        );
+}
+
+render
+
 // no warning for separately scoped types
 let e: foo.String;
 

--- a/test/rules/ban-types/tslint.json
+++ b/test/rules/ban-types/tslint.json
@@ -4,7 +4,8 @@
       true,
       ["String", "Use 'string' instead."],
       ["Object"],
-      ["Fo*"]
+      ["Fo*"],
+      ["h", "Use 'div' instead."]
     ]
   }
 }


### PR DESCRIPTION
#### PR checklist

- [X ] New feature, bugfix, or enhancement
  - [ X] Includes tests

#### Overview of change:
Currently, banType doesn't work as expected for JSX Elements.
This pull request fixes this problem and adds new tests.
I didn't update the documentation as I think this is a bug, not a new feature.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[bugfix] `banType` --> supports JSX elements.
