### PR TITLE
no-implicit-dependencies always checks peer dependencies

### DIFF
--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -41,7 +41,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         `,
         optionsDescription: Lint.Utils.dedent`
             By default the rule looks at \`"dependencies"\` and \`"peerDependencies"\`.
-            By adding the \`"${OPTION_DEV}"\` option the rule looks at \`"devDependencies"\` instead of \`"peerDependencies"\`.
+            By adding the \`"${OPTION_DEV}"\` option the rule also looks at \`"devDependencies"\`.
             By adding the \`"${OPTION_OPTIONAL}"\` option the rule also looks at \`"optionalDependencies"\`.
         `,
         options: {
@@ -121,7 +121,7 @@ function getDependencies(fileName: string, options: Options): Set<string> {
             if (content.dependencies !== undefined) {
                 addDependencies(result, content.dependencies);
             }
-            if (!options.dev && content.peerDependencies !== undefined) {
+            if (content.peerDependencies !== undefined) {
                 addDependencies(result, content.peerDependencies);
             }
             if (options.dev && content.devDependencies !== undefined) {

--- a/test/rules/no-implicit-dependencies/dev/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/dev/test.ts.lint
@@ -1,5 +1,4 @@
 import * as ts from 'typescript';
-                    ~~~~~~~~~~~~ [err % ('typescript')]
 
 import {assert} from 'chai';
 


### PR DESCRIPTION
I would like to modify current behavior of `no-implicit-dependencies` to include peer dependencies even if dev dependencies are set to be checked.

#### PR checklist

- [x] enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Currently `no-implicit-dependencies` considers by default dependencies and peer dependencies. When `dev` option is configured, it will consider dev dependencies instead of peer dependencies. This change makes `dev` option include peer dependencies, so it's no longer one or the other.

#### CHANGELOG.md entry:

[rule-change] no-implicit-dependencies now always considers peer dependencies
