### PR TITLE
Remove comment-type

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -188,7 +188,6 @@ export const rules = {
         "check-space",
         "check-uppercase",
     ],
-    "comment-type": [true, "singleline", "multiline", "doc", "directive"],
     "completed-docs": true,
     // "file-header": No sensible default
     "deprecation": true,


### PR DESCRIPTION
Could not find implementations for the following rules specified in the configuration:
    comment-type
Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
If TSLint was recently upgraded, you may have old rules configured which need to be cleaned up.

#### PR checklist

- [X] New feature, bugfix, or enhancement

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?


#### CHANGELOG.md entry:
[bugfix] `comment-type` is removed from config/all.ts