### PR TITLE
no-console -- new config which offers ability to add custom failure string

### DIFF
--- a/src/rules/code-examples/no-console.examples.ts
+++ b/src/rules/code-examples/no-console.examples.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "../../index";
+
+// tslint:disable: object-literal-sort-keys
+export const codeExamples = [
+    {
+        description: "Disallow all console calls (default)",
+        config: Lint.Utils.dedent`
+            "rules": { "no-console": true }
+        `,
+        pass: Lint.Utils.dedent`
+            LogService.Log("Hello world!");
+        `,
+        fail: Lint.Utils.dedent`
+            console.log("Hello world!");
+        `,
+    },
+    {
+        description: "Choose which console methods to disallow",
+        config: Lint.Utils.dedent`
+            "rules": { "no-console": [true, "log", "warn"] }
+        `,
+        pass: Lint.Utils.dedent`
+            LogService.Log("Hello world!");
+            console.error("Something went wrong...");
+        `,
+        fail: Lint.Utils.dedent`
+            console.log("Hello world!");
+            console.warn("Something concerning happened...");
+        `,
+    },
+    {
+        description: "Choose which console methods to disallow and provide a custom error message",
+        config: Lint.Utils.dedent`
+            "rules": {
+                "no-console": [
+                    true,
+                    {
+                        "banned-methods": ["error"],
+                        "failure-string": "Instead of using console, try importing LogService."
+                    }
+                ]
+            }
+        `,
+        pass: Lint.Utils.dedent`
+            LogService.Log("Hello world!");
+            console.log("Hello world!");
+        `,
+        fail: Lint.Utils.dedent`
+            console.error("Something went wrong...");
+            // Calls to 'console.error' are not allowed. Instead of using console, try importing LogService.
+        `,
+    },
+];

--- a/src/rules/noConsoleRule.ts
+++ b/src/rules/noConsoleRule.ts
@@ -66,7 +66,16 @@ export class Rule extends Lint.Rules.AbstractRule {
                 },
             ],
         },
-        optionExamples: [[true, "log", "error"], [true, [], "Instead of using console, try importing LogService."]],
+        optionExamples: [
+            [true, "log", "error"],
+            [
+                true,
+                {
+                    "banned-methods": ["error", "warn"],
+                    "failure-string": "Instead of using console, try importing LogService."
+                },
+            ],
+        ],
         type: "functionality",
         typescriptOnly: false,
         codeExamples,

--- a/src/rules/noConsoleRule.ts
+++ b/src/rules/noConsoleRule.ts
@@ -18,7 +18,7 @@
 import { isCallExpression, isIdentifier, isPropertyAccessExpression } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
-import { codeExamples } from "./code-examples/preferWhile.examples";
+import { codeExamples } from "./code-examples/no-console.examples";
 
 interface Config {
     "banned-methods": string[] | undefined;

--- a/src/rules/noConsoleRule.ts
+++ b/src/rules/noConsoleRule.ts
@@ -72,7 +72,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 true,
                 {
                     "banned-methods": ["error", "warn"],
-                    "failure-string": "Instead of using console, try importing LogService."
+                    "failure-string": "Instead of using console, try importing LogService.",
                 },
             ],
         ],
@@ -90,10 +90,10 @@ export class Rule extends Lint.Rules.AbstractRule {
         return this.applyWithFunction(sourceFile, walk, this.parseOptions(this.ruleArguments));
     }
 
-    private parseOptions(ruleArguments: any[]): Options {
+    private parseOptions(ruleArguments: [Config] | string[]): Options {
         if (ruleArguments.length === 0 || typeof ruleArguments[0] === "string") {
             return {
-                bannedMethods: [...ruleArguments],
+                bannedMethods: [...ruleArguments as string[]],
                 customFailureString: undefined,
             };
         } else if (typeof ruleArguments[0] === "object") {

--- a/test/rules/no-console/custom-failure-string/test.ts.lint
+++ b/test/rules/no-console/custom-failure-string/test.ts.lint
@@ -1,0 +1,13 @@
+console.time();
+console.log("log");
+~~~~~~~~~~~             [Calls to 'console.log' are not allowed. Use the project's logging service, please.]
+console.dir(object);
+~~~~~~~~~~~             [Calls to 'console.dir' are not allowed. Use the project's logging service, please.]
+console.info("info");
+console.trace("trace");
+console.warn("warn");
+~~~~~~~~~~~~            [Calls to 'console.warn' are not allowed. Use the project's logging service, please.]
+console.error("error");
+~~~~~~~~~~~~~           [Calls to 'console.error' are not allowed. Use the project's logging service, please.]
+console.something();
+console.timeEnd();

--- a/test/rules/no-console/custom-failure-string/tslint.json
+++ b/test/rules/no-console/custom-failure-string/tslint.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "no-console": [
+      true,
+      {
+        "banned-methods": ["dir", "error", "log", "warn"],
+        "failure-string": "Use the project's logging service, please."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
There wasn't a public outcry for this enhancement or anything :laughing: . I do think it's a worthwhile feature but my feelings wont be hurt if it doesn't make it in. 

#### PR checklist
- [X] Addresses an existing issue: #3923 
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### Overview of change:
Adds a new configuration object to the `no-console` rule, but hopefully maintains the legacy configuration. 

#### Is there anything you'd like reviewers to focus on?
Did I cover all my bases with the new config? Am I properly accounting for legacy configurations? 
