### PR TITLE
no-implicit-dependencies - find similar package names

### DIFF
--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -60,9 +60,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING_FACTORY(module: string, similarPackage?: string) {
-        return similarPackage
-            ? `Module '${module}' is not listed as dependency in package.json. Did you mean '${similarPackage}'?`
-            : `Module '${module}' is not listed as dependency in package.json`;
+        if (similarPackage === undefined) {
+            return `Module '${module}' is not listed as dependency in package.json`;
+        } else {
+            return `Module '${module}' is not listed as dependency in package.json. Did you mean '${similarPackage}'?`;
+        }
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -108,7 +110,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
 
     // Shift4 algorithm (common version) by Costin Manda (siderite)
     // for implementation details see: https://siderite.blogspot.com/2014/11/super-fast-and-accurate-string-distance.html
-    function sift4(s1: string, s2: string) {
+    function sift4(s1: string, s2: string): number {
         const maxOffset = 2;
         const l1 = s1.length;
         const l2 = s2.length;

--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -59,7 +59,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_FACTORY(module: string, similarPackage: string | boolean) {
+    public static FAILURE_STRING_FACTORY(module: string, similarPackage?: string) {
         return similarPackage
             ? `Module '${module}' is not listed as dependency in package.json. Did you mean '${similarPackage}'?`
             : `Module '${module}' is not listed as dependency in package.json`;
@@ -92,7 +92,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
         return dependencies.has(module);
     }
 
-    function findSimilarPackage(module: string): string | boolean {
+    function findSimilarPackage(module: string): string | undefined {
         let minDifference = 2;
         let similarPackageName;
         dependencies!.forEach((dependency) => {
@@ -103,7 +103,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
             }
         });
 
-        return similarPackageName ? similarPackageName : false;
+        return similarPackageName;
     }
 
     // Shift4 algorithm (common version) by Costin Manda (siderite)

--- a/test/rules/no-implicit-dependencies/default/subdir/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/subdir/test.ts.lint
@@ -17,7 +17,7 @@ export * from "@angular/common/http";
 import * as ts from "typescript";
 
 import "baz/foo";
-       ~~~~~~~~~ [err % ('baz')]
+       ~~~~~~~~~ [err1 % ('baz', 'bar')]
 
 const http = require('http');
 

--- a/test/rules/no-implicit-dependencies/default/subdir/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/subdir/test.ts.lint
@@ -3,7 +3,7 @@ import {assert} from 'chai';
 import foo from 'foo';
 
 import Foo from 'Foo';
-                ~~~~~ [err % ('Foo')]
+                ~~~~~ [err1 % ('Foo', 'foo')]
 
 if (foo) {
     const common = require('common');
@@ -24,3 +24,4 @@ const http = require('http');
 import test from '../test.ts';
 
 [err]: Module '%s' is not listed as dependency in package.json
+[err1]: Module '%s' is not listed as dependency in package.json. Did you mean '%s'?

--- a/test/rules/no-implicit-dependencies/default/test.js.lint
+++ b/test/rules/no-implicit-dependencies/default/test.js.lint
@@ -1,10 +1,11 @@
 const foo = require('foo');
 const bar = require('bar');
 const baz = require('baz');
-                    ~~~~~ [err % ('baz')]
+                    ~~~~~ [err1 % ('baz', 'bar')]
 
 import storageHelper from 'storage-helper';
                           ~~~~~~~~~~~~~~~~ [err % ('storage-helper')]
 const myModule = require('./myModule');
 
 [err]: Module '%s' is not listed as dependency in package.json
+[err1]: Module '%s' is not listed as dependency in package.json. Did you mean '%s'?

--- a/test/rules/no-implicit-dependencies/default/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/test.ts.lint
@@ -16,7 +16,7 @@ export * from "@ngular/core";
               ~~~~~~~~~~~~~~ [err1 % ('@ngular/core', '@angular/core')]
 
 export * from "@nglar/core";
-              ~~~~~~~~~~~~~~ [err % ('@nglar/core')]
+              ~~~~~~~~~~~~~ [err % ('@nglar/core')]
 
 export * from "@angular/common/http";
 

--- a/test/rules/no-implicit-dependencies/default/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/test.ts.lint
@@ -12,17 +12,32 @@ export * from "@angular/core";
 export * from "@Angular/core";
               ~~~~~~~~~~~~~~~ [err1 % ('@Angular/core', '@angular/core')]
 
+export * from "@ngular/core";
+              ~~~~~~~~~~~~~~ [err1 % ('@ngular/core', '@angular/core')]
+
+export * from "@nglar/core";
+              ~~~~~~~~~~~~~~ [err % ('@nglar/core')]
+
 export * from "@angular/common/http";
 
 import * as ts from "typescript";
 
+import * as ts from "tepscript";
+                    ~~~~~~~~~~~ [err1 % ('tepscript', 'typescript')]
+
+import * as ts from "ypescript";
+                    ~~~~~~~~~~~ [err1 % ('ypescript', 'typescript')]
+
+import * as ts from "terscript";
+                    ~~~~~~~~~~~ [err % ('terscript')]
+
 import "baz";
-       ~~~~~ [err % ('baz')]
+       ~~~~~ [err1 % ('baz', 'bar')]
 
 const http = require('http');
 
 import * as fsevents from "fsevents";
                           ~~~~~~~~~~ [err % ('fsevents')]
-
+                          
 [err]: Module '%s' is not listed as dependency in package.json
 [err1]: Module '%s' is not listed as dependency in package.json. Did you mean '%s'?

--- a/test/rules/no-implicit-dependencies/default/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/test.ts.lint
@@ -9,6 +9,9 @@ if (foo) {
 
 export * from "@angular/core";
 
+export * from "@Angular/core";
+              ~~~~~~~~~~~~~~~ [err1 % ('@Angular/core', '@angular/core')]
+
 export * from "@angular/common/http";
 
 import * as ts from "typescript";
@@ -22,3 +25,4 @@ import * as fsevents from "fsevents";
                           ~~~~~~~~~~ [err % ('fsevents')]
 
 [err]: Module '%s' is not listed as dependency in package.json
+[err1]: Module '%s' is not listed as dependency in package.json. Did you mean '%s'?

--- a/test/rules/no-implicit-dependencies/dev/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/dev/test.ts.lint
@@ -6,10 +6,11 @@ import {assert} from 'chai';
 import foo from 'foo';
 
 import {baz} from 'baz';
-                  ~~~~~ [err % ('baz')]
+                  ~~~~~ [err1 % ('baz', 'bar')]
 
 
 import * as fsevents from "fsevents";
                           ~~~~~~~~~~ [err % ('fsevents')]
 
 [err]: Module '%s' is not listed as dependency in package.json
+[err1]: Module '%s' is not listed as dependency in package.json. Did you mean '%s'?

--- a/test/rules/no-implicit-dependencies/optional/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/optional/test.ts.lint
@@ -6,8 +6,9 @@ import {assert} from 'chai';
 import foo from 'foo';
 
 import {baz} from 'baz';
-                  ~~~~~ [err % ('baz')]
+                  ~~~~~ [err1 % ('baz', 'bar')]
 
 import * as fsevents from "fsevents";
 
 [err]: Module '%s' is not listed as dependency in package.json
+[err1]: Module '%s' is not listed as dependency in package.json. Did you mean '%s'?


### PR DESCRIPTION
#### PR checklist

- [x ] Addresses an existing issue: #3446
- [x ] New feature, bugfix, or enhancement
  - [x ] Includes tests
- [ ] Documentation update

#### Overview of change:
The message from no-implicit-dependencies now contains a hint if someone typed dependency name with simple typos.

#### Is there anything you'd like reviewers to focus on?
I'm wondering if we can do this more helpful and try to 'guess' which dependency author had in mind using some kind of names comparison and looking for similarity (see for example: https://github.com/aceakash/string-similarity).

#### CHANGELOG.md entry:
[enhancement]: message from no-implicit-dependencies contains a hint with dependency name