### PR TITLE
[enhancement] Add support for blacklisting import names

### DIFF
--- a/src/rules/importBlacklistRule.ts
+++ b/src/rules/importBlacklistRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { findImports, ImportKind } from "tsutils";
+import { findImports, ImportKind, isNamedImports } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -24,25 +24,49 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "import-blacklist",
         description: Lint.Utils.dedent`
-            Disallows importing the specified modules directly via \`import\` and \`require\`.
-            Instead only sub modules may be imported from that module.`,
+            Disallows importing the specified module or only certain imports from module via \`import\` and \`require\`.
+        `,
         rationale: Lint.Utils.dedent`
             Some libraries allow importing their submodules instead of the entire module.
             This is good practise as it avoids loading unused modules.`,
         optionsDescription: "A list of blacklisted modules.",
         options: {
             type: "array",
-            items: {
-                type: "string",
-            },
-            minLength: 1,
+            items: [
+                {
+                    type: "string"
+                },
+                {
+                    type: "object",
+                    properties: {
+                        name: { type: "string" },
+                        importNames: { type: "array", items: { type: "string " } },
+                        message: { type: "string" }
+                    }
+                }
+            ],
+            minLength: 1
         },
-        optionExamples: [true, [true, "rxjs", "lodash"]],
+        optionExamples: [
+            true,
+            [true, "rxjs", "lodash"],
+            [
+                true,
+                "rxjs",
+                { name: "underscore", message: "Please use lodash" },
+                {
+                    name: "react-intl",
+                    importNames: ["FormattedHtmlMessage"],
+                    message: "Please use react-intl-phraseapp"
+                }
+            ]
+        ],
         type: "functionality",
-        typescriptOnly: false,
+        typescriptOnly: false
     };
 
-    public static FAILURE_STRING = "This import is blacklisted, import a submodule instead";
+    public static FAILURE_IMPORT_STRING = "This import is blacklisted, import a submodule instead";
+    public static FAILURE_IMPORT_NAME_STRING = "This import name is blacklisted";
 
     public isEnabled(): boolean {
         return super.isEnabled() && this.ruleArguments.length > 0;
@@ -53,10 +77,56 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
-function walk(ctx: Lint.WalkContext<string[]>) {
-    for (const name of findImports(ctx.sourceFile, ImportKind.All)) {
-        if (ctx.options.indexOf(name.text) !== -1) {
-            ctx.addFailure(name.getStart(ctx.sourceFile) + 1, name.end - 1, Rule.FAILURE_STRING);
+interface ImportBlacklistObjectOption {
+    name: string;
+    importNames?: string[];
+    message?: string;
+}
+
+function walk(ctx: Lint.WalkContext<Array<string | ImportBlacklistObjectOption>>) {
+    for (const importName of findImports(ctx.sourceFile, ImportKind.All)) {
+        for (const option of ctx.options) {
+            if (typeof option === "string") {
+                if (importName.text === option) {
+                    ctx.addFailure(
+                        importName.getStart(ctx.sourceFile) + 1,
+                        importName.end - 1,
+                        Rule.FAILURE_IMPORT_STRING
+                    );
+                }
+            } else {
+                if (importName.text === option.name) {
+                    const { importClause } = importName.parent as ts.ImportDeclaration;
+
+                    if (option.importNames !== undefined) {
+                        if (
+                            importClause !== undefined &&
+                            importClause.namedBindings !== undefined &&
+                            isNamedImports(importClause.namedBindings)
+                        ) {
+                            const namedBindings = importClause.namedBindings;
+
+                            for (const importSpecifier of namedBindings.elements) {
+                                const name = importSpecifier.name;
+
+                                if (option.importNames.indexOf(name.text) !== -1) {
+                                    ctx.addFailure(
+                                        name.getStart(ctx.sourceFile),
+                                        name.end,
+                                        option.message || Rule.FAILURE_IMPORT_NAME_STRING
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        ctx.addFailure(
+                            importName.getStart(ctx.sourceFile) + 1,
+                            importName.end - 1,
+                            option.message || Rule.FAILURE_IMPORT_STRING
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/src/rules/importBlacklistRule.ts
+++ b/src/rules/importBlacklistRule.ts
@@ -110,19 +110,29 @@ function walk(ctx: Lint.WalkContext<Array<string | ImportBlacklistObjectOption>>
                                 const name = importSpecifier.name;
 
                                 if (option.importNames.indexOf(name.text) !== -1) {
+                                    const message =
+                                        option.message !== undefined
+                                            ? option.message
+                                            : Rule.FAILURE_IMPORT_NAME_STRING;
+
                                     ctx.addFailure(
                                         name.getStart(ctx.sourceFile),
                                         name.end,
-                                        option.message || Rule.FAILURE_IMPORT_NAME_STRING
+                                        message
                                     );
                                 }
                             }
                         }
                     } else {
+                        const message =
+                            option.message !== undefined
+                                ? option.message
+                                : Rule.FAILURE_IMPORT_STRING;
+
                         ctx.addFailure(
                             importName.getStart(ctx.sourceFile) + 1,
                             importName.end - 1,
-                            option.message || Rule.FAILURE_IMPORT_STRING
+                            message
                         );
                     }
                 }

--- a/test/rules/import-blacklist/test.ts.lint
+++ b/test/rules/import-blacklist/test.ts.lint
@@ -2,17 +2,44 @@ import { Observable } from 'rxjs';
                             ~~~~ [0]
 import { Observable } from 'rxjs/Observable';
 
-import forOwn = require('lodash');
-                         ~~~~~~ [0]
-import forOwn = require('lodash/forOwn');
+const { Observable } = require('rxjs');
+                                ~~~~ [0]
+const Observable = require('rxjs/Observable');
 
-// non-static imports cannot be checked
-import {Observable} from rxjs;
-import forOwn = require(lodash);
+// export all from
+export * from 'rxjs';
+               ~~~~ [0]
+
+// blacklist import with custom message
+import { first }  from 'underscore';
+                        ~~~~~~~~~~ [1]
+
+// blacklist import names with default message
+import {
+    includes,
+    ~~~~~~~~ [2]
+    find,
+    ~~~~ [2]
+    head,
+} from 'utils';
+
+// blacklist import names with custom message
+import {
+    FormattedMessage,
+    ~~~~~~~~~~~~~~~~ [3]
+    FormattedHtmlMessage,
+    ~~~~~~~~~~~~~~~~~~~~ [3]
+    FormattedPlural,
+} from 'react-intl';
 
 import * as notBlacklisted from "not-blacklisted";
 
-export * from 'lodash';
-               ~~~~~~ [0]
+// non-static imports cannot be checked
+import {Observable} from rxjs;
+import forOwn = require(rxjs);
 
 [0]: This import is blacklisted, import a submodule instead
+[1]: Please use lodash
+[2]: This import name is blacklisted
+[3]: Please import from react-intl-phraseapp
+

--- a/test/rules/import-blacklist/tslint.json
+++ b/test/rules/import-blacklist/tslint.json
@@ -1,5 +1,21 @@
 {
-  "rules": {
-    "import-blacklist": [true, "lodash", "rxjs"]
-  }
+    "rules": {
+        "import-blacklist": [
+            true,
+            "rxjs",
+            {
+                "name": "underscore",
+                "message": "Please use lodash"
+            },
+            {
+                "name": "utils",
+                "importNames": ["includes", "find"]
+            },
+            {
+                "name": "react-intl",
+                "importNames": ["FormattedMessage", "FormattedHtmlMessage"],
+                "message": "Please import from react-intl-phraseapp"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Enhancement for `import-blacklist`
- [x] Includes tests
- [x] Documentation update

#### Overview of change:
Support for blacklisting not only whole module but also separate imports.
