### PR TITLE
Removed duplicate word from no-floating-promise docs

### DIFF
--- a/rules/no-floating-promises/index.html
+++ b/rules/no-floating-promises/index.html
@@ -17,7 +17,7 @@ optionExamples:
   - '[true, "JQueryPromise"]'
 rationale: |-
 
-  Creating a Promise and not storing or returning may lets other code run independent of of its results.
+  Creating a Promise and not storing or returning may let other code run independent of its results.
   This can cause unexpected and/or non-deterministic behavior depending on external timing factors.
 
   It's typically better to return Promises from functions that start them, then handle them in calling code.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### Overview of change:
Existing documentation for the no-floating-promises rule included a duplicate word and a typo, which has been addressed here.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
