### PR TITLE
fix(#3881): allow `exclude` to work with node API

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -82,7 +82,7 @@ export const DEFAULT_CONFIG: IConfigurationFile = {
     extends: ["tslint:recommended"],
     jsRules: new Map<string, Partial<IOptions>>(),
     rules: new Map<string, Partial<IOptions>>(),
-    rulesDirectory: [],
+    rulesDirectory: []
 };
 
 export const EMPTY_CONFIG: IConfigurationFile = {
@@ -90,7 +90,7 @@ export const EMPTY_CONFIG: IConfigurationFile = {
     extends: [],
     jsRules: new Map<string, Partial<IOptions>>(),
     rules: new Map<string, Partial<IOptions>>(),
-    rulesDirectory: [],
+    rulesDirectory: []
 };
 
 const BUILT_IN_CONFIG = /^tslint:(.*)$/;
@@ -102,9 +102,18 @@ const BUILT_IN_CONFIG = /^tslint:(.*)$/;
  * of the search for a configuration.
  * @returns Load status for a TSLint configuration object
  */
-export function findConfiguration(configFile: string | null, inputFilePath: string): IConfigurationLoadResult;
-export function findConfiguration(configFile: string, inputFilePath?: string): IConfigurationLoadResult;
-export function findConfiguration(configFile: string | null, inputFilePath?: string): IConfigurationLoadResult {
+export function findConfiguration(
+    configFile: string | null,
+    inputFilePath: string
+): IConfigurationLoadResult;
+export function findConfiguration(
+    configFile: string,
+    inputFilePath?: string
+): IConfigurationLoadResult;
+export function findConfiguration(
+    configFile: string | null,
+    inputFilePath?: string
+): IConfigurationLoadResult {
     const configPath = findConfigurationPath(configFile, inputFilePath!);
     const loadResult: IConfigurationLoadResult = { path: configPath };
 
@@ -112,7 +121,10 @@ export function findConfiguration(configFile: string | null, inputFilePath?: str
         loadResult.results = loadConfigurationFromPath(configPath);
         return loadResult;
     } catch (error) {
-        throw new FatalError(`Failed to load ${configPath}: ${(error as Error).message}`, error as Error);
+        throw new FatalError(
+            `Failed to load ${configPath}: ${(error as Error).message}`,
+            error as Error
+        );
     }
 }
 
@@ -126,12 +138,23 @@ export function findConfiguration(configFile: string | null, inputFilePath?: str
  * @returns An absolute path to a tslint.json or tslint.yml or tslint.yaml file
  * or undefined if neither can be found.
  */
-export function findConfigurationPath(suppliedConfigFilePath: string | null, inputFilePath: string): string | undefined;
-export function findConfigurationPath(suppliedConfigFilePath: string, inputFilePath?: string): string | undefined;
-export function findConfigurationPath(suppliedConfigFilePath: string | null, inputFilePath?: string): string | undefined {
+export function findConfigurationPath(
+    suppliedConfigFilePath: string | null,
+    inputFilePath: string
+): string | undefined;
+export function findConfigurationPath(
+    suppliedConfigFilePath: string,
+    inputFilePath?: string
+): string | undefined;
+export function findConfigurationPath(
+    suppliedConfigFilePath: string | null,
+    inputFilePath?: string
+): string | undefined {
     if (suppliedConfigFilePath != undefined) {
         if (!fs.existsSync(suppliedConfigFilePath)) {
-            throw new FatalError(`Could not find config file at: ${path.resolve(suppliedConfigFilePath)}`);
+            throw new FatalError(
+                `Could not find config file at: ${path.resolve(suppliedConfigFilePath)}`
+            );
         } else {
             return path.resolve(suppliedConfigFilePath);
         }
@@ -198,9 +221,11 @@ function findup(filenames: string[], directory: string): string | undefined {
             }
             // TODO: remove in v6.0.0
             // Try reading in the entire directory and looking for a file with different casing.
-            const result = dirFiles.find((entry) => entry.toLowerCase() === filename);
+            const result = dirFiles.find(entry => entry.toLowerCase() === filename);
             if (result !== undefined) {
-                showWarningOnce(`Using mixed case ${filename} is deprecated. Found: ${path.join(cwd, result)}`);
+                showWarningOnce(
+                    `Using mixed case ${filename} is deprecated. Found: ${path.join(cwd, result)}`
+                );
                 return result;
             }
         }
@@ -219,14 +244,17 @@ function findup(filenames: string[], directory: string): string | undefined {
  * @returns a configuration object for TSLint loaded from the file at configFilePath
  */
 export function loadConfigurationFromPath(configFilePath?: string, _originalFilePath?: string) {
-
     if (configFilePath == undefined) {
         return DEFAULT_CONFIG;
     } else {
         const resolvedConfigFilePath = resolveConfigurationPath(configFilePath);
         const rawConfigFile = readConfigurationFile(resolvedConfigFilePath);
 
-        return parseConfigFile(rawConfigFile, path.dirname(resolvedConfigFilePath), readConfigurationFile);
+        return parseConfigFile(
+            rawConfigFile,
+            path.dirname(resolvedConfigFilePath),
+            readConfigurationFile
+        );
     }
 }
 
@@ -244,7 +272,7 @@ export function readConfigurationFile(filepath: string): RawConfigFile {
                     // but this trips up the no-unsafe-any rule.
                     // tslint:disable-next-line:no-unsafe-any
                     schema: yaml.JSON_SCHEMA,
-                    strict: true,
+                    strict: true
                 }) as RawConfigFile;
             }
         } catch (e) {
@@ -272,7 +300,9 @@ function resolveConfigurationPath(filePath: string, relativeTo?: string) {
         try {
             return require.resolve(`./configs/${configName}`);
         } catch (err) {
-            throw new Error(`${filePath} is not a built-in config, try "tslint:recommended" instead.`);
+            throw new Error(
+                `${filePath} is not a built-in config, try "tslint:recommended" instead.`
+            );
         }
     }
 
@@ -283,16 +313,19 @@ function resolveConfigurationPath(filePath: string, relativeTo?: string) {
         try {
             return require.resolve(filePath);
         } catch (err) {
-            throw new Error(`Invalid "extends" configuration value - could not require "${filePath}". ` +
-                "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +
-                "for the approximate method TSLint uses to find the referenced configuration file.");
+            throw new Error(
+                `Invalid "extends" configuration value - could not require "${filePath}". ` +
+                    "Review the Node lookup algorithm (https://nodejs.org/api/modules.html#modules_all_together) " +
+                    "for the approximate method TSLint uses to find the referenced configuration file."
+            );
         }
     }
 }
 
-export function extendConfigurationFile(targetConfig: IConfigurationFile,
-                                        nextConfigSource: IConfigurationFile): IConfigurationFile {
-
+export function extendConfigurationFile(
+    targetConfig: IConfigurationFile,
+    nextConfigSource: IConfigurationFile
+): IConfigurationFile {
     function combineProperties<T>(targetProperty: T | undefined, nextProperty: T | undefined): T {
         const combinedProperty: { [key: string]: any } = {};
         add(targetProperty);
@@ -311,7 +344,10 @@ export function extendConfigurationFile(targetConfig: IConfigurationFile,
         }
     }
 
-    function combineMaps(target: Map<string, Partial<IOptions>>, next: Map<string, Partial<IOptions>>) {
+    function combineMaps(
+        target: Map<string, Partial<IOptions>>,
+        next: Map<string, Partial<IOptions>>
+    ) {
         const combined = new Map<string, Partial<IOptions>>();
         target.forEach((options, ruleName) => {
             combined.set(ruleName, options);
@@ -333,9 +369,12 @@ export function extendConfigurationFile(targetConfig: IConfigurationFile,
     return {
         extends: [],
         jsRules: combineMaps(targetConfig.jsRules, nextConfigSource.jsRules),
-        linterOptions: combineProperties(targetConfig.linterOptions, nextConfigSource.linterOptions),
+        linterOptions: combineProperties(
+            targetConfig.linterOptions,
+            nextConfigSource.linterOptions
+        ),
         rules: combineMaps(targetConfig.rules, nextConfigSource.rules),
-        rulesDirectory: dedupedRulesDirs,
+        rulesDirectory: dedupedRulesDirs
     };
 }
 
@@ -365,25 +404,28 @@ export function useAsPath(directory: string) {
  * should be the path to the tslint.json file.
  * @return An array of absolute paths to directories potentially containing rules
  */
-export function getRulesDirectories(directories?: string | string[], relativeTo?: string): string[] {
-    return arrayify(directories)
-        .map((dir) => {
-            if (!useAsPath(dir)) {
-                try {
-                    return path.dirname(resolve.sync(dir, { basedir: relativeTo }));
-                } catch (err) {
-                    // swallow error and fallback to using directory as path
-                }
+export function getRulesDirectories(
+    directories?: string | string[],
+    relativeTo?: string
+): string[] {
+    return arrayify(directories).map(dir => {
+        if (!useAsPath(dir)) {
+            try {
+                return path.dirname(resolve.sync(dir, { basedir: relativeTo }));
+            } catch (err) {
+                // swallow error and fallback to using directory as path
             }
+        }
 
-            const absolutePath = relativeTo === undefined ? path.resolve(dir) : path.resolve(relativeTo, dir);
-            if (absolutePath !== undefined) {
-                if (!fs.existsSync(absolutePath)) {
-                    throw new FatalError(`Could not find custom rule directory: ${dir}`);
-                }
+        const absolutePath =
+            relativeTo === undefined ? path.resolve(dir) : path.resolve(relativeTo, dir);
+        if (absolutePath !== undefined) {
+            if (!fs.existsSync(absolutePath)) {
+                throw new FatalError(`Could not find custom rule directory: ${dir}`);
             }
-            return absolutePath;
-        });
+        }
+        return absolutePath;
+    });
 }
 
 /**
@@ -391,7 +433,10 @@ export function getRulesDirectories(directories?: string | string[], relativeTo?
  *
  * @param ruleConfigValue The raw option setting of a rule
  */
-function parseRuleOptions(ruleConfigValue: RawRuleConfig, rawDefaultRuleSeverity: string | undefined): Partial<IOptions> {
+function parseRuleOptions(
+    ruleConfigValue: RawRuleConfig,
+    rawDefaultRuleSeverity: string | undefined
+): Partial<IOptions> {
     let ruleArguments: any[] | undefined;
     let defaultRuleSeverity: RuleSeverity = "error";
 
@@ -454,7 +499,7 @@ function parseRuleOptions(ruleConfigValue: RawRuleConfig, rawDefaultRuleSeverity
 
     return {
         ruleArguments,
-        ruleSeverity,
+        ruleSeverity
     };
 }
 
@@ -469,10 +514,15 @@ export interface RawConfigFile {
 export interface RawRulesConfig {
     [key: string]: RawRuleConfig;
 }
-export type RawRuleConfig = null | undefined | boolean | any[] | {
-    severity?: RuleSeverity | "warn" | "none" | "default";
-    options?: any;
-};
+export type RawRuleConfig =
+    | null
+    | undefined
+    | boolean
+    | any[]
+    | {
+          severity?: RuleSeverity | "warn" | "none" | "default";
+          options?: any;
+      };
 
 /**
  * Parses a config file and normalizes legacy config settings.
@@ -485,7 +535,7 @@ export type RawRuleConfig = null | undefined | boolean | any[] | {
 export function parseConfigFile(
     configFile: RawConfigFile,
     configFileDir?: string,
-    readConfig?: (path: string) => RawConfigFile,
+    readConfig?: (path: string) => RawConfigFile
 ): IConfigurationFile {
     let defaultSeverity = configFile.defaultSeverity;
     if (readConfig === undefined || configFileDir === undefined) {
@@ -493,12 +543,12 @@ export function parseConfigFile(
     }
 
     return loadExtendsRecursive(configFile, configFileDir)
-        .map(({dir, config}) => parse(config, dir))
+        .map(({ dir, config }) => parse(config, dir))
         .reduce(extendConfigurationFile, EMPTY_CONFIG);
 
     /** Read files in order, depth first, and assign `defaultSeverity` (last config in extends wins). */
     function loadExtendsRecursive(raw: RawConfigFile, dir: string) {
-        const configs: Array<{dir: string; config: RawConfigFile}> = [];
+        const configs: Array<{ dir: string; config: RawConfigFile }> = [];
         for (const relativePath of arrayify(raw.extends)) {
             const resolvedPath = resolveConfigurationPath(relativePath, dir);
             const extendedRaw = readConfig!(resolvedPath);
@@ -507,23 +557,24 @@ export function parseConfigFile(
         if (raw.defaultSeverity !== undefined) {
             defaultSeverity = raw.defaultSeverity;
         }
-        configs.push({dir, config: raw});
+        configs.push({ dir, config: raw });
         return configs;
     }
 
     function parse(config: RawConfigFile, dir?: string): IConfigurationFile {
         const rulesDirectory: string | string[] = getRulesDirectories(config.rulesDirectory, dir);
         const rules = parseRules(config.rules);
-        const jsRules = typeof config.jsRules === "boolean" ?
-                            filterValidJsRules(rules, config.jsRules, rulesDirectory) :
-                            parseRules(config.jsRules);
+        const jsRules =
+            typeof config.jsRules === "boolean"
+                ? filterValidJsRules(rules, config.jsRules, rulesDirectory)
+                : parseRules(config.jsRules);
 
         return {
             extends: arrayify(config.extends),
             jsRules,
             linterOptions: parseLinterOptions(config.linterOptions, dir),
             rules,
-            rulesDirectory,
+            rulesDirectory
         };
     }
 
@@ -539,16 +590,21 @@ export function parseConfigFile(
         return map;
     }
 
-    function filterValidJsRules(rules: Map<string, Partial<IOptions>>,
-                                copyRulestoJsRules = false,
-                                rulesDirectory?: string | string[]): Map<string, Partial<IOptions>> {
+    function filterValidJsRules(
+        rules: Map<string, Partial<IOptions>>,
+        copyRulestoJsRules = false,
+        rulesDirectory?: string | string[]
+    ): Map<string, Partial<IOptions>> {
         const validJsRules = new Map<string, Partial<IOptions>>();
         if (copyRulestoJsRules) {
             rules.forEach((ruleOptions, ruleName) => {
                 if (ruleOptions.ruleSeverity !== "off") {
                     const Rule = findRule(ruleName, rulesDirectory);
-                    if ((Rule !== undefined && (Rule.metadata === undefined || !Rule.metadata.typescriptOnly))) {
-                    validJsRules.set(ruleName, ruleOptions);
+                    if (
+                        Rule !== undefined &&
+                        (Rule.metadata === undefined || !Rule.metadata.typescriptOnly)
+                    ) {
+                        validJsRules.set(ruleName, ruleOptions);
                     }
                 }
             });
@@ -557,14 +613,17 @@ export function parseConfigFile(
         return validJsRules;
     }
 
-    function parseLinterOptions(raw: RawConfigFile["linterOptions"], dir?: string): IConfigurationFile["linterOptions"] {
+    function parseLinterOptions(
+        raw: RawConfigFile["linterOptions"],
+        dir?: string
+    ): IConfigurationFile["linterOptions"] {
         if (raw === undefined || raw.exclude === undefined) {
             return {};
         }
         return {
             exclude: arrayify(raw.exclude).map(
-                (pattern) => dir === undefined ? path.resolve(pattern) : path.resolve(dir, pattern),
-            ),
+                pattern => (dir === undefined ? path.resolve(pattern) : path.resolve(dir, pattern))
+            )
         };
     }
 }
@@ -579,17 +638,21 @@ export function convertRuleOptions(ruleConfiguration: Map<string, Partial<IOptio
             disabledIntervals: [], // deprecated, so just provide an empty array.
             ruleArguments: ruleArguments != undefined ? ruleArguments : [],
             ruleName,
-            ruleSeverity: ruleSeverity != undefined ? ruleSeverity : "error",
+            ruleSeverity: ruleSeverity != undefined ? ruleSeverity : "error"
         };
         output.push(options);
     });
     return output;
 }
 
-export function isFileExcluded(filepath: string, configFile: IConfigurationFile) {
-    if (configFile === undefined || configFile.linterOptions == undefined || configFile.linterOptions.exclude == undefined) {
+export function isFileExcluded(filepath: string, configFile?: IConfigurationFile) {
+    if (
+        configFile === undefined ||
+        configFile.linterOptions == undefined ||
+        configFile.linterOptions.exclude == undefined
+    ) {
         return false;
     }
     const fullPath = path.resolve(filepath);
-    return configFile.linterOptions.exclude.some((pattern) => new Minimatch(pattern).match(fullPath));
+    return configFile.linterOptions.exclude.some(pattern => new Minimatch(pattern).match(fullPath));
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,7 @@
 
 import * as fs from "fs";
 import * as yaml from "js-yaml";
+import { Minimatch } from "minimatch";
 import * as os from "os";
 import * as path from "path";
 import * as resolve from "resolve";
@@ -25,7 +26,6 @@ import { FatalError, showWarningOnce } from "./error";
 import { IOptions, RuleSeverity } from "./language/rule/rule";
 import { findRule } from "./ruleLoader";
 import { arrayify, hasOwnProperty, stripComments } from "./utils";
-import { Minimatch } from "minimatch";
 
 export interface IConfigurationFile {
     /**

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -25,6 +25,7 @@ import { FatalError, showWarningOnce } from "./error";
 import { IOptions, RuleSeverity } from "./language/rule/rule";
 import { findRule } from "./ruleLoader";
 import { arrayify, hasOwnProperty, stripComments } from "./utils";
+import { Minimatch } from "minimatch";
 
 export interface IConfigurationFile {
     /**
@@ -583,4 +584,12 @@ export function convertRuleOptions(ruleConfiguration: Map<string, Partial<IOptio
         output.push(options);
     });
     return output;
+}
+
+export function isFileExcluded(filepath: string, configFile: IConfigurationFile) {
+    if (configFile === undefined || configFile.linterOptions == undefined || configFile.linterOptions.exclude == undefined) {
+        return false;
+    }
+    const fullPath = path.resolve(filepath);
+    return configFile.linterOptions.exclude.some((pattern) => new Minimatch(pattern).match(fullPath));
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -113,8 +113,10 @@ export class Linter {
     }
 
     public lint(fileName: string, source: string, configuration: IConfigurationFile = DEFAULT_CONFIG): void {
+        if (isFileExcluded(fileName, configuration)) {
+            return;
+        }
         const sourceFile = this.getSourceFile(fileName, source);
-        if (configuration && isFileExcluded(fileName, configuration)) { return; }
         const isJs = /\.jsx?$/i.test(fileName);
         const enabledRules = this.getEnabledRules(configuration, isJs);
 

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -27,6 +27,7 @@ import {
     getRulesDirectories,
     IConfigurationFile,
     loadConfigurationFromPath,
+    isFileExcluded,
 } from "./configuration";
 import { removeDisabledFailures } from "./enableDisableRules";
 import { FatalError, isError, showRuleCrashWarning } from "./error";
@@ -113,6 +114,9 @@ export class Linter {
 
     public lint(fileName: string, source: string, configuration: IConfigurationFile = DEFAULT_CONFIG): void {
         const sourceFile = this.getSourceFile(fileName, source);
+        if (configuration && isFileExcluded(fileName, configuration)) {
+            return [];
+        }
         const isJs = /\.jsx?$/i.test(fileName);
         const enabledRules = this.getEnabledRules(configuration, isJs);
 

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -114,9 +114,7 @@ export class Linter {
 
     public lint(fileName: string, source: string, configuration: IConfigurationFile = DEFAULT_CONFIG): void {
         const sourceFile = this.getSourceFile(fileName, source);
-        if (configuration && isFileExcluded(fileName, configuration)) {
-            return [];
-        }
+        if (configuration && isFileExcluded(fileName, configuration)) { return; }
         const isJs = /\.jsx?$/i.test(fileName);
         const enabledRules = this.getEnabledRules(configuration, isJs);
 

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -26,8 +26,8 @@ import {
     findConfigurationPath,
     getRulesDirectories,
     IConfigurationFile,
-    loadConfigurationFromPath,
     isFileExcluded,
+    loadConfigurationFromPath,
 } from "./configuration";
 import { removeDisabledFailures } from "./enableDisableRules";
 import { FatalError, isError, showRuleCrashWarning } from "./error";

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -26,8 +26,8 @@ import * as ts from "typescript";
 import {
     DEFAULT_CONFIG,
     findConfiguration,
-    JSON_CONFIG_FILENAME,
     isFileExcluded,
+    JSON_CONFIG_FILENAME,
 } from "./configuration";
 import { FatalError } from "./error";
 import { LintResult } from "./index";

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -264,7 +264,7 @@ async function doLinting(options: Options, files: string[], program: ts.Program 
                 lastFolder = folder;
             }
         }
-        if (configFile && isFileExcluded(file, configFile)) {
+        if (isFileExcluded(file, configFile)) {
             continue;
         }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -27,6 +27,7 @@ import {
     DEFAULT_CONFIG,
     findConfiguration,
     JSON_CONFIG_FILENAME,
+    isFileExcluded,
 } from "./configuration";
 import { FatalError } from "./error";
 import { LintResult } from "./index";
@@ -263,7 +264,7 @@ async function doLinting(options: Options, files: string[], program: ts.Program 
                 lastFolder = folder;
             }
         }
-        if (isFileExcluded(file)) {
+        if (configFile && isFileExcluded(file, configFile)) {
             continue;
         }
 
@@ -283,14 +284,6 @@ async function doLinting(options: Options, files: string[], program: ts.Program 
     }
 
     return linter.getResult();
-
-    function isFileExcluded(filepath: string) {
-        if (configFile === undefined || configFile.linterOptions == undefined || configFile.linterOptions.exclude == undefined) {
-            return false;
-        }
-        const fullPath = path.resolve(filepath);
-        return configFile.linterOptions.exclude.some((pattern) => new Minimatch(pattern).match(fullPath));
-    }
 }
 
 /** Read a file, but return undefined if it is an MPEG '.ts' file. */


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3881 
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- ~~[ ] Documentation update~~

#### Overview of change:

Moves `isFileExcluded` from runner to configuration, then import it to both runner and linter.

No documentation update because this is already what is expected from the existing documentation.

#### CHANGELOG.md entry:
[bugfix] allow `exclude` to work with node API