### PR TITLE
no-magic-numbers - support for negative zero

### DIFF
--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -64,12 +64,17 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static DEFAULT_ALLOWED = [ -1, 0, 1 ];
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const allowedNumbers = this.ruleArguments.length > 0 ? this.ruleArguments : Rule.DEFAULT_ALLOWED;
-        return this.applyWithWalker(new NoMagicNumbersWalker(sourceFile, this.ruleName, new Set(allowedNumbers.map(String))));
+        return this.applyWithWalker(
+            new NoMagicNumbersWalker(
+                sourceFile,
+                this.ruleName,
+                this.ruleArguments.length > 0 ? this.ruleArguments : Rule.DEFAULT_ALLOWED,
+            ),
+        );
     }
 }
 
-class NoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
+class NoMagicNumbersWalker extends Lint.AbstractWalker<number[]> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
             if (isCallExpression(node) && isIdentifier(node.expression) && node.expression.text === "parseInt") {
@@ -88,7 +93,11 @@ class NoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
     }
 
     private checkNumericLiteral(node: ts.Node, num: string) {
-        if (!Rule.ALLOWED_NODES.has(node.parent!.kind) && !this.options.has(num)) {
+        /* Using Object.is() to differentiate between pos/neg zero */
+        if (
+            !Rule.ALLOWED_NODES.has(node.parent!.kind) &&
+            !this.options.some((allowedNum) => Object.is(allowedNum, parseFloat(num)))
+        ) {
             this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
     }

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -3,6 +3,7 @@ parseInt('123', 2);
 parseInt('123', 8);
 parseInt('123', 10);
 parseInt('123', 16);
+console.log(-0);
 console.log(1337);
 console.log(-1337);
 console.log(- 1337);
@@ -13,8 +14,10 @@ console.log(-1338)
             ~~~~~                     ['magic numbers' are not allowed]
 parseInt(foo === 4711 ? bar : baz, 10);
                  ~~~~                 ['magic numbers' are not allowed]
+parseInt(foo === -0 ? bar : baz, 10);
 export let x = 1337;
 export let x = -1337;
 export let x = 1337.7;
 export let x = 1338;
 export let x = -1338;
+export let x = -0;

--- a/test/rules/no-magic-numbers/custom/tslint.json
+++ b/test/rules/no-magic-numbers/custom/tslint.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "no-magic-numbers": [true, 1337, 1337.7, -1337]
+    "no-magic-numbers": [true, 1337, 1337.7, -1337, -0]
   }
 }

--- a/test/rules/no-magic-numbers/default/test.ts.lint
+++ b/test/rules/no-magic-numbers/default/test.ts.lint
@@ -1,6 +1,8 @@
 console.log(-1, 0, 1);
 console.log(42.42);
             ~~~~~                     ['magic numbers' are not allowed]
+console.log(-0);
+            ~~                            ['magic numbers' are not allowed]
 const a = 1337;
 const b = {
     a: 1338,


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #3840 
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:
The rule's `allowed-numbers` were mapped using the`String` constructor, which strips the `-` off of `-0`. Using `Object.is` because `0 === -0` in JS. 
