### PR TITLE
[Feature] Add include property to linterOptions

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -50,6 +50,7 @@ export interface IConfigurationFile {
      */
     linterOptions?: Partial<{
         exclude: string[];
+        include: string[];
     }>;
 
     /**
@@ -532,11 +533,14 @@ export function parseConfigFile(
     }
 
     function parseLinterOptions(raw: RawConfigFile["linterOptions"], dir?: string): IConfigurationFile["linterOptions"] {
-        if (raw === undefined || raw.exclude === undefined) {
+        if (raw === undefined || (raw.exclude === undefined && raw.include === undefined)) {
             return {};
         }
         return {
             exclude: arrayify(raw.exclude).map(
+                (pattern) => dir === undefined ? path.resolve(pattern) : path.resolve(dir, pattern),
+            ),
+            include: arrayify(raw.include).map(
                 (pattern) => dir === undefined ? path.resolve(pattern) : path.resolve(dir, pattern),
             ),
         };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -263,7 +263,8 @@ async function doLinting(options: Options, files: string[], program: ts.Program 
                 lastFolder = folder;
             }
         }
-        if (isFileExcluded(file)) {
+
+        if (!isFileIncluded(file) || isFileExcluded(file)) {
             continue;
         }
 
@@ -290,6 +291,16 @@ async function doLinting(options: Options, files: string[], program: ts.Program 
         }
         const fullPath = path.resolve(filepath);
         return configFile.linterOptions.exclude.some((pattern) => new Minimatch(pattern).match(fullPath));
+    }
+
+    /** Ignore if include array is empty */
+    function isFileIncluded(filepath: string) {
+        if (configFile === undefined || configFile.linterOptions == undefined ||
+            configFile.linterOptions.include == undefined || !configFile.linterOptions.include.length) {
+            return false;
+        }
+        const fullPath = path.resolve(filepath);
+        return configFile.linterOptions.include.some((pattern) => new Minimatch(pattern).match(fullPath));
     }
 }
 

--- a/test/configurationTests.ts
+++ b/test/configurationTests.ts
@@ -116,6 +116,21 @@ describe("Configuration", () => {
                 parseConfigFile(config, "/path").linterOptions,
                 {
                     exclude: [path.resolve("/path", "foo.ts"), path.resolve("/path", "**/*.d.ts")],
+                    include: [],
+                },
+            );
+        });
+        it("resolves include pattern relative to the configuration file", () => {
+            const config: RawConfigFile = {
+                linterOptions: {
+                    include: ["foo.ts", "**/*.d.ts"],
+                },
+            };
+            assert.deepEqual(
+                parseConfigFile(config, "/path").linterOptions,
+                {
+                    exclude: [],
+                    include: [path.resolve("/path", "foo.ts"), path.resolve("/path", "**/*.d.ts")],
                 },
             );
         });

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -200,6 +200,35 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
         });
     });
 
+    describe("Config with included files", () => {
+        it("exits with code 2 if linter options include file with lint errors", async () => {
+            const status = await execRunner(
+                {config: "./test/files/config-include/tslint-include-one.json", files: ["./test/files/config-include/included.ts"]},
+            );
+            assert.equal(status, Status.LintError, "error code should be 2");
+        });
+
+        it("exits with code 0 if file not matching included pattern", async () => {
+            const status = await execRunner(
+                {config: "./test/files/config-include/tslint-include-one.json", files: [
+                    "./test/files/config-include/excluded.ts"]},
+            );
+            assert.equal(status, Status.Ok, "process should exit without an error");
+        });
+
+        it("exits with code 2 if linter options includes many files with lint errors", async () => {
+            const status = await execRunner(
+                {
+                    config: "./test/files/config-include/tslint-include-many.json",
+                    files: ["./test/files/config-include/subdir/included2.ts",
+                            "./test/files/config-include/subdir/included1.ts"],
+                },
+            );
+            assert.strictEqual(status, Status.LintError, "process should exit without an error");
+        });
+
+    });
+
     describe("Config with excluded files", () => {
         it("exits with code 2 if linter options doesn't exclude file with lint errors", async () => {
             const status = await execRunner(

--- a/test/files/config-include/excluded.ts
+++ b/test/files/config-include/excluded.ts
@@ -1,0 +1,1 @@
+console.log("missing semicolon at end of line")

--- a/test/files/config-include/excluded1.ts
+++ b/test/files/config-include/excluded1.ts
@@ -1,0 +1,1 @@
+console.log("missing semicolon at end of line")

--- a/test/files/config-include/included.ts
+++ b/test/files/config-include/included.ts
@@ -1,0 +1,1 @@
+console.log("missing semicolon at end of line")

--- a/test/files/config-include/subdir/included1.ts
+++ b/test/files/config-include/subdir/included1.ts
@@ -1,0 +1,1 @@
+console.log("missing semicolon at end of line")

--- a/test/files/config-include/subdir/included2.ts
+++ b/test/files/config-include/subdir/included2.ts
@@ -1,0 +1,1 @@
+console.log("missing semicolon at end of line")

--- a/test/files/config-include/subdir/tslint-extending.json
+++ b/test/files/config-include/subdir/tslint-extending.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../tslint-include-one.json"
+}

--- a/test/files/config-include/tslint-include-many.json
+++ b/test/files/config-include/tslint-include-many.json
@@ -1,0 +1,14 @@
+{
+    "rules": {
+        "semicolon": [
+            true,
+            "always"
+        ]
+    },
+    "linterOptions": {
+        "include": [
+            "**/*/included1.ts",
+            "included2.ts"
+        ]
+    }
+}

--- a/test/files/config-include/tslint-include-one.json
+++ b/test/files/config-include/tslint-include-one.json
@@ -1,0 +1,13 @@
+{
+    "rules": {
+        "semicolon": [
+            true,
+            "always"
+        ]
+    },
+    "linterOptions": {
+        "include": [
+            "included.ts"
+        ]
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #4027
- [ ] New feature
- [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Adds support for `include` property in the config file. Works same way, as in babel:
The file will be processed only if at least one `include` regex is matching the filename. 
Usage:
```json
"lintingOptions": {
    "include" : ["fileName.ts", "**/*name.ts"]
}
```

#### Is there anything you'd like reviewers to focus on?


#### CHANGELOG.md entry:
[new-feature] `include` option to `lintingOptions` in config.