### PR TITLE
no-invalid-this: false positive for method syntax

### DIFF
--- a/src/rules/noInvalidThisRule.ts
+++ b/src/rules/noInvalidThisRule.ts
@@ -61,21 +61,18 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
+const enum parentType {
+    None,
+    Class,
+    ClassMethod,
+    BoundRegularFunction,
+    UnboundRegularFunction,
+}
+const thisAllowedParents = new Set([parentType.ClassMethod, parentType.BoundRegularFunction]);
+
 function walk(ctx: Lint.WalkContext<boolean>): void {
     const { sourceFile, options: checkFuncInMethod } = ctx;
 
-    const enum parentType {
-        None,
-        Class,
-        ClassMethod,
-        BoundRegularFunction,
-        UnboundRegularFunction,
-    }
-
-    function thisIsAllowed(parent: parentType): boolean {
-        return [parentType.ClassMethod, parentType.BoundRegularFunction]
-            .some((t) => parent === t);
-    }
     let currentParent: parentType = parentType.None;
     let inClass = false;
 
@@ -115,7 +112,7 @@ function walk(ctx: Lint.WalkContext<boolean>): void {
                 }
 
             case ts.SyntaxKind.ThisKeyword:
-                if (!thisIsAllowed(currentParent)) {
+                if (!thisAllowedParents.has(currentParent)) {
                     if (!inClass) {
                         ctx.addFailureAtNode(node, Rule.FAILURE_STRING_OUTSIDE);
                     } else if (checkFuncInMethod) {

--- a/src/rules/noInvalidThisRule.ts
+++ b/src/rules/noInvalidThisRule.ts
@@ -63,39 +63,64 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<boolean>): void {
     const { sourceFile, options: checkFuncInMethod } = ctx;
+
+    const enum parentType {
+        None,
+        Class,
+        ClassMethod,
+        BoundRegularFunction,
+        UnboundRegularFunction,
+    }
+
+    function thisIsAllowed(parent: parentType): boolean {
+        return [parentType.ClassMethod, parentType.BoundRegularFunction]
+            .some((t) => parent === t);
+    }
+    let currentParent: parentType = parentType.None;
     let inClass = false;
-    let inFunctionInClass = false;
 
     ts.forEachChild(sourceFile, function cb(node: ts.Node) {
+        const originalParent = currentParent;
+        const originalInClass = inClass;
         switch (node.kind) {
             case ts.SyntaxKind.ClassDeclaration:
             case ts.SyntaxKind.ClassExpression:
-                if (!inClass) {
-                    inClass = true;
-                    ts.forEachChild(node, cb);
-                    inClass = false;
-                    return;
-                }
-                break;
+                inClass = true;
+                currentParent = parentType.Class;
+                ts.forEachChild(node, cb);
+                currentParent = originalParent;
+                inClass = originalInClass;
+                return;
 
+            case ts.SyntaxKind.MethodDeclaration:
+            case ts.SyntaxKind.GetAccessor:
+            case ts.SyntaxKind.SetAccessor:
+            case ts.SyntaxKind.Constructor:
+            case ts.SyntaxKind.PropertyDeclaration:
             case ts.SyntaxKind.FunctionDeclaration:
             case ts.SyntaxKind.FunctionExpression:
-                if ((node as ts.FunctionLikeDeclaration).parameters.some(isThisParameter)) {
-                    return;
-                }
-                if (inClass) {
-                    inFunctionInClass = true;
+                if (currentParent === parentType.Class) {
+                    currentParent = parentType.ClassMethod;
                     ts.forEachChild(node, cb);
-                    inFunctionInClass = false;
+                    currentParent = originalParent;
+                    return;
+                } else {
+                    currentParent
+                        = (node as ts.FunctionLikeDeclaration).parameters.some(isThisParameter)
+                        ? parentType.BoundRegularFunction
+                        : parentType.UnboundRegularFunction;
+                    ts.forEachChild(node, cb);
+                    currentParent = originalParent;
                     return;
                 }
-                break;
 
             case ts.SyntaxKind.ThisKeyword:
-                if (!inClass) {
-                    ctx.addFailureAtNode(node, Rule.FAILURE_STRING_OUTSIDE);
-                } else if (checkFuncInMethod && inFunctionInClass) {
-                    ctx.addFailureAtNode(node, Rule.FAILURE_STRING_INSIDE);
+                if (!thisIsAllowed(currentParent)) {
+                    if (!inClass) {
+                        ctx.addFailureAtNode(node, Rule.FAILURE_STRING_OUTSIDE);
+                    } else if (checkFuncInMethod) {
+                        ctx.addFailureAtNode(node, Rule.FAILURE_STRING_INSIDE);
+                    }
                 }
                 return;
         }

--- a/test/rules/no-invalid-this/enabled/test.ts.lint
+++ b/test/rules/no-invalid-this/enabled/test.ts.lint
@@ -1,3 +1,23 @@
+function setSomeProperty(this: { someProperty: number }) {
+    this.someProperty = 7;
+}
+
+function bindProperty(this: { someProperty: number }, fn: Function) {
+    return fn.bind(this);
+}
+
+const objectLiteralStyle = {
+    bindProperty: function(this: { someProperty: number }, fn: Function) {
+        return fn.bind(this);
+    },
+};
+
+const objectMethodStyle = {
+    bindProperty(this: { someProperty: number }, fn: Function) {
+        return fn.bind(this);
+    },
+};
+
 export function f<T>(this: Observable<T>): Observable<T> {
     const nestedFunction = function(this) => {
         console.log(this)
@@ -10,6 +30,7 @@ class ContextualThisClass {
         let nestedFunction: (this: number[]) => number[] = function(this) {
             [3,4].forEach(function(nr){
                 console.log(this);
+                            ~~~~           [the "this" keyword is disallowed in function bodies inside class methods, use arrow functions instead]
             });
             return this.map(i=>i);
         };
@@ -66,6 +87,25 @@ class AClass {
     public eMethod() {
         [3,4].forEach(badFunction);
         let badFunction = nr => console.log(this.x === nr);
+    }
+
+    public fMethod() {
+        const objectLiteralStyle = {
+            bindProperty: function(this: { someProperty: number }, fn: Function) {
+                return fn.bind(this);
+            },
+        };
+
+        const objectMethodStyle = {
+            bindProperty(this: { someProperty: number }, fn: Function) {
+                return fn.bind(this);
+            },
+        };
+
+        return {
+            objectLiteralStyle,
+            objectMethodStyle,
+        };
     }
 }
 


### PR DESCRIPTION
* Keep track of evaluation context: look to the closest parent function
  and decide if it is allowed to refer to `this`
* Fix a false negative in the tests from #3267

#### PR checklist

- [x] Addresses an existing issue: #4033
- [x] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update

#### Overview of change:

Previously, the `no-invalid-this` rule only had shallow tracking of context. `this` should be allowed if any only iff the closest parent non-arrow function is either a) a class method, or b) a function with a `this` type parameter.

There were several drawbacks of not tracking context directly:
- The rule didn't treat method declaration syntax the same as function declaration syntax on object literals, causing a false positive on method declaration syntax in object literals (#4033)
- The rule could not distinguish between a correct function with a `this` type parameter and a function _inside_ a function with a `this` type parameter - in fact, there was a test checked in which enforced bad behavior: https://github.com/palantir/tslint/blob/b104e5ad8fdbbb75f1271a1016ff6272f1aafb9d/test/rules/no-invalid-this/enabled/test.ts.lint#L12 - the `this` on this line does _not_ inherit type parameter

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

[bugfix] [`no-invalid-this`](https://palantir.github.io/tslint/rules/no-invalid-this/) rule fixes false positives on method-like syntax and false negatives on nested functions
