### PR TITLE
no-console: fix #3207

### DIFF
--- a/src/rules/noConsoleRule.ts
+++ b/src/rules/noConsoleRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isCallExpression, isIdentifier, isPropertyAccessExpression } from "tsutils";
+import { isIdentifier, isPropertyAccessExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -48,13 +48,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<string[]>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
-        if (isCallExpression(node) &&
-            isPropertyAccessExpression(node.expression) &&
-            isIdentifier(node.expression.expression) &&
-            node.expression.expression.text === "console" &&
-            (ctx.options.length === 0 || ctx.options.indexOf(node.expression.name.text) !== -1)) {
+        if (isPropertyAccessExpression(node) &&
+            isIdentifier(node.expression) &&
+            node.expression.text === "console" &&
+            (ctx.options.length === 0 || ctx.options.indexOf(node.name.text) !== -1)) {
 
-            ctx.addFailureAtNode(node.expression, Rule.FAILURE_STRING_FACTORY(node.expression.name.text));
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(node.name.text));
         }
         return ts.forEachChild(node, cb);
     });

--- a/test/rules/no-console/all/test.ts.lint
+++ b/test/rules/no-console/all/test.ts.lint
@@ -16,5 +16,7 @@ console.something();
 ~~~~~~~~~~~~~~~~~           [err % ('something')]
 console.timeEnd();
 ~~~~~~~~~~~~~~~           [err % ('timeEnd')]
+[].forEach(console.log);
+           ~~~~~~~~~~~   [err % ('log')]
 
 [err]: Calls to 'console.%s' are not allowed.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3207
- [x]  bugfix
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
In the code below:
``` typescript
let x = [1, 2, 3];
console.log(x);
x.forEach(console.log);
```
The linter not warns only on line 2, but also on line 3

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
