### PR TITLE
Add esSpecCompliant: true to recommended trailing-comma config

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -162,6 +162,7 @@ export const rules = {
     "object-literal-sort-keys": true,
     "prefer-const": true,
     "trailing-comma": [true, {
+        "esSpecCompliant": true,
         "multiline": "always",
         "singleline": "never",
     }],

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -155,6 +155,7 @@ export const rules = {
     },
     "trailing-comma": {
         options: {
+            esSpecCompliant: true,
             multiline: "always",
             singleline: "never",
         },


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3960
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

TypeScript 2.9 enforces no trailing comma after rest/spread, so this
change adds `esSpecCompliant: true` to `trailing-comma` in the
`tslint:recommended` config.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
