### PR TITLE
Turn on strictPropertyInitialization for src/ and test/.

### DIFF
--- a/src/rules/noDuplicateVariableRule.ts
+++ b/src/rules/noDuplicateVariableRule.ts
@@ -63,7 +63,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class NoDuplicateVariableWalker extends Lint.AbstractWalker<Options> {
-    private scope: Set<string>;
+    private scope: Set<string> = new Set();
     public walk(sourceFile: ts.SourceFile) {
         this.scope = new Set();
         const cb = (node: ts.Node): void => {

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -150,7 +150,7 @@ class Scope {
 }
 
 class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
-    private scope: Scope;
+    private scope: Scope = new Scope();
     public walk(sourceFile: ts.SourceFile) {
         if (sourceFile.isDeclarationFile) {
             return;

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -121,7 +121,7 @@ interface DestructuringInfo {
 }
 
 class PreferConstWalker extends Lint.AbstractWalker<Options> {
-    private scope: Scope;
+    private scope: Scope = new Scope();
     public walk(sourceFile: ts.SourceFile) {
         // don't check anything on declaration files
         if (sourceFile.isDeclarationFile) {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -8,6 +8,7 @@
         "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictPropertyInitialization": true,
         "importHelpers": true,
         "declaration": true,
         "sourceMap": false,

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -8,6 +8,7 @@
         "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictPropertyInitialization": true,
         "sourceMap": true,
         "target": "es5",
         "lib": ["es6"],


### PR DESCRIPTION
Some Walker fields had to be initialized with inline initializers
instead of lazily intialized when .walk() is called.

#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Turns on a new TS strictness flag.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:
 [no-log] internal change

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
