### PR TITLE
no-empty: fix lack of methods handling

### DIFF
--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -97,7 +97,8 @@ function isExcluded(node: ts.Node, options: Options): boolean {
     }
 
     if (options.allowEmptyFunctions &&
-        (node.kind === ts.SyntaxKind.FunctionDeclaration ||
+        (node.kind === ts.SyntaxKind.MethodDeclaration ||
+         node.kind === ts.SyntaxKind.FunctionDeclaration ||
          node.kind === ts.SyntaxKind.FunctionExpression ||
          node.kind === ts.SyntaxKind.ArrowFunction)) {
         return true;

--- a/test/rules/no-empty/allow-empty-catch/test.ts.lint
+++ b/test/rules/no-empty/allow-empty-catch/test.ts.lint
@@ -73,6 +73,14 @@ class PublicClassConstructor {
                          ~~ [block is empty]
 }
 
+class ClassMethod {
+    public methodWithoutResultTypehinting() {}
+                                            ~~ [block is empty]
+
+    public methodWithResultTypehinting(): void {}
+                                               ~~ [block is empty]
+}
+
 try {
     throw new Error();
 } catch (error) {}

--- a/test/rules/no-empty/allow-empty-catch/test.ts.lint
+++ b/test/rules/no-empty/allow-empty-catch/test.ts.lint
@@ -22,6 +22,9 @@ const testFunction2 = () => { };
 const testFunction3 = function() {}
                                  ~~ [block is empty]
 
+const testFunction4 = function(): void {}
+                                       ~~ [block is empty]
+
 for (var x = 0; x < 1; ++x) { }
                             ~~~ [block is empty]
 

--- a/test/rules/no-empty/allow-empty-functions/test.ts.lint
+++ b/test/rules/no-empty/allow-empty-functions/test.ts.lint
@@ -69,6 +69,12 @@ class PublicClassConstructor {
                          ~~ [block is empty]
 }
 
+class ClassMethod {
+    public methodWithoutResultTypehinting() {}
+
+    public methodWithResultTypehinting(): void {}
+}
+
 try {
     throw new Error();
 } catch (error) {}

--- a/test/rules/no-empty/allow-empty-functions/test.ts.lint
+++ b/test/rules/no-empty/allow-empty-functions/test.ts.lint
@@ -19,6 +19,8 @@ const testFunction2 = () => { };
 
 const testFunction3 = function() {}
 
+const testFunction4 = function(): void {}
+
 for (var x = 0; x < 1; ++x) { }
                             ~~~ [block is empty]
 

--- a/test/rules/no-empty/default/test.ts.lint
+++ b/test/rules/no-empty/default/test.ts.lint
@@ -73,6 +73,14 @@ class PublicClassConstructor {
                          ~~ [block is empty]
 }
 
+class ClassMethod {
+    public methodWithoutResultTypehinting() {}
+                                            ~~ [block is empty]
+
+    public methodWithResultTypehinting(): void {}
+                                               ~~ [block is empty]
+}
+
 try {
     throw new Error();
 } catch (error) {}

--- a/test/rules/no-empty/default/test.ts.lint
+++ b/test/rules/no-empty/default/test.ts.lint
@@ -22,6 +22,9 @@ const testFunction2 = () => { };
 const testFunction3 = function() {}
                                  ~~ [block is empty]
 
+const testFunction4 = function(): void {}
+                                       ~~ [block is empty]
+
 for (var x = 0; x < 1; ++x) { }
                             ~~~ [block is empty]
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3624 => that is the feature PR that incorporate the bug
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
I do like #3624 and I wanted to use it.
It already has support for classes, as it has special test case with constructor, which is handled differently.
Yet, class might need to have an empty method - and even if one is using `allow-empty-function`, then empty method is considered as violation.
When empty method may be valid? Class implements interface, want to provide empty implementation for abstract method from parent class or one is using ducktyping.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

`[bugfix] allow-empty-functions option of no-empty rule is now properly respecting empty methods`