### PR TITLE
Removes trailing whitespace from file-header

### DIFF
--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -86,7 +86,8 @@ export class Rule extends Lint.Rules.AbstractRule {
             "/*",
             // split on both types of line endings in case users just typed "\n" in their configs
             // but are working in files with \r\n line endings
-            ...commentText.split(/\r?\n/g).map((line) => ` * ${line}`),
+            // Trim trailing spaces to play nice with `no-trailing-whitespace` rule
+            ...commentText.split(/\r?\n/g).map((line) => ` * ${line}`.replace(/\s+$/, "")),
             " */",
         ].join(lineEnding) + lineEnding.repeat(trailingNewlines);
     }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
The rule `file-header` does not play nice with `no-trailing-whitespace` if the file header includes blank lines. For example, after applying `file-header` with `--fix`, you might end up with something like this:

```js
/* 
 * Copyright My Company 2018
 * 
 * Project Identifier
 * 
 * All Rights Reserved, blah blah blah legal stuff.
 */
```

Note the trailing whitespace on the ` * ` lines. This means you would have to run `tslint --fix` *twice* to get the desired result.

This PR adds a simple solution of right-trimming each line of the file header.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[bugfix] Makes rule `file-header` play nice with rule `no-trailing-whitespace`
