### PR TITLE
Add context to shorthand errors.

### DIFF
--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -88,7 +88,7 @@ function enforceShorthandWalker(ctx: Lint.WalkContext<void>) {
                 node.name.text === node.initializer.text) {
                 ctx.addFailureAtNode(
                     node,
-                    `${Rule.LONGHAND_PROPERTY}('{${node.name.text}}').`,
+                    `${Rule.LONGHAND_PROPERTY}('{..., ${node.name.text}, ...}').`,
                     Lint.Replacement.deleteFromTo(node.name.end, node.end),
                 );
             } else if (isFunctionExpression(node.initializer) &&
@@ -98,7 +98,7 @@ function enforceShorthandWalker(ctx: Lint.WalkContext<void>) {
                 ctx.addFailure(
                     node.getStart(ctx.sourceFile),
                     getChildOfKind(node.initializer, ts.SyntaxKind.OpenParenToken, ctx.sourceFile)!.pos,
-                    `${Rule.LONGHAND_METHOD}('{${name}() {...}}').`,
+                    `${Rule.LONGHAND_METHOD}('{..., ${name}() {...}, ...}').`,
                     fix,
                 );
             }

--- a/test/rules/object-literal-shorthand/always/test.ts.lint
+++ b/test/rules/object-literal-shorthand/always/test.ts.lint
@@ -1,12 +1,12 @@
 const bad = {
   w: function() {},
-  ~~~~~~~~~~~ [Expected method shorthand in object literal ('{w() {...}}').]
+  ~~~~~~~~~~~ [Expected method shorthand in object literal ('{..., w() {...}, ...}').]
   x: function *() {},
-  ~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{*x() {...}}').]
+  ~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{..., *x() {...}, ...}').]
   [y]: function() {},
-  ~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{[y]() {...}}').]
+  ~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{..., [y]() {...}, ...}').]
   z: z
-  ~~~~  [Expected property shorthand in object literal ('{z}').]
+  ~~~~  [Expected property shorthand in object literal ('{..., z, ...}').]
 };
 
 const good = {
@@ -26,7 +26,7 @@ const namedFunctions = {
 
 const quotes = {
   "foo-bar": function() {},
-  ~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{"foo-bar"() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{..., "foo-bar"() {...}, ...}').]
   "foo-bar"() {}
 };
 
@@ -37,17 +37,17 @@ const extraCases = {
   c: 'c',
   ["a" + "nested"]: {
     x: x
-    ~~~~  [Expected property shorthand in object literal ('{x}').]
+    ~~~~  [Expected property shorthand in object literal ('{..., x, ...}').]
   }
 };
 
 const asyncFn = {
   foo: async function() {},
-  ~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{async foo() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{..., async foo() {...}, ...}').]
   bar: async function*() {}
-  ~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{async *bar() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{..., async *bar() {...}, ...}').]
 }
 
 ({foo: foo} = {foo: foo});
-  ~~~~~~~~ [Expected property shorthand in object literal ('{foo}').]
-               ~~~~~~~~ [Expected property shorthand in object literal ('{foo}').]
+  ~~~~~~~~ [Expected property shorthand in object literal ('{..., foo, ...}').]
+               ~~~~~~~~ [Expected property shorthand in object literal ('{..., foo, ...}').]


### PR DESCRIPTION
The error message "Expected property shorthand in object literal ('{injector}')." confused me because
it appeared within an object literal like:
  const x = { <lines of properties with initializers>, injector: injector, <more lines of other properties>}
As I was unfamiliar with the combination of object literals and short-hand properties,
I took the authoritative voice of the lint message literally and attempted
  const x = { <lines of properties with initializers>, {injector}, <more lines of other properties>}
which of course is silly in retrospect, but that was exactly the suggestion of the error message.

The new result will be
  Expected property shorthand in object literal ('{..., injector, ...}').
showing that the braces are context, not something to be added to obey the linter.

By adding context indicators around the token, novice users learn from lint that the syntax for shorthand properties is simple.
