### PR TITLE
feat(configuration): set js rules to all valid active rules

### DIFF
--- a/docs/usage/configuration/index.md
+++ b/docs/usage/configuration/index.md
@@ -29,7 +29,7 @@ A path to a directory or an array of paths to directories of [custom rules][2]. 
   - A boolean value may be specified instead of the above object, and is equivalent to setting no options with default severity.
   - Any rules specified in this block will override those configured in any base configuration being extended.
   - [Check out the full rules list here][3].
-* `jsRules?: any`: Same format as `rules`. These rules are applied to `.js` and `.jsx` files.
+* `jsRules?: any | boolean`: Same format as `rules` or explicit `true` to copy all valid active rules from rules. These rules are applied to `.js` and `.jsx` files.
 * `defaultSeverity?: "error" | "warning" | "off"`: The severity level that is applied to rules in this config file as well as rules in any inherited config files which have their severity set to "default". If undefined, "error" is used as the defaultSeverity.
 * `linterOptions?: { exclude?: string[] }`:
   - `exclude: string[]`: An array of globs. Any file matching these globs will not be linted. All exclude patterns are relative to the configuration file they were specified in.

--- a/test/configurationTests.ts
+++ b/test/configurationTests.ts
@@ -119,6 +119,53 @@ describe("Configuration", () => {
                 },
             );
         });
+
+        it("parses jsRules when jsRules is a config", () => {
+            const rawConfig: RawConfigFile = {
+                jsRules: {
+                    a: true,
+                },
+            };
+
+            const expected = getEmptyConfig();
+            expected.jsRules.set("a", { ruleArguments: [], ruleSeverity: "error" });
+            assertConfigEquals(parseConfigFile(rawConfig), expected);
+        });
+
+        it("copies valid rules to jsRules when jsRules is a boolean", () => {
+            let rawConfig: RawConfigFile = {
+                jsRules: true,
+                rules: {},
+            };
+
+            const expected = getEmptyConfig();
+            assertConfigEquals(parseConfigFile(rawConfig), expected);
+
+            rawConfig = {
+                jsRules: true,
+                rules: {
+                    eofline: true,
+                },
+            };
+
+            let {rules, jsRules} = parseConfigFile(rawConfig);
+            assert.deepEqual(demap(rules), demap(jsRules));
+
+            rawConfig = {
+                jsRules: true,
+                rules: {
+                    eofline: true,
+                    typedef: true,
+                },
+            };
+
+            ({rules, jsRules} = parseConfigFile(rawConfig));
+            assert(jsRules.has("eofline"));
+            assert(!jsRules.has("typedef"));
+
+            rules.delete("typedef");
+            assert.deepEqual(demap(rules), demap(jsRules));
+        });
     });
 
     describe("defaultSeverity", () => {


### PR DESCRIPTION
jsRules can now be a boolean. If it is set to true then parseConfig file, will copy over all active rules that can be applied to js to the jsRules configuration.

#### PR checklist

- [x] Addresses an existing issue: #2198
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

I added comments to the files changed

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
