### PR TITLE
Fixed "manging" typo in no-this-assignment

### DIFF
--- a/src/rules/noThisAssignmentRule.ts
+++ b/src/rules/noThisAssignmentRule.ts
@@ -80,7 +80,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`${ALLOW_THIS_DESTRUCTURING}\` allows using destructuring to access members of \`this\` (e.g. \`{ foo, bar } = this;\`).
             * \`${ALLOWED_THIS_NAMES}\` may be specified as a list of regular expressions to match allowed variable names.`,
         rationale: "Assigning a variable to `this` instead of properly using arrow lambdas "
-            + "may be a symptom of pre-ES6 practices or not manging scope well.",
+            + "may be a symptom of pre-ES6 practices or not managing scope well.",
         ruleName: "no-this-assignment",
         type: "functionality",
         typescriptOnly: false,


### PR DESCRIPTION
It's been there since Jun 2017 :(