### PR TITLE
Used colons for separating the line and character number in prose formatter

### DIFF
--- a/src/formatters/proseFormatter.ts
+++ b/src/formatters/proseFormatter.ts
@@ -54,9 +54,11 @@ export class Formatter extends AbstractFormatter {
             const failureString = failure.getFailure();
 
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
-            const positionTuple = `[${lineAndCharacter.line + 1}, ${lineAndCharacter.character + 1}]`;
+            const positionTuple = `${lineAndCharacter.line + 1}:${lineAndCharacter.character + 1}`;
 
-            return `${failure.getRuleSeverity().toUpperCase()}: ${fileName}${positionTuple}: ${failureString}`;
+            return `${failure
+                .getRuleSeverity()
+                .toUpperCase()}: ${fileName}:${positionTuple} - ${failureString}`;
         });
 
         return `${fixLines.concat(errorLines).join("\n")}\n`;

--- a/test/formatters/proseFormatterTests.ts
+++ b/test/formatters/proseFormatterTests.ts
@@ -79,6 +79,6 @@ describe("Prose Formatter", () => {
     });
 
     function getPositionString(line: number, character: number) {
-        return `[${line}, ${character}]: `;
+        return `:${line}:${character} - `;
     }
 });


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3861
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Changed the prose formatter to use the format:
```
file:line:column - message
```
instead of:
```
file[line, column]: message
```

#### Is there anything you'd like reviewers to focus on?

Nope.

#### CHANGELOG.md entry:

[enhancement] prose formatter uses `line:column` instead of `[line, column]`
