### PR TITLE
[bugfix][enhancement][rule-change] Get rid of check-type option in `whitespace` rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -265,7 +265,6 @@ export const rules = {
         "check-operator",
         "check-module",
         "check-separator",
-        "check-type",
         "check-typecast",
         "check-preblock",
         "check-type-operator",

--- a/test/rules/_integration/react/test.tsx.lint
+++ b/test/rules/_integration/react/test.tsx.lint
@@ -13,11 +13,6 @@ interface IFooProps extends React.Props<FooComponent> {
     fooProp: string;
 }
 
-interface IFooState {
-    bar:string[]; // whitespace failure
-        ~                               [missing whitespace]
-}
-
 export class FooComponent extends React.Component<IFooProps, IFooState> {
     public state = {
         bar: [] as string[]
@@ -31,7 +26,6 @@ export class FooComponent extends React.Component<IFooProps, IFooState> {
                                                                    ~              [missing whitespace]
                                                                     ~             [missing whitespace]
                                                                          ~        [missing whitespace]
-                                                                          ~       [missing whitespace]
                 {this.state.bar.map((s) => <span>{s}</span>)}
                 <BazComponent someProp={123} anotherProp={456} />
             </div>

--- a/test/rules/_integration/react/tslint.json
+++ b/test/rules/_integration/react/tslint.json
@@ -1,21 +1,21 @@
 {
-  "rules": {
-    "curly": true,
-    "eofline": true,
-    "indent": [true, "spaces"],
-    "max-line-length": [true, 120],
-    "no-bitwise": true,
-    "no-unused-expression": true,
-    "quotemark": [true, "double"],
-    "semicolon": [true, "always"],
-    "whitespace": [true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-module",
-      "check-separator",
-      "check-type",
-      "check-typecast"
-    ]
-  }
+    "rules": {
+        "curly": true,
+        "eofline": true,
+        "indent": [true, "spaces"],
+        "max-line-length": [true, 120],
+        "no-bitwise": true,
+        "no-unused-expression": true,
+        "quotemark": [true, "double"],
+        "semicolon": [true, "always"],
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-module",
+            "check-separator",
+            "check-typecast"
+        ]
+    }
 }

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -2,9 +2,7 @@ import ast = AST;
 module M {
     export var ast = AST;
 
-    var x: number;
-
-    var y = (x === 10) ? 1 : 2;
+    var y = (x === 10) ? 1 :2;
 
     var zz = (y === 4);
 
@@ -12,13 +10,7 @@ module M {
 
     var a, b;
 
-    switch (x) {
-        case 1: break;
-        default: break;
-    }
-
     for (x = 1; x < 2; ++x) {
-        goto: console.log("hi");
     }
 
     for (x = 2; x--;) {}
@@ -56,10 +48,9 @@ var test = `
   <div class="repeat"
 `;
 
-var withinTemplateExpression = `${name === "something" ? "foo" : "bar"}`;
+var withinTemplateExpression = `${name === "something" ? "foo" :"bar"}`;
 var withinTemplateExpression = `${name === "something" ? "foo" : "bar"}`;
 
-var objectInsideTemplateExpression = `${({foo: "bar"}).foo}`;
 var objectInsideTemplateExpression = `${({foo: "bar"}).foo}`;
 
 import { importA } from "libA";
@@ -92,7 +83,7 @@ function foorbar()
 
 if () {
     //
-} else {}
+}
 
 if ()
 {}

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -6,14 +6,10 @@ module M {
                   ~     [missing whitespace]
                    ~    [missing whitespace]
 
-    var x:number;
-          ~       [missing whitespace]
-
     var y = (x === 10)?1:2;
                       ~     [missing whitespace]
                        ~    [missing whitespace]
                         ~   [missing whitespace]
-                         ~  [missing whitespace]
 
     var zz = (y===4);
                ~      [missing whitespace]
@@ -26,21 +22,11 @@ module M {
     var a,b;
           ~  [missing whitespace]
 
-    switch(x) {
-          ~     [missing whitespace]
-        case 1:break;
-               ~      [missing whitespace]
-        default:break;
-                ~      [missing whitespace]
-    }
-
     for(x = 1;x <2; ++x){
        ~                   [missing whitespace]
               ~            [missing whitespace]
                  ~         [missing whitespace]
                         ~  [missing whitespace]
-        goto:console.log("hi");
-             ~                  [missing whitespace]
     }
 
     for (x = 2; x--;) {}
@@ -97,11 +83,8 @@ var withinTemplateExpression = `${name==="something"?"foo":"bar"}`;
                                                     ~               [missing whitespace]
                                                      ~              [missing whitespace]
                                                           ~         [missing whitespace]
-                                                           ~        [missing whitespace]
 var withinTemplateExpression = `${name === "something" ? "foo" : "bar"}`;
 
-var objectInsideTemplateExpression = `${({foo:"bar"}).foo}`;
-                                              ~                     [missing whitespace]
 var objectInsideTemplateExpression = `${({foo: "bar"}).foo}`;
 
 import { importA } from "libA";
@@ -148,8 +131,7 @@ function foorbar()
 if (){
      ~ [missing whitespace]
     //
-} else{}
-      ~ [missing whitespace]
+}
 
 if ()
 {}

--- a/test/rules/whitespace/all/tslint.json
+++ b/test/rules/whitespace/all/tslint.json
@@ -8,7 +8,6 @@
       "check-preblock",
       "check-separator",
       "check-rest-spread",
-      "check-type",
       "check-typecast",
       "check-type-operator"
     ]


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Get rid of **check-type** option of `whitespace` rule because of its inconsistency: basing on code, rule's walker determines whether a previous token is a colon and then checks a need for whitespace. The problem is that the colon is used not only for type definition, but also, for example, for conditional operator.

I propose to use separate `typedef-whitespace` rule instead.
