### PR TITLE
Configure format from file

### DIFF
--- a/docs/usage/configuration/index.md
+++ b/docs/usage/configuration/index.md
@@ -33,6 +33,7 @@ A path to a directory or an array of paths to directories of [custom rules][2]. 
 * `defaultSeverity?: "error" | "warning" | "off"`: The severity level that is applied to rules in this config file as well as rules in any inherited config files which have their severity set to "default". If undefined, "error" is used as the defaultSeverity.
 * `linterOptions?: { exclude?: string[] }`:
   - `exclude: string[]`: An array of globs. Any file matching these globs will not be linted. All exclude patterns are relative to the configuration file they were specified in.
+  - `format: string`: Default [lint formatter][4]
 
 `tslint.json` configuration files may have JavaScript-style `// single-line` and `/* multi-line */` comments in them (even though this is technically invalid JSON). If this confuses your syntax highlighter, you may want to switch it to JavaScript format.
 
@@ -129,6 +130,7 @@ Some commonly used custom rule packages in the TSLint community are listed in th
 [1]: {{site.baseurl | append: "/usage/third-party-tools"}}
 [2]: {{site.baseurl | append: "/develop/custom-rules"}}
 [3]: {{site.baseurl | append: "/rules"}}
+[4]: {{site.baseurl | append: "/formatters"}}
 [rule-ban]: {{site.baseurl | append: "/rules/ban"}}
 [rule-import-blacklist]: {{site.baseurl | append: "/rules/import-blacklist"}}
 [rule-file-header]: {{site.baseurl | append: "/rules/file-header"}}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -622,7 +622,7 @@ export function parseConfigFile(
             return {};
         }
         return {
-            ...(raw.exclude
+            ...(raw.exclude !== undefined
                 ? {
                     exclude: arrayify(raw.exclude).map(
                         pattern =>
@@ -630,7 +630,7 @@ export function parseConfigFile(
                     )
                 }
                 : {}),
-            ...(raw.format
+            ...(raw.format !== undefined
                 ? {
                     format: raw.format
                 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -52,6 +52,7 @@ export interface IConfigurationFile {
      */
     linterOptions?: Partial<{
         exclude: string[];
+        format: string;
     }>;
 
     /**
@@ -617,13 +618,23 @@ export function parseConfigFile(
         raw: RawConfigFile["linterOptions"],
         dir?: string
     ): IConfigurationFile["linterOptions"] {
-        if (raw === undefined || raw.exclude === undefined) {
+        if (raw === undefined) {
             return {};
         }
         return {
-            exclude: arrayify(raw.exclude).map(
-                pattern => (dir === undefined ? path.resolve(pattern) : path.resolve(dir, pattern))
-            )
+            ...(raw.exclude
+                ? {
+                    exclude: arrayify(raw.exclude).map(
+                        pattern =>
+                            dir === undefined ? path.resolve(pattern) : path.resolve(dir, pattern)
+                    )
+                }
+                : {}),
+            ...(raw.format
+                ? {
+                    format: raw.format
+                }
+                : {})
         };
     }
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -242,10 +242,21 @@ function resolveGlobs(files: string[], ignore: string[], outputAbsolutePaths: bo
 }
 
 async function doLinting(options: Options, files: string[], program: ts.Program | undefined, logger: Logger): Promise<LintResult> {
+    let configFile =
+        options.config !== undefined ? findConfiguration(options.config).results : undefined;
+
+    let formatter = options.format;
+    if (formatter === undefined) {
+        formatter =
+            configFile && configFile.linterOptions && configFile.linterOptions.format
+                ? configFile.linterOptions.format
+                : "prose";
+    }
+
     const linter = new Linter(
         {
             fix: !!options.fix,
-            formatter: options.format,
+            formatter,
             formattersDirectory: options.formattersDirectory,
             quiet: !!options.quiet,
             rulesDirectory: options.rulesDirectory,
@@ -254,7 +265,6 @@ async function doLinting(options: Options, files: string[], program: ts.Program 
     );
 
     let lastFolder: string | undefined;
-    let configFile = options.config !== undefined ? findConfiguration(options.config).results : undefined;
 
     for (const file of files) {
         if (options.config === undefined) {

--- a/src/tslintCli.ts
+++ b/src/tslintCli.ts
@@ -264,7 +264,7 @@ run(
         files: arrayify(commander.args),
         fix: argv.fix,
         force: argv.force,
-        format: argv.format === undefined ? "prose" : argv.format,
+        format: argv.format,
         formattersDirectory: argv.formattersDir,
         init: argv.init,
         out: argv.out,

--- a/test/config/tslint-custom-rules-with-dir-and-format.json
+++ b/test/config/tslint-custom-rules-with-dir-and-format.json
@@ -1,0 +1,16 @@
+{
+    "rulesDirectory": "../files/custom-rules/",
+    "jsRules": {
+        "always-fail": {
+            "severity": "error"
+        }
+    },
+    "rules": {
+        "always-fail": {
+            "severity": "error"
+        }
+    },
+    "linterOptions": {
+        "format": "tslint-test-custom-formatter"
+    }
+}

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -134,18 +134,40 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
     });
 
     describe("Custom formatters", () => {
-        it("can be loaded from node_modules", (done) => {
+        const createFormatVerifier = (done: MochaDone): ExecFileCallback => (err, stdout) => {
+            assert.isNotNull(err, "process should exit with error");
+            assert.strictEqual(err.code, 2, "error code should be 2");
+            assert.include(
+                stdout,
+                "hello from custom formatter",
+                "stdout should contain output of custom formatter"
+            );
+            done();
+        };
+
+        it("can be loaded from node_modules", done => {
             execCli(
-                ["-c", "tslint-custom-rules-with-dir.json", "../../src/test.ts", "-t", "tslint-test-custom-formatter"],
+                [
+                    "-c",
+                    "tslint-custom-rules-with-dir.json",
+                    "../../src/test.ts",
+                    "-t",
+                    "tslint-test-custom-formatter"
+                ],
                 {
-                    cwd: "./test/config",
+                    cwd: "./test/config"
                 },
-                (err, stdout) => {
-                    assert.isNotNull(err, "process should exit with error");
-                    assert.strictEqual(err.code, 2, "error code should be 2");
-                    assert.include(stdout, "hello from custom formatter", "stdout should contain output of custom formatter");
-                    done();
+                createFormatVerifier(done)
+            );
+        });
+
+        it("can be specified from config", done => {
+            execCli(
+                ["-c", "tslint-custom-rules-with-dir-and-format.json", "../../src/test.ts"],
+                {
+                    cwd: "./test/config"
                 },
+                createFormatVerifier(done)
             );
         });
     });


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2227 (partially)
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Makes it possible to configure the lint formatter from the config file.