### PR TITLE
no-use-before-declare rule ignores creating instances of a class

### DIFF
--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -79,7 +79,8 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
         const declaredBefore = declarations.some((decl) => {
             switch (decl.kind) {
                 case ts.SyntaxKind.FunctionDeclaration:
-                    // Functions may be declared later.
+                case ts.SyntaxKind.ClassDeclaration:
+                    // Functions and classes may be declared later.
                     return true;
                 default:
                     // Use `<=` in case this *is* the declaration.

--- a/test/rules/no-use-before-declare/test.ts.lint
+++ b/test/rules/no-use-before-declare/test.ts.lint
@@ -94,3 +94,14 @@ class Greeter {
 }
 
 undefined;
+
+class A { b: B = new B(); }
+class B { }
+
+class Foo {
+  test() {
+      const bar = new Bar();
+  }
+}
+
+class Bar {}


### PR DESCRIPTION
#### PR checklist

- [x ] Addresses an existing issue: #3011
- [ x] New feature, bugfix, or enhancement
  - [x ] Includes tests
- [ ] Documentation update

#### Overview of change:
Rule no-use-before-declare ignores creating instance of a class before class declaration.

#### Is there anything you'd like reviewers to focus on?

#### CHANGELOG.md entry:
[enhancement]:  no-use-before-declare ignores using class before its declaration
