### PR TITLE
Added missing `no-switch-case-fall-through` config

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -123,6 +123,7 @@ export const rules = {
     "no-shadowed-variable": true,
     "no-string-literal": true,
     "no-string-throw": true,
+    "no-switch-case-fall-through": true,
     "no-sparse-arrays": true,
     "no-submodule-imports": true,
     "no-unbound-method": true,


### PR DESCRIPTION
Added missing `no-switch-case-fall-through` rule configuration to the list of all configuration rules

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
