### PR TITLE
Improved "complete docs" docs

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -181,9 +181,9 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "completed-docs",
-        description: "Enforces documentation for important items be filled out.",
+        description: "Enforces JSDoc comments for important items be filled out.",
         optionsDescription: Lint.Utils.dedent`
-            \`true\` to enable for [${Object.keys(Rule.defaultArguments).join(", ")}]],
+            \`true\` to enable for `[${Object.keys(Rule.defaultArguments).join(", ")}]`,
             or an array with each item in one of two formats:
 
             * \`string\` to enable for that type


### PR DESCRIPTION
#### PR checklist

- [x] Documentation update

#### Overview of change:
- It was unclear to me if it works for JSDocs (because in another rule "JSDoc comment" is used instead of "Documentation"

- Updated the style for the inline code


#### Is there anything you'd like reviewers to focus on?


supersedes https://github.com/palantir/tslint/pull/3006
