### PR TITLE
Fix CI: no-implicit-dependencies test failure; typescript@next failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "resolve": "^1.3.2",
     "semver": "^5.3.0",
     "tslib": "^1.8.0",
-    "tsutils": "^2.12.1"
+    "tsutils": "^2.27.2"
   },
   "peerDependencies": {
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"
@@ -75,7 +75,7 @@
     "ts-node": "^3.3.0",
     "tslint": "^5.8.0",
     "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
-    "typescript": "~2.8.3"
+    "typescript": "~2.9.2"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -42,6 +42,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public static FAILURE_STRING = "object access via string literals is disallowed";
 
+    public static id(input: string) {
+        return input;
+    }
+
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
     }
@@ -52,8 +56,12 @@ function walk(ctx: Lint.WalkContext<void>) {
         if (isElementAccessExpression(node)) {
             const argument = node.argumentExpression;
             if (argument !== undefined && isStringLiteral(argument) && isValidPropertyAccess(argument.text)) {
-                // for compatibility with typescript@<2.5.0 to avoid fixing expr['__foo'] to expr.___foo
-                const propertyName = ts.unescapeIdentifier(argument.text); // tslint:disable-line:deprecation
+                // typescript@<2.5.0 has an extra underscore in escaped identifier text content,
+                // to avoid fixing issue `expr['__foo'] → expr.___foo`, unescapeIdentifier() is to be used
+                // As of typescript@3, unescapeIdentifier() removed, thus check in runtime, if the method exists
+                // tslint:disable-next-line no-unsafe-any strict-boolean-expressions
+                const unescapeIdentifier: typeof Rule["id"] = (ts as any).unescapeIdentifier || Rule.id;
+                const propertyName = unescapeIdentifier(argument.text);
                 ctx.addFailureAtNode(
                     argument,
                     Rule.FAILURE_STRING,

--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -365,7 +365,7 @@ function isPropertyAny(node: ts.PropertyDeclaration, checker: ts.TypeChecker) {
     if (!isNodeAny(node.name, checker) || node.name.kind === ts.SyntaxKind.ComputedPropertyName) {
         return false;
     }
-    for (const base of checker.getBaseTypes(checker.getTypeAtLocation(node.parent!) as ts.InterfaceType)) {
+    for (const base of checker.getBaseTypes(checker.getTypeAtLocation(node.parent) as ts.InterfaceType)) {
         const prop = base.getProperty(node.name.text);
         if (prop !== undefined && prop.declarations !== undefined) {
             return isAny(checker.getTypeOfSymbolAtLocation(prop, prop.declarations[0]));

--- a/test/rules/no-implicit-dependencies/whitelist-with-dev/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/whitelist-with-dev/test.ts.lint
@@ -1,5 +1,4 @@
 import * as ts from 'typescript';
-                    ~~~~~~~~~~~~ [err % ('typescript')]
 
 import * from 'src/a';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1568,6 +1568,10 @@ tslib@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
 
+tslib@^1.8.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
 "tslint-test-config-non-relative@file:test/external/tslint-test-config-non-relative":
   version "0.0.1"
 
@@ -1593,6 +1597,12 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.7.1"
 
+tsutils@^2.27.2:
+  version "2.27.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
+  dependencies:
+    tslib "^1.8.1"
+
 type-detect@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
@@ -1601,9 +1611,9 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-typescript@~2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@~2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 uglify-js@^2.6:
   version "2.8.28"


### PR DESCRIPTION
### Fixes build status:

#### Failing tests on `master` caused by consequent merges of #3979 and #3875.

`whitelist-with-dev` with option `"dev"`: the rule looks at both `dev` and `peer` dependencies, thus allowing `typescript` package to be used.

_As it turned out, there is another PR fixing this (https://github.com/palantir/tslint/pull/4011)_

#### Failing `testNext` step caused by removed `unescapeIdentifier()` (https://github.com/Microsoft/TypeScript/pull/25333)

Changes overview:

* the method was used in `noStringLiteralRule.ts`
* the method was used in `tsutils` (fixed in 2.27.2, version bumped)
* `tsutils@2.27.2` relies on typescript@2.9.x (version bumped)
* minor change in `noUnsafeAnyRule.ts` due to updated typings
