### PR TITLE
[new-rule] add whitespace rule for open braces

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -32,6 +32,7 @@ const OPTION_TYPE = "check-type";
 const OPTION_TYPECAST = "check-typecast";
 const OPTION_TYPE_OPERATOR = "check-type-operator";
 const OPTION_PREBLOCK = "check-preblock";
+const OPTION_POSTBRACE = "check-postbrace";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
@@ -50,23 +51,33 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`"check-type"\` checks for whitespace before a variable type specification.
             * \`"check-typecast"\` checks for whitespace between a typecast and its target.
             * \`"check-type-operator"\` checks for whitespace between type operators \`|\` and \`&\`.
-            * \`"check-preblock"\` checks for whitespace before the opening brace of a block`,
+            * \`"check-preblock"\` checks for whitespace before the opening brace of a block.
+            * \`"check-postbrace"\` checks for whitespace after an opening brace.`,
         options: {
             type: "array",
             items: {
                 type: "string",
                 enum: [
-                    "check-branch", "check-decl", "check-operator", "check-module", "check-separator",
-                    "check-rest-spread", "check-type", "check-typecast", "check-type-operator", "check-preblock",
-                ],
+                    "check-branch",
+                    "check-decl",
+                    "check-operator",
+                    "check-module",
+                    "check-separator",
+                    "check-rest-spread",
+                    "check-type",
+                    "check-typecast",
+                    "check-type-operator",
+                    "check-preblock",
+                    "check-postbrace"
+                ]
             },
             minLength: 0,
-            maxLength: 10,
+            maxLength: 11
         },
         optionExamples: [[true, "check-branch", "check-operator", "check-typecast"]],
         type: "style",
         typescriptOnly: false,
-        hasFix: true,
+        hasFix: true
     };
 
     public static FAILURE_STRING_MISSING = "missing whitespace";
@@ -78,8 +89,19 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 type Options = Record<
-    "branch" | "decl" | "operator" | "module" | "separator" | "restSpread" | "type" | "typecast" | "typeOperator" | "preblock",
-    boolean>;
+    | "branch"
+    | "decl"
+    | "operator"
+    | "module"
+    | "separator"
+    | "restSpread"
+    | "type"
+    | "typecast"
+    | "typeOperator"
+    | "preblock"
+    | "postbrace",
+    boolean
+>;
 
 function parseOptions(ruleArguments: string[]): Options {
     return {
@@ -93,6 +115,7 @@ function parseOptions(ruleArguments: string[]): Options {
         typecast: has(OPTION_TYPECAST),
         typeOperator: has(OPTION_TYPE_OPERATOR),
         preblock: has(OPTION_PREBLOCK),
+        postbrace: has(OPTION_POSTBRACE)
     };
 
     function has(option: string): boolean {
@@ -244,10 +267,11 @@ function walk(ctx: Lint.WalkContext<Options>) {
 
     let prevTokenShouldBeFollowedByWhitespace = false;
     utils.forEachTokenWithTrivia(sourceFile, (_text, tokenKind, range, parent) => {
-        if (tokenKind === ts.SyntaxKind.WhitespaceTrivia ||
+        if (
+            tokenKind === ts.SyntaxKind.WhitespaceTrivia ||
             tokenKind === ts.SyntaxKind.NewLineTrivia ||
-            tokenKind === ts.SyntaxKind.EndOfFileToken) {
-
+            tokenKind === ts.SyntaxKind.EndOfFileToken
+        ) {
             prevTokenShouldBeFollowedByWhitespace = false;
             return;
         } else if (prevTokenShouldBeFollowedByWhitespace) {
@@ -277,9 +301,11 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 }
 
                 const nextPosition = range.pos + 1;
-                const semicolonInTrivialFor = parent.kind === ts.SyntaxKind.ForStatement &&
+                const semicolonInTrivialFor =
+                    parent.kind === ts.SyntaxKind.ForStatement &&
                     nextPosition !== sourceFile.end &&
-                    (sourceFile.text[nextPosition] === ";" || sourceFile.text[nextPosition] === ")");
+                    (sourceFile.text[nextPosition] === ";" ||
+                        sourceFile.text[nextPosition] === ")");
 
                 if (!semicolonInTrivialFor) {
                     prevTokenShouldBeFollowedByWhitespace = true;
@@ -295,9 +321,23 @@ function walk(ctx: Lint.WalkContext<Options>) {
                     prevTokenShouldBeFollowedByWhitespace = true;
                 }
                 break;
+            case ts.SyntaxKind.OpenBraceToken:
+                const nextPos = range.pos + 1;
+                if (
+                    options.postbrace &&
+                    (sourceFile.text[nextPos] !== " " &&
+                        sourceFile.text[nextPos] !== "\r" &&
+                        sourceFile.text[nextPos] !== "\t" &&
+                        sourceFile.text[nextPos] !== "\n")
+                ) {
+                    addMissingWhitespaceErrorAt(nextPos);
+                }
+                break;
             case ts.SyntaxKind.ImportKeyword:
-                if (parent.kind === ts.SyntaxKind.CallExpression &&
-                    (parent as ts.CallExpression).expression.kind === ts.SyntaxKind.ImportKeyword) {
+                if (
+                    parent.kind === ts.SyntaxKind.CallExpression &&
+                    (parent as ts.CallExpression).expression.kind === ts.SyntaxKind.ImportKeyword
+                ) {
                     return; // Don't check ImportCall
                 }
             // falls through
@@ -314,7 +354,11 @@ function walk(ctx: Lint.WalkContext<Options>) {
             return;
         }
 
-        const equalsGreaterThanToken = utils.getChildOfKind(node, ts.SyntaxKind.EqualsGreaterThanToken, sourceFile);
+        const equalsGreaterThanToken = utils.getChildOfKind(
+            node,
+            ts.SyntaxKind.EqualsGreaterThanToken,
+            sourceFile
+        );
         // condition so we don't crash if the arrow is somehow missing
         if (equalsGreaterThanToken === undefined) {
             return;
@@ -325,14 +369,17 @@ function walk(ctx: Lint.WalkContext<Options>) {
     }
 
     function checkForTrailingWhitespace(position: number, whiteSpacePos: number = position): void {
-        if (position !== sourceFile.end && !Lint.isWhiteSpace(sourceFile.text.charCodeAt(position))) {
+        if (
+            position !== sourceFile.end &&
+            !Lint.isWhiteSpace(sourceFile.text.charCodeAt(position))
+        ) {
             addMissingWhitespaceErrorAt(whiteSpacePos);
         }
     }
 
     function addMissingWhitespaceErrorAt(position: number): void {
         // TODO: this rule occasionally adds duplicate failures.
-        if (ctx.failures.some((f) => f.getStartPosition().getPosition() === position)) {
+        if (ctx.failures.some(f => f.getStartPosition().getPosition() === position)) {
             return;
         }
         const fix = Lint.Replacement.appendText(position, " ");
@@ -340,7 +387,10 @@ function walk(ctx: Lint.WalkContext<Options>) {
     }
 
     function checkForExcessiveWhitespace(position: number): void {
-        if (position !== sourceFile.end && Lint.isWhiteSpace(sourceFile.text.charCodeAt(position))) {
+        if (
+            position !== sourceFile.end &&
+            Lint.isWhiteSpace(sourceFile.text.charCodeAt(position))
+        ) {
             addInvalidWhitespaceErrorAt(position);
         }
     }

--- a/test/rules/whitespace/check-postbrace/test.ts.fix
+++ b/test/rules/whitespace/check-postbrace/test.ts.fix
@@ -1,0 +1,5 @@
+function() { return 5;}
+
+function() {
+    const something: number = 5;
+}

--- a/test/rules/whitespace/check-postbrace/test.ts.lint
+++ b/test/rules/whitespace/check-postbrace/test.ts.lint
@@ -1,0 +1,6 @@
+function() {return 5;}
+            ~ [missing whitespace]
+
+function() {
+    const something: number = 5;
+}

--- a/test/rules/whitespace/check-postbrace/tslint.json
+++ b/test/rules/whitespace/check-postbrace/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "whitespace": [true, "check-postbrace"]
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Implements a whitespace option `check-postbrace` that is checking for a space, new line or tab after an open curly brace.