### PR TITLE
Add `ignore-rhs` option for `strict-boolean-expressions`

### DIFF
--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -26,8 +26,9 @@ const OPTION_ALLOW_ENUM = "allow-enum";
 const OPTION_ALLOW_NUMBER = "allow-number";
 const OPTION_ALLOW_MIX = "allow-mix";
 const OPTION_ALLOW_BOOLEAN_OR_UNDEFINED = "allow-boolean-or-undefined";
+const OPTION_IGNORE_RHS = "ignore-rhs";
 
-// tslint:disable object-literal-sort-keys
+// tslint:disable object-literal-sort-keys no-bitwise
 
 export class Rule extends Lint.Rules.TypedRule {
     public static metadata: Lint.IRuleMetadata = {
@@ -64,6 +65,7 @@ export class Rule extends Lint.Rules.TypedRule {
               - Also allows \`true | false | undefined\`.
               - Does not allow \`false | undefined\`.
               - This option is a subset of \`${OPTION_ALLOW_UNDEFINED_UNION}\`, so you don't need to enable both options at the same time.
+            * \`${OPTION_IGNORE_RHS}\` ignores the right-hand operand of \`&&\` and \`||\'
         `,
         options: {
             type: "array",
@@ -76,10 +78,11 @@ export class Rule extends Lint.Rules.TypedRule {
                     OPTION_ALLOW_ENUM,
                     OPTION_ALLOW_NUMBER,
                     OPTION_ALLOW_BOOLEAN_OR_UNDEFINED,
+                    OPTION_IGNORE_RHS,
                 ],
             },
             minLength: 0,
-            maxLength: 5,
+            maxLength: 7,
         },
         optionExamples: [
             true,
@@ -116,6 +119,7 @@ interface Options {
     allowNumber: boolean;
     allowMix: boolean;
     allowBooleanOrUndefined: boolean;
+    ignoreRhs: boolean;
 }
 
 function parseOptions(ruleArguments: string[], strictNullChecks: boolean): Options {
@@ -128,6 +132,7 @@ function parseOptions(ruleArguments: string[], strictNullChecks: boolean): Optio
         allowNumber: has(OPTION_ALLOW_NUMBER),
         allowMix: has(OPTION_ALLOW_MIX),
         allowBooleanOrUndefined: has(OPTION_ALLOW_BOOLEAN_OR_UNDEFINED),
+        ignoreRhs: has(OPTION_IGNORE_RHS),
     };
 
     function has(name: string): boolean {
@@ -143,14 +148,19 @@ function walk(ctx: Lint.WalkContext<Options>, checker: ts.TypeChecker): void {
                 const b = node as ts.BinaryExpression;
                 if (binaryBooleanExpressionKind(b) !== undefined) {
                     const { left, right } = b;
-                    const checkHalf = (expr: ts.Expression) => {
-                        // If it's another boolean binary expression, we'll check it when recursing.
-                        if (!isBooleanBinaryExpression(expr)) {
-                            checkExpression(expr, b);
-                        }
-                    };
-                    checkHalf(left);
-                    checkHalf(right);
+                    // If ignore-rhs is off, we don't have to analyze a boolean binary expression
+                    // on the left side because it will be checked well enough on its own.  However,
+                    // if ignore-rhs is on, we have to analyze the overall result of the left
+                    // side no matter what, because its right side might not follow the rules.
+                    if (options.ignoreRhs || !isBooleanBinaryExpression(left)) {
+                        checkExpression(left, b);
+                    }
+                    // If ignore-rhs is on, we don't have to analyze the right hand side
+                    // We also don't have to analyze the right hand side if it is also a
+                    // boolean binary expression; its own inner check is sufficient.
+                    if (!(options.ignoreRhs || isBooleanBinaryExpression(right))) {
+                        checkExpression(right, b);
+                    }
                 }
                 break;
             }
@@ -224,7 +234,6 @@ function getTypeFailure(type: ts.Type, options: Options): TypeFailure | undefine
     switch (triState(kind)) {
         case true:
             // Allow 'any'. Allow 'true' itself, but not any other always-truthy type.
-            // tslint:disable-next-line no-bitwise
             return isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.BooleanLiteral)
                 ? undefined
                 : TypeFailure.AlwaysTruthy;
@@ -382,9 +391,8 @@ function getKind(type: ts.Type): TypeKind {
             : is(ts.TypeFlags.Boolean)
                 ? TypeKind.Boolean
                 : is(ts.TypeFlags.Null)
-                    ? TypeKind.Null
-                    : // tslint:disable-next-line:no-bitwise
-                      is(ts.TypeFlags.Undefined | ts.TypeFlags.Void)
+                    ? TypeKind.Null // tslint:disable-next-line:no-bitwise
+                    : is(ts.TypeFlags.Undefined | ts.TypeFlags.Void)
                         ? TypeKind.Undefined
                         : is(ts.TypeFlags.EnumLike)
                             ? TypeKind.Enum

--- a/test/rules/strict-boolean-expressions/ignore-rhs/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/ignore-rhs/test.ts.lint
@@ -1,0 +1,49 @@
+class C { }
+enum MyEnum {
+	A, B, C
+}
+let anyType: {};
+let boolType: boolean;
+let boolType2: boolean;
+let bwrapType: Boolean;
+let numType = 9;
+let strType = "string";
+let objType = new Object();
+let classType = new C();
+let enumType = MyEnum.A;
+let boolFn = () => { return true; };
+let strFn = () => { return strType; };
+let numFn = () => { return numType; };
+let boolExpr = (strType !== undefined);
+
+/*** Binary Expressions ***/
+/*** Invalid Boolean Expressions ***/
+classType && boolType;
+~~~~~~~~~ [This type is not allowed in the operand for the '&&' operator because it is always truthy. Only booleans are allowed.]
+anyType && boolType;
+~~~~~~~ [This type is not allowed in the operand for the '&&' operator because it is always truthy. Only booleans are allowed.]
+numType && boolType;
+~~~~~~~ [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
+boolType && strType;
+boolType && objType && enumType;
+bwrapType && boolType;
+~~~~~~~~~              [This type is not allowed in the operand for the '&&' operator because it is always truthy. Only booleans are allowed.]
+
+boolType || classType;
+boolType || anyType;
+boolType || numType;
+strType || boolType;
+~~~~~~~              [This type is not allowed in the operand for the '||' operator because it is a string. Only booleans are allowed.]
+bwrapType || boolType;
+~~~~~~~~~              [This type is not allowed in the operand for the '||' operator because it is always truthy. Only booleans are allowed.]
+objType || boolType || enumType;
+~~~~~~~                          [This type is not allowed in the operand for the '||' operator because it is always truthy. Only booleans are allowed.]
+~~~~~~~~~~~~~~~~~~~              [This type is not allowed in the operand for the '||' operator because it is always truthy. Only booleans are allowed.]
+boolExpr && strType;
+numType || boolExpr;
+~~~~~~~              [This type is not allowed in the operand for the '||' operator because it is a number. Only booleans are allowed.]
+numType && boolExpr || strType;
+~~~~~~~                         [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
+~~~~~~~~~~~~~~~~~~~             [This type is not allowed in the operand for the '||' operator because it could be a number. Only booleans are allowed.]
+bwrapType || boolExpr && bwrapType;
+~~~~~~~~~                           [This type is not allowed in the operand for the '||' operator because it is always truthy. Only booleans are allowed.]

--- a/test/rules/strict-boolean-expressions/ignore-rhs/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/ignore-rhs/test.ts.lint
@@ -26,6 +26,9 @@ numType && boolType;
 ~~~~~~~ [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
 boolType && strType;
 boolType && objType && enumType;
+#if typescript < 2.2.0
+~~~~~~~~~~~~~~~~~~~              [This type is not allowed in the operand for the '&&' operator because it is always truthy. Only booleans are allowed.]
+#endif
 bwrapType && boolType;
 ~~~~~~~~~              [This type is not allowed in the operand for the '&&' operator because it is always truthy. Only booleans are allowed.]
 

--- a/test/rules/strict-boolean-expressions/ignore-rhs/tsconfig.json
+++ b/test/rules/strict-boolean-expressions/ignore-rhs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    }
+}

--- a/test/rules/strict-boolean-expressions/ignore-rhs/tslint.json
+++ b/test/rules/strict-boolean-expressions/ignore-rhs/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "strict-boolean-expressions": [true, "ignore-rhs"]
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: https://github.com/palantir/tslint/issues/4158
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

If specified, the right-hand operand of `&&` and `||` will not be checked
as a strict boolean expression.

#### CHANGELOG.md entry:

[new-rule-option] `strict-boolean-expressions` accepts `ignore-rhs` option to disable checking the right-hand side of the `&&` and `||` operators as strictly boolean.

