### PR TITLE
Improve documentation of cli flag --project

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -174,9 +174,10 @@ const options: Option[] = [
         type: "string",
         describe: "tsconfig.json file",
         description: dedent`
-            The path or directory containing a tsconfig.json file that will be
-            used to determine which files will be linted. This flag also enables
-            rules that require the type checker.`,
+            The path to the tsconfig.json file or to the directory containing
+            the tsconfig.json file. The file will be used to determine which
+            files will be linted. This flag also enables rules that require the
+            type checker.`,
     },
     {
         name: "type-check",


### PR DESCRIPTION
The current documentation of the cli flag `--project` is a little confusing as to which the path of a file or the path of a directory can be specified.

As both are valid options, updating the documentation to make it clear that either the path to a `tsconfig.json` file or the path to a directory containing a `tsconfig.json` file can be specified.

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
