### PR TITLE
Added 2 (+/-1) sentence rationales for 2/3 of rules

### DIFF
--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -40,7 +40,11 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "align",
         description: "Enforces vertical alignment.",
         hasFix: true,
-        rationale: "Helps maintain a readable, consistent style in your codebase.",
+        rationale: Lint.Utils.dedent`
+            Helps maintain a readable, consistent style in your codebase.
+
+            Consistent alignment for code statements helps keep code readable and clear.
+            Statements misaligned from the standard can be harder to read and understand.`,
         optionsDescription: Lint.Utils.dedent`
             Five arguments may be optionally provided:
 

--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -39,6 +39,10 @@ export class Rule extends Lint.Rules.AbstractRule {
             true,
             [true, OPTION_MULTILINE],
         ],
+        rationale: Lint.Utils.dedent`
+            It's unnecessary to include \`return\` and \`{}\` brackets in arrow lambdas.
+            Leaving them out results in simpler and easier to read code.
+        `,
         type: "style",
         typescriptOnly: false,
     };

--- a/src/rules/awaitPromiseRule.ts
+++ b/src/rules/awaitPromiseRule.ts
@@ -40,8 +40,11 @@ export class Rule extends Lint.Rules.TypedRule {
         },
         optionExamples: [true, [true, "Thenable"]],
         rationale: Lint.Utils.dedent`
-            While it is valid TypeScript to await a non-Promise-like value (it will resolve immediately),
+            While it is valid JavaScript to await a non-Promise-like value (it will resolve immediately),
             this pattern is often a programmer error and the resulting semantics can be unintuitive.
+
+            Awaiting non-Promise-like values often is an indication of programmer error, such as
+            forgetting to add parenthesis to call a function that returns a Promise.
         `,
         type: "functionality",
         typescriptOnly: true,

--- a/src/rules/binaryExpressionOperandOrderRule.ts
+++ b/src/rules/binaryExpressionOperandOrderRule.ts
@@ -31,6 +31,12 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            Expressions like \`1 + x\` are sometimes referred to as "Yoda" expressions because they read
+            opposite to how we would normally speak the expression.
+
+            Sticking to a consistent grammar for conditions helps keep code readable and understandable.
+        `,
         type: "style",
         typescriptOnly: false,
     };

--- a/src/rules/classNameRule.ts
+++ b/src/rules/classNameRule.ts
@@ -26,7 +26,12 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "class-name",
         description: "Enforces PascalCased class and interface names.",
-        rationale: "Makes it easy to differentiate classes from regular variables at a glance.",
+        rationale: Lint.Utils.dedent`
+            Makes it easy to differentiate classes from regular variables at a glance.
+
+            JavaScript and general programming convention is to refer to classes in PascalCase.
+            It's confusing to use camelCase or other conventions for class names.
+        `,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -280,7 +280,12 @@ export class Rule extends Lint.Rules.TypedRule {
                 },
             ],
         ],
+        rationale: Lint.Utils.dedent`
+            Helps ensure important components are documented.
 
+            Note: use this rule sparingly. It's better to have self-documenting names on components with single, consice responsibilities.
+            Comments that only restate the names of variables add nothing to code, and can easily become outdated.
+        `,
         type: "style",
         typescriptOnly: false,
         requiresTypeInfo: true,

--- a/src/rules/cyclomaticComplexityRule.ts
+++ b/src/rules/cyclomaticComplexityRule.ts
@@ -42,7 +42,9 @@ export class Rule extends Lint.Rules.AbstractRule {
         rationale: Lint.Utils.dedent`
             Cyclomatic complexity is a code metric which indicates the level of complexity in a
             function. High cyclomatic complexity indicates confusing code which may be prone to
-            errors or difficult to modify.`,
+            errors or difficult to modify.
+
+            It's better to have smaller, single-purpose functions with self-documenting names.`,
         optionsDescription: Lint.Utils.dedent`
             An optional upper limit for cyclomatic complexity can be specified. If no limit option
             is provided a default value of ${Rule.DEFAULT_THRESHOLD} will be used.`,

--- a/src/rules/eoflineRule.ts
+++ b/src/rules/eoflineRule.ts
@@ -25,7 +25,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "eofline",
         description: "Ensures the file ends with a newline.",
         descriptionDetails: "Fix for single-line files is not supported.",
-        rationale: "It is a [standard convention](http://stackoverflow.com/q/729692/3124288) to end files with a newline.",
+        rationale: "It is a [standard convention](https://stackoverflow.com/q/729692/3124288) to end files with a newline.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/forinRule.ts
+++ b/src/rules/forinRule.ts
@@ -35,7 +35,13 @@ export class Rule extends Lint.Rules.AbstractRule {
             \`\`\`
             Prevents accidental iteration over properties inherited from an object's prototype.
             See [MDN's \`for...in\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in)
-            documentation for more information about \`for...in\` loops.`,
+            documentation for more information about \`for...in\` loops.
+
+            Also consider using a [\`Map\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
+            or [\`Set\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
+            if you're storing collections of objects.
+            Using \`Object\`s can cause occasional edge case bugs, such as if a key is named "hasOwnProperty".
+        `,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -47,7 +47,12 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "member-access",
         description: "Requires explicit visibility declarations for class members.",
-        rationale: "Explicit visibility declarations can make code more readable and accessible for those new to TS.",
+        rationale: Lint.Utils.dedent`
+            Explicit visibility declarations can make code more readable and accessible for those new to TS.
+
+            Other languages such as C# default to \`private\`, unlike TypeScript's default of \`public\`.
+            Members lacking a visibility declaration may be an indication of an accidental leak of class internals.
+        `,
         optionsDescription: Lint.Utils.dedent`
             These arguments may be optionally provided:
 

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -132,7 +132,13 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "member-ordering",
         description: "Enforces member ordering.",
-        rationale: "A consistent ordering for class members can make classes easier to read, navigate, and edit.",
+        rationale: Lint.Utils.dedent`
+            A consistent ordering for class members can make classes easier to read, navigate, and edit.
+
+            A common opposite practice to \`member-ordering\` is to keep related groups of classes together.
+            Instead of creating clases with multiple separate groups, consider splitting class responsibilities
+            apart across multiple single-responsibility classes.
+        `,
         optionsDescription,
         options: {
             type: "object",

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -25,7 +25,17 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "no-any",
         description: "Disallows usages of `any` as a type declaration.",
         hasFix: false,
-        rationale: "Using `any` as a type declaration nullifies the compile-time benefits of the type system.",
+        rationale: Lint.Utils.dedent`
+            Using \`any\` as a type declaration nullifies the compile-time benefits of the type system.
+
+            If you're dealing with data of unknown or "any" types, you shouldn't be accessing members of it.
+            Either add type annotations for properties that may exist or change the data type to the empty object type \`{}\`.
+
+            Alternately, if you're creating storage or handling for consistent but unknown types, such as in data structures
+            or serialization, use \`<T>\` template types for generic type handling.
+
+            Also see the \`no-unsafe-any\` rule.
+        `,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/noBooleanLiteralCompareRule.ts
+++ b/src/rules/noBooleanLiteralCompareRule.ts
@@ -29,6 +29,10 @@ export class Rule extends Lint.Rules.TypedRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            Comparing boolean values to boolean literals is unnecessary, as those expressions will result in booleans too.
+            Just use the boolean values directly or negate them.
+        `,
         type: "style",
         typescriptOnly: true,
         requiresTypeInfo: true,

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -28,7 +28,14 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "no-consecutive-blank-lines",
         description: "Disallows one or more blank lines in a row.",
         hasFix: true,
-        rationale: "Helps maintain a readable style in your codebase.",
+        rationale: Lint.Utils.dedent`
+            Helps maintain a readable style in your codebase.
+
+            Extra blank lines take up extra space and add little to a semantic understanding of the code.
+            It can be harder to read through files when fewer components can fit into the screen.
+            If you find a file is so large you feel a need to split them up with extra blank lines or comments,
+            consider splitting your file into smaller files.
+        `,
         optionsDescription: Lint.Utils.dedent`
             An optional number of maximum allowed sequential blanks can be specified. If no value
             is provided, a default of ${Rule.DEFAULT_ALLOWED_BLANKS} will be used.`,

--- a/src/rules/noDynamicDeleteRule.ts
+++ b/src/rules/noDynamicDeleteRule.ts
@@ -26,7 +26,14 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionExamples: [true],
         options: null,
         optionsDescription: "Not configurable.",
-        rationale: "Deleting dynamically computed keys is dangerous and not well optimized.",
+        rationale: Lint.Utils.dedent`
+            Deleting dynamically computed keys is dangerous and not well optimized.
+
+            Also consider using a [\`Map\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
+            or [\`Set\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
+            if you're storing collections of objects.
+            Using \`Object\`s can cause occasional edge case bugs, such as if a key is named "hasOwnProperty".
+        `,
         ruleName: "no-dynamic-delete",
         type: "functionality",
         typescriptOnly: false,

--- a/src/rules/noFloatingPromisesRule.ts
+++ b/src/rules/noFloatingPromisesRule.ts
@@ -25,7 +25,7 @@ export class Rule extends Lint.Rules.TypedRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-floating-promises",
         description: "Promises returned by functions must be handled appropriately.",
-        descriptionDetails: "Use `no-unused-expression` in addition to this rule to reveal even more floating promises.",
+        descriptionDetails: "Unhandled Promises can cause unexpected behavior, such as resolving at unexpected times.",
         optionsDescription: Lint.Utils.dedent`
             A list of \'string\' names of any additional classes that should also be handled as Promises.
         `,
@@ -37,7 +37,14 @@ export class Rule extends Lint.Rules.TypedRule {
             },
         },
         optionExamples: [true, [true, "JQueryPromise"]],
-        rationale: "Unhandled Promises can cause unexpected behavior, such as resolving at unexpected times.",
+        rationale: Lint.Utils.dedent`
+            Creating a Promise and not storing or returning may lets other code run independent of of its results.
+            This can cause unexpected and/or non-deterministic behavior depending on external timing factors.
+
+            It's typically better to return Promises from functions that start them, then handle them in calling code.
+
+            Use \`no-unused-expression\` in addition to this rule to reveal even more floating promises.
+        `,
         type: "functionality",
         typescriptOnly: true,
         requiresTypeInfo: true,

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -27,6 +27,11 @@ export class Rule extends Lint.Rules.TypedRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            When function or constructor may be called with a type parameter but one isn't supplied or inferrable,
+            TypeScript defaults to \`{}\`.
+            This is often undesirable as the call is meant to be of a more specific type.
+        `,
         type: "functionality",
         typescriptOnly: true,
         requiresTypeInfo: true,

--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -28,6 +28,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: "Interpolation will only work for template strings.",
         type: "functionality",
         typescriptOnly: false,
     };

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -29,8 +29,9 @@ export class Rule extends Lint.Rules.AbstractRule {
             Disallows the use constant number values outside of variable assignments.
             When no list of allowed values is specified, -1, 0 and 1 are allowed by default.`,
         rationale: Lint.Utils.dedent`
-            Magic numbers should be avoided as they often lack documentation, forcing
-            them to be stored in variables gives them implicit documentation.`,
+            Magic numbers should be avoided as they often lack documentation.
+            Forcing them to be stored in variables gives them implicit documentation.
+        `,
         optionsDescription: "A list of allowed numbers.",
         options: {
             type: "array",

--- a/src/rules/noMisusedNewRule.ts
+++ b/src/rules/noMisusedNewRule.ts
@@ -28,6 +28,11 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            Interfaces in TypeScript aren't meant to describe constructors on their implementations.
+            The \`new\` descriptor is primarily for describing JavaScript libraries.
+            If you're trying to describe a function known to be a class, it's typically better to \`declare class\`.
+        `,
         type: "functionality",
         typescriptOnly: true,
     };

--- a/src/rules/noNonNullAssertionRule.ts
+++ b/src/rules/noNonNullAssertionRule.ts
@@ -24,7 +24,35 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-non-null-assertion",
         description: "Disallows non-null assertions using the `!` postfix operator.",
-        rationale: "Using non-null assertion cancels the benefits of the strict null checking mode.",
+        rationale: `
+            Using non-null assertion cancels the benefits of the strict null checking mode.
+
+            Instead of assuming objects exist:
+
+            \`\`\`
+            function foo(instance: MyClass | undefined) {
+                instance!.doWork();
+            }
+            \`\`\`
+
+            Either inform the strict type system that the object must exist:
+
+            \`\`\`
+            function foo(instance: MyClass) {
+                instance.doWork();
+            }
+            \`\`\`
+
+            Or verify that the instance exists, which will inform the type checker:
+
+            \`\`\`
+            function foo(instance: MyClass | undefined) {
+                if (instance !== undefined) {
+                    instance.doWork();
+                }
+            }
+            \`\`\`
+        `,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/noNonNullAssertionRule.ts
+++ b/src/rules/noNonNullAssertionRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-non-null-assertion",
         description: "Disallows non-null assertions using the `!` postfix operator.",
-        rationale: `
+        rationale: Lint.Utils.dedent`
             Using non-null assertion cancels the benefits of the strict null checking mode.
 
             Instead of assuming objects exist:

--- a/src/rules/noNullKeywordRule.ts
+++ b/src/rules/noNullKeywordRule.ts
@@ -29,7 +29,26 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Disallows use of the `null` keyword literal.",
         rationale: Lint.Utils.dedent`
             Instead of having the dual concepts of \`null\` and\`undefined\` in a codebase,
-            this rule ensures that only \`undefined\` is used.`,
+            this rule ensures that only \`undefined\` is used.
+
+            JavaScript originally intended \`undefined\` to refer to a value that doesn't yet exist,
+            while \`null\` was meant to refer to a value that does exist but points to nothing.
+            That's confusing.
+            \`undefined\` is the default value when object members don't exist, and is the return value
+            for newer native collection APIs such as \`Map.get\` when collection values don't exist.
+
+            \`\`\`
+            const myObject = {};
+            myObject.doesNotExist; // undefined
+            \`\`\`
+
+            \`\`\`
+            const myMap = new Map<string, number>();
+            myMap.get("doesNotExist"); // undefined
+            \`\`\`
+
+            To remove confusion over the two similar values, it's better to stick with just \`undefined\`.
+        `,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/noParameterPropertiesRule.ts
+++ b/src/rules/noParameterPropertiesRule.ts
@@ -27,7 +27,11 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Disallows parameter properties in class constructors.",
         rationale: Lint.Utils.dedent`
             Parameter properties can be confusing to those new to TS as they are less explicit
-            than other ways of declaring and initializing class members.`,
+            than other ways of declaring and initializing class members.
+
+            It can be cleaner to keep member variable declarations in one list directly only the class
+            (instead of mixed between direct class members and constructor parameter properties).
+        `,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -28,7 +28,16 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-shadowed-variable",
         description: "Disallows shadowing variable declarations.",
-        rationale: "Shadowing a variable masks access to it and obscures to what value an identifier actually refers.",
+        rationale: Lint.Utils.dedent`
+            Shadowing a variable masks access to it and obscures to what value an identifier actually refers.
+            For example, in the following code, it can be confusing why the filter is likely never true:
+
+            \`\`\`
+            const findNeighborsWithin = (instance: MyClass, instances: MyClass[]): MyClass[] => {
+                return instances.filter((instance) => instance.neighbors.includes(instance));
+            };
+            \`\`\`
+        `,
         optionsDescription: Lint.Utils.dedent`
             You can optionally pass an object to disable checking for certain kinds of declarations.
             Possible keys are \`"class"\`, \`"enum"\`, \`"function"\`, \`"import"\`, \`"interface"\`, \`"namespace"\`, \`"typeAlias"\`

--- a/src/rules/noStringThrowRule.ts
+++ b/src/rules/noStringThrowRule.ts
@@ -24,11 +24,14 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-string-throw",
-        description: "Flags throwing plain strings or concatenations of strings " +
-            "because only Errors produce proper stack traces.",
+        description: "Flags throwing plain strings or concatenations of strings.",
         hasFix: true,
         options: null,
         optionsDescription: "Not configurable.",
+        rationale: Lint.Utils.dedent`
+            Only Error objects contain a \`.stack\` member equivalent to the current stack trace.
+            Primitives such as strings do not.
+        `,
         type: "functionality",
         typescriptOnly: false,
     };

--- a/src/rules/noThisAssignmentRule.ts
+++ b/src/rules/noThisAssignmentRule.ts
@@ -79,8 +79,28 @@ export class Rule extends Lint.Rules.AbstractRule {
 
             * \`${ALLOW_THIS_DESTRUCTURING}\` allows using destructuring to access members of \`this\` (e.g. \`{ foo, bar } = this;\`).
             * \`${ALLOWED_THIS_NAMES}\` may be specified as a list of regular expressions to match allowed variable names.`,
-        rationale: "Assigning a variable to `this` instead of properly using arrow lambdas "
-            + "may be a symptom of pre-ES6 practices or not manging scope well.",
+        rationale: Lint.Utils.dedent`
+            Assigning a variable to \`this\` instead of properly using arrow lambdas may be a symptom of pre-ES6 practices
+            or not managing scope well.
+
+            Instead of storing a reference to \`this\` and using it inside a \`function () {\`:
+
+            \`\`\`
+            const self = this;
+
+            setTimeout(function () {
+                self.doWork();
+            });
+            \`\`\`
+
+            Use \`() =>\` arrow lambdas, as they preserve \`this\` scope for you:
+
+            \`\`\`
+            setTimeout(() => {
+                this.doWork();
+            });
+            \`\`\`
+        `,
         ruleName: "no-this-assignment",
         type: "functionality",
         typescriptOnly: false,

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -36,6 +36,44 @@ export class Rule extends Lint.Rules.TypedRule {
             enum: [OPTION_IGNORE_STATIC],
         },
         optionExamples: [true, [true, OPTION_IGNORE_STATIC]],
+        rationale: Lint.Utils.dedent`
+            Class functions don't preserve the class scope when passed as standalone variables.
+            For example, this code will log the global scope (\`window\`/\`global\`), not the class instance:
+
+            \`\`\`
+            class MyClass {
+                public log(): void {
+                    console.log(this);
+                }
+            }
+
+            const instance = new MyClass();
+            const log = instance.log;
+
+            log();
+            \`\`\`
+
+            You need to either use an arrow lambda (\`() => {...}\`) or call the function with the correct scope.
+
+            \`\`\`
+            class MyClass {
+                public logArrowBound = (): void => {
+                    console.log(bound);
+                };
+
+                public logManualBind(): void {
+                    console.log(this);
+                }
+            }
+
+            const instance = new MyClass();
+            const logArrowBound = instance.logArrowBound;
+            const logManualBind = instance.logManualBind.bind(instance);
+
+            logArrowBound();
+            logManualBind();
+            \`\`\`
+        `,
         type: "functionality",
         typescriptOnly: true,
         requiresTypeInfo: true,

--- a/src/rules/noUnnecessaryCallbackWrapperRule.ts
+++ b/src/rules/noUnnecessaryCallbackWrapperRule.ts
@@ -30,6 +30,10 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            There's generally no reason to wrap a function with a callback wrapper if it's directly called anyway.
+            Doing so creates extra inline lambdas that slow the runtime down.
+        `,
         type: "style",
         typescriptOnly: false,
     };

--- a/src/rules/noUnnecessaryInitializerRule.ts
+++ b/src/rules/noUnnecessaryInitializerRule.ts
@@ -29,6 +29,10 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            Values in JavaScript default to \`undefined\`.
+            There's no need to do so manually.
+        `,
         type: "style",
         typescriptOnly: false,
     };

--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -31,6 +31,15 @@ export class Rule extends Lint.Rules.TypedRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            If you're dealing with data of unknown or "any" types, you shouldn't be accessing members of it.
+            Either add type annotations for properties that may exist or change the data type to the empty object type \`{}\`.
+
+            Alternately, if you're creating storage or handling for consistent but unknown types, such as in data structures
+            or serialization, use \`<T>\` template types for generic type handling.
+
+            Also see the \`no-any\` rule.
+        `,
         type: "functionality",
         typescriptOnly: true,
         requiresTypeInfo: true,

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -27,7 +27,8 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-unused-variable",
-        description: Lint.Utils.dedent`Disallows unused imports, variables, functions and
+        description: Lint.Utils.dedent`
+            Disallows unused imports, variables, functions and
             private class members. Similar to tsc's --noUnusedParameters and --noUnusedLocals
             options, but does not interrupt code compilation.`,
         descriptionDetails: Lint.Utils.dedent`
@@ -64,6 +65,10 @@ export class Rule extends Lint.Rules.TypedRule {
             maxLength: 3,
         },
         optionExamples: [true, [true, {"ignore-pattern": "^_"}]],
+        rationale: Lint.Utils.dedent`
+            Variables that are declared and not used anywhere in code are likely an error due to incomplete refactoring.
+            Such variables take up space in the code, are mild performance pains, and can lead to confusion by readers.
+        `,
         type: "functionality",
         typescriptOnly: true,
         requiresTypeInfo: true,

--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -30,6 +30,14 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            Declaring variables using \`var\` has several edge case behaviors that make \`var\` unsuitable for modern code.
+            Variables declared by \`var\` have their parent function block as their scope, ignoring other control flow statements.
+            \`var\`s have declaration "hoisting" (similar to \`function\`s) and can appear to be used before declaration.
+
+            Variables declared by \`const\` and \`let\` instead have as their scope the block in which they are defined,
+            and are not allowed to used before declaration or be re-declared with another \`const\` or \`let\`.
+        `,
         type: "functionality",
         typescriptOnly: false,
     };

--- a/src/rules/noVarRequiresRule.ts
+++ b/src/rules/noVarRequiresRule.ts
@@ -26,10 +26,17 @@ export class Rule extends Lint.Rules.AbstractRule {
         description: "Disallows the use of require statements except in import statements.",
         descriptionDetails: Lint.Utils.dedent`
             In other words, the use of forms such as \`var module = require("module")\` are banned.
-            Instead use ES6 style imports or \`import foo = require('foo')\` imports.`,
+            Instead use ES2015-style imports or \`import foo = require('foo')\` imports.`,
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            AMD-style \`require([])\` and CommonJS-style \`require("")\` statements are environment-specific
+            and more difficult to statically analyze.
+
+            ES2015-style \`import\`s are part of the JavaScript language specfication and recommended as the path going forward.
+            TypeScript will compile them to environment-specific forms as needed.
+        `,
         type: "typescript",
         typescriptOnly: true,
     };

--- a/src/rules/noVoidExpressionRule.ts
+++ b/src/rules/noVoidExpressionRule.ts
@@ -38,6 +38,20 @@ export class Rule extends Lint.Rules.TypedRule {
             minLength: 0,
             maxLength: 1,
         },
+        rationale: Lint.Utils.dedent`
+            It's misleading returning the results of an expression whose type is \`void\`.
+            Attempting to do so is likely a symptom of expecting a different return type from a function.
+            For example, the following code will log \`undefined\` but looks like it logs a value:
+
+            \`\`\`
+            const performWork = (): void => {
+                workFirst();
+                workSecond();
+            };
+
+            console.log(performWork());
+            \`\`\`
+        `,
         requiresTypeInfo: true,
         type: "functionality",
         typescriptOnly: false,

--- a/src/rules/numberLiteralFormatRule.ts
+++ b/src/rules/numberLiteralFormatRule.ts
@@ -29,6 +29,10 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            Helps keep a consistent style with numeric literals.
+            Non-standard literals are more difficult to scan through and can be a symptom of typos.
+        `,
         type: "style",
         typescriptOnly: false,
     };


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: Fixes #3357; happens to help with #2189; addresses #467
- [x] Documentation update

#### Overview of change:

Adds `rationale`s to about many of the core rules (I ran out of steam about 2/3 of the way through). I'd considered sending a separate PR for each, but don't want to irritate ajafff too much. 😄 