### PR TITLE
Reduce false positive rate in no-invalid-template-strings

### DIFF
--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -51,15 +51,14 @@ function walk(ctx: Lint.WalkContext<void>) {
 
     function check(node: ts.StringLiteral): void {
         const text = node.getText(ctx.sourceFile);
-        const findTemplateStrings = /\\*\$\{/g;
+        const findTemplateStrings = /(\\*)(\$\{.+?\})/g;
         let instance = findTemplateStrings.exec(text);
         while (instance !== null) {
-            const matchLength = instance[0].length;
-            const backslashCount = matchLength - 2;
+            const backslashCount = instance[1].length;
             const instanceIsEscaped = backslashCount % 2 === 1;
             if (!instanceIsEscaped) {
                 const start = node.getStart() + (instance.index + backslashCount);
-                ctx.addFailureAt(start, 2, Rule.FAILURE_STRING);
+                ctx.addFailureAt(start, instance[2].length, Rule.FAILURE_STRING);
             }
             instance = findTemplateStrings.exec(text);
         }

--- a/test/rules/no-invalid-template-strings/test.ts.lint
+++ b/test/rules/no-invalid-template-strings/test.ts.lint
@@ -3,31 +3,39 @@ new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comme
 new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comment-tab=\${b}></div>',Tab.mixins.AlwaysHasData('\${c}'))))
 
 Tab.mixins.Templated('<div mbr-comment-tab=\${which}></div>',Tab.mixins.AlwaysHasData('\\${d}'))
-                                                                                         ~~ [0]
+                                                                                         ~~~~ [0]
 
 Tab.mixins.Templated(`<div mbr-comment-tab=\${e}></div>`,Tab.mixins.AlwaysHasData('${f}'))
-                                                                                   ~~ [0]
+                                                                                   ~~~~ [0]
 
 Tab.mixins.Templated('<div mbr-comment-tab=${g}></div>',Tab.mixins.AlwaysHasData('${h}'), Tab.mixin.SomeMethod('${i}'))
-                                           ~~ [0]
-                                                                                  ~~ [0]
-                                                                                                                ~~ [0]
+                                           ~~~~ [0]
+                                                                                  ~~~~ [0]
+                                                                                                                ~~~~ [0]
 
 new (Tab.mixins.Controlled('MemberComments',Tab.mixins.Templated('<div mbr-comment-tab=\\${j}></div>',Tab.mixins.AlwaysHasData())))
-                                                                                         ~~ [0]
+                                                                                         ~~~~ [0]
 
 new (Tab.mixins.Templated('<div mbr-comment-tab=\\\\\${b}></div>',Tab.mixins.AlwaysHasData('\\\\${c}'))))
-                                                                                                ~~ [0]
+                                                                                                ~~~~ [0]
 
 "\${a} = ${a}";
-         ~~ [0]
+         ~~~~ [0]
 
 "One plus one is ${1 + 1}.";
-                 ~~ [0]
+                 ~~~~~~~~ [0]
 
 'One plus one is ${1 + 1}.';
-                 ~~ [0]
+                 ~~~~~~~~ [0]
 
 `One plus one is ${1 + 1}.`;
+
+"${";
+
+"${" + '}';
+
+"${() => {}} ${abc}"
+ ~~~~~~~~~~ [0]
+             ~~~~~~ [0]
 
 [0]: Interpolation will only work for template strings.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

* Don't flag unmatched ${ in a regular string
* Also flag the entire expression, not just the opening brace

#### CHANGELOG.md entry:

[enhancement] Don't flag unmatched ${ in no-invalid-template-strings
