### PR TITLE
[new-rule-option] [no-implicit-dependencies] - add whitelist (#3839)

### DIFF
--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -26,6 +26,7 @@ import * as Lint from "../index";
 interface Options {
     dev: boolean;
     optional: boolean;
+    whitelist: string[];
 }
 
 const OPTION_DEV = "dev";
@@ -43,17 +44,28 @@ export class Rule extends Lint.Rules.AbstractRule {
             By default the rule looks at \`"dependencies"\` and \`"peerDependencies"\`.
             By adding the \`"${OPTION_DEV}"\` option the rule looks at \`"devDependencies"\` instead of \`"peerDependencies"\`.
             By adding the \`"${OPTION_OPTIONAL}"\` option the rule also looks at \`"optionalDependencies"\`.
+            An array of whitelisted modules can be added to skip checking their existence in package.json.
         `,
         options: {
             type: "array",
-            items: {
-                type: "string",
-                enum: [OPTION_DEV, OPTION_OPTIONAL],
-            },
+            items: [
+                {
+                    type: "string",
+                    enum: [OPTION_DEV, OPTION_OPTIONAL],
+                },
+                {
+                    type: "array",
+                },
+            ],
             minItems: 0,
-            maxItems: 2,
+            maxItems: 3,
         },
-        optionExamples: [true, [true, OPTION_DEV], [true, OPTION_OPTIONAL]],
+        optionExamples: [
+          true,
+          [true, OPTION_DEV],
+          [true, OPTION_OPTIONAL],
+          [true, ["src", "app"]],
+        ],
         type: "functionality",
         typescriptOnly: false,
     };
@@ -64,9 +76,15 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        let whitelist = this.ruleArguments.find((arg) => Array.isArray(arg)) as string[];
+        if (whitelist === null || whitelist === undefined) {
+          whitelist = [];
+        }
+
         return this.applyWithFunction(sourceFile, walk, {
             dev: this.ruleArguments.indexOf(OPTION_DEV) !== - 1,
             optional: this.ruleArguments.indexOf(OPTION_OPTIONAL) !== -1,
+            whitelist,
         });
     }
 }
@@ -77,7 +95,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
     for (const name of findImports(ctx.sourceFile, ImportKind.All)) {
         if (!ts.isExternalModuleNameRelative(name.text)) {
             const packageName = getPackageName(name.text);
-            if (builtins.indexOf(packageName) === -1 && !hasDependency(packageName)) {
+            if (options.whitelist.indexOf(packageName) === -1 && builtins.indexOf(packageName) === -1 && !hasDependency(packageName)) {
                 ctx.addFailureAtNode(name, Rule.FAILURE_STRING_FACTORY(packageName));
             }
         }

--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -92,10 +92,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<Options>) {
     const {options} = ctx;
     let dependencies: Set<string> | undefined;
+    const whitelist = new Set(options.whitelist);
     for (const name of findImports(ctx.sourceFile, ImportKind.All)) {
         if (!ts.isExternalModuleNameRelative(name.text)) {
             const packageName = getPackageName(name.text);
-            if (options.whitelist.indexOf(packageName) === -1 && builtins.indexOf(packageName) === -1 && !hasDependency(packageName)) {
+            if (!whitelist.has(packageName) && builtins.indexOf(packageName) === -1 && !hasDependency(packageName)) {
                 ctx.addFailureAtNode(name, Rule.FAILURE_STRING_FACTORY(packageName));
             }
         }

--- a/test/rules/no-implicit-dependencies/whitelist-with-dev/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/whitelist-with-dev/test.ts.lint
@@ -1,0 +1,11 @@
+import * as ts from 'typescript';
+                    ~~~~~~~~~~~~ [err % ('typescript')]
+
+import * from 'src/a';
+
+import * from 'app/b';
+
+import * from 'notapp/c';
+              ~~~~~~~~~~ [err % ('notapp')]
+
+[err]: Module '%s' is not listed as dependency in package.json

--- a/test/rules/no-implicit-dependencies/whitelist-with-dev/tslint.json
+++ b/test/rules/no-implicit-dependencies/whitelist-with-dev/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-implicit-dependencies": [true, "dev", ["src", "app"]]
+  }
+}

--- a/test/rules/no-implicit-dependencies/whitelist/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/whitelist/test.ts.lint
@@ -1,0 +1,10 @@
+import * as ts from 'typescript';
+
+import * from 'src/a';
+
+import * from 'app/b';
+
+import * from 'notapp/c';
+              ~~~~~~~~~~ [err % ('notapp')]
+
+[err]: Module '%s' is not listed as dependency in package.json

--- a/test/rules/no-implicit-dependencies/whitelist/tslint.json
+++ b/test/rules/no-implicit-dependencies/whitelist/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-implicit-dependencies": [true, ["src", "app"]]
+  }
+}


### PR DESCRIPTION
This allows you to specify a whitelist of modules that will not be part of package.json such as project-relative aliases

#### PR checklist

- [x] Addresses an existing issue: #3839 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
This adds an option to `no-implicit-dependencies` to specify dependencies that will be known not to be included in package.json such as project-relative imports.

#### CHANGELOG.md entry:
[new-rule-option] [no-implicit-dependencies] whitelist