### PR TITLE
[fix-build] Fix completed-docs rule

### DIFF
--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -183,7 +183,7 @@ export class Rule extends Lint.Rules.TypedRule {
         ruleName: "completed-docs",
         description: "Enforces JSDoc comments for important items be filled out.",
         optionsDescription: Lint.Utils.dedent`
-            \`true\` to enable for `[${Object.keys(Rule.defaultArguments).join(", ")}]`,
+            \`true\` to enable for \`[${Object.keys(Rule.defaultArguments).join(", ")}]\`,
             or an array with each item in one of two formats:
 
             * \`string\` to enable for that type


### PR DESCRIPTION

- [X] Addresses an existing issue: No issue logged, but was discussed in #3750 [link to conversation](https://github.com/palantir/tslint/pull/3750#issuecomment-385942053)
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
- Fixes building of master
- Add escaping to backticks introduced in #3823
