### PR TITLE
allow whitelisted modules to start with `@` symbol

### DIFF
--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -91,7 +91,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
     const whitelist = new Set(options.whitelist);
     for (const name of findImports(ctx.sourceFile, ImportKind.All)) {
         if (!ts.isExternalModuleNameRelative(name.text)) {
-            const packageName = getPackageName(name.text);
+            const packageName = getPackageName(name.text, whitelist);
             if (
                 !whitelist.has(packageName) &&
                 builtins.indexOf(packageName) === -1 &&
@@ -110,11 +110,16 @@ function walk(ctx: Lint.WalkContext<Options>) {
     }
 }
 
-function getPackageName(name: string): string {
+function getPackageName(name: string, whitelist: Set<string>): string {
     const parts = name.split(/\//g);
-    if (name[0] !== "@") {
+    if (name[0] !== "@" || whitelist.has(parts[0])) {
         return parts[0];
     }
+
+    if (whitelist.has(name)) {
+        return name;
+    }
+
     return `${parts[0]}/${parts[1]}`;
 }
 

--- a/test/rules/no-implicit-dependencies/whitelist/test.ts.lint
+++ b/test/rules/no-implicit-dependencies/whitelist/test.ts.lint
@@ -2,9 +2,19 @@ import * as ts from 'typescript';
 
 import * from 'src/a';
 
+import * from '@components/a';
+
+import * from '@com/fixer';
+
 import * from 'app/b';
 
 import * from 'notapp/c';
               ~~~~~~~~~~ [err % ('notapp')]
+
+import * from '@notapp/c';
+              ~~~~~~~~~~~ [err % ('@notapp/c')]
+
+import * from '@com/c';
+              ~~~~~~~~ [err % ('@com/c')]
 
 [err]: Module '%s' is not listed as dependency in package.json

--- a/test/rules/no-implicit-dependencies/whitelist/tslint.json
+++ b/test/rules/no-implicit-dependencies/whitelist/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rules": {
-    "no-implicit-dependencies": [true, ["src", "app"]]
-  }
+    "rules": {
+        "no-implicit-dependencies": [true, ["src", "app", "@components", "@com/fixer"]]
+    }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3364
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

For the rule `no-implicit-dependencies` an array of whitelisted modules can be added. However, this didn't work when trying to whitelist a module that started with an `@` symbol.

This is important since projects with custom paths in their compiler options can now use this lint configuration option without the false positives.

With this change, the rule can be used as follows.

```json
"no-implicit-dependencies": [true, ["@components", "@app"]]
```


#### CHANGELOG.md entry:

[bugfix]
