### PR TITLE
Handle tsconfig.json errors without using JSON.stringify

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -75,7 +75,7 @@ export function runTest(testDirectory: string, rulesDirectory?: string | string[
     if (hasConfig) {
         const {config, error} = ts.readConfigFile(tsConfig, ts.sys.readFile);
         if (error !== undefined) {
-            throw new Error(JSON.stringify(error));
+            throw new Error(ts.formatDiagnostics([error], ts.createCompilerHost({})));
         }
 
         const parseConfigHost = {


### PR DESCRIPTION
JSON.stringify fails in some cases because its fails to convert circular structure to string

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
