### PR TITLE
Handle SpreadElement with trailing comma (fix #3870)

### DIFF
--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -38,14 +38,21 @@ function fillOptions<T>(value: T): Record<OptionName, T> {
         functions: value,
         imports: value,
         objects: value,
-        typeLiterals: value,
+        typeLiterals: value
     };
 }
 
-type OptionsJson = Partial<Record<"multiline" | "singleline", Partial<CustomOptionValue> | OptionValue> & {esSpecCompliant: boolean}>;
+type OptionsJson = Partial<
+    Record<"multiline" | "singleline", Partial<CustomOptionValue> | OptionValue> & {
+        esSpecCompliant: boolean;
+    }
+>;
 function normalizeOptions(options: OptionsJson): Options {
-    return { multiline: normalize(options.multiline), singleline: normalize(options.singleline), specCompliant: !!options.esSpecCompliant};
-
+    return {
+        multiline: normalize(options.multiline),
+        singleline: normalize(options.singleline),
+        specCompliant: !!options.esSpecCompliant
+    };
 }
 function normalize(value: OptionsJson["multiline"]): CustomOptionValue {
     return typeof value === "string" ? fillOptions(value) : { ...defaultOptions, ...value };
@@ -56,16 +63,16 @@ const metadataOptionShape = {
     anyOf: [
         {
             type: "string",
-            enum: ["always", "never"],
+            enum: ["always", "never"]
         },
         {
             type: "object",
             properties: fillOptions({
                 type: "string",
-                enum: ["always", "never", "ignore"],
-            }),
-        },
-    ],
+                enum: ["always", "never", "ignore"]
+            })
+        }
+    ]
 };
 /* tslint:enable:object-literal-sort-keys */
 
@@ -102,12 +109,12 @@ export class Rule extends Lint.Rules.AbstractRule {
             properties: {
                 multiline: metadataOptionShape,
                 singleline: metadataOptionShape,
-                esSpecCompliant: {type: "boolean"},
+                esSpecCompliant: { type: "boolean" }
             },
-            additionalProperties: false,
+            additionalProperties: false
         },
         optionExamples: [
-            [true, {multiline: "always", singleline: "never"}],
+            [true, { multiline: "always", singleline: "never" }],
             [
                 true,
                 {
@@ -115,14 +122,14 @@ export class Rule extends Lint.Rules.AbstractRule {
                         objects: "always",
                         arrays: "always",
                         functions: "never",
-                        typeLiterals: "ignore",
+                        typeLiterals: "ignore"
                     },
-                    esSpecCompliant: true,
-                },
-            ],
+                    esSpecCompliant: true
+                }
+            ]
         ],
         type: "maintainability",
-        typescriptOnly: false,
+        typescriptOnly: false
     };
     /* tslint:enable:object-literal-sort-keys */
 
@@ -145,13 +152,28 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         const cb = (node: ts.Node): void => {
             switch (node.kind) {
                 case ts.SyntaxKind.ArrayLiteralExpression:
-                    this.checkList((node as ts.ArrayLiteralExpression).elements, node.end, "arrays", isArrayRest);
+                    this.checkList(
+                        (node as ts.ArrayLiteralExpression).elements,
+                        node.end,
+                        "arrays",
+                        isArrayRest
+                    );
                     break;
                 case ts.SyntaxKind.ArrayBindingPattern:
-                    this.checkList((node as ts.BindingPattern).elements, node.end, "arrays", isDestructuringRest);
+                    this.checkList(
+                        (node as ts.BindingPattern).elements,
+                        node.end,
+                        "arrays",
+                        isDestructuringRest
+                    );
                     break;
                 case ts.SyntaxKind.ObjectBindingPattern:
-                    this.checkList((node as ts.BindingPattern).elements, node.end, "objects", isDestructuringRest);
+                    this.checkList(
+                        (node as ts.BindingPattern).elements,
+                        node.end,
+                        "objects",
+                        isDestructuringRest
+                    );
                     break;
                 case ts.SyntaxKind.NamedImports:
                     this.checkList((node as ts.NamedImports).elements, node.end, "imports", noRest);
@@ -160,25 +182,43 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
                     this.checkList((node as ts.NamedExports).elements, node.end, "exports", noRest);
                     break;
                 case ts.SyntaxKind.ObjectLiteralExpression:
-                    this.checkList((node as ts.ObjectLiteralExpression).properties, node.end, "objects", isObjectRest);
+                    this.checkList(
+                        (node as ts.ObjectLiteralExpression).properties,
+                        node.end,
+                        "objects",
+                        isObjectRest
+                    );
                     break;
                 case ts.SyntaxKind.EnumDeclaration:
-                    this.checkList((node as ts.EnumDeclaration).members, node.end, "objects", noRest);
+                    this.checkList(
+                        (node as ts.EnumDeclaration).members,
+                        node.end,
+                        "objects",
+                        noRest
+                    );
                     break;
                 case ts.SyntaxKind.NewExpression:
                     if ((node as ts.NewExpression).arguments === undefined) {
                         break;
                     }
-                    // falls through
+                // falls through
                 case ts.SyntaxKind.CallExpression:
-                    this.checkList((node as ts.CallExpression | ts.NewExpression).arguments!, node.end, "functions", noRest);
+                    this.checkList(
+                        (node as ts.CallExpression | ts.NewExpression).arguments!,
+                        node.end,
+                        "functions",
+                        noRest
+                    );
                     break;
                 case ts.SyntaxKind.ArrowFunction:
                     // don't check arrow functions without parens around the parameter
-                    if (getChildOfKind(node, ts.SyntaxKind.OpenParenToken, this.sourceFile) === undefined) {
+                    if (
+                        getChildOfKind(node, ts.SyntaxKind.OpenParenToken, this.sourceFile) ===
+                        undefined
+                    ) {
                         break;
                     }
-                    // falls through
+                // falls through
                 case ts.SyntaxKind.Constructor:
                 case ts.SyntaxKind.FunctionDeclaration:
                 case ts.SyntaxKind.FunctionExpression:
@@ -193,7 +233,7 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
                         (node as ts.SignatureDeclaration).parameters,
                         getChildOfKind(node, ts.SyntaxKind.CloseParenToken, this.sourceFile)!.end,
                         "functions",
-                        isRestParameter,
+                        isRestParameter
                     );
                     break;
                 case ts.SyntaxKind.TypeLiteral:
@@ -223,7 +263,12 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         return this.checkComma(hasTrailingComma, members, node.end, "typeLiterals", noRest);
     }
 
-    private checkList<T extends ts.Node>(list: ts.NodeArray<T>, closeElementPos: number, optionKey: OptionName, isRest: (n: T) => boolean) {
+    private checkList<T extends ts.Node>(
+        list: ts.NodeArray<T>,
+        closeElementPos: number,
+        optionKey: OptionName,
+        isRest: (n: T) => boolean
+    ) {
         if (list.length === 0) {
             return;
         }
@@ -236,12 +281,17 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         list: ts.NodeArray<T>,
         closeTokenPos: number,
         optionKey: OptionName,
-        isRest: (node: T) => boolean,
+        isRest: (node: T) => boolean
     ) {
         const last = list[list.length - 1];
         if (this.options.specCompliant && isRest(last)) {
             if (hasTrailingComma) {
-                this.addFailureAt(list.end - 1, 1, Rule.FAILURE_STRING_FORBIDDEN, Lint.Replacement.deleteText(list.end - 1, 1));
+                this.addFailureAt(
+                    list.end - 1,
+                    1,
+                    Rule.FAILURE_STRING_FORBIDDEN,
+                    Lint.Replacement.deleteText(list.end - 1, 1)
+                );
             }
             return;
         }
@@ -252,9 +302,19 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         const option = options[optionKey];
 
         if (option === "always" && !hasTrailingComma) {
-            this.addFailureAt(list.end, 0, Rule.FAILURE_STRING_ALWAYS, Lint.Replacement.appendText(list.end, ","));
+            this.addFailureAt(
+                list.end,
+                0,
+                Rule.FAILURE_STRING_ALWAYS,
+                Lint.Replacement.appendText(list.end, ",")
+            );
         } else if (option === "never" && hasTrailingComma) {
-            this.addFailureAt(list.end - 1, 1, Rule.FAILURE_STRING_NEVER, Lint.Replacement.deleteText(list.end - 1, 1));
+            this.addFailureAt(
+                list.end - 1,
+                1,
+                Rule.FAILURE_STRING_NEVER,
+                Lint.Replacement.deleteText(list.end - 1, 1)
+            );
         }
     }
 }

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -207,7 +207,7 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
                         (node as ts.CallExpression | ts.NewExpression).arguments!,
                         node.end,
                         "functions",
-                        isSpreadParameter
+                        isSpreadElement
                     );
                     break;
                 case ts.SyntaxKind.ArrowFunction:
@@ -333,10 +333,6 @@ function isObjectRest(node: ts.ObjectLiteralElementLike) {
 
 function isArrayRest(node: ts.Expression) {
     return node.kind === ts.SyntaxKind.SpreadElement && isReassignmentTarget(node);
-}
-
-function isSpreadParameter(node: ts.Node) {
-    return isSpreadElement(node);
 }
 
 function noRest() {

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { getChildOfKind, isReassignmentTarget, isSameLine } from "tsutils";
+import { getChildOfKind, isReassignmentTarget, isSameLine, isSpreadElement } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -207,7 +207,7 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
                         (node as ts.CallExpression | ts.NewExpression).arguments!,
                         node.end,
                         "functions",
-                        noRest
+                        isSpreadParameter
                     );
                     break;
                 case ts.SyntaxKind.ArrowFunction:
@@ -333,6 +333,10 @@ function isObjectRest(node: ts.ObjectLiteralElementLike) {
 
 function isArrayRest(node: ts.Expression) {
     return node.kind === ts.SyntaxKind.SpreadElement && isReassignmentTarget(node);
+}
+
+function isSpreadParameter(node: ts.Node) {
+    return isSpreadElement(node);
 }
 
 function noRest() {

--- a/test/rules/trailing-comma/spec-compliant/test.ts.fix
+++ b/test/rules/trailing-comma/spec-compliant/test.ts.fix
@@ -59,7 +59,11 @@ function foo(...z) {}
     ...x,
     y,
 })
-foo(...y,);
+foo(...y);
+foo(
+    a,
+    ...b
+);
 
 function combined([a, ...arr], {b, ...obj}, regular,) {}
 

--- a/test/rules/trailing-comma/spec-compliant/test.ts.lint
+++ b/test/rules/trailing-comma/spec-compliant/test.ts.lint
@@ -73,7 +73,11 @@ function foo(...z) {}
      ~nil [Missing trailing comma]
 })
 foo(...y);
-        ~nil [Missing trailing comma]
+foo(
+    a,
+    ...b,
+        ~ [Forbidden trailing comma]
+);
 
 function combined([a, ...arr], {b, ...obj}, regular) {}
                                                    ~nil [Missing trailing comma]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3870
- [x] Bugfix
  - [x] Includes tests

#### Overview of change:

Handle trailing comma in `esSpecCompliant` mode
```ts
foo(...y,);
        ~ [Forbidden trailing comma]
```

#### CHANGELOG.md entry:

[bugfix]  `trailing-comma` — "esSpecCompliant" is not applied to function call