### PR TITLE
Radix rule checks Number.parseInt(), window.Number.parseInt(), global…

### DIFF
--- a/src/rules/radixRule.ts
+++ b/src/rules/radixRule.ts
@@ -44,20 +44,45 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
+function isParseInt(expression: ts.LeftHandSideExpression) {
+    return isIdentifier(expression) && expression.text === "parseInt";
+}
+
+function isPropertyAccessParseInt(
+    expression: ts.LeftHandSideExpression,
+): expression is ts.PropertyAccessExpression {
+    return isPropertyAccessExpression(expression) && expression.name.text === "parseInt";
+}
+
+function isPropertyAccessOfIdentifier(
+    expression: ts.LeftHandSideExpression,
+    identifers: string[],
+): expression is ts.PropertyAccessExpression {
+    return isPropertyAccessExpression(expression) && isIdentifier(expression.expression) &&
+        identifers.some((identifer) => (expression.expression as ts.Identifier).text === identifer);
+}
+
+function isPropertyAccessOfProperty(
+    expression: ts.LeftHandSideExpression,
+    identifers: string[],
+): expression is ts.PropertyAccessExpression {
+    return isPropertyAccessExpression(expression) && isPropertyAccessExpression(expression.expression) &&
+        identifers.some((identifer) => (expression.expression as ts.PropertyAccessExpression).name.text === identifer);
+}
+
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (isCallExpression(node) && node.arguments.length === 1 &&
             (
                 // parseInt("123")
-                isIdentifier(node.expression) && node.expression.text === "parseInt" ||
-                // window.parseInt("123") || global.parseInt("123")
-                isPropertyAccessExpression(node.expression) &&
-                node.expression.name.text === "parseInt" &&
-                isIdentifier(node.expression.expression) &&
-                (
-                    node.expression.expression.text === "global" ||
-                    node.expression.expression.text === "window"
-                )
+                isParseInt(node.expression) ||
+                // window.parseInt("123") || global.parseInt("123") || Number.parseInt("123")
+                isPropertyAccessParseInt(node.expression) &&
+                isPropertyAccessOfIdentifier(node.expression, [ "global", "window", "Number" ])  ||
+                // window.Number.parseInt("123") || global.Number.parseInt("123")
+                isPropertyAccessParseInt(node.expression) &&
+                isPropertyAccessOfProperty(node.expression, [ "Number" ]) &&
+                isPropertyAccessOfIdentifier(node.expression.expression, [ "global", "window" ])
             )) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }

--- a/test/rules/radix/test.ts.lint
+++ b/test/rules/radix/test.ts.lint
@@ -11,3 +11,18 @@ global.parseInt("123");
 global.global.parseInt("123");
 window.parseInt("123");
 ~~~~~~~~~~~~~~~~~~~~~~  [Missing radix parameter]
+
+Number.parseInt("123", 10);
+Number.parseInt("123");
+~~~~~~~~~~~~~~~~~~~~~~  [Missing radix parameter]
+other.Number.parseInt("123");
+
+global.Number.parseInt("123", 10);
+global.Number.parseInt("123");
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Missing radix parameter]
+other.global.Number.parseInt("123");
+
+window.Number.parseInt("123", 10);
+window.Number.parseInt("123");
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Missing radix parameter]
+other.window.Number.parseInt("123");


### PR DESCRIPTION
….Number.parseInt()

#### PR checklist

- [x] Addresses an existing issue: #3895 
- [x] bugfix
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
radix rule now enforced on calls to Number.parseInt(), window.Number.parseInt(), and global.Number.parseInt()

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
