### PR TITLE
[New Rule] no-parent-dir-import rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -118,6 +118,7 @@ export const rules = {
     "no-misused-new": true,
     "no-null-keyword": true,
     "no-object-literal-type-assertion": true,
+    "no-parent-dir-import": false,
     "no-return-await": true,
     "no-shadowed-variable": true,
     "no-string-literal": true,

--- a/src/rules/noParentDirImportRule.ts
+++ b/src/rules/noParentDirImportRule.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findImports, ImportKind } from "tsutils";
+
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-parent-dir-import",
+        description: "Disallows imports from parent directory",
+        rationale: Lint.Utils.dedent`
+            enforces relative path usage either from baseUrl or specialized paths (e.g. @common/)
+        `,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: [true],
+        type: "functionality",
+        typescriptOnly: false,
+        hasFix: false,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Import from parent directory";
+
+    public static PARENT_DIR = "../";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>) {
+    for (const name of findImports(ctx.sourceFile, ImportKind.All)) {
+        if (name.text.indexOf(Rule.PARENT_DIR) !== -1) {
+            ctx.addFailure(name.getStart(ctx.sourceFile) + 1, name.end - 1, Rule.FAILURE_STRING);
+        }
+    }
+}

--- a/test/rules/no-parent-dir-import/test.ts.lint
+++ b/test/rules/no-parent-dir-import/test.ts.lint
@@ -1,0 +1,14 @@
+// ok 
+import { Foo } from "some/dir/file";
+
+import content = require("@common/some/dir/file");
+
+import * as fs from "fs";
+
+// fail
+import { Foo } from "../../some/dir";
+                     ~~~~~~~~~~~~~~  [Import from parent directory]
+
+// fail
+import content = require("../../some/dir");
+                          ~~~~~~~~~~~~~~  [Import from parent directory]

--- a/test/rules/no-parent-dir-import/tslint.json
+++ b/test/rules/no-parent-dir-import/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-parent-dir-import": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3974
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

A rule to enforce imports from base directory or from configured paths: https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping

At least for the project at work, this would be a good addition - we've decided quite a long time ago to almost always use full path from `src` folder when importing something. There is only one exception: when a file is in same directory (or sub-directory). The main reason for this is that the project went through numerous refactors and having full path in imports made it easier to rearrange file structure without going through all the imports in every moved file.

#### Is there anything you'd like reviewers to focus on?

1. rule name
2. a need for a fixer?

#### CHANGELOG.md entry:

"[new-rule] `no-parent-dir-import`"


P.S. Nice work on the repo, this was easier than I thought initially!