### PR TITLE
enhancement: Add quiet flag to hide warnings

### DIFF
--- a/docs/usage/cli/index.md
+++ b/docs/usage/cli/index.md
@@ -44,6 +44,7 @@ Options:
 -r, --rules-dir [rules-dir]            rules directory
 -s, --formatters-dir [formatters-dir]  formatters directory
 -t, --format [format]                  output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)
+-q, --quiet                            hide non "error" severity linting errors from output
 --test                                 test that tslint produces the correct output for the specified directory
 -p, --project [project]                tsconfig.json file
 --type-check                           (deprecated) check for type errors before linting the project
@@ -116,6 +117,11 @@ tslint accepts the following command-line options:
     Other built-in options include pmd, msbuild, checkstyle, and vso.
     Additional formatters can be added and used if the --formatters-dir
     option is set.
+
+-q, --quiet
+    Hide non "error" severity linting errors from output. This can be
+    especially useful in CI environments, where you may want only "error"
+    severity linting errors to cause linting to fail.
 
 --test:
     Runs tslint on matched directories and checks if tslint outputs

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,5 +47,6 @@ export interface ILinterOptions {
     fix: boolean;
     formatter?: string | FormatterConstructor;
     formattersDirectory?: string;
+    quiet?: boolean;
     rulesDirectory?: string | string[];
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -142,6 +142,9 @@ export class Linter {
     }
 
     public getResult(): LintResult {
+        const errors = this.failures.filter((failure) => failure.getRuleSeverity() === "error");
+        const failures = this.options.quiet ? errors : this.failures;
+
         const formatterName = this.options.formatter !== undefined ? this.options.formatter : "prose";
         const Formatter = findFormatter(formatterName, this.options.formattersDirectory);
         if (Formatter === undefined) {
@@ -149,16 +152,16 @@ export class Linter {
         }
         const formatter = new Formatter();
 
-        const output = formatter.format(this.failures, this.fixes);
+        const output = formatter.format(failures, this.fixes);
 
-        const errorCount = this.failures.filter((failure) => failure.getRuleSeverity() === "error").length;
+        const errorCount = errors.length;
         return {
             errorCount,
-            failures: this.failures,
+            failures,
             fixes: this.fixes,
             format: formatterName,
             output,
-            warningCount: this.failures.length - errorCount,
+            warningCount: failures.length - errorCount,
         };
     }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -90,6 +90,11 @@ export interface Options {
     project?: string;
 
     /**
+     * Whether to hide warnings
+     */
+    quiet?: boolean;
+
+    /**
      * Rules directory paths.
      */
     rulesDirectory?: string | string[];
@@ -241,9 +246,11 @@ async function doLinting(options: Options, files: string[], program: ts.Program 
             fix: !!options.fix,
             formatter: options.format,
             formattersDirectory: options.formattersDirectory,
+            quiet: !!options.quiet,
             rulesDirectory: options.rulesDirectory,
         },
-        program);
+        program,
+    );
 
     let lastFolder: string | undefined;
     let configFile = options.config !== undefined ? findConfiguration(options.config).results : undefined;

--- a/src/tslintCli.ts
+++ b/src/tslintCli.ts
@@ -40,6 +40,7 @@ interface Argv {
     typeCheck?: boolean;
     test?: boolean;
     version?: boolean;
+    quiet?: boolean;
 }
 
 interface Option {
@@ -180,6 +181,13 @@ const options: Option[] = [
             type checker.`,
     },
     {
+        short: "q",
+        name: "quiet",
+        type: "boolean",
+        describe: "hide errors on lint",
+        description: "If true, hides warnings from linting output.",
+    },
+    {
         name: "type-check",
         type: "boolean",
         describe: "(deprecated) check for type errors before linting the project",
@@ -262,6 +270,7 @@ run(
         out: argv.out,
         outputAbsolutePaths: argv.outputAbsolutePaths,
         project: argv.project,
+        quiet: argv.quiet,
         rulesDirectory: argv.rulesDir,
         test: argv.test,
         typeCheck: argv.typeCheck,

--- a/test/linterTests.ts
+++ b/test/linterTests.ts
@@ -18,10 +18,10 @@
 import { assert } from "chai";
 import * as fs from "fs";
 import { createSourceFile, ScriptTarget } from "typescript";
+import { DEFAULT_CONFIG } from "../src/configuration";
 import { Replacement, RuleFailure } from "../src/language/rule/rule";
-import { createTempFile } from "./utils";
-
 import { Linter } from "../src/linter";
+import { createTempFile } from "./utils";
 
 class TestLinter extends Linter {
     public applyFixesHelper(fileName: string, source: string, ruleFailures: RuleFailure[]) {
@@ -49,6 +49,11 @@ const templateDeclarationFixed =
 <div></div>
 `;
 
+const withWarningDeclaration =
+`
+  console.log("This line will not pass linting with the default rule set");
+`;
+
 describe("Linter", () => {
 
     it("apply fixes to correct files", () => {
@@ -64,4 +69,39 @@ describe("Linter", () => {
         assert.equal(fs.readFileSync(templateFile, "utf-8"), templateDeclarationFixed);
     });
 
+    it("shows warnings", () => {
+        const config = DEFAULT_CONFIG;
+        config.rules.set("no-console", {
+            ruleArguments: ["log"],
+            ruleName: "no-console",
+            ruleSeverity: "warning",
+        });
+
+        const linter = new TestLinter({ fix: false });
+        const fileToLint = createTempFile("ts");
+        fs.writeFileSync(fileToLint, withWarningDeclaration);
+        linter.lint(fileToLint, withWarningDeclaration, config);
+        const result = linter.getResult();
+
+        assert.equal(result.warningCount, 1);
+        assert.equal(result.errorCount, 0);
+    });
+
+    it("does not show warnings when `quiet` is `true`", () => {
+        const config = DEFAULT_CONFIG;
+        config.rules.set("no-console", {
+            ruleArguments: ["log"],
+            ruleName: "no-console",
+            ruleSeverity: "warning",
+        });
+
+        const linter = new TestLinter({ fix: false, quiet: true });
+        const fileToLint = createTempFile("ts");
+        fs.writeFileSync(fileToLint, withWarningDeclaration);
+        linter.lint(fileToLint, withWarningDeclaration, config);
+        const result = linter.getResult();
+
+        assert.equal(result.warningCount, 0);
+        assert.equal(result.errorCount, 0);
+    });
 });


### PR DESCRIPTION
Sometimes you may want to run linting but ignore any warnings produced, such as in a CI environment where you only want lint failures to fail the build (many runners will check both the exit code and STDERR to see if the program has passed).

This mimics the `quiet` flag available in ESLint, which hides errors from output when passed.

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Adds a new CLI flag, `quiet`, to allow hiding of lint warnings.

#### Is there anything you'd like reviewers to focus on?

What's the best way to test this? I've been having trouble trying to do it in the `linterTests`. I've been trying:

```typescript
const withWarningDeclaration =
`
  console.log("This line will not pass linting with the default rule set");
`;

it("shows warnings", () => {
    const config = DEFAULT_CONFIG;
    config.rules.set("no-console", {
        ruleArguments: ["log"],
        ruleName: "no-console",
        ruleSeverity: "warning",
    });
    
    const linter = new TestLinter({ fix: false });
    const fileToLint = createTempFile("ts");
    fs.writeFileSync(fileToLint, withWarningDeclaration);
    linter.lint(fileToLint, "Don't Need This If We Have A Program", config);
    const result = linter.getResult();

    assert.equal(result.warningCount, 1);
    assert.equal(result.errorCount, 0);
});

describe("when the `quiet` flag is passed", () => {
    ...
    it("does not show warnings", () => {
        ...
    });
});
```

But that doesn't seem to produce any warnings or errors. Any idea why?

#### CHANGELOG.md entry:

enhancement: added `quiet` flag to allow hiding of lint warnings