### PR TITLE
[new rule] Key spacing rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -198,6 +198,7 @@ export const rules = {
     "interface-name": true,
     "interface-over-type-literal": true,
     "jsdoc-format": [true, "check-multiline-start"],
+    "key-spacing": true,
     "match-default-export-name": true,
     "new-parens": true,
     "newline-before-return": true,

--- a/src/rules/keySpacingRule.ts
+++ b/src/rules/keySpacingRule.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getChildOfKind, isBindingElement, isPropertyAssignment } from "tsutils";
+import * as ts from "typescript";
+import * as Lint from "../index";
+
+type Option = boolean;
+type OptionType = "beforeColon" | "afterColon";
+type Options = Partial<Record<OptionType, Option>>;
+
+const SPACE_OPTIONS = {
+    type: "boolean"
+};
+
+/* tslint:disable:object-literal-sort-keys */
+const SPACE_OBJECT = {
+    type: "object",
+    properties: {
+        beforeColon: SPACE_OPTIONS,
+        afterColon: SPACE_OPTIONS
+    },
+    additionalProperties: false
+};
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "key-spacing",
+        description: "Requires or restricts whitespace for property assignments.",
+        descriptionDetails: `
+            Determines whether a space is required before and/or after a colon in a property assignment.
+            Based on \`'typedef-whitespace'\` tslint core rule`,
+        optionsDescription: Lint.Utils.dedent`
+            Rule accepts an argument of object type with two optional keys \`'beforeColon'\` and \`'afterColon'\`.
+        `,
+        options: {
+            type: "array",
+            items: [SPACE_OBJECT],
+            addittionalItems: false,
+            maxLength: 1
+        },
+        optionExamples: [
+            [
+                true,
+                {
+                    beforeColon: true,
+                    afterColon: true
+                }
+            ]
+        ],
+        type: "style",
+        typescriptOnly: false,
+        hasFix: true
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING(option: Option, location: "before" | "after"): string {
+        return `expected ${option ? "one space" : "no space"} ${location} colon`;
+    }
+
+    public apply(sourcefile: ts.SourceFile): Lint.RuleFailure[] {
+        const options = this.ruleArguments[0] || { beforeColon: false, afterColon: true };
+
+        return this.applyWithWalker(new KeySpacingWalker(sourcefile, this.ruleName, options));
+    }
+}
+
+class KeySpacingWalker extends Lint.AbstractWalker<Options> {
+    public walk(sourceFile: ts.SourceFile): {} | void {
+        const cb = (node: ts.Node): void => {
+            if (isPropertyAssignment(node) || isBindingElement(node)) {
+                this.checkSpace(node);
+            }
+            return ts.forEachChild(node, cb);
+        };
+        return ts.forEachChild(sourceFile, cb);
+    }
+
+    private checkSpace(
+        node: ts.VariableLikeDeclaration | ts.ObjectBindingOrAssignmentPattern
+    ): void {
+        const { beforeColon, afterColon } = this.options;
+        const colon = getChildOfKind(node, ts.SyntaxKind.ColonToken, this.sourceFile);
+
+        if (!colon) {
+            return;
+        }
+        if (beforeColon !== undefined) {
+            this.checkBeforeColon(colon.end - 1, beforeColon);
+        }
+        if (afterColon !== undefined) {
+            this.checkAfterColon(colon.end, afterColon);
+        }
+    }
+
+    private checkBeforeColon(colonStart: number, option: Option): void {
+        const { text } = this.sourceFile;
+        let currentIndex = colonStart;
+        let currentChar = text.charCodeAt(currentIndex - 1);
+
+        if (ts.isLineBreak(currentChar)) {
+            return;
+        }
+
+        while (ts.isWhiteSpaceSingleLine(currentChar)) {
+            currentIndex -= 1;
+            currentChar = text.charCodeAt(currentIndex - 1);
+        }
+        return this.validateRule(currentIndex, colonStart, option, "before");
+    }
+
+    private checkAfterColon(colonEnd: number, option: Option): void {
+        const { text } = this.sourceFile;
+        let currentIndex = colonEnd;
+        let currentChar = text.charCodeAt(colonEnd);
+
+        if (ts.isLineBreak(currentChar)) {
+            return;
+        }
+
+        while (ts.isWhiteSpaceSingleLine(currentChar)) {
+            currentIndex += 1;
+            currentChar = text.charCodeAt(currentIndex);
+        }
+        return this.validateRule(colonEnd, currentIndex, option, "after");
+    }
+
+    private validateRule(
+        start: number,
+        end: number,
+        option: Option,
+        location: "before" | "after"
+    ): void {
+        if (option) {
+            switch (end - start) {
+                case 0:
+                    this.addFailure(
+                        end,
+                        end,
+                        Rule.FAILURE_STRING(option, location),
+                        Lint.Replacement.appendText(end, " ")
+                    );
+                    break;
+                case 1:
+                    break;
+                default:
+                    this.addFailure(
+                        start + 1,
+                        end,
+                        Rule.FAILURE_STRING(option, location),
+                        Lint.Replacement.deleteFromTo(start + 1, end)
+                    );
+            }
+        } else if (start !== end) {
+            this.addFailure(
+                start,
+                end,
+                Rule.FAILURE_STRING(option, location),
+                Lint.Replacement.deleteFromTo(start, end)
+            );
+        }
+    }
+}

--- a/test/rules/key-spacing/after-colon-onespace/test.ts.lint
+++ b/test/rules/key-spacing/after-colon-onespace/test.ts.lint
@@ -1,0 +1,15 @@
+const r = {aProp: 'testA', prop1 :1, bProp:'testbProp'};
+                                ~ [before]
+                                  ~nil [after]
+                                           ~nil [after]
+
+const z = {x : 'testX', prop2:   2};
+            ~ [before]
+                               ~~ [after]
+
+const fx = { a: 1, b: 2 };
+
+
+[_base]: expected %s %s colon
+[before]: _base % ('no space', 'before')
+[after]: _base % ('one space', 'after')

--- a/test/rules/key-spacing/after-colon-onespace/tslint.json
+++ b/test/rules/key-spacing/after-colon-onespace/tslint.json
@@ -1,0 +1,11 @@
+{
+    "rules": {
+        "key-spacing": [
+            true,
+            {
+                "beforeColon": false,
+                "afterColon": true
+            }
+        ]
+    }
+}

--- a/test/rules/key-spacing/after-colon-only/test.ts.lint
+++ b/test/rules/key-spacing/after-colon-only/test.ts.lint
@@ -1,0 +1,9 @@
+const r = {aProp: 'testA', prop1 :1, bProp:'testbProp'};
+                                  ~nil [after]
+                                           ~nil [after]
+
+const z = {x : 'testX', prop2 :  2};
+                                ~ [after]
+
+[_base]: expected one space %s colon
+[after]: _base % ('after')

--- a/test/rules/key-spacing/after-colon-only/tslint.json
+++ b/test/rules/key-spacing/after-colon-only/tslint.json
@@ -1,0 +1,10 @@
+{
+    "rules": {
+        "key-spacing": [
+            true,
+            {
+                "afterColon": true
+            }
+        ]
+    }
+}

--- a/test/rules/key-spacing/before-colon-only/test.ts.lint
+++ b/test/rules/key-spacing/before-colon-only/test.ts.lint
@@ -1,0 +1,11 @@
+const r = {aProp: 'testA', prop1 :1, bProp:'testbProp'};
+                                ~ [before]
+
+const z = {x  : 'testX', prop2:  2};
+            ~~ [before]
+
+const fx = { a: 1, b: 2 };
+
+
+[_base]: expected %s %s colon
+[before]: _base % ('no space', 'before')

--- a/test/rules/key-spacing/before-colon-only/tslint.json
+++ b/test/rules/key-spacing/before-colon-only/tslint.json
@@ -1,0 +1,10 @@
+{
+    "rules": {
+        "key-spacing": [
+            true,
+            {
+                "beforeColon": false
+            }
+        ]
+    }
+}

--- a/test/rules/key-spacing/both-nospace/test.ts.lint
+++ b/test/rules/key-spacing/both-nospace/test.ts.lint
@@ -1,0 +1,22 @@
+const r = {aProp: 'testA', prop1 :1, bProp:'testbProp'};
+                 ~ [after]
+                                ~ [before]
+
+const z = {x : 'testX', prop2  :  2};
+            ~ [before]
+              ~ [after]
+                             ~~ [before]
+                                ~~ [after]
+
+const v = { r:1, x:{ a:1 } };
+
+const {
+        x  :  1,
+         ~~ [before]
+            ~~ [after]
+        y:5
+} = v;
+
+[_base]: expected no space %s colon
+[before]: _base % ('before')
+[after]: _base % ('after')

--- a/test/rules/key-spacing/both-nospace/tslint.json
+++ b/test/rules/key-spacing/both-nospace/tslint.json
@@ -1,0 +1,11 @@
+{
+    "rules": {
+        "key-spacing": [
+            true,
+            {
+                "beforeColon": false,
+                "afterColon": false
+            }
+        ]
+    }
+}

--- a/test/rules/key-spacing/both-onespace/test.ts.lint
+++ b/test/rules/key-spacing/both-onespace/test.ts.lint
@@ -1,0 +1,25 @@
+const r = {aProp: 'testA', prop1 :1, bProp:'testbProp', prop3 :   { x : 1 }};
+                ~nil [before]
+                                  ~nil [after]
+                                          ~nil [before]
+                                           ~nil [after]
+                                                                ~~ [after]
+const z = {x : 'testX', prop2 : 2};
+
+const {
+        props:{ routeName, location, currentUser },
+             ~nil [before]
+              ~nil [after]   
+        onTabSelect
+} = this;
+
+const {
+        x  :  1,
+          ~ [before]
+             ~ [after]
+        y : 5
+} = v;
+
+[_base]: expected one space %s colon
+[before]: _base % ('before')
+[after]: _base % ('after')

--- a/test/rules/key-spacing/both-onespace/tslint.json
+++ b/test/rules/key-spacing/both-onespace/tslint.json
@@ -1,0 +1,11 @@
+{
+    "rules": {
+        "key-spacing": [
+            true,
+            {
+                "beforeColon": true,
+                "afterColon": true
+            }
+        ]
+    }
+}

--- a/test/rules/key-spacing/none/test.ts.lint
+++ b/test/rules/key-spacing/none/test.ts.lint
@@ -1,0 +1,11 @@
+const test = { x :1, y :  2, z: 123};
+                ~ [before]
+                  ~nil [after]
+                      ~ [before]
+                         ~ [after]
+
+const correct = { x: { t: 1 }, z: 2 };
+
+[_base]: expected %s %s colon
+[before]: _base % ('no space', 'before')
+[after]: _base % ('one space', 'after')

--- a/test/rules/key-spacing/none/tslint.json
+++ b/test/rules/key-spacing/none/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "key-spacing": true
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Add rule to check spaces before and after colon token. Works both for property and destructuring assignments