### PR TITLE
Don't run no-unused-variable tests when deprecated against version of TS

### DIFF
--- a/test/rules/no-unused-variable/check-parameters/test.ts.lint
+++ b/test/rules/no-unused-variable/check-parameters/test.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 export function func1(x: number, y: number, ...args: number[]) {
                                                ~~~~              [err % ('args')]
     return x + y;

--- a/test/rules/no-unused-variable/default/class.ts.lint
+++ b/test/rules/no-unused-variable/default/class.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 class ABCD {
     private z2: number;
             ~~          [err % ('z2')]

--- a/test/rules/no-unused-variable/default/false-positives.ts.lint
+++ b/test/rules/no-unused-variable/default/false-positives.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 // case 1
 const fs = require("fs");
 

--- a/test/rules/no-unused-variable/default/function.ts.lint
+++ b/test/rules/no-unused-variable/default/function.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 function func1(x: number, y: number) {
     return x + y;
 }

--- a/test/rules/no-unused-variable/default/import.ts.lint
+++ b/test/rules/no-unused-variable/default/import.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 /**
  * Some license that appears in the leading trivia of a statement that will be deleted.
  * This text will not be deleted.

--- a/test/rules/no-unused-variable/default/react-addons1.tsx.lint
+++ b/test/rules/no-unused-variable/default/react-addons1.tsx.lint
@@ -1,4 +1,4 @@
-[typescript]: >= 2.1.0
+[typescript]: >= 2.1.0 < 2.9.0
 
 import * as React from "react/addons";
 

--- a/test/rules/no-unused-variable/default/react-addons2.tsx.lint
+++ b/test/rules/no-unused-variable/default/react-addons2.tsx.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 import * as React from "react/addons";
 
 export class MyComponent extends React.Component<{}, {}> {}

--- a/test/rules/no-unused-variable/default/react-addons3.tsx.lint
+++ b/test/rules/no-unused-variable/default/react-addons3.tsx.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 import * as React from "react/addons";
 #if typescript >= 2.6.0
             ~~~~~               ['React' is declared but its value is never read.]

--- a/test/rules/no-unused-variable/default/react1.tsx.lint
+++ b/test/rules/no-unused-variable/default/react1.tsx.lint
@@ -1,4 +1,4 @@
-[typescript]: >= 2.1.0
+[typescript]: >= 2.1.0 < 2.9.0
 
 import * as React from "react";
 

--- a/test/rules/no-unused-variable/default/react2.tsx.lint
+++ b/test/rules/no-unused-variable/default/react2.tsx.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 import * as React from "react";
 
 export class MyComponent extends React.Component<{}, {}> {}

--- a/test/rules/no-unused-variable/default/react3.tsx.lint
+++ b/test/rules/no-unused-variable/default/react3.tsx.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 import * as React from "react";
 #if typescript >= 2.6.0
             ~~~~~               ['React' is declared but its value is never read.]

--- a/test/rules/no-unused-variable/default/react4.tsx.lint
+++ b/test/rules/no-unused-variable/default/react4.tsx.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 import * as React from "react";
 #if typescript >= 2.6.0
             ~~~~~               ['React' is declared but its value is never read.]

--- a/test/rules/no-unused-variable/default/var.ts.lint
+++ b/test/rules/no-unused-variable/default/var.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 var x = 3;
 
 var y = x;

--- a/test/rules/no-unused-variable/ignore-pattern/var.ts.lint
+++ b/test/rules/no-unused-variable/ignore-pattern/var.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 import { _A } from './a.test';
 
 var x = 3;

--- a/test/rules/no-unused-variable/type-checked/destructuring.ts.lint
+++ b/test/rules/no-unused-variable/type-checked/destructuring.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 import { SomeClass, someVar } from "./some.test";
 const person = { name: "alice" };
 const { name } = person;

--- a/test/rules/no-unused-variable/type-checked/test.ts.lint
+++ b/test/rules/no-unused-variable/type-checked/test.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: < 2.9.0
 import {a, A} from './a.test';
 
 export class B {


### PR DESCRIPTION
#### Overview of change:
Fixes current test errors with TypeScript@next by disabling `no-unused-variable` tests when running against a version of TS that makes it deprecated

#### CHANGELOG.md entry:
[no-log]
