### PR TITLE
Resolve custom paths when loading rules

### DIFF
--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -123,13 +123,13 @@ function loadCachedRule(directory: string, ruleName: string, isCustomPath?: bool
         return cachedRule === "not-found" ? undefined : cachedRule;
     }
 
-    // get absolute path
+    // resolve directory as an absolute path if it's a custom rule directory
     let absolutePath: string = directory;
     if (isCustomPath) {
-        if (!fs.existsSync(directory)) {
+        absolutePath = path.resolve(directory);
+        if (!fs.existsSync(absolutePath)) {
             throw new FatalError(`Could not find custom rule directory: ${directory}`);
         }
-        absolutePath = path.resolve(directory);
     }
 
     const Rule = loadRule(absolutePath, ruleName);

--- a/src/ruleLoader.ts
+++ b/src/ruleLoader.ts
@@ -81,6 +81,7 @@ export function loadRules(ruleOptionsList: IOptions[],
     return rules;
 }
 
+/** @internal private API */
 export function findRule(name: string, rulesDirectories?: string | string[]): RuleConstructor | undefined {
     const camelizedName = transformName(name);
     // first check for core rules
@@ -123,12 +124,12 @@ function loadCachedRule(directory: string, ruleName: string, isCustomPath?: bool
         return cachedRule === "not-found" ? undefined : cachedRule;
     }
 
-    // resolve directory as an absolute path if it's a custom rule directory
+    // treat directory as a relative path (which needs to be resolved) if it's a custom rule directory
     let absolutePath: string = directory;
     if (isCustomPath) {
         absolutePath = path.resolve(directory);
         if (!fs.existsSync(absolutePath)) {
-            throw new FatalError(`Could not find custom rule directory: ${directory}`);
+            throw new FatalError(`Could not find custom rule directory: ${absolutePath}`);
         }
     }
 


### PR DESCRIPTION
Fixes #3638 

tslint-loader was using an undocumented feature which allowed `rulesDirectory` to be an empty string without warnings or errors: https://github.com/wbuchwalter/tslint-loader/blob/4d166651d916a0c43dd5a11099d6ff532350e27b/index.js#L59

This did expose a bug in tslint 5.9.0, though, because we started throwing an error prematurely before resolving the rulesDirectory path to an absolute path.