### PR TITLE
TypeScript 2.8 & 2.9 adaptations (dependencies & tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "tsutils": "^2.12.1"
   },
   "peerDependencies": {
-    "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev"
+    "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"
   },
   "devDependencies": {
     "@types/babel-code-frame": "^6.20.0",

--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -166,7 +166,7 @@ function getDeprecation(node: ts.Identifier, tc: ts.TypeChecker): string | undef
 function findDeprecationTag(tags: ts.JSDocTagInfo[]): string | undefined {
     for (const tag of tags) {
         if (tag.name === "deprecated") {
-            return tag.text;
+            return tag.text === undefined ? "" : tag.text;
         }
     }
     return undefined;

--- a/test/rules/completed-docs/defaults/test.ts.lint
+++ b/test/rules/completed-docs/defaults/test.ts.lint
@@ -12,9 +12,12 @@ export class Aaa {
     public set prop(value) { this.bbb = value; }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       [Documentation must exist for public properties.]
 
-    // TODO: TypeScript API doesn't give us a symbol for this, so we must ignore it.
+    // TypeScript API doesn't give a symbol for this before version 2.8.0
     // https://github.com/Microsoft/TypeScript/issues/14257
     [Symbol.iterator]() {}
+#if typescript >= 2.8.0
+    ~~~~~~~~~~~~~~~~~~~~~~ [Documentation must exist for methods.]
+#endif
 }
 
 export enum Ddd { }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of changes:

##### As a dependant module with npm 2.x
Adding typescript 2.9.0-dev to `peerDependencies`, as modules depending on `"typescript": "next"` and _tslint_ are failing to install with npm version 2.x (as npm versions prior to 3 were failing unmet peerDependencies):
```
npm ERR! peerinvalid The package typescript@2.9.0-dev.20180324 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer tslint@5.9.1 wants typescript@>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev
```

package.json:
```
"devDependencies": {
  "tslint": "^5.9.1",
  "typescript": "next"
}
```

##### Updates for TypeScript 2.8+
Many places previously returned empty string as text when JSDoc declaration had no comment, but now it returns `undefined` and it was failing the tests for `typescript@next`.

#### Is there anything you'd like reviewers to focus on?

-- none --

#### CHANGELOG.md entry:

[bugfix] Using tslint with typescript 2.9.0 would cause errors under npm 2.x