### PR TITLE
Improve object shorthand

### DIFF
--- a/test/rules/object-literal-shorthand/always/test.ts.lint
+++ b/test/rules/object-literal-shorthand/always/test.ts.lint
@@ -1,12 +1,12 @@
 const bad = {
   w: function() {},
-  ~~~~~~~~~~~ [Expected method shorthand in object literal ('{w() {...}}').]
+  ~~~~~~~~~~~ [LONGHAND_METHOD % ("('{w() {...}}')")]
   x: function *() {},
-  ~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{*x() {...}}').]
+  ~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{*x() {...}}')")]
   [y]: function() {},
-  ~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{[y]() {...}}').]
+  ~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{[y]() {...}}')")]
   z: z
-  ~~~~  [Expected property shorthand in object literal ('{z}').]
+  ~~~~  [LONGHAND_PROPERTY % ("('{z}')")]
 };
 
 const good = {
@@ -26,7 +26,7 @@ const namedFunctions = {
 
 const quotes = {
   "foo-bar": function() {},
-  ~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{"foo-bar"() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{\"foo-bar\"() {...}}')")]
   "foo-bar"() {}
 };
 
@@ -37,17 +37,19 @@ const extraCases = {
   c: 'c',
   ["a" + "nested"]: {
     x: x
-    ~~~~  [Expected property shorthand in object literal ('{x}').]
+    ~~~~  [LONGHAND_PROPERTY % ("('{x}')")]
   }
 };
 
 const asyncFn = {
   foo: async function() {},
-  ~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{async foo() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{async foo() {...}}')")]
   bar: async function*() {}
-  ~~~~~~~~~~~~~~~~~~~~  [Expected method shorthand in object literal ('{async *bar() {...}}').]
+  ~~~~~~~~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{async *bar() {...}}')")]
 }
 
 ({foo: foo} = {foo: foo});
-  ~~~~~~~~ [Expected property shorthand in object literal ('{foo}').]
-               ~~~~~~~~ [Expected property shorthand in object literal ('{foo}').]
+  ~~~~~~~~ [LONGHAND_PROPERTY % ("('{foo}')")]
+               ~~~~~~~~ [LONGHAND_PROPERTY % ("('{foo}')")]
+[LONGHAND_METHOD]: Expected method shorthand in object literal %s.
+[LONGHAND_PROPERTY]: Expected property shorthand in object literal %s.

--- a/test/rules/object-literal-shorthand/never/test.ts.lint
+++ b/test/rules/object-literal-shorthand/never/test.ts.lint
@@ -1,31 +1,31 @@
 const asyncFn = {
   async f() {
-        ~ [OBJECT_LITERAL_DISALLOWED]
+        ~ [SHORTHAND_ASSIGNMENT]
     await some_promise;
   },
   async* fa() {
-         ~~ [OBJECT_LITERAL_DISALLOWED]
+         ~~ [SHORTHAND_ASSIGNMENT]
     await some_promise;
   }
 };
 
 const bad = {
   w() {
-  ~ [OBJECT_LITERAL_DISALLOWED]
+  ~ [SHORTHAND_ASSIGNMENT]
     const alsoBad = {
         bad,
-        ~~~ [OBJECT_LITERAL_DISALLOWED]
+        ~~~ [SHORTHAND_ASSIGNMENT]
     };
   },
   *x() {},
-   ~ [OBJECT_LITERAL_DISALLOWED]
+   ~ [SHORTHAND_ASSIGNMENT]
   [y]() {},
-  ~~~ [OBJECT_LITERAL_DISALLOWED]
+  ~~~ [SHORTHAND_ASSIGNMENT]
   z,
-  ~ [OBJECT_LITERAL_DISALLOWED]
+  ~ [SHORTHAND_ASSIGNMENT]
   nest: {
     nestBad() {},
-    ~~~~~~~ [OBJECT_LITERAL_DISALLOWED]
+    ~~~~~~~ [SHORTHAND_ASSIGNMENT]
     nextGood: function(prop: string): void {}
   }
 };
@@ -47,12 +47,12 @@ const namedFunctions = {
 const quotes = {
   "foo-bar": function() {},
   "foo-bar"() {}
-  ~~~~~~~~~ [OBJECT_LITERAL_DISALLOWED]
+  ~~~~~~~~~ [SHORTHAND_ASSIGNMENT]
 };
 
 const extraCases = {
   x,
-  ~ [OBJECT_LITERAL_DISALLOWED]
+  ~ [SHORTHAND_ASSIGNMENT]
   a: 123,
   b: "hello",
   c: 'c',
@@ -66,7 +66,7 @@ export class ClassA extends ClassZ {
 }
 
 ({foo} = {foo});
-  ~~~ [OBJECT_LITERAL_DISALLOWED]
-          ~~~ [OBJECT_LITERAL_DISALLOWED]
+  ~~~ [SHORTHAND_ASSIGNMENT]
+          ~~~ [SHORTHAND_ASSIGNMENT]
 
-[OBJECT_LITERAL_DISALLOWED]: Shorthand property assignments have been disallowed.
+[SHORTHAND_ASSIGNMENT]: Shorthand property assignments have been disallowed.

--- a/test/rules/object-literal-shorthand/never/test.ts.lint
+++ b/test/rules/object-literal-shorthand/never/test.ts.lint
@@ -69,4 +69,4 @@ export class ClassA extends ClassZ {
   ~~~ [SHORTHAND_ASSIGNMENT]
           ~~~ [SHORTHAND_ASSIGNMENT]
 
-[SHORTHAND_ASSIGNMENT]: Shorthand property assignments have been disallowed.
+[SHORTHAND_ASSIGNMENT]: Shorthand property and method assignments have been disallowed.

--- a/test/rules/object-literal-shorthand/never/tslint.json
+++ b/test/rules/object-literal-shorthand/never/tslint.json
@@ -1,6 +1,5 @@
 {
     "rules": {
-      "object-literal-shorthand": [true, "never"]
+        "object-literal-shorthand": [true, "never"]
     }
-  }
-  
+}

--- a/test/rules/object-literal-shorthand/onlyMethods/test.ts.fix
+++ b/test/rules/object-literal-shorthand/onlyMethods/test.ts.fix
@@ -1,0 +1,45 @@
+const badMethodsGoodProps = {
+  w() {},
+  *x() {},
+  [y]() {},
+  z: z
+};
+
+const goodMethodsBadProps = {
+  w() {},
+  *x() {},
+  [y]() {},
+  z: z
+};
+
+const arrows = {
+  x: (y) => y  // this is OK.
+};
+
+const namedFunctions = {
+  x: function y() {}  // named function expressions are also OK.
+};
+
+const quotes = {
+  "foo-bar"() {},
+  "foo-bar"() {}
+};
+
+const extraCases = {
+  x: x,
+  a: 123,
+  b: "hello",
+  c: 'c',
+  ["a" + "nested"]: {
+    x: x
+  }
+};
+
+const asyncFn = {
+  async foo() {},
+  async *bar() {}
+}
+
+({foo: foo} = {foo: foo});
+({foo: foo} = {foo: foo});
+

--- a/test/rules/object-literal-shorthand/onlyMethods/test.ts.lint
+++ b/test/rules/object-literal-shorthand/onlyMethods/test.ts.lint
@@ -1,0 +1,58 @@
+const badMethodsGoodProps = {
+  w: function() {},
+  ~~~~~~~~~~~ [LONGHAND_METHOD % ("('{w() {...}}')")]
+  x: function *() {},
+  ~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{*x() {...}}')")]
+  [y]: function() {},
+  ~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{[y]() {...}}')")]
+  z: z
+};
+
+const goodMethodsBadProps = {
+  w() {},
+  *x() {},
+  [y]() {},
+  z
+  ~  [OBJECT_LITERAL_DISALLOWED]
+};
+
+const arrows = {
+  x: (y) => y  // this is OK.
+};
+
+const namedFunctions = {
+  x: function y() {}  // named function expressions are also OK.
+};
+
+const quotes = {
+  "foo-bar": function() {},
+  ~~~~~~~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{\"foo-bar\"() {...}}')")]
+  "foo-bar"() {}
+};
+
+const extraCases = {
+  x,
+  ~  [OBJECT_LITERAL_DISALLOWED]
+  a: 123,
+  b: "hello",
+  c: 'c',
+  ["a" + "nested"]: {
+    x: x
+  }
+};
+
+const asyncFn = {
+  foo: async function() {},
+  ~~~~~~~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{async foo() {...}}')")]
+  bar: async function*() {}
+  ~~~~~~~~~~~~~~~~~~~~  [LONGHAND_METHOD % ("('{async *bar() {...}}')")]
+}
+
+({foo: foo} = {foo: foo});
+({foo} = {foo});
+  ~~~ [OBJECT_LITERAL_DISALLOWED]
+          ~~~ [OBJECT_LITERAL_DISALLOWED]
+
+[OBJECT_LITERAL_DISALLOWED]: Shorthand property assignments have been disallowed.
+[LONGHAND_METHOD]: Expected method shorthand in object literal %s.
+[LONGHAND_PROPERTY]: Expected property shorthand in object literal %s.

--- a/test/rules/object-literal-shorthand/onlyMethods/tslint.json
+++ b/test/rules/object-literal-shorthand/onlyMethods/tslint.json
@@ -1,0 +1,10 @@
+{
+    "rules": {
+        "object-literal-shorthand": [
+            true,
+            {
+                "property": "never"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3778
- [x] Enhancement
  - [x] Includes tests

#### Overview of change:

Support granular configuration in `object-literal-shorthand`

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
[new-rule-option] `object-literal-shorthand` supports `{"property"?: "never", "method"?: "never"}` as config options