### PR TITLE
Assign concat rule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -29,19 +29,25 @@ export const rules = {
     "ban-types": {
         options: [
             ["Object", "Avoid using the `Object` type. Did you mean `object`?"],
-            ["Function", "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."],
+            [
+                "Function",
+                "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."
+            ],
             ["Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?"],
             ["Number", "Avoid using the `Number` type. Did you mean `number`?"],
             ["String", "Avoid using the `String` type. Did you mean `string`?"],
-            ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"],
-        ],
+            ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"]
+        ]
     },
     "ban-ts-ignore": true,
     "member-access": [true, "check-accessor", "check-constructor", "check-parameter-property"],
-    "member-ordering": [true, {
-        "order": "statics-first",
-        "alphabetize": true,
-    }],
+    "member-ordering": [
+        true,
+        {
+            order: "statics-first",
+            alphabetize: true
+        }
+    ],
     "no-any": true,
     "no-empty-interface": true,
     "no-import-side-effect": true,
@@ -58,7 +64,7 @@ export const rules = {
     "prefer-for-of": true,
     "prefer-readonly": true,
     "promise-function-async": true,
-    "typedef": [
+    typedef: [
         true,
         "call-signature",
         "arrow-call-signature",
@@ -66,33 +72,34 @@ export const rules = {
         "arrow-parameter",
         "property-declaration",
         "variable-declaration",
-        "member-variable-declaration",
+        "member-variable-declaration"
     ],
     "typedef-whitespace": [
         true,
         {
             "call-signature": "nospace",
             "index-signature": "nospace",
-            "parameter": "nospace",
+            parameter: "nospace",
             "property-declaration": "nospace",
-            "variable-declaration": "nospace",
+            "variable-declaration": "nospace"
         },
         {
             "call-signature": "onespace",
             "index-signature": "onespace",
-            "parameter": "onespace",
+            parameter: "onespace",
             "property-declaration": "onespace",
-            "variable-declaration": "onespace",
-        },
+            "variable-declaration": "onespace"
+        }
     ],
     "unified-signatures": true,
 
     // Functionality
+    "assign-concat": true,
     "await-promise": true,
     // "ban": no sensible default
     "ban-comma-operator": true,
-    "curly": true,
-    "forin": true,
+    curly: true,
+    forin: true,
     // "import-blacklist": no sensible default
     "label-position": true,
     "no-arg": true,
@@ -103,10 +110,7 @@ export const rules = {
     "no-debugger": true,
     "no-duplicate-super": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-variable": [
-        true,
-        "check-parameters",
-    ],
+    "no-duplicate-variable": [true, "check-parameters"],
     "no-dynamic-delete": true,
     "no-empty": true,
     "no-eval": true,
@@ -135,7 +139,7 @@ export const rules = {
     "no-var-keyword": true,
     "no-void-expression": true,
     "prefer-conditional-expression": true,
-    "radix": true,
+    radix: true,
     "restrict-plus-operands": true,
     "strict-boolean-expressions": true,
     "strict-type-predicates": true,
@@ -147,8 +151,8 @@ export const rules = {
     // Maintainability
 
     "cyclomatic-complexity": true,
-    "eofline": true,
-    "indent": [true, "spaces"],
+    eofline: true,
+    indent: [true, "spaces"],
     "linebreak-style": [true, "LF"],
     "max-classes-per-file": [true, 1],
     "max-file-line-count": [true, 1000],
@@ -162,38 +166,30 @@ export const rules = {
     "no-trailing-whitespace": true,
     "object-literal-sort-keys": true,
     "prefer-const": true,
-    "trailing-comma": [true, {
-        "esSpecCompliant": true,
-        "multiline": "always",
-        "singleline": "never",
-    }],
+    "trailing-comma": [
+        true,
+        {
+            esSpecCompliant: true,
+            multiline: "always",
+            singleline: "never"
+        }
+    ],
 
     // Style
 
-    "align": [
-        true,
-        "parameters",
-        "arguments",
-        "statements",
-        "elements",
-        "members",
-    ],
+    align: [true, "parameters", "arguments", "statements", "elements", "members"],
     "array-type": [true, "array-simple"],
     "arrow-parens": true,
     "arrow-return-shorthand": [true, "multiline"],
     "binary-expression-operand-order": true,
     "callable-types": true,
     "class-name": true,
-    "comment-format": [
-        true,
-        "check-space",
-        "check-uppercase",
-    ],
+    "comment-format": [true, "check-space", "check-uppercase"],
     "comment-type": [true, "singleline", "multiline", "doc", "directive"],
     "completed-docs": true,
     // "file-header": No sensible default
-    "deprecation": true,
-    "encoding": true,
+    deprecation: true,
+    encoding: true,
     "file-name-casing": [true, "camel-case"],
     "import-spacing": true,
     "increment-decrement": true,
@@ -223,44 +219,41 @@ export const rules = {
         "check-else",
         "check-finally",
         "check-open-brace",
-        "check-whitespace",
+        "check-whitespace"
     ],
     "one-variable-per-declaration": true,
-    "ordered-imports": [true, {
-        "import-sources-order": "case-insensitive",
-        "named-imports-order": "case-insensitive",
-        "module-source-path": "full",
-    }],
+    "ordered-imports": [
+        true,
+        {
+            "import-sources-order": "case-insensitive",
+            "named-imports-order": "case-insensitive",
+            "module-source-path": "full"
+        }
+    ],
     "prefer-function-over-method": true,
     "prefer-method-signature": true,
     "prefer-object-spread": true,
     "prefer-switch": true,
     "prefer-template": true,
     "prefer-while": true,
-    "quotemark": [
-        true,
-        "double",
-        "avoid-escape",
-        "avoid-template",
-    ],
+    quotemark: [true, "double", "avoid-escape", "avoid-template"],
     "return-undefined": true,
-    "semicolon": [true, "always"],
-    "space-before-function-paren": [true, {
-        "anonymous": "never",
-        "asyncArrow": "always",
-        "constructor": "never",
-        "method": "never",
-        "named": "never",
-    }],
+    semicolon: [true, "always"],
+    "space-before-function-paren": [
+        true,
+        {
+            anonymous: "never",
+            asyncArrow: "always",
+            constructor: "never",
+            method: "never",
+            named: "never"
+        }
+    ],
     "space-within-parens": [true, 0],
     "switch-final-break": true,
     "type-literal-delimiter": true,
-    "variable-name": [
-        true,
-        "ban-keywords",
-        "check-format",
-    ],
-    "whitespace": [
+    "variable-name": [true, "ban-keywords", "check-format"],
+    whitespace: [
         true,
         "check-branch",
         "check-decl",
@@ -271,12 +264,19 @@ export const rules = {
         "check-typecast",
         "check-preblock",
         "check-type-operator",
-        "check-rest-spread",
-    ],
+        "check-rest-spread"
+    ]
 };
 
-export const RULES_EXCLUDED_FROM_ALL_CONFIG =
-    ["ban", "fileHeader", "importBlacklist", "noInvalidThis", "noSwitchCaseFallThrough", "typeofCompare", "noUnusedVariable"];
+export const RULES_EXCLUDED_FROM_ALL_CONFIG = [
+    "ban",
+    "fileHeader",
+    "importBlacklist",
+    "noInvalidThis",
+    "noSwitchCaseFallThrough",
+    "typeofCompare",
+    "noUnusedVariable"
+];
 
 // Exclude typescript-only rules from jsRules, otherwise it's identical.
 export const jsRules: { [key: string]: any } = {};

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -17,57 +17,57 @@
 
 export const rules = {
     "adjacent-overload-signatures": true,
-    "align": {
-        options: [
-            "parameters",
-            "statements",
-        ],
+    align: {
+        options: ["parameters", "statements"]
     },
     "array-type": {
-        options: ["array-simple"],
+        options: ["array-simple"]
     },
     "arrow-parens": true,
     "arrow-return-shorthand": true,
     "ban-types": {
         options: [
             ["Object", "Avoid using the `Object` type. Did you mean `object`?"],
-            ["Function", "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."],
+            [
+                "Function",
+                "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."
+            ],
             ["Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?"],
             ["Number", "Avoid using the `Number` type. Did you mean `number`?"],
             ["String", "Avoid using the `String` type. Did you mean `string`?"],
-            ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"],
-        ],
+            ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"]
+        ]
     },
     "callable-types": true,
     "class-name": true,
     "comment-format": {
-        options: ["check-space"],
+        options: ["check-space"]
     },
-    "curly": true,
+    curly: true,
     "cyclomatic-complexity": false,
-    "eofline": true,
-    "forin": true,
+    eofline: true,
+    forin: true,
     "import-spacing": true,
-    "indent":  {
-        options: ["spaces"],
+    indent: {
+        options: ["spaces"]
     },
     "interface-name": {
-        options: ["always-prefix"],
+        options: ["always-prefix"]
     },
     "interface-over-type-literal": true,
     "jsdoc-format": true,
     "label-position": true,
     "max-classes-per-file": {
-        options: [1],
+        options: [1]
     },
     "max-line-length": {
-        options: [120],
+        options: [120]
     },
     "member-access": true,
     "member-ordering": {
         options: {
-            order: "statics-first",
-        },
+            order: "statics-first"
+        }
     },
     "new-parens": true,
     "no-angle-bracket-type-assertion": true,
@@ -103,7 +103,7 @@ export const rules = {
     "no-var-keyword": true,
     "no-var-requires": true,
     "object-literal-key-quotes": {
-        options: ["consistent-as-needed"],
+        options: ["consistent-as-needed"]
     },
     "object-literal-shorthand": true,
     "object-literal-sort-keys": true,
@@ -113,36 +113,30 @@ export const rules = {
             "check-else",
             "check-finally",
             "check-open-brace",
-            "check-whitespace",
-        ],
+            "check-whitespace"
+        ]
     },
     "one-variable-per-declaration": {
-        options: ["ignore-for-loop"],
+        options: ["ignore-for-loop"]
     },
     "only-arrow-functions": {
-        options: [
-            "allow-declarations",
-            "allow-named-functions",
-        ],
+        options: ["allow-declarations", "allow-named-functions"]
     },
     "ordered-imports": {
         options: {
             "import-sources-order": "case-insensitive",
             "module-source-path": "full",
-            "named-imports-order": "case-insensitive",
-        },
+            "named-imports-order": "case-insensitive"
+        }
     },
     "prefer-const": true,
     "prefer-for-of": true,
-    "quotemark": {
-        options: [
-            "double",
-            "avoid-escape",
-        ],
+    quotemark: {
+        options: ["double", "avoid-escape"]
     },
-    "radix": true,
-    "semicolon": {
-        options: ["always"],
+    radix: true,
+    semicolon: {
+        options: ["always"]
     },
     "space-before-function-paren": {
         options: {
@@ -150,78 +144,72 @@ export const rules = {
             asyncArrow: "always",
             constructor: "never",
             method: "never",
-            named: "never",
-        },
+            named: "never"
+        }
     },
     "trailing-comma": {
         options: {
             esSpecCompliant: true,
             multiline: "always",
-            singleline: "never",
-        },
+            singleline: "never"
+        }
     },
     "triple-equals": {
-        options: ["allow-null-check"],
+        options: ["allow-null-check"]
     },
-    "typedef": false,
+    typedef: false,
     "typedef-whitespace": {
         options: [
             {
                 "call-signature": "nospace",
                 "index-signature": "nospace",
-                "parameter": "nospace",
+                parameter: "nospace",
                 "property-declaration": "nospace",
-                "variable-declaration": "nospace",
+                "variable-declaration": "nospace"
             },
             {
                 "call-signature": "onespace",
                 "index-signature": "onespace",
-                "parameter": "onespace",
+                parameter: "onespace",
                 "property-declaration": "onespace",
-                "variable-declaration": "onespace",
-            },
-        ],
+                "variable-declaration": "onespace"
+            }
+        ]
     },
     "typeof-compare": false, // deprecated in TSLint 5.9.0
     "unified-signatures": true,
     "use-isnan": true,
     "variable-name": {
-        options: [
-            "ban-keywords",
-            "check-format",
-            "allow-pascal-case",
-        ],
+        options: ["ban-keywords", "check-format", "allow-pascal-case"]
     },
-    "whitespace": {
+    whitespace: {
         options: [
             "check-branch",
             "check-decl",
             "check-operator",
             "check-separator",
             "check-type",
-            "check-typecast",
-        ],
-    },
+            "check-typecast"
+        ]
+    }
 };
 export const jsRules = {
-    "align": {
-        options: [
-            "parameters",
-            "statements",
-        ],
+    align: {
+        options: ["parameters", "statements"]
     },
+    "assign-concat": true,
     "class-name": true,
-    "curly": true,
-    "eofline": true,
-    "forin": true,
+    curly: true,
+    eofline: true,
+    forin: true,
     "import-spacing": true,
-    "indent":  {
-        options: ["spaces"],
+    indent: {
+        options: ["spaces"]
     },
     "jsdoc-format": true,
     "label-position": true,
     "max-line-length": {
-        options: [120],
+        options: [120]
     },
     "new-parens": true,
     "no-arg": true,
@@ -251,21 +239,18 @@ export const jsRules = {
             "check-else",
             "check-finally",
             "check-open-brace",
-            "check-whitespace",
-        ],
+            "check-whitespace"
+        ]
     },
     "one-variable-per-declaration": {
-        options: ["ignore-for-loop"],
+        options: ["ignore-for-loop"]
     },
-    "quotemark": {
-        options: [
-            "double",
-            "avoid-escape",
-        ],
+    quotemark: {
+        options: ["double", "avoid-escape"]
     },
-    "radix": true,
-    "semicolon": {
-        options: ["always"],
+    radix: true,
+    semicolon: {
+        options: ["always"]
     },
     "space-before-function-paren": {
         options: {
@@ -273,34 +258,30 @@ export const jsRules = {
             asyncArrow: "always",
             constructor: "never",
             method: "never",
-            named: "never",
-        },
+            named: "never"
+        }
     },
     "trailing-comma": {
         options: {
             multiline: "always",
-            singleline: "never",
-        },
+            singleline: "never"
+        }
     },
     "triple-equals": {
-        options: ["allow-null-check"],
+        options: ["allow-null-check"]
     },
     "use-isnan": true,
     "variable-name": {
-        options: [
-            "ban-keywords",
-            "check-format",
-            "allow-pascal-case",
-        ],
+        options: ["ban-keywords", "check-format", "allow-pascal-case"]
     },
-    "whitespace": {
+    whitespace: {
         options: [
             "check-branch",
             "check-decl",
             "check-operator",
             "check-separator",
             "check-type",
-            "check-typecast",
-        ],
-    },
+            "check-typecast"
+        ]
+    }
 };

--- a/src/rules/assignConcatRule.ts
+++ b/src/rules/assignConcatRule.ts
@@ -46,7 +46,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class AssignConcatWalker extends Lint.RuleWalker {
-    private checker: Checkable;
+    private readonly checker: Checkable;
 
     constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
         super(sourceFile, options);
@@ -77,7 +77,7 @@ class AssignConcatWalker extends Lint.RuleWalker {
 }
 
 abstract class Checkable {
-    private childs: Checkable[];
+    private readonly childs: Checkable[];
 
     public abstract check(node: ts.Node): boolean;
 
@@ -95,7 +95,7 @@ abstract class Checkable {
 }
 
 class OperatorTokenKind extends Checkable {
-    private kind: ts.SyntaxKind;
+    private readonly kind: ts.SyntaxKind;
 
     constructor(kind: ts.SyntaxKind, childs: Checkable[] = []) {
         super(childs);
@@ -109,7 +109,7 @@ class OperatorTokenKind extends Checkable {
 }
 
 class ParentKind extends Checkable {
-    private kind: ts.SyntaxKind;
+    private readonly kind: ts.SyntaxKind;
 
     constructor(kind: ts.SyntaxKind, childs: Checkable[] = []) {
         super(childs);

--- a/src/rules/assignConcatRule.ts
+++ b/src/rules/assignConcatRule.ts
@@ -64,6 +64,8 @@ class AssignConcatWalker extends Lint.RuleWalker {
                     // Assigment: concat is being correctly used.
                 } else if (node.parent!.kind === ts.SyntaxKind.PropertyAccessExpression) {
                     // Here the result of the concat it is being accesed at least.
+                } else if (node.parent!.kind === ts.SyntaxKind.CallExpression) {
+                    // Here the result of the concat it is being used as a param.
                 } else {
                     // tslint:disable-next-line:no-console
                     console.log(node.parent!.kind);

--- a/src/rules/assignConcatRule.ts
+++ b/src/rules/assignConcatRule.ts
@@ -69,15 +69,11 @@ abstract class Checkable {
     }
 
     protected runChecks(cond: boolean, node: ts.Node) {
-        if (this.childs.length === 0) {
-            // leaf
-            return cond;
-        } else if (!cond) {
-            // branch with no precondition
-            return true;
-        } else {
-            return this.childs.map(c => c.check(node)).reduce((acc, cur) => acc && cur);
-        }
+        return (
+            cond &&
+            (this.childs.length === 0 ||
+                !!this.childs.map(c => c.check(node)).find(result => result))
+        );
     }
 }
 
@@ -115,9 +111,8 @@ class ConcatPropertyAccessExpression extends Checkable {
 
     public check(node: ts.CallExpression) {
         const pae = node.expression as ts.PropertyAccessExpression;
-        return this.runChecks(
-            pae.kind === ts.SyntaxKind.PropertyAccessExpression && pae.name.text === "concat",
-            node
-        );
+        const cond =
+            pae.kind === ts.SyntaxKind.PropertyAccessExpression && pae.name.text === "concat";
+        return !cond || this.runChecks(true, node);
     }
 }

--- a/src/rules/assignConcatRule.ts
+++ b/src/rules/assignConcatRule.ts
@@ -17,8 +17,27 @@
 
 import * as ts from "typescript";
 import * as Lint from "../index";
+import { codeExamples } from "./code-examples/assignConcat.example";
 
 export class Rule extends Lint.Rules.AbstractRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "assign-concat",
+        description: "Prevents user assuming concat is destructive.",
+        hasFix: false,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            Helps one remember that the concat method in javascript is not destructive.
+            Every once and then happens that one forgets that and incurs in hard to find bugs.
+        `,
+        type: "functionality",
+        typescriptOnly: false,
+        codeExamples
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
     public static FAILURE_STRING = "concat operation should be assigned";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -50,9 +69,7 @@ class AssignConcatWalker extends Lint.RuleWalker {
 
     public visitCallExpression(node: ts.CallExpression) {
         if (!this.checker.check(node)) {
-            this.addFailure(
-                this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING)
-            );
+            this.addFailureAt(node.getStart(), node.getWidth(), Rule.FAILURE_STRING);
         }
 
         super.visitCallExpression(node);

--- a/src/rules/assignConcatRule.ts
+++ b/src/rules/assignConcatRule.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from "typescript";
+import * as Lint from "../index";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "concat operation should be assigned";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new AssignConcatWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class AssignConcatWalker extends Lint.RuleWalker {
+    public visitCallExpression(node: ts.CallExpression) {
+        if (node.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+            const pae = node.expression as ts.PropertyAccessExpression;
+
+            if (pae.name.text === "concat") {
+                if (node.parent!.kind === ts.SyntaxKind.BinaryExpression) {
+                    const be = node.parent as ts.BinaryExpression;
+
+                    if (be.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+                        // Assigment: concat is being correctly used.
+                    } else if (be.parent!.kind === ts.SyntaxKind.VariableDeclaration) {
+                        // Assigment: concat is being correctly used.
+                    } else if (be.parent!.kind === ts.SyntaxKind.BinaryExpression) {
+                        // Here we can't decide, will have to analize the parent chain.
+                    } else if (be.parent!.kind === ts.SyntaxKind.ExpressionStatement) {
+                        // Here we can't decide, will have to analize the parent chain.
+                    } else {
+                        // tslint:disable-next-line:no-console
+                        console.log(be.parent!.kind);
+                        // tslint:disable-next-line:no-console
+                        // console.log(be.parent);
+                        this.addFailure(
+                            this.createFailure(
+                                node.getStart(),
+                                node.getWidth(),
+                                Rule.FAILURE_STRING
+                            )
+                        );
+                    }
+                } else if (node.parent!.kind === ts.SyntaxKind.VariableDeclaration) {
+                    // Assigment: concat is being correctly used.
+                } else if (node.parent!.kind === ts.SyntaxKind.ArrowFunction) {
+                    // Assigment: concat is being correctly used.
+                } else if (node.parent!.kind === ts.SyntaxKind.ReturnStatement) {
+                    // Assigment: concat is being correctly used.
+                } else if (node.parent!.kind === ts.SyntaxKind.PropertyAccessExpression) {
+                    // Here the result of the concat it is being accesed at least.
+                } else {
+                    // tslint:disable-next-line:no-console
+                    console.log(node.parent!.kind);
+
+                    this.addFailure(
+                        this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING)
+                    );
+                }
+            }
+        }
+
+        super.visitCallExpression(node);
+    }
+}

--- a/src/rules/code-examples/assignConcat.example.ts
+++ b/src/rules/code-examples/assignConcat.example.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Lint from "../../index";
+
+// tslint:disable: object-literal-sort-keys
+export const codeExamples = [
+    {
+        description: "Warns when the user thinks concat is destructive",
+        config: Lint.Utils.dedent`
+            "rules": { "assign-concat": true }
+        `,
+        pass: Lint.Utils.dedent`
+            let a = [1];
+            let b = [2];
+            let c;
+            c = a.concat(b);
+        `,
+        fail: Lint.Utils.dedent`
+            let a = [1];
+            let b = [2];
+            a.concat(b);
+        `
+    }
+];

--- a/test/rules/assign-concat/test.ts.lint
+++ b/test/rules/assign-concat/test.ts.lint
@@ -1,0 +1,32 @@
+let a = [1];
+let b = [2];
+
+// good
+let c = [];
+c = a.concat(b);
+
+let d = a.concat(b);
+
+a.reduce((acc, cur) => acc.concat(cur), []);
+
+a.filter((val) => val.concat(b).length > 1, []);
+
+a.reduce((acc, cur) => { return acc.concat(cur) }, []);
+
+a.reduce((acc, cur) => {
+    const next = acc.concat(cur);
+    return next;
+}, []);
+
+let e = false || a.concat(b);
+
+e = true && a.concat(b);
+
+e = false || true && a.concat(b);
+
+//bad
+a.concat(b);
+~~~~~~~~~~~  [concat operation should be assigned]
+
+a.reduce((acc, cur) => { acc.concat(cur) }, []);
+                         ~~~~~~~~~~~~~~~        [concat operation should be assigned]

--- a/test/rules/assign-concat/test.ts.lint
+++ b/test/rules/assign-concat/test.ts.lint
@@ -1,5 +1,4 @@
 // good
-/*
 c = a.concat(b);
 
 let d = a.concat(b);
@@ -22,7 +21,7 @@ e = true && a.concat(b);
 e = false || true && a.concat(b);
 
 func(a.concat(b));
-*/
+
 //bad
 a.concat(b);
 ~~~~~~~~~~~  [concat operation should be assigned]

--- a/test/rules/assign-concat/test.ts.lint
+++ b/test/rules/assign-concat/test.ts.lint
@@ -1,8 +1,5 @@
-let a = [1];
-let b = [2];
-
 // good
-let c = [];
+/*
 c = a.concat(b);
 
 let d = a.concat(b);
@@ -24,10 +21,8 @@ e = true && a.concat(b);
 
 e = false || true && a.concat(b);
 
-let func = (arr) => arr.length > 0;
-
 func(a.concat(b));
-
+*/
 //bad
 a.concat(b);
 ~~~~~~~~~~~  [concat operation should be assigned]

--- a/test/rules/assign-concat/test.ts.lint
+++ b/test/rules/assign-concat/test.ts.lint
@@ -24,6 +24,10 @@ e = true && a.concat(b);
 
 e = false || true && a.concat(b);
 
+let func = (arr) => arr.length > 0;
+
+func(a.concat(b));
+
 //bad
 a.concat(b);
 ~~~~~~~~~~~  [concat operation should be assigned]

--- a/test/rules/assign-concat/tslint.json
+++ b/test/rules/assign-concat/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "assign-concat": true
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #1154 
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [X] Documentation update

#### Overview of change:
Add a new rule that helps one remember that the concat method in javascript is not destructive.
Every once and then happens that one forgets that and incurs in hard to find bugs.

#### Is there anything you'd like reviewers to focus on?
I added many scenarios to avoid false positives, if you guys have another let me know and I'll fix it.
<!-- optional -->

#### CHANGELOG.md entry:
[new-rule] `assign-concat` helps prevent forgetting that concat method is not destructive.
