### PR TITLE
[Bugfix] Fix for whitespace rule requiring extra space in ImportType in TS 2.9

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -296,6 +296,10 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 }
                 break;
             case ts.SyntaxKind.ImportKeyword:
+                if ((ts.SyntaxKind as any).ImportType !== undefined && parent.kind === (ts.SyntaxKind as any).ImportType) {
+                    return; // Don't check ImportType
+                }
+
                 if (parent.kind === ts.SyntaxKind.CallExpression &&
                     (parent as ts.CallExpression).expression.kind === ts.SyntaxKind.ImportKeyword) {
                     return; // Don't check ImportCall

--- a/test/rules/whitespace/all/import-type.ts.lint
+++ b/test/rules/whitespace/all/import-type.ts.lint
@@ -1,0 +1,31 @@
+[typescript]: >=2.9.0
+const foo: import("bar");
+const foo: import ("bar");
+
+function foo(a: import("bar")): import("baz") {}
+function foo(a: import ("bar")): import ("baz") {}
+
+const foo = (a: import("bar")): import("baz") => {};
+const foo = (a: import ("bar")): import ("baz") => {};
+
+type foo = { bar: import("baz") } & import("qux");
+type foo = { bar: import ("baz") } & import ("qux");
+
+interface Foo {
+    bar: import("baz");
+    qux: import ("quux");
+}
+
+class Foo {
+    bar: import("baz");
+    qux: import ("quux");
+}
+
+/**
+ * @param bar { import("qux") }
+ * @param baz { import ("qux") }
+ */
+function foo(bar, baz) { }
+
+type foo = Bar<import("baz")>;
+type foo = Bar<import ("baz")>;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3987 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Fixes the bug where the new `ImportType` syntax required extra spacing when `whitespace` rule was enabled.

#### Is there anything you'd like reviewers to focus on?

- Beware, my first dive into TSLint and the AST. 😄 
- Might have overdone or missed the test cases
- As this seems to be only relevant in TS 2.9 and above, not sure how you usually deal with cases like this if you want to support older TS versions?
  - I've done the first thing that came to mind and typecasted the `SyntaxKind` as `any` and let the `ImportKind` end up `undefined` to fail the check. 
  - Is there an standard way on how this is handled usually?
  - I've extracted the tests for this to a file which is only ran on TS 2.9, I'm assuming that's fine as the syntax for this to work should get struck down by the TS compiler for users of the older TS anyway?

#### CHANGELOG.md entry:

[bugfix] `whitespace` rule no longer requires extra spaces with the TS 2.9 import type syntax
