### PR TITLE
Default logger.error should log to stderr.

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -271,7 +271,7 @@ run(
             outputStream.write(m);
         },
         error(m) {
-            process.stdout.write(m);
+            process.stderr.write(m);
         },
     })
     .then((rc) => {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
`Logger.error` used to print to stderr but was changed in https://github.com/palantir/tslint/pull/3374/files#diff-6797028d8925eecff5ec1c3293f47258.
I assume that's not intentional change?

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
