### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -286,7 +286,7 @@ async function tryReadFile(filename: string, logger: Logger): Promise<string | u
     const fd = fs.openSync(filename, "r");
     try {
         fs.readSync(fd, buffer, 0, 256, 0);
-        if (buffer.readInt8(0, true) === 0x47 && buffer.readInt8(188, true) === 0x47) {
+        if (buffer.readInt8(0) === 0x47 && buffer.readInt8(188) === 0x47) {
             // MPEG transport streams use the '.ts' file extension. They use 0x47 as the frame
             // separator, repeating every 188 bytes. It is unlikely to find that pattern in
             // TypeScript source, so tslint ignores files with the specific pattern.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

The support for the `noAssert` argument dropped in the upcoming
Node.js version 10.x and the argument should be removed therefore.
I would call it a bug fix. It can be argued against that just as well though.

Refs: https://github.com/nodejs/node/pull/18395

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

I was not able to compile anything and was not able to run the tests therefore.
I always got the following error: 

```
node_modules/tsutils/typeguard/type.d.ts(15,73): error TS2694: Namespace 'ts' has no exported member 'UniqueESSymbolType'.
```

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

Not sure what to choose here...