### PR TITLE
Fix4057 Correct the broken auto-fix code of `prefer-method-signature` rule.

### DIFF
--- a/src/rules/preferMethodSignatureRule.ts
+++ b/src/rules/preferMethodSignatureRule.ts
@@ -30,11 +30,31 @@ export class Rule extends Lint.Rules.AbstractRule {
         options: null,
         optionExamples: [true],
         type: "style",
-        typescriptOnly: false,
+        typescriptOnly: false
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Use a method signature instead of a property signature of function type.";
+    public static FAILURE_STRING =
+        "Use a method signature instead of a property signature of function type.";
+
+    public static METH_SIGN_STRING(ps: ts.PropertySignature): string {
+        const { type, questionToken } = ps;
+
+        let result = ps.name.getText();
+        if (questionToken !== undefined) {
+            result += "?";
+        }
+        if (type !== undefined && isFunctionTypeNode(type) && type.type !== undefined) {
+            if (type.typeParameters !== undefined) {
+                const tps = type.typeParameters.map(tp => tp.getText()).join(", ");
+                result += `<${tps}>`;
+            }
+            const args = type.parameters.map(v => v.getText()).join(", ");
+            result += `(${args}): ${type.type.getText()};`;
+        }
+
+        return result;
+    }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -46,10 +66,13 @@ function walk(ctx: Lint.WalkContext<void>): void {
         if (isPropertySignature(node)) {
             const { type } = node;
             if (type !== undefined && isFunctionTypeNode(type)) {
-                ctx.addFailureAtNode(node.name, Rule.FAILURE_STRING, type.type === undefined ? undefined : [
-                    Lint.Replacement.deleteFromTo(type.pos - 1, type.getStart()), // delete colon in 'foo: () => void'
-                    Lint.Replacement.replaceFromTo(type.parameters.end + 1, type.type.pos, ":"), // replace => with colon
-                ]);
+                ctx.addFailureAtNode(
+                    node.name,
+                    Rule.FAILURE_STRING,
+                    type.type === undefined
+                        ? undefined
+                        : [Lint.Replacement.replaceNode(node, Rule.METH_SIGN_STRING(node))]
+                );
             }
         }
         return ts.forEachChild(node, cb);

--- a/test/rules/prefer-method-signature/test.ts.fix
+++ b/test/rules/prefer-method-signature/test.ts.fix
@@ -12,3 +12,7 @@ class C {
     foo: () => void;
 }
 
+export interface Bar {
+  someMethod(someArg: Pick<HTMLAllCollection, "item">): string;
+}
+

--- a/test/rules/prefer-method-signature/test.ts.lint
+++ b/test/rules/prefer-method-signature/test.ts.lint
@@ -15,4 +15,11 @@ class C {
     foo: () => void;
 }
 
+export interface Bar {
+  someMethod: (
+  ~~~~~~~~~~ [0]
+    someArg: Pick<HTMLAllCollection, "item">
+  ) => string;
+}
+
 [0]: Use a method signature instead of a property signature of function type.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4057
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Correct the broken auto-fix code of `prefer-method-signature` rule.
#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[bugfix] Correct the auto-fix code of `prefer-method-signature` rule, now capable to handle 
multiline signature.