### PR TITLE
Fix max-line-length "< 0" typo

### DIFF
--- a/rules/max-line-length/index.html
+++ b/rules/max-line-length/index.html
@@ -11,7 +11,7 @@ optionsDescription: |-
   It can take one argument, which can be any of the following:
   * integer indicating maximum length of lines.
   * object with keys:
-    * `limit` - number < 0 defining max line length
+    * `limit` - number > 0 defining max line length
     * `ignore-pattern` - string defining ignore pattern for this rule, being parsed by `new RegExp()`.
       For example:
        * `// ` pattern will ignore all in-line comments.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

Noticed a typo in the docs for the `max-line-length` rule, where it states that the `limit` property is a number _less_ than 0

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
