### PR TITLE
Don't check space after import-ed type. Fixes #3987

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -335,10 +335,13 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 break;
             case ts.SyntaxKind.ImportKeyword:
                 if (
-                    parent.kind === ts.SyntaxKind.CallExpression &&
-                    (parent as ts.CallExpression).expression.kind === ts.SyntaxKind.ImportKeyword
+                    utils.isCallExpression(parent) &&
+                    parent.expression.kind === ts.SyntaxKind.ImportKeyword
                 ) {
                     return; // Don't check ImportCall
+                }
+                if (utils.isImportTypeNode(parent)) {
+                    return; // Don't check TypeQuery
                 }
             // falls through
             case ts.SyntaxKind.ExportKeyword:

--- a/test/rules/whitespace/all/import-type.lint
+++ b/test/rules/whitespace/all/import-type.lint
@@ -1,0 +1,32 @@
+[typescript]: >=2.9.0
+
+const foo: import("bar");
+const foo: import ("bar");
+
+function foo(a: import("bar")): import("baz") {}
+function foo(a: import ("bar")): import ("baz") {}
+
+const foo = (a: import("bar")): import("baz") => {};
+const foo = (a: import ("bar")): import ("baz") => {};
+
+type foo = { bar: import("baz") } & import("qux");
+type foo = { bar: import ("baz") } & import ("qux");
+
+interface Foo {
+    bar: import("baz");
+    qux: import ("quux");
+}
+
+class Foo {
+    bar: import("baz");
+    qux: import ("quux");
+}
+
+/**
+ * @param bar { import("qux") }
+ * @param baz { import ("qux") }
+ */
+function foo(bar, baz) { }
+
+type foo = Bar<import("baz")>;
+type foo = Bar<import ("baz")>;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3987
- [x] bugfix
  - [x] Includes tests

#### Overview of change:

Don't check for space after `import` in `TypeQuery`

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

[bugfix] `whitespace` Don't require space between import and paren with in type imports