### PR TITLE
no-unbound-method: Fix description typo

### DIFF
--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -29,7 +29,7 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-unbound-method",
-        description: "Warns when a method is used as outside of a method call.",
+        description: "Warns when a method is used outside of a method call.",
         optionsDescription: `You may optionally pass "${OPTION_IGNORE_STATIC}" to ignore static methods.`,
         options: {
             type: "string",


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

Fixes typo in description of `no-unbound-method` rule. Extra word "as".

#### Is there anything you'd like reviewers to focus on?

No.

#### CHANGELOG.md entry:

