### PR TITLE
added no-implicit-constructor-visibility rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -202,6 +202,7 @@ export const rules = {
     "no-angle-bracket-type-assertion": true,
     "no-boolean-literal-compare": true,
     "no-consecutive-blank-lines": true,
+    "no-implicit-constructor-visibility": true,
     "no-parameter-properties": true,
     "no-redundant-jsdoc": true,
     "no-reference-import": true,

--- a/src/error.ts
+++ b/src/error.ts
@@ -26,7 +26,7 @@ export declare class Error {
     public name?: string;
     public message: string;
     public stack?: string;
-    constructor(message?: string);
+    public constructor(message?: string);
 }
 
 /**
@@ -34,7 +34,7 @@ export declare class Error {
  */
 export class FatalError extends Error {
     public static NAME = "FatalError";
-    constructor(public message: string, public innerError?: Error) {
+    public constructor(public message: string, public innerError?: Error) {
         super(message);
         this.name = FatalError.NAME;
 

--- a/src/language/rule/abstractRule.ts
+++ b/src/language/rule/abstractRule.ts
@@ -28,7 +28,7 @@ export abstract class AbstractRule implements IRule {
     protected readonly ruleSeverity: RuleSeverity;
     public ruleName: string;
 
-    constructor(private readonly options: IOptions) {
+    public constructor(private readonly options: IOptions) {
         this.ruleName = options.ruleName;
         this.ruleArguments = options.ruleArguments;
         this.ruleSeverity = options.ruleSeverity;

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -183,7 +183,8 @@ export class Replacement {
         return new Replacement(start, 0, text);
     }
 
-    constructor(readonly start: number, readonly length: number, readonly text: string) {}
+    public constructor(readonly start: number, readonly length: number, readonly text: string) {
+    }
 
     get end() {
         return this.start + this.length;
@@ -205,7 +206,7 @@ export class Replacement {
 }
 
 export class RuleFailurePosition {
-    constructor(private readonly position: number, private readonly lineAndCharacter: ts.LineAndCharacter) {
+    public constructor(private readonly position: number, private readonly lineAndCharacter: ts.LineAndCharacter) {
     }
 
     public getPosition() {
@@ -251,12 +252,12 @@ export class RuleFailure {
         return a.startPosition.getPosition() - b.startPosition.getPosition();
     }
 
-    constructor(private readonly sourceFile: ts.SourceFile,
-                start: number,
-                end: number,
-                private readonly failure: string,
-                private readonly ruleName: string,
-                private readonly fix?: Fix) {
+    public constructor(private readonly sourceFile: ts.SourceFile,
+                       start: number,
+                       end: number,
+                       private readonly failure: string,
+                       private readonly ruleName: string,
+                       private readonly fix?: Fix) {
 
         this.fileName = sourceFile.fileName;
         this.startPosition = this.createFailurePosition(start);

--- a/src/language/walker/blockScopeAwareRuleWalker.ts
+++ b/src/language/walker/blockScopeAwareRuleWalker.ts
@@ -32,7 +32,7 @@ import { ScopeAwareRuleWalker } from "./scopeAwareRuleWalker";
 export abstract class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalker<T> {
     private readonly blockScopeStack: U[];
 
-    constructor(sourceFile: ts.SourceFile, options: IOptions) {
+    public constructor(sourceFile: ts.SourceFile, options: IOptions) {
         super(sourceFile, options);
 
         // initialize with global scope if file is not a module

--- a/src/language/walker/programAwareRuleWalker.ts
+++ b/src/language/walker/programAwareRuleWalker.ts
@@ -23,7 +23,7 @@ import { RuleWalker } from "./ruleWalker";
 export class ProgramAwareRuleWalker extends RuleWalker {
     private readonly typeChecker: ts.TypeChecker;
 
-    constructor(sourceFile: ts.SourceFile, options: IOptions, private readonly program: ts.Program) {
+    public constructor(sourceFile: ts.SourceFile, options: IOptions, private readonly program: ts.Program) {
         super(sourceFile, options);
 
         this.typeChecker = program.getTypeChecker();

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -27,7 +27,7 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
     private readonly failures: RuleFailure[];
     private readonly ruleName: string;
 
-    constructor(private readonly sourceFile: ts.SourceFile, options: IOptions) {
+    public constructor(private readonly sourceFile: ts.SourceFile, options: IOptions) {
         super();
 
         this.failures = [];

--- a/src/language/walker/scopeAwareRuleWalker.ts
+++ b/src/language/walker/scopeAwareRuleWalker.ts
@@ -58,7 +58,7 @@ import { RuleWalker } from "./ruleWalker";
 export abstract class ScopeAwareRuleWalker<T> extends RuleWalker {
     private readonly scopeStack: T[];
 
-    constructor(sourceFile: ts.SourceFile, options: IOptions) {
+    public constructor(sourceFile: ts.SourceFile, options: IOptions) {
         super(sourceFile, options);
 
         // initialize with global scope if file is not a module

--- a/src/language/walker/walkContext.ts
+++ b/src/language/walker/walkContext.ts
@@ -22,7 +22,7 @@ import { Fix, RuleFailure } from "../rule/rule";
 export class WalkContext<T> {
     public readonly failures: RuleFailure[] = [];
 
-    constructor(public readonly sourceFile: ts.SourceFile, public readonly ruleName: string, public readonly options: T) {}
+    public constructor(public readonly sourceFile: ts.SourceFile, public readonly ruleName: string, public readonly options: T) {}
 
     /** Add a failure with any arbitrary span. Prefer `addFailureAtNode` if possible. */
     public addFailureAt(start: number, width: number, failure: string, fix?: Fix) {

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -101,7 +101,7 @@ export class Linter {
         );
     }
 
-    constructor(private readonly options: ILinterOptions, private program?: ts.Program) {
+    public constructor(private readonly options: ILinterOptions, private program?: ts.Program) {
         if (typeof options !== "object") {
             throw new Error(`Unknown Linter options type: ${typeof options}`);
         }

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -364,7 +364,7 @@ function getMemberKind(member: Member): MemberKind | undefined {
 
 type MemberCategoryJson = { name: string; kinds: string[] } | string;
 class MemberCategory {
-    constructor(readonly name: string, private readonly kinds: Set<MemberKind>) {}
+    public constructor(readonly name: string, private readonly kinds: Set<MemberKind>) {}
     public has(kind: MemberKind) { return this.kinds.has(kind); }
 }
 

--- a/src/rules/noImplicitConstructorVisibilityRule.ts
+++ b/src/rules/noImplicitConstructorVisibilityRule.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static metadata: Lint.IRuleMetadata = {
+        description: "Forces specifying a visibility modifier for constructor statements.",
+        options: null,
+        optionsDescription: "Not configurable.",
+        ruleName: "no-implicit-constructor-visibility",
+        type: "style",
+        typescriptOnly: true,
+    };
+
+    public static FAILURE_STRING = "Constructor visibility must be specified";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+const isConstructorVisibilityDefined = (node: ts.ConstructorDeclaration): boolean =>
+    node.modifiers !== undefined;
+
+const createFix = (node: ts.ConstructorDeclaration): Lint.Replacement =>
+    Lint.Replacement.appendText(node.getStart(), "public ");
+
+function walk(context: Lint.WalkContext<void>) {
+    const callback = (node: ts.Node): void => {
+        if (ts.isConstructorDeclaration(node) && !isConstructorVisibilityDefined(node)) {
+            context.addFailureAtNode(node.getFirstToken(), Rule.FAILURE_STRING, createFix(node));
+        } else {
+            ts.forEachChild(node, callback);
+        }
+    };
+
+    return ts.forEachChild(context.sourceFile, callback);
+}

--- a/src/rules/noImplicitConstructorVisibilityRule.ts
+++ b/src/rules/noImplicitConstructorVisibilityRule.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
+import * as utils from "tsutils";
 import * as ts from "typescript";
-
 import * as Lint from "../index";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -44,7 +44,7 @@ const createFix = (node: ts.ConstructorDeclaration): Lint.Replacement =>
 
 function walk(context: Lint.WalkContext<void>) {
     const callback = (node: ts.Node): void => {
-        if (ts.isConstructorDeclaration(node) && !isConstructorVisibilityDefined(node)) {
+        if (utils.isConstructorDeclaration(node) && !isConstructorVisibilityDefined(node)) {
             context.addFailureAtNode(node.getFirstToken(), Rule.FAILURE_STRING, createFix(node));
         } else {
             ts.forEachChild(node, callback);

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -42,7 +42,7 @@ export class Rule extends Lint.Rules.TypedRule {
 }
 
 class NoInferredEmptyObjectTypeRule extends Lint.AbstractWalker<void> {
-    constructor(sourceFile: ts.SourceFile, ruleName: string, private readonly checker: ts.TypeChecker) {
+    public constructor(sourceFile: ts.SourceFile, ruleName: string, private readonly checker: ts.TypeChecker) {
         super(sourceFile, ruleName, undefined);
     }
 

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -119,7 +119,7 @@ class Scope {
     public variables = new Map<string, VariableInfo[]>();
     public variablesSeen = new Map<string, ts.Identifier[]>();
     public reassigned = new Set<string>();
-    constructor(functionScope?: Scope) {
+    public constructor(functionScope?: Scope) {
         // if no functionScope is provided we are in the process of creating a new function scope, which for consistency links to itself
         this.functionScope = functionScope !== undefined ? functionScope : this;
     }

--- a/src/rules/noUnnecessaryTypeAssertionRule.ts
+++ b/src/rules/noUnnecessaryTypeAssertionRule.ts
@@ -47,7 +47,7 @@ export class Rule extends Lint.Rules.TypedRule {
 }
 
 class Walker extends Lint.AbstractWalker<string[]> {
-    constructor(sourceFile: ts.SourceFile, ruleName: string, options: string[], private readonly checker: ts.TypeChecker) {
+    public constructor(sourceFile: ts.SourceFile, ruleName: string, options: string[], private readonly checker: ts.TypeChecker) {
         super(sourceFile, ruleName, options);
     }
 

--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -45,7 +45,7 @@ export class Rule extends Lint.Rules.TypedRule {
 }
 
 class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
-    constructor(sourceFile: ts.SourceFile, ruleName: string, private readonly checker: ts.TypeChecker) {
+    public constructor(sourceFile: ts.SourceFile, ruleName: string, private readonly checker: ts.TypeChecker) {
         super(sourceFile, ruleName, undefined);
     }
 

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -76,7 +76,7 @@ class Scope {
     public functionScope: Scope;
     public variables = new Map<string, VariableInfo>();
     public reassigned = new Set<string>();
-    constructor(functionScope?: Scope) {
+    public constructor(functionScope?: Scope) {
         // if no functionScope is provided we are in the process of creating a new function scope, which for consistency links to itself
         this.functionScope = functionScope === undefined ? this : functionScope;
     }

--- a/src/verify/lines.ts
+++ b/src/verify/lines.ts
@@ -16,13 +16,13 @@
 
 // Use classes here instead of interfaces because we want runtime type data
 export class Line { }
-export class CodeLine extends Line { constructor(public contents: string) { super(); } }
-export class MessageSubstitutionLine extends Line { constructor(public key: string, public message: string) { super(); } }
+export class CodeLine extends Line { public constructor(public contents: string) { super(); } }
+export class MessageSubstitutionLine extends Line { public constructor(public key: string, public message: string) { super(); } }
 
-export class ErrorLine extends Line { constructor(public startCol: number) { super(); } }
-export class MultilineErrorLine extends ErrorLine { constructor(startCol: number) { super(startCol); } }
+export class ErrorLine extends Line { public constructor(public startCol: number) { super(); } }
+export class MultilineErrorLine extends ErrorLine { public constructor(startCol: number) { super(startCol); } }
 export class EndErrorLine extends ErrorLine {
-    constructor(startCol: number, public endCol: number, public message: string) { super(startCol); }
+    public constructor(startCol: number, public endCol: number, public message: string) { super(startCol); }
 }
 
 // example matches (between the quotes):

--- a/test/rules/no-implicit-constructor-visibility/test.ts.fix
+++ b/test/rules/no-implicit-constructor-visibility/test.ts.fix
@@ -1,0 +1,36 @@
+class Constructor {
+    public constructor(anotherConstructorParameter: string) { }
+}
+
+class ConstructorContainsContents {
+    public constructor() {
+        console.log("Hello!");
+    }
+}
+
+class ConstructorWithParametersInitialisedManually {
+    private parameter: string;
+
+    public constructor(parameter: string) {
+        this.parameter = parameter;
+    }
+}
+
+class ConstructorWithParametersInitialisedByCompiler {
+    private parameter: string;
+
+    public constructor(parameter: string) {
+    }
+}
+
+class PublicConstructor {
+    public constructor(anotherConstructorParameter: string) { }
+}
+
+class PrivateConstructor {
+    private constructor(anotherConstructorParameter: string) { }
+}
+
+class ProtectedConstructor {
+    protected constructor(anotherConstructorParameter: string) { }
+}

--- a/test/rules/no-implicit-constructor-visibility/test.ts.lint
+++ b/test/rules/no-implicit-constructor-visibility/test.ts.lint
@@ -1,0 +1,40 @@
+class Constructor {
+    constructor(anotherConstructorParameter: string) { }
+    ~~~~~~~~~~~      [Constructor visibility must be specified]
+}
+
+class ConstructorContainsContents {
+    constructor() {
+    ~~~~~~~~~~~      [Constructor visibility must be specified]
+        console.log("Hello!");
+    }
+}
+
+class ConstructorWithParametersInitialisedManually {
+    private parameter: string;
+
+    constructor(parameter: string) {
+    ~~~~~~~~~~~      [Constructor visibility must be specified]
+        this.parameter = parameter;
+    }
+}
+
+class ConstructorWithParametersInitialisedByCompiler {
+    private parameter: string;
+
+    constructor(parameter: string) {
+    ~~~~~~~~~~~      [Constructor visibility must be specified]
+    }
+}
+
+class PublicConstructor {
+    public constructor(anotherConstructorParameter: string) { }
+}
+
+class PrivateConstructor {
+    private constructor(anotherConstructorParameter: string) { }
+}
+
+class ProtectedConstructor {
+    protected constructor(anotherConstructorParameter: string) { }
+}

--- a/test/rules/no-implicit-constructor-visibility/tslint.json
+++ b/test/rules/no-implicit-constructor-visibility/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-implicit-constructor-visibility": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Adds the `no-implicit-constructor-visibility` rule, which forces to specify visibility modifiers for constructors and not rely in the default `public` modifier. The fix for it just prepends the `public` keyword at the beginning of the constructor statement.

#### Is there anything you'd like reviewers to focus on?
I am being very restrictive with the implementation and detecting cases where constructors have no modifiers at all. If this is a concern I am happy to modify it to constructors that don't have `public`/`private`/`protected` modifiers, specifically.

Enabling this rule has made me fix almost 20 files from the source, I am also happy to add `//disable` statements instead of the fixes if that is what's preferred, sorry unaware of the conventions here as this is my first PR against the project.

<!-- optional -->

#### CHANGELOG.md entry:
[new-rule] `arrow-return-shorthand`

<!-- optional (example: "[new-rule] `no-implicit-constructor-visibility`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
