### PR TITLE
[docs] Fix typo in align docs

### DIFF
--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -53,7 +53,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             * \`"${OPTION_STATEMENTS}"\` checks alignment of statements.
             * \`"${OPTION_MEMBERS}"\` checks alignment of members of classes, interfaces, type literal, object literals and
             object destructuring.
-            * \`"${OPTION_ELEMENTS}"\` checks alignment of elements of array iterals, array destructuring and tuple types.`,
+            * \`"${OPTION_ELEMENTS}"\` checks alignment of elements of array literals, array destructuring and tuple types.`,
         options: {
             type: "array",
             items: {


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### Overview of change:

Fix a typo in the options description for the "align" rule.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[docs] Fix docs typo