### PR TITLE
Fix misleading error message for no-implicit-dependencies

### DIFF
--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -60,7 +60,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING_FACTORY(module: string) {
-        return `Module '${module}' is not listed as dependency in package.json`;
+        return `Module '${module}' is not listed as dependency in relevant section(s) of package.json`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/test/rules/no-implicit-dependencies/default/bom/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/bom/test.ts.lint
@@ -1,2 +1,2 @@
 import * as ts from "typescript";
-                    ~~~~~~~~~~~~ [Module 'typescript' is not listed as dependency in package.json]
+                    ~~~~~~~~~~~~ [Module 'typescript' is not listed as dependency in relevant section(s) of package.json]

--- a/test/rules/no-implicit-dependencies/default/malformed/tets.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/malformed/tets.ts.lint
@@ -1,2 +1,2 @@
 import foo from 'foo';
-                ~~~~~ [Module 'foo' is not listed as dependency in package.json]
+                ~~~~~ [Module 'foo' is not listed as dependency in relevant section(s) of package.json]

--- a/test/rules/no-implicit-dependencies/default/nested-package/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/nested-package/test.ts.lint
@@ -21,4 +21,4 @@ import "baz";
 
 const http = require('http');
 
-[err]: Module '%s' is not listed as dependency in package.json
+[err]: Module '%s' is not listed as dependency in relevant section(s) of package.json

--- a/test/rules/no-implicit-dependencies/default/subdir/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/subdir/test.ts.lint
@@ -23,4 +23,4 @@ const http = require('http');
 
 import test from '../test.ts';
 
-[err]: Module '%s' is not listed as dependency in package.json
+[err]: Module '%s' is not listed as dependency in relevant section(s) of package.json

--- a/test/rules/no-implicit-dependencies/default/test.js.lint
+++ b/test/rules/no-implicit-dependencies/default/test.js.lint
@@ -7,4 +7,4 @@ import storageHelper from 'storage-helper';
                           ~~~~~~~~~~~~~~~~ [err % ('storage-helper')]
 const myModule = require('./myModule');
 
-[err]: Module '%s' is not listed as dependency in package.json
+[err]: Module '%s' is not listed as dependency in relevant section(s) of package.json

--- a/test/rules/no-implicit-dependencies/default/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/test.ts.lint
@@ -21,4 +21,4 @@ const http = require('http');
 import * as fsevents from "fsevents";
                           ~~~~~~~~~~ [err % ('fsevents')]
 
-[err]: Module '%s' is not listed as dependency in package.json
+[err]: Module '%s' is not listed as dependency in relevant section(s) of package.json

--- a/test/rules/no-implicit-dependencies/dev/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/dev/test.ts.lint
@@ -12,4 +12,4 @@ import {baz} from 'baz';
 import * as fsevents from "fsevents";
                           ~~~~~~~~~~ [err % ('fsevents')]
 
-[err]: Module '%s' is not listed as dependency in package.json
+[err]: Module '%s' is not listed as dependency in relevant section(s) of package.json

--- a/test/rules/no-implicit-dependencies/optional/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/optional/test.ts.lint
@@ -10,4 +10,4 @@ import {baz} from 'baz';
 
 import * as fsevents from "fsevents";
 
-[err]: Module '%s' is not listed as dependency in package.json
+[err]: Module '%s' is not listed as dependency in relevant section(s) of package.json


### PR DESCRIPTION
#### PR checklist

- [X] bugfix, though not for an issue reported in the issue tracker

#### Overview of change:

The error message would make false claims about dependencies not
appearing in package.json.  A grep on the intended package.json would
show the dependency, making one start to suspect some kind of nasty
interaction with other package.json files in the monorepo.  Fix the error
message to hint that the dependency in the package.json was just in the
wrong section.

#### Is there anything you'd like reviewers to focus on?

It's just a simple one-line change to src/rules/noImplicitDependenciesRule.ts, with necessary updates to various *.ts.lint files to match.

Side note: Why is the 'tets.ts.lint' file named as it is?  Any chance it was a typo and that 'test.ts.lint' was intended?  (If it is, is it even worth submitting a PR for that?)

#### CHANGELOG.md entry:

[bugfix]: Clarify no-implicit-dependencies error message