### PR TITLE
Updated max-line-length ignore-pattern example

### DIFF
--- a/src/rules/maxLineLengthRule.ts
+++ b/src/rules/maxLineLengthRule.ts
@@ -43,8 +43,8 @@ export class Rule extends Lint.Rules.AbstractRule {
              * \`\/\/ \` pattern will ignore all in-line comments.
              * \`^import \` pattern will ignore all import statements.
              * \`^export \{(.*?)\}\` pattern will ignore all multiple export statements.
-             * \`class [a-zA-Z] implements \` pattern will ignore all class declarations implementing interfaces.
-             * \`^import |^export \{(.*?)\}|class [a-zA-Z] implements |// \` pattern will ignore all the cases listed above.
+             * \`class [a-zA-Z]+ implements \` pattern will ignore all class declarations implementing interfaces.
+             * \`^import |^export \{(.*?)\}|class [a-zA-Z]+ implements |// \` pattern will ignore all the cases listed above.
          `,
         options: {
             type: "array",


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:
The example uses:

```
class [a-zA-Z] implements 
```

but this only matches a class that has a single character as name. Even if it is an example, the rule should accept more than one character for the class name. I struggled with this ignore pattern in a project, because I didn't read the pattern itself completely. Therefore I want to give this feedback, such that other people don't have to search for the reason of a failing rule, like me.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
