### PR TITLE
ordered-imports: check that all imports of the same type are groupped

### DIFF
--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -116,7 +116,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         "Import sources of different groups must be sorted by: libraries, parent directories, current directory.";
     public static IMPORT_SOURCES_UNORDERED = "Import sources within a group must be alphabetized.";
     public static NAMED_IMPORTS_UNORDERED = "Named imports must be alphabetized.";
-    public static IMPORT_SOURCES_OF_SAME_TYPE_NOT_IN_ONE_GROUP = "Import sources of the same type must be grouped together.";
+    public static IMPORT_SOURCES_OF_SAME_TYPE_NOT_IN_ONE_GROUP =
+        "Import sources of the same type (package, same folder, different folder) must be grouped together.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new Walker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)));

--- a/test/rules/ordered-imports/grouped-imports/test.ts.fix
+++ b/test/rules/ordered-imports/grouped-imports/test.ts.fix
@@ -7,5 +7,6 @@ import {bar} from '../bar';
 
 import './baa';
 import './baz'; // required
+import './caa';
 
 export class Test {}

--- a/test/rules/ordered-imports/grouped-imports/test.ts.lint
+++ b/test/rules/ordered-imports/grouped-imports/test.ts.lint
@@ -10,6 +10,10 @@ import './baz'; // required
 import './baa';
 ~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
 
+import './caa';
+~~~~~~~~~~~~~~~ [Import sources of the same type must be grouped together.]
+
 import x = require('y');
+~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of the same type must be grouped together.]
 
 export class Test {}

--- a/test/rules/ordered-imports/grouped-imports/test.ts.lint
+++ b/test/rules/ordered-imports/grouped-imports/test.ts.lint
@@ -11,9 +11,9 @@ import './baa';
 ~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
 
 import './caa';
-~~~~~~~~~~~~~~~ [Import sources of the same type must be grouped together.]
+~~~~~~~~~~~~~~~ [Import sources of the same type (package, same folder, different folder) must be grouped together.]
 
 import x = require('y');
-~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of the same type must be grouped together.]
+~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources of the same type (package, same folder, different folder) must be grouped together.]
 
 export class Test {}


### PR DESCRIPTION
#### Fixes #3873 

#### PR checklist

- [x] Addresses an existing issue: #3727
- [x] Enhancement
  - [x] Includes tests
- [x] Documentation update (not needed as the change conforms to the current docs)

#### Overview of change:

As stated in #3727 when enforcing grouping we should also enforce there is at most one group of imports of the same type in the file. 

#### CHANGELOG.md entry:

[enhancement] When `grouped-imports` option of the `ordered-imports` rule is set, the fact that imports of the same type are all in one group is also checked.

