### PR TITLE
Use Buffer.allocUnsafe instead of the deprecated new Buffer()

### DIFF
--- a/src/rules/encodingRule.ts
+++ b/src/rules/encodingRule.ts
@@ -66,7 +66,7 @@ function showEncoding(encoding: Encoding): string {
 function detectEncoding(fileName: string): Encoding {
     const fd = fs.openSync(fileName, "r");
     const maxBytesRead = 3; // Only need 3 bytes to detect the encoding.
-    const buffer = new Buffer(maxBytesRead);
+    const buffer = Buffer.allocUnsafe(maxBytesRead);
     const bytesRead = fs.readSync(fd, buffer, /*offset*/ 0, /*length*/ maxBytesRead, /*position*/ 0);
     fs.closeSync(fd);
     return detectBufferEncoding(buffer, bytesRead);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -291,7 +291,7 @@ async function tryReadFile(filename: string, logger: Logger): Promise<string | u
     if (!fs.existsSync(filename)) {
         throw new FatalError(`Unable to open file: ${filename}`);
     }
-    const buffer = new Buffer(256);
+    const buffer = Buffer.allocUnsafe(256);
     const fd = fs.openSync(filename, "r");
     try {
         fs.readSync(fd, buffer, 0, 256, 0);


### PR DESCRIPTION
(node:16148) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
allocUnsafe should be fine because in both cases, the buffer is immediately filled and thrown out.

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [X] bugfix
- [ ] Includes tests
- [ ] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
