### PR TITLE
Change normalisation of ordered-imports

### DIFF
--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -50,6 +50,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             Possible values for \`"import-sources-order"\` are:
 
             * \`"case-insensitive'\`: Correct order is \`"Bar"\`, \`"baz"\`, \`"Foo"\`. (This is the default.)
+            * \`"case-insensitive-legacy'\`: Correct order is \`"Bar"\`, \`"baz"\`, \`"Foo"\`.
             * \`"lowercase-first"\`: Correct order is \`"baz"\`, \`"Bar"\`, \`"Foo"\`.
             * \`"lowercase-last"\`: Correct order is \`"Bar"\`, \`"Foo"\`, \`"baz"\`.
             * \`"any"\`: Allow any order.
@@ -68,6 +69,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             Possible values for \`"named-imports-order"\` are:
 
             * \`"case-insensitive'\`: Correct order is \`{A, b, C}\`. (This is the default.)
+            * \`"case-insensitive-legacy'\`: Correct order is \`"Bar"\`, \`"baz"\`, \`"Foo"\`.
             * \`"lowercase-first"\`: Correct order is \`{b, A, C}\`.
             * \`"lowercase-last"\`: Correct order is \`{A, C, b}\`.
             * \`"any"\`: Allow any order.
@@ -89,11 +91,23 @@ export class Rule extends Lint.Rules.AbstractRule {
                 },
                 "import-sources-order": {
                     type: "string",
-                    enum: ["case-insensitive", "lowercase-first", "lowercase-last", "any"],
+                    enum: [
+                        "case-insensitive",
+                        "case-insensitive-legacy",
+                        "lowercase-first",
+                        "lowercase-last",
+                        "any",
+                    ],
                 },
                 "named-imports-order": {
                     type: "string",
-                    enum: ["case-insensitive", "lowercase-first", "lowercase-last", "any"],
+                    enum: [
+                        "case-insensitive",
+                        "case-insensitive-legacy",
+                        "lowercase-first",
+                        "lowercase-last",
+                        "any",
+                    ],
                 },
                 "module-source-path": {
                     type: "string",
@@ -135,6 +149,7 @@ type Transform = (x: string) => string;
 const TRANSFORMS = new Map<string, Transform>([
     ["any", () => ""],
     ["case-insensitive", x => x.toUpperCase()],
+    ["case-insensitive-legacy", x => x.toLowerCase()],
     ["lowercase-first", flipCase],
     ["lowercase-last", x => x],
     ["full", x => x],

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -24,7 +24,6 @@ import {
     isStringLiteral,
 } from "tsutils";
 import * as ts from "typescript";
-
 import * as Lint from "../index";
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -135,7 +134,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 type Transform = (x: string) => string;
 const TRANSFORMS = new Map<string, Transform>([
     ["any", () => ""],
-    ["case-insensitive", x => x.toLowerCase()],
+    ["case-insensitive", x => x.toUpperCase()],
     ["lowercase-first", flipCase],
     ["lowercase-last", x => x],
     ["full", x => x],

--- a/test/rules/ordered-imports/case-insensitive-legacy/test.ts.fix
+++ b/test/rules/ordered-imports/case-insensitive-legacy/test.ts.fix
@@ -6,9 +6,9 @@ import {A, B} from 'foo'; // failure
 import {A, bz, C} from 'foo'; // failure
 import {A, b, C} from 'zfoo';
 
-// Underscores come last.
-import {A, C, d, _b} from 'zfoo'; // failure
-import {A, C, d, _b} from 'zfoo';
+// Underscores come first.
+import {_b, A, C, d} from 'zfoo'; // failure
+import {_b, A, C, d} from 'zfoo';
 
 import {g} from "y"; // failure
 import {

--- a/test/rules/ordered-imports/case-insensitive-legacy/test.ts.lint
+++ b/test/rules/ordered-imports/case-insensitive-legacy/test.ts.lint
@@ -9,10 +9,10 @@ import {bz, A, C} from 'foo'; // failure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~            [Import sources within a group must be alphabetized.]
         ~~~~~                            [Named imports must be alphabetized.]
 
-// Underscores come last.
+// Underscores come first.
 import {A, _b, C, d} from 'zfoo'; // failure
-           ~~~~~              [Named imports must be alphabetized.]
-import {A, C, d, _b} from 'zfoo';
+        ~~~~~                                [Named imports must be alphabetized.]
+import {_b, A, C, d} from 'zfoo';
 
 import {
     b as c,

--- a/test/rules/ordered-imports/case-insensitive-legacy/tslint.json
+++ b/test/rules/ordered-imports/case-insensitive-legacy/tslint.json
@@ -1,0 +1,11 @@
+{
+    "rules": {
+        "ordered-imports": [
+            true,
+            {
+                "import-sources-order": "case-insensitive-legacy",
+                "named-imports-order": "case-insensitive-legacy"
+            }
+        ]
+    }
+}

--- a/test/rules/ordered-imports/case-insensitive/test.ts.fix
+++ b/test/rules/ordered-imports/case-insensitive/test.ts.fix
@@ -6,6 +6,10 @@ import {A, B} from 'foo'; // failure
 import {A, bz, C} from 'foo'; // failure
 import {A, b, C} from 'zfoo';
 
+// Underscores come last.
+import {A, C, _b} from 'zfoo'; // failure
+import {A, C, _b} from 'zfoo';
+
 import {g} from "y"; // failure
 import {
     a as d,

--- a/test/rules/ordered-imports/case-insensitive/test.ts.lint
+++ b/test/rules/ordered-imports/case-insensitive/test.ts.lint
@@ -9,6 +9,11 @@ import {bz, A, C} from 'foo'; // failure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~            [Import sources within a group must be alphabetized.]
         ~~~~~                            [Named imports must be alphabetized.]
 
+// Underscores come last.
+import {A, _b, C} from 'zfoo'; // failure
+           ~~~~~              [Named imports must be alphabetized.]
+import {A, C, _b} from 'zfoo';
+
 import {
     b as c,
     ~~~~~~~


### PR DESCRIPTION
This makes it consistent with TypeScript's Organize Imports command

Fixes #4063

#### PR checklist

- [x] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

This makes the sorting consistent with what TypeScript's Organise Imports ordering does, see https://github.com/Microsoft/TypeScript/issues/25114

#### Is there anything you'd like reviewers to focus on?

Nothing in particular.

#### CHANGELOG.md entry:

[bugfix] Make `ordered-imports` consistent with TypeScript's Organise Imports ordering
[new-rule-option] `case-insensitive-legacy` for `ordered-imports` rule