### PR TITLE
[enhancement] [no-implicit-dependencies] - nested packages checks (#3980)

### DIFF
--- a/test/rules/no-implicit-dependencies/default/nested-package-no-dependencies/package.json
+++ b/test/rules/no-implicit-dependencies/default/nested-package-no-dependencies/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "nested-no-dependencies",
+  "version": "0.0.1"
+}

--- a/test/rules/no-implicit-dependencies/default/nested-package-no-dependencies/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/default/nested-package-no-dependencies/test.ts.lint
@@ -1,0 +1,24 @@
+import {assert} from 'chai';
+                     ~~~~~~ [err % ('chai')]
+import foo from 'foo';
+
+if (foo) {
+    const common = require('common');
+                           ~~~~~~~~ [err % ('common')]
+}
+
+export * from "@angular/core";
+
+export * from "@angular/common/http";
+
+import * as ts from "typescript";
+
+import "baz";
+       ~~~~~ [err % ('baz')]
+
+const http = require('http');
+
+import * as fsevents from "fsevents";
+                          ~~~~~~~~~~ [err % ('fsevents')]
+
+[err]: Module '%s' is not listed as dependency in package.json


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3980
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
This updates the check to find `package.json` to exclude any `package.json` that don't declare any dependencies at all. These can sometimes be used for organizational purposes. In this case, it's very possible that dependencies are appropriately declared in a `package.json` higher up in the directory structure, but this is missed if there is any `package.json` at all lower in the file system structure.

This is at least a partial fix to #3980, although the ability to specify the location of dependencies would ultimately be better. This is a less intrusive change.

#### CHANGELOG.md entry:
[enhancement] [no-implicit-dependencies] skip `package.json` with no dependencies.
