### PR TITLE
[new-rule] strict-error-throw

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -137,6 +137,7 @@ export const rules = {
     "radix": true,
     "restrict-plus-operands": true,
     "strict-boolean-expressions": true,
+    "strict-error-throw": true,
     "strict-type-predicates": true,
     "switch-default": true,
     "triple-equals": true,

--- a/src/rules/strictErrorThrowRule.ts
+++ b/src/rules/strictErrorThrowRule.ts
@@ -90,7 +90,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
 
     function isInstanceOfClass(type: ts.Type, className: string) {
         if (isTypeFlagSet(type, ts.TypeFlags.Object)) {
-            if (ts.symbolName(type.symbol!) === className) {
+            if (type.symbol!.name === className) {
                 return true;
             } else {
                 const baseTypes = type.getBaseTypes();

--- a/src/rules/strictErrorThrowRule.ts
+++ b/src/rules/strictErrorThrowRule.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isThrowStatement, isTypeFlagSet } from "tsutils";
+import * as ts from "typescript";
+import * as Lint from "../index";
+
+// tslint:disable:no-bitwise
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "strict-error-throw",
+        description: Lint.Utils.dedent`
+            Restricts that only instances of \`Error\` or its subclass be thrown.`,
+        descriptionDetails: Lint.Utils.dedent`
+            Example – Doing it right
+
+            \`\`\`ts
+            throw new Error("message");
+
+            class Exception extends Error {
+                // ...
+            }
+            const exception = new Exception("message");
+            throw exception;
+            \`\`\`
+
+            Example – Anti Pattern
+
+            \`\`\`ts
+            throw "error";
+
+            throw { message: "error" };
+
+            class MyError {
+                // ...
+            }
+            throw new MyError();
+            \`\`\`
+
+            This rule is stricter than \`no-string-throw\`.
+            You can disable \`no-string-throw\` when you have enabled \`strict-error-throw\`.
+            `,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            It is considered good practice to only throw the \`Error\` object itself
+            or an object using the \`Error\` object as base objects for user-defined exceptions.
+            The fundamental benefit of \`Error\` objects is that they automatically keep track
+            of where they were built and originated.`,
+        type: "functionality",
+        typescriptOnly: true,
+        requiresTypeInfo: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING = "Expected an instance of 'Error' or its subclass to throw";
+
+    public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (isThrowStatement(node)) {
+            const type = checker.getTypeAtLocation((node as ts.ThrowStatement).expression);
+            if (!isTypeFlagSet(type, ts.TypeFlags.Any) && !isInstanceOfClass(type, "Error")) {
+                ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+            }
+        }
+        return ts.forEachChild(node, cb);
+    });
+
+    function isInstanceOfClass(type: ts.Type, className: string) {
+        if (isTypeFlagSet(type, ts.TypeFlags.Object)) {
+            if (checker.getFullyQualifiedName(type.symbol!) === className) {
+                return true;
+            } else {
+                const baseTypes = type.getBaseTypes();
+                if (baseTypes) {
+                    for (const baseType of baseTypes) {
+                        if (isInstanceOfClass(baseType, className)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/rules/strictErrorThrowRule.ts
+++ b/src/rules/strictErrorThrowRule.ts
@@ -90,7 +90,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
 
     function isInstanceOfClass(type: ts.Type, className: string) {
         if (isTypeFlagSet(type, ts.TypeFlags.Object)) {
-            if (checker.getFullyQualifiedName(type.symbol!) === className) {
+            if (ts.symbolName(type.symbol!) === className) {
                 return true;
             } else {
                 const baseTypes = type.getBaseTypes();

--- a/src/rules/strictErrorThrowRule.ts
+++ b/src/rules/strictErrorThrowRule.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Palantir Technologies, Inc.
+ * Copyright 2018 Palantir Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,12 @@ import { isThrowStatement, isTypeFlagSet } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
-// tslint:disable:no-bitwise
-
 export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "strict-error-throw",
         description: Lint.Utils.dedent`
-            Restricts that only instances of \`Error\` or its subclass be thrown.`,
+            Restricts that only instances or subclasses of \`Error\` be thrown.`,
         descriptionDetails: Lint.Utils.dedent`
             Example – Doing it right
 

--- a/src/rules/strictErrorThrowRule.ts
+++ b/src/rules/strictErrorThrowRule.ts
@@ -80,7 +80,7 @@ export class Rule extends Lint.Rules.TypedRule {
 function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (isThrowStatement(node)) {
-            const type = checker.getTypeAtLocation((node as ts.ThrowStatement).expression);
+            const type = checker.getTypeAtLocation(node.expression);
             if (!isTypeFlagSet(type, ts.TypeFlags.Any) && !isInstanceOfClass(type, "Error")) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
@@ -94,7 +94,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
                 return true;
             } else {
                 const baseTypes = type.getBaseTypes();
-                if (baseTypes) {
+                if (baseTypes !== undefined) {
                     for (const baseType of baseTypes) {
                         if (isInstanceOfClass(baseType, className)) {
                             return true;

--- a/test/rules/strict-error-throw/other.test.ts
+++ b/test/rules/strict-error-throw/other.test.ts
@@ -1,0 +1,1 @@
+export class AppError extends Error {};

--- a/test/rules/strict-error-throw/test.ts.lint
+++ b/test/rules/strict-error-throw/test.ts.lint
@@ -1,0 +1,43 @@
+import {AppError} from './other.test';
+
+class Exception extends AppError {}
+throw new Exception();
+
+const ex = new Exception();
+throw ex;
+
+throw new Error('error');
+
+const err = new Error();
+throw err;
+
+try {
+  throw new Error("error");
+} catch(e) {
+  throw e;
+}
+
+throw "error";
+~~~~~~~~~~~~~~    [0]
+
+throw ('message');
+~~~~~~~~~~~~~~~~~~ [0]
+
+throw {message: 'error'};
+~~~~~~~~~~~~~~~~~~~~~~~~~  [0]
+
+class MyError {}
+throw new MyError();
+~~~~~~~~~~~~~~~~~~~~  [0]
+
+const code = 1;
+throw code;
+~~~~~~~~~~~  [0]
+
+const foo: { bar: string } = {
+    bar: "error"
+};
+throw foo.bar;
+~~~~~~~~~~~~~~    [0]
+
+[0]: Expected an instance of 'Error' or its subclass to throw

--- a/test/rules/strict-error-throw/tsconfig.json
+++ b/test/rules/strict-error-throw/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}
+  

--- a/test/rules/strict-error-throw/tslint.json
+++ b/test/rules/strict-error-throw/tslint.json
@@ -1,0 +1,6 @@
+{
+    "rules": {
+      "strict-error-throw": true
+    }
+  }
+  


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Add a new rule to restricts that only instances of `Error` or its subclass be thrown.

There is an existing rule `no-string-throw` which forbids to throw string, but it still allows to throw other types.

This rule is stricter and only allows `Error` and its subclass. Below code will not pass the rule:

``` ts
throw {message: 'error'};    // arbitrarily object

class MyError {        // does no extend `Error`
  // ...
}
throw new MyError();
```

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[new-rule] `strict-error-throw`