### PR TITLE
Implement --stdin and --stdin-filename CLI options

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -243,7 +243,7 @@ function resolveFiles(
             // Use a filename for shadowing stdin, if the option is set.
             return [{filename: path.resolve(stdinFilename), isStdin: true}];
         } else {
-            return [{filename: "", isStdin: true}];
+            throw new Error("--stdin-filename must be provided with --stdin.");
         }
     }
 

--- a/src/tslintCli.ts
+++ b/src/tslintCli.ts
@@ -141,7 +141,8 @@ const options: Option[] = [
         type: "string",
         describe: "stdin input",
         description: dedent`
-            Read and check a file via stdin.`,
+            Read and check a file via stdin. The --stdin-filename option must
+            also be given.`,
     },
     {
         name: "stdin-filename",
@@ -256,13 +257,16 @@ if (parsed.unknown.length !== 0) {
 const argv = commander.opts() as any as Argv;
 
 if (!(
-  argv.init
-  || argv.test !== undefined
-  || argv.project !== undefined
-  || commander.args.length > 0
-  || argv.stdin
+    argv.init
+    || argv.test !== undefined
+    || argv.project !== undefined
+    || commander.args.length > 0
+    || argv.stdin
 )) {
-    console.error("No files specified. Use --project to lint a project folder.");
+    console.error(
+        "No files specified. Use --project to lint a project folder "
+        + "or use --stdin and --stdin-filename.",
+    );
     process.exit(1);
 }
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #1590
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

Hello! I am the guy who created the ALE plugin for Vim, for checking for problems while you type in Vim, and I am an active JavaScript and TypeScript developer. I use ESLint in my day job, and I would like to use TSLint more. One of the key features that ESLint has, which works really well with ALE, is that you can both pass in a Vim buffer via stdin and also tell it where the file for the buffer is in your file system. This means you can check for problems before you've saved a file to disk, but still benefit from plugins which need to know where the file is for resolving modules and so on. Currently, ALE can't support all of the features of TSLint, while also checking for problems while you type, because TSLint doesn't yet support a feature like this.

I'm interested in using such a feature myself, so I thought I'd start trying to implement it myself. A new `--stdin` option ought to read a file to check from stdin, and `--stdin-filename` should tell TSLint where the file you're checking will be saved to disk.

#### Is there anything you'd like reviewers to focus on?

I'm not familiar with the TSLint codebase at all. I just quickly scanned through the codebase and modified what seemed logical to modify to me, to get anything working at all. I haven't written any tests yet, and I'm sure what I've written so far will probably cause some bugs. I'm not familiar with the coding standards, so let me know what to change there. This work certainly isn't finished yet.

One thing I know that I couldn't get working yet is that I couldn't figure out an easy way to support `--stdin` without the `--stdin-filename` option, as some rules seem to depend on there being some file to actually look at in the filesystem, and I imagine this will extend to some third party rules as well. It might be that some rules will have to be modified to not throw exceptions if the file doesn't exist yet, they will probably cause problems for new files you haven't saved to disk yet, even with the `--stdin-filename` option. Maybe for supporting `--stdin` alone, rules will have to be modified to tolerate blank filenames, or a special filename like `"-"`. Let me know your thoughts.

#### CHANGELOG.md entry:

 suggested tags: [enhancement], [api]