### PR TITLE
[new-rule] add comment-type rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -187,6 +187,7 @@ export const rules = {
         "check-space",
         "check-uppercase",
     ],
+    "comment-type": [true, "singleline", "multiline", "doc", "directive"],
     "completed-docs": true,
     // "file-header": No sensible default
     "deprecation": true,

--- a/src/rules/commentTypeRule.ts
+++ b/src/rules/commentTypeRule.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as utils from "tsutils";
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+// Options
+type CommentType = "singleline" | "multiline" | "doc" | "directive";
+
+type Options = Set<CommentType>;
+
+function parseOptions(opts: any[]): Options {
+    return new Set(opts);
+}
+
+// Constant Messages
+const MULTILINE_FAILURE = "multiline comments are not allowed";
+const SINGLE_LINE_FAILURE = "singleline comments are not allowed";
+const DOC_FAILURE = "doc comments are not allowed";
+const DIRECTIVE_FAILURE = "triple-slash directives are not allowed";
+
+// Logic
+export class Rule extends Lint.Rules.AbstractRule {
+
+    // tslint:disable:object-literal-sort-keys
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "comment-type",
+        description: "Allows a limited set of comment types",
+        optionsDescription: Lint.Utils.dedent`
+            One or more of the following mutually exclusive comment types may be provided:
+
+            * \`singleline\`: Comments starting with \`//\`
+            * \`multiline\`:  Comments between \`/*\` and \`*/\` but are not doc comments
+            * \`doc\`:        Multiline comments that start with \`/**\`
+            * \'directive\':  Triple-slash directives that are singleline comments starting with \`///\``,
+        options: {
+            type: "array",
+            items: {
+                type: "string",
+                enum: ["singleline", "multiline", "doc", "directive"],
+            },
+            uniqueItems: true,
+        },
+        optionExamples: [
+            [true, "doc", "singleline"],
+            [true, "singleline"],
+            [true, "multiline"],
+        ],
+        hasFix: false,
+        type: "style",
+        typescriptOnly: false,
+    };
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk, parseOptions(this.ruleArguments));
+    }
+
+}
+
+function walk(ctx: Lint.WalkContext<Options>) {
+    utils.forEachComment(ctx.sourceFile, (fullText, {kind, pos, end}) => {
+        if (kind === ts.SyntaxKind.SingleLineCommentTrivia) {
+            // directive
+            if (fullText.slice(pos, pos + 3) === "///" && !ctx.options.has("directive")) {
+                ctx.addFailure(pos, end, DIRECTIVE_FAILURE);
+            // singleline
+            } else if (fullText.slice(pos, pos + 3) !== "///" && !ctx.options.has("singleline")) {
+                ctx.addFailure(pos, end, SINGLE_LINE_FAILURE);
+            }
+        } else if (kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+            // doc
+            if (fullText.slice(pos, pos + 3) === "/**" && !ctx.options.has("doc")) {
+                ctx.addFailure(pos, end, DOC_FAILURE);
+            // multiline
+            } else if (fullText.slice(pos, pos + 3) !== "/**" && !ctx.options.has("multiline")) {
+                ctx.addFailure(pos, end, MULTILINE_FAILURE);
+            }
+        }
+    });
+}

--- a/test/rules/comment-type/combo/test.ts.lint
+++ b/test/rules/comment-type/combo/test.ts.lint
@@ -1,0 +1,25 @@
+/// <reference path=".." />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [directive]
+
+// single comment
+
+/* multiline comment */
+~~~~~~~~~~~~~~~~~~~~~~~ [multiline]
+
+/** doc comment */
+
+  /** indented doc comment */
+
+const x = /** inline doc comment */ 3;
+
+/*
+~~
+actually
+~~~~~~~~
+multiline
+~~~~~~~~~
+*/
+~~ [multiline]
+
+[multiline]: multiline comments are not allowed
+[directive]: triple-slash directives are not allowed

--- a/test/rules/comment-type/combo/tslint.json
+++ b/test/rules/comment-type/combo/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "comment-type": [true, "singleline", "doc"]
+  }
+}

--- a/test/rules/comment-type/directive/test.ts.tslint
+++ b/test/rules/comment-type/directive/test.ts.tslint
@@ -1,0 +1,29 @@
+/// <reference path=".." />
+
+// single comment
+~~~~~~~~~~~~~~~~~ [singleline]
+
+/* multiline comment */
+~~~~~~~~~~~~~~~~~~~~~~~ [multiline]
+
+/** doc comment */
+~~~~~~~~~~~~~~~~~~ [doc]
+
+  /** indented doc comment */
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~ [doc]
+
+const x = /** inline doc comment */ 3;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~ [doc]
+
+/*
+~~
+actually
+~~~~~~~~
+multiline
+~~~~~~~~~
+*/
+~~ [multiline]
+
+[singleline]: singleline comments are not allowed
+[multiline]: multiline comments are not allowed
+[doc]: doc comments are not allowed

--- a/test/rules/comment-type/directive/tslint.json
+++ b/test/rules/comment-type/directive/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "comment-type": [true, "directive"]
+  }
+}

--- a/test/rules/comment-type/doc/test.ts.lint
+++ b/test/rules/comment-type/doc/test.ts.lint
@@ -1,0 +1,27 @@
+/// <reference path=".." />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [directive]
+
+// single comment
+~~~~~~~~~~~~~~~~~ [singleline]
+
+/* multiline comment */
+~~~~~~~~~~~~~~~~~~~~~~~ [multiline]
+
+/** doc comment */
+
+  /** indented doc comment */
+
+const x = /** inline doc comment */ 3;
+
+/*
+~~
+actually
+~~~~~~~~
+multiline
+~~~~~~~~~
+*/
+~~ [multiline]
+
+[singleline]: singleline comments are not allowed
+[multiline]: multiline comments are not allowed
+[directive]: triple-slash directives are not allowed

--- a/test/rules/comment-type/doc/tslint.json
+++ b/test/rules/comment-type/doc/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "comment-type": [true, "doc"]
+  }
+}

--- a/test/rules/comment-type/multiline/test.ts.lint
+++ b/test/rules/comment-type/multiline/test.ts.lint
@@ -1,0 +1,25 @@
+/// <reference path=".." />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [directive]
+
+// single comment
+~~~~~~~~~~~~~~~~~ [singleline]
+
+/* multiline comment */
+
+/** doc comment */
+~~~~~~~~~~~~~~~~~~ [doc]
+
+  /** indented doc comment */
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~ [doc]
+
+const x = /** inline doc comment */ 3;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~ [doc]
+
+/*
+actually
+multiline
+*/
+
+[singleline]: singleline comments are not allowed
+[doc]: doc comments are not allowed
+[directive]: triple-slash directives are not allowed

--- a/test/rules/comment-type/multiline/tslint.json
+++ b/test/rules/comment-type/multiline/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "comment-type": [true, "multiline"]
+  }
+}

--- a/test/rules/comment-type/single-line/test.ts.lint
+++ b/test/rules/comment-type/single-line/test.ts.lint
@@ -1,0 +1,29 @@
+/// <reference path=".." />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ [directive]
+
+// single comment
+
+/* multiline comment */
+~~~~~~~~~~~~~~~~~~~~~~~ [multiline]
+
+/** doc comment */
+~~~~~~~~~~~~~~~~~~ [doc]
+
+  /** indented doc comment */
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~ [doc]
+
+const x = /** inline doc comment */ 3;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~ [doc]
+
+/*
+~~
+actually
+~~~~~~~~
+multiline
+~~~~~~~~~
+*/
+~~ [multiline]
+
+[multiline]: multiline comments are not allowed
+[doc]: doc comments are not allowed
+[directive]: triple-slash directives are not allowed

--- a/test/rules/comment-type/single-line/tslint.json
+++ b/test/rules/comment-type/single-line/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "comment-type": [true, "singleline"]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4005 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Adds a new rule `comment-type` which allows you to specify the type of comments you allow in your project.

#### CHANGELOG.md entry:
[new-rule] comment-type
