### PR TITLE
Fix object-literal-sort-keys description

### DIFF
--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -46,16 +46,20 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
             By default, this rule checks that keys are in alphabetical order.
             The following may optionally be passed:
 
-            * "${OPTION_IGNORE_CASE}" will compare keys in a case insensitive way.
-            * "${OPTION_MATCH_DECLARATION_ORDER}" will prefer to use the key ordering of the contextual type of the object literal, as in:
+            * \`${OPTION_IGNORE_CASE}\` will compare keys in a case insensitive way.
+            * \`${OPTION_MATCH_DECLARATION_ORDER}\` will prefer to use the key ordering of the contextual type of the object literal, as in:
 
+                \`\`\`
                 interface I { foo: number; bar: number; }
                 const obj: I = { foo: 1, bar: 2 };
+                \`\`\`
 
-            If a contextual type is not found, alphabetical ordering will be used instead.
-            * "${OPTION_SHORTHAND_FIRST}" will enforce shorthand properties to appear first, as in:
+                If a contextual type is not found, alphabetical ordering will be used instead.
+            * \`${OPTION_SHORTHAND_FIRST}\` will enforce shorthand properties to appear first, as in:
 
+                \`\`\`
                 const obj = { a, c, b: true };
+                \`\`\`
             `,
         options: {
             type: "string",


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### Overview of change:

Fixed the Markdown in the options description of the [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/) rule:

- Indent text under the `match-declaration-order` option
- Display code samples as code instead of raw text
- Display config options in monospace text

There is an open pull request for this rule (#2831) but it is already lagging behind the master branch, so merging this PR won't interfere.

#### CHANGELOG.md entry:

[no-log] [docs] Fix `object-literal-sort-keys` typo
