### PR TITLE
fix(#4210): fix whitespace rule in importClause with 'as' statement

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -191,7 +191,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
                                         checkForTrailingWhitespace(token.getFullStart());
                                     }
                                     if (idx === 0) {
-                                        const startPos = internalName.getStart() - 1;
+                                        const startPos = element.getStart() - 1;
                                         checkForTrailingWhitespace(startPos, startPos + 1);
                                     }
                                 }

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -67,6 +67,8 @@ import { importB } from "libB";
 import { importC } from "libC";
 import moduleD, { importD } from "libD";
 import { importD, importE } from "libD";
+import { importF as F } from "libF";
+import { importF as F, importG as G } from "libF";
 
 import {
   importA,

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -120,6 +120,13 @@ import moduleD, {importD}from "libD";
 import {importD, importE} from "libD";
         ~                    [missing whitespace]
                         ~    [missing whitespace]
+import {importF as F} from "libF";
+        ~                    [missing whitespace]
+                    ~    [missing whitespace]
+import {importF as F,importG as G} from "libF";
+        ~                             [missing whitespace]
+                     ~                [missing whitespace]
+                                 ~    [missing whitespace]
 
 import {
   importA,


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4210
- [x] bugfix
  - [x] Includes tests
- ~[ ] Documentation update~

#### Overview of change:
The missing whitespace after open brace is marked as an error.
(It didn't work with 'as' statement)

#### Is there anything you'd like reviewers to focus on?
