### PR TITLE
bugfix - no-use-before-declare - exception for destructuring w/ rename

### DIFF
--- a/src/rules/code-examples/noUseBeforeDeclare.examples.ts
+++ b/src/rules/code-examples/noUseBeforeDeclare.examples.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2013 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "../../index";
+
+// tslint:disable: object-literal-sort-keys
+export const codeExamples = [
+    {
+        description: "Check that referenced variables are declared beforehand (default)",
+        config: Lint.Utils.dedent`
+            "rules": { "no-use-before-declare": true }
+        `,
+        pass: Lint.Utils.dedent`
+            var hello = 'world';
+            var foo;
+
+            console.log(hello, foo, capitalize(hello));
+            // 'world', undefined, 'WORLD'
+
+            function capitalize(val) {
+                return val.toUpperCase();
+            }
+
+            import { default as foo1 } from "./lib";
+            import foo2 from "./lib";
+            import _, { map, foldl } from "./underscore";
+            import * as foo3 from "./lib";
+            import "./lib";
+
+            function declaredImports() {
+                console.log(foo1);
+                console.log(foo2);
+                console.log(foo3);
+                map([], (x) => x);
+            }
+        `,
+        fail: Lint.Utils.dedent`
+            console.log(hello, foo);
+
+            var hello = 'world';
+            var foo;
+
+            function undeclaredImports() {
+                console.log(foo1);
+                console.log(foo2);
+                console.log(foo3);
+                map([], (x) => x);
+            }
+
+            import { default as foo1 } from "./lib";
+            import foo2 from "./lib";
+            import _, { map, foldl } from "./underscore";
+            import * as foo3 from "./lib";
+            import "./lib";
+        `,
+    },
+];

--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -17,6 +17,7 @@
 
 import * as ts from "typescript";
 
+import { isBindingElement } from "tsutils";
 import * as Lint from "../index";
 
 export class Rule extends Lint.Rules.TypedRule {
@@ -60,6 +61,10 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
                 // Ignore `y` in `x.y`, but recurse to `x`.
                 return recur((node as ts.PropertyAccessExpression).expression);
             case ts.SyntaxKind.Identifier:
+                // Destructured params are declared later in the source.
+                if (node.parent !== undefined && isBindingElement(node.parent)) {
+                    return;
+                }
                 return checkIdentifier(node as ts.Identifier, checker.getSymbolAtLocation(node));
             case ts.SyntaxKind.ExportSpecifier:
                 return checkIdentifier(

--- a/test/rules/no-use-before-declare/test.ts.lint
+++ b/test/rules/no-use-before-declare/test.ts.lint
@@ -76,6 +76,8 @@ export {
 var undeclaredA = 42;
 var { undeclaredB } = { undeclaredB: 43 };
 var { undeclaredB: undeclaredA } = { undeclaredB: 43 };
+var { undeclaredB: undeclaredA, undeclaredC } = { undeclaredB: 43, undeclaredC: 'hello' };
+var { undeclaredB: undeclaredA, undeclaredC: undeclaredD } = { undeclaredB: 43, undeclaredC: 'hello' };
 const [ undeclaredC, [undeclaredD] ] = [ 1, [2] ];
 
 // shouldn't crash tslint

--- a/test/rules/no-use-before-declare/test.ts.lint
+++ b/test/rules/no-use-before-declare/test.ts.lint
@@ -1,3 +1,7 @@
+subscribe(({ meta: newMeta }:  {meta: SessionMeta}) => {
+    this.setCount(newMeta.match_count);
+});
+
 $.x = 3;
 ~        [variable '$' used before declaration]
 import $ = require("./$");

--- a/test/rules/no-use-before-declare/test.ts.lint
+++ b/test/rules/no-use-before-declare/test.ts.lint
@@ -2,6 +2,8 @@ subscribe(({ meta: newMeta }:  {meta: SessionMeta}) => {
     this.setCount(newMeta.match_count);
 });
 
+subscribe(({ meta: newMeta }) => this.setCount(meta.match_count));
+
 $.x = 3;
 ~        [variable '$' used before declaration]
 import $ = require("./$");
@@ -72,7 +74,8 @@ export {
 };
 
 var undeclaredA = 42;
-let { undeclaredB } = { undeclaredB: 43 };
+var { undeclaredB } = { undeclaredB: 43 };
+var { undeclaredB: undeclaredA } = { undeclaredB: 43 };
 const [ undeclaredC, [undeclaredD] ] = [ 1, [2] ];
 
 // shouldn't crash tslint


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #3761 
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [x] Documentation update

#### Overview of change:
The rule checks that identifiers have a declaration with a `pos` <= to the reference `pos`, which isn't the case when destructuring w/ a rename. 

```ts
var { x: y } = { x: 43 };
```

#### Is there anything you'd like reviewers to focus on?
Any edge cases with the destructuring syntax that would require additional tests?

#### CHANGELOG.md entry:
[bugfix] [`no-use-before-declare`](https://palantir.github.io/tslint/rules/no-use-before-declare/) Fixes false positives when using the destructuring syntax (#3761) 
