### PR TITLE
Add snake_case option for file-name-casing rule

### DIFF
--- a/src/rules/fileNameCasingRule.ts
+++ b/src/rules/fileNameCasingRule.ts
@@ -19,12 +19,13 @@ import * as path from "path";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { isCamelCased, isKebabCased, isPascalCased } from "../utils";
+import { isCamelCased, isKebabCased, isPascalCased, isSnakeCased } from "../utils";
 
 enum Casing {
     CamelCase = "camel-case",
     PascalCase = "pascal-case",
     KebabCase = "kebab-case",
+    SnakeCase = "snake-case",
 }
 
 export class Rule extends Lint.Rules.AbstractRule {
@@ -38,13 +39,14 @@ export class Rule extends Lint.Rules.AbstractRule {
 
             * \`${Casing.CamelCase}\`: File names must be camel-cased: \`fileName.ts\`.
             * \`${Casing.PascalCase}\`: File names must be Pascal-cased: \`FileName.ts\`.
-            * \`${Casing.KebabCase}\`: File names must be kebab-cased: \`file-name.ts\`.`,
+            * \`${Casing.KebabCase}\`: File names must be kebab-cased: \`file-name.ts\`.
+            * \`${Casing.SnakeCase}\`: File names must be snake-cased: \`file_name.ts\`.`,
         options: {
             type: "array",
             items: [
                 {
                     type: "string",
-                    enum: [Casing.CamelCase, Casing.PascalCase, Casing.KebabCase],
+                    enum: [Casing.CamelCase, Casing.PascalCase, Casing.KebabCase, Casing.SnakeCase],
                 },
             ],
         },
@@ -52,6 +54,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             [true, Casing.CamelCase],
             [true, Casing.PascalCase],
             [true, Casing.KebabCase],
+            [true, Casing.SnakeCase],
         ],
         hasFix: false,
         type: "style",
@@ -71,6 +74,8 @@ export class Rule extends Lint.Rules.AbstractRule {
                 return "PascalCase";
             case Casing.KebabCase:
                 return "kebab-case";
+            case Casing.SnakeCase:
+                return "snake_case";
         }
     }
 
@@ -82,6 +87,8 @@ export class Rule extends Lint.Rules.AbstractRule {
                 return isPascalCased(fileName);
             case Casing.KebabCase:
                 return isKebabCased(fileName);
+            case Casing.SnakeCase:
+                return isSnakeCased(fileName);
         }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -222,12 +222,20 @@ export function isCamelCased(name: string): boolean {
     return isLowerCase(name[0]) && !name.includes("_") && !name.includes("-");
 }
 
-export function isKebabCased(name: string): boolean {
+function isSeparatorCased(name: string, disallowedSeparator: string): boolean {
     for (let i = 0; i < name.length; i++) {
         const c = name.charAt(i);
-        if (c === "_" || !isLowerCase(c)) {
+        if (c === disallowedSeparator || !isLowerCase(c)) {
             return false;
         }
     }
     return true;
+}
+
+export function isKebabCased(name: string): boolean {
+    return isSeparatorCased(name, "_");
+}
+
+export function isSnakeCased(name: string): boolean {
+    return isSeparatorCased(name, "-");
 }

--- a/test/rules/file-name-casing/snake-case/NoPascalCase.lint
+++ b/test/rules/file-name-casing/snake-case/NoPascalCase.lint
@@ -1,0 +1,2 @@
+
+~nil [File name must be snake_case]

--- a/test/rules/file-name-casing/snake-case/no-camel-case.ts.lint
+++ b/test/rules/file-name-casing/snake-case/no-camel-case.ts.lint
@@ -1,0 +1,2 @@
+
+~nil [File name must be snake_case]

--- a/test/rules/file-name-casing/snake-case/tslint.json
+++ b/test/rules/file-name-casing/snake-case/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "file-name-casing": [true, "snake-case"]
+    }
+}


### PR DESCRIPTION
#### Overview of change:

Adds an option to enforce snake-cased filenames (follow-up to #3434).

Fixes #4088 


#### CHANGELOG.md entry:
[new-rule-option]: `"snake-case"` in `"file-name-casing"`