### PR TITLE
[new-fixer]: Add space before comment message fixer

### DIFF
--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -106,6 +106,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ],
         type: "style",
         typescriptOnly: false,
+        hasFix: true,
     };
     /* tslint:enable:object-literal-sort-keys */
 
@@ -179,7 +180,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
         }
 
         if (ctx.options.space && commentText[0] !== " ") {
-            ctx.addFailure(start, end, Rule.LEADING_SPACE_FAILURE);
+            ctx.addFailure(start, end, Rule.LEADING_SPACE_FAILURE, [ Lint.Replacement.appendText(start, " ") ]);
         }
 
         if (ctx.options.case === Case.None ||

--- a/test/rules/comment-format/exceptions-pattern/test.ts.fix
+++ b/test/rules/comment-format/exceptions-pattern/test.ts.fix
@@ -1,0 +1,30 @@
+///<reference path="something.ts"/>
+class Clazz { // this comment is correct
+    /* block comment
+     * adada
+     */
+    public funcxion() { // This comment has a capital letter starting it
+        // This comment is on its own line, and starts with a capital _and_ no space
+        console.log("test"); // this comment has no space
+    }
+    /// <not a reference/>
+    //// foo
+}
+
+//#region test
+//#endregion
+
+`${location.protocol}//${location.hostname}`
+
+//noinspection JSUnusedGlobalSymbols
+const unusedVar = 'unneeded value';
+
+// TODO: Write more tests
+// HACKING is not an exception
+
+// STDIN for input
+// STDOUT for output
+// stderr for errors
+
+
+


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
- Add fixer for check-space option in comment-format rule

#### CHANGELOG.md entry:
[new-fixer] `comment-format`
