### PR TITLE
Add missing ignore-bound-class-methods value to semicolon rules enum.

### DIFF
--- a/_data/rules.json
+++ b/_data/rules.json
@@ -2938,7 +2938,8 @@
         {
           "type": "string",
           "enum": [
-            "ignore-interfaces"
+            "ignore-interfaces",
+            "ignore-bound-class-methods"
           ]
         }
       ],


### PR DESCRIPTION
#### PR checklist

- [ ] Documentation update

#### Overview of change:

[The semicolon rule docs](https://palantir.github.io/tslint/rules/semicolon/) mention the `ignore-bound-class-methods` enum value, but don't include it in the provided schema.  This PR updates the schema accordingly.