### PR TITLE
Re-ran Prettier on source files again, with some more ignores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,167 +1,167 @@
 version: 2
 jobs:
-  build:
-    docker:
-      - image: circleci/node:latest
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run:
-          name: Install dependencies
-          command: yarn
-      - save_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
-      - run: yarn compile
-      - persist_to_workspace:
-          root: '.'
-          paths:
-            - lib
-            - build
-            - yarn.lock
-  lint:
-    docker:
-      - image: circleci/node:latest
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn lint
-  test:
-    docker:
-      - image: circleci/node:8
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn test
-  test2.1:
-    docker:
-      - image: circleci/node:4
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@2.1
-      - run: yarn test
-  test2.4:
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@2.4
-      - run: yarn test
-  test2.7:
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@2.7
-      - run: yarn test
-  test2.8:
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@2.8
-      - run: yarn test
-  test2.9:
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@2.9
-      - run: yarn test
-  test3.0:
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@3.0.1
-      - run: yarn test
-  testRc:
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@rc
-      - run: yarn test
-  testNext:
-    docker:
-      - image: circleci/node:latest
-    steps:
-      - checkout
-      - attach_workspace:
-          at: '.'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}
-      - run: yarn add typescript@next
-      - run: yarn test
+    build:
+        docker:
+            - image: circleci/node:latest
+        steps:
+            - checkout
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run:
+                  name: Install dependencies
+                  command: yarn
+            - save_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+                  paths:
+                      - node_modules
+            - run: yarn compile
+            - persist_to_workspace:
+                  root: "."
+                  paths:
+                      - lib
+                      - build
+                      - yarn.lock
+    lint:
+        docker:
+            - image: circleci/node:latest
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn lint
+    test:
+        docker:
+            - image: circleci/node:8
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn test
+    test2.1:
+        docker:
+            - image: circleci/node:4
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn add typescript@2.1
+            - run: yarn test
+    test2.4:
+        docker:
+            - image: circleci/node:6
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn add typescript@2.4
+            - run: yarn test
+    test2.7:
+        docker:
+            - image: circleci/node:6
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn add typescript@2.7
+            - run: yarn test
+    test2.8:
+        docker:
+            - image: circleci/node:6
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn add typescript@2.8
+            - run: yarn test
+    test2.9:
+        docker:
+            - image: circleci/node:6
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn add typescript@2.9
+            - run: yarn test
+    test3.0:
+        docker:
+            - image: circleci/node:6
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn add typescript@3.0.1
+            - run: yarn test
+    testRc:
+        docker:
+            - image: circleci/node:6
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn add typescript@rc
+            - run: yarn test
+    testNext:
+        docker:
+            - image: circleci/node:latest
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: "."
+            - restore_cache:
+                  key: dependency-cache-{{ checksum "yarn.lock" }}
+            - run: yarn add typescript@next
+            - run: yarn test
 
 workflows:
-  version: 2
-  build_lint_test:
-    jobs:
-      - build
-      - lint:
-          requires:
+    version: 2
+    build_lint_test:
+        jobs:
             - build
-      - test:
-          requires:
-            - build
-      - test2.1:
-          requires:
-            - build
-      - test2.4:
-          requires:
-            - build
-      - test2.7:
-          requires:
-            - build
-      - test2.8:
-          requires:
-            - build
-      - test2.9:
-          requires:
-            - build
-      - test3.0:
-          requires:
-            - build
-      - testRc:
-          requires:
-            - build
-      - testNext:
-          requires:
-            - build
+            - lint:
+                  requires:
+                      - build
+            - test:
+                  requires:
+                      - build
+            - test2.1:
+                  requires:
+                      - build
+            - test2.4:
+                  requires:
+                      - build
+            - test2.7:
+                  requires:
+                      - build
+            - test2.8:
+                  requires:
+                      - build
+            - test2.9:
+                  requires:
+                      - build
+            - test3.0:
+                  requires:
+                      - build
+            - testRc:
+                  requires:
+                      - build
+            - testNext:
+                  requires:
+                      - build

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,16 +3,25 @@
 # dependencies
 /node_modules
 
+# docs
+.github
+/docs
+
 # testing
 /coverage
+/test/external/
+/test/files/
+/test/rules/
 
 # production
 /build
+/lib
 
 # ide
 /.idea
 
 # npm
+package.json
 package-lock.json
 
 # misc

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,19 @@
 {
     "tabWidth": 4,
     "printWidth": 100,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "overrides": [
+        {
+            "files": "*.json",
+            "options": {
+                "parser": "json"
+            }
+        },
+        {
+            "files": "*.scss",
+            "options": {
+                "parser": "scss"
+            }
+        }
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,129 +1,123 @@
-Change Log
-===
+# Change Log
 
-v5.11.0
----
+## v5.11.0
 
 ## :warning: Deprecations
 
-- [deprecation] [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) is deprecated because typescript now covers most of its functionality (#3919)
-
-## :tada: Features
-- [new-rule] [`file-name-casing`](https://palantir.github.io/tslint/rules/file-name-casing/) (#3978)
-- [new-fixer] Add fixer for [`switch-final-break`](https://palantir.github.io/tslint/rules/switch-final-break/) (#3615)
-- [new-fixer] Implemented fixer for [`member-ordering`](https://palantir.github.io/tslint/rules/member-ordering/) and added corresponding tests. (#3935)
-- [new-rule-option] Add whitelist for [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) (#3979)
-
-## :hammer_and_wrench: Bugfixes & enhancements
-
-- [bugfix] [`no-use-before-declare`](https://palantir.github.io/tslint/rules/no-use-before-declare/) Fixes false positives when using the destructuring syntax (#3761)  (#3876)
-- [bugfix] Fix Copyright: @license JSDoc tag was missing (#3879)
-- [bugfix] Fix missing newline at end of file (#3896)
-- [bugfix] allow-empty-functions option of [`no-empty`](https://palantir.github.io/tslint/rules/no-empty/) rule is now properly respecting empty methods (#3897)
-- [bugfix] [`no-magic-numbers`](https://palantir.github.io/tslint/rules/no-magic-numbers/) - support for negative zero (#3903)
-- [bugfix] Handle tsconfig.json errors without using JSON.stringify (#3908)
-- [bugfix] Fix CI: [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) test failure; typescript@next failure (#4019)
-- [bugfix] Fix edge case in [`no-console`](https://palantir.github.io/tslint/rules/no-console/) rule (#4041)
-- [docs] Fix typos in the [`no-floating-promises`](https://palantir.github.io/tslint/rules/no-floating-promises/) rule docs. (#3886)
-- [docs] Updated [`prefer-while`](https://palantir.github.io/tslint/rules/prefer-while/) docs to be semantically correct (#3888)
-- [docs] Fix link to configuration page (#3891)
-- [docs] Fix docs typo (#3898)
-- [docs] Fix docs typo (#3910)
-- [enhancement] Turn on strictPropertyInitialization for src/ and test/ (#3924)
-- [enhancement] Use Buffer.allocUnsafe instead of the deprecated new Buffer() (#3985)
-- [enhancement] Improve [`radix`](https://palantir.github.io/tslint/rules/radix/) rule checks (#3901)
-- [enhancement] Output +/- on diff so added/removed empty lines are visible. (#3973)
-- [rule-change] [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) now always considers peer dependencies (#3875)
-
-Thanks to our contributors!
-
-- Bowen Ni
-- Peter Safranek
-- Saugat Acharya
-- Jason Mendes
-- Ryan Waskiewicz
-- Dariusz Rumiński
-- Xinhu Liu
-- Rado Kirov
-- aervin_
-- Josh Goldberg
-- mertdeg2
-- Jason Killian
-- Adrian Leonhard
-- david-cannady
-- Andy Russell
-- Tibor Blenessy
-- Andrew Crites
-- Pavel Birukov
-- shalomdotnet
-
-
-v5.10.0
----
+-   [deprecation][`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) is deprecated because typescript now covers most of its functionality (#3919)
 
 ## :tada: Features
 
-- [new-rule] [`prefer-while`](https://palantir.github.io/tslint/rules/prefer-while/) (#3750)
-- [new-fixer] [`comment-format`](https://palantir.github.io/tslint/rules/comment-format/) (#3845)
-- [new-rule-option] `"allow-empty-functions"` for [`no-empty`](https://palantir.github.io/tslint/rules/no-empty/) rule (#3624)
-- [new-rule-option] New options for [`promise-function-async`](https://palantir.github.io/tslint/rules/promise-function-async/) specifying what kinds of functions to check (#3807)
+-   [new-rule][`file-name-casing`](https://palantir.github.io/tslint/rules/file-name-casing/) (#3978)
+-   [new-fixer] Add fixer for [`switch-final-break`](https://palantir.github.io/tslint/rules/switch-final-break/) (#3615)
+-   [new-fixer] Implemented fixer for [`member-ordering`](https://palantir.github.io/tslint/rules/member-ordering/) and added corresponding tests. (#3935)
+-   [new-rule-option] Add whitelist for [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) (#3979)
 
 ## :hammer_and_wrench: Bugfixes & enhancements
 
-- [bugfix] [`file-header`](https://palantir.github.io/tslint/rules/file-header/) rule plays nice with [`no-trailing-whitespace`](https://palantir.github.io/tslint/rules/no-trailing-whitespace/) rule (#3802)
-- [bugfix] [`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/) rule allows square bracket property access (#3610)
-- [bugfix] [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) no longer marks native JSX elements as unsafe (#3699)
-- [enhancement] [`file-header`](https://palantir.github.io/tslint/rules/file-header/) auto-fixes use '!' character to ensure header stays above imports (#3741)
-- [enhancement] Better error messages if a rule crashes (#3836)
-- [enhancement] Better error messages when no valid rules are specified (#3729)
-- [enhancement] Better lint messages for unused imports in [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) rule (#3831)
-- [docs] Improve documentation of cli flag --project (#3703)
-- [docs] Added short rationales for about thirty rules (#3734)
-- [docs] Added optional capability to provide code examples in rules' metadata (#3602)
-- [docs] Many small docs fixes and tweaks from many great contributors!
+-   [bugfix][`no-use-before-declare`](https://palantir.github.io/tslint/rules/no-use-before-declare/) Fixes false positives when using the destructuring syntax (#3761) (#3876)
+-   [bugfix] Fix Copyright: @license JSDoc tag was missing (#3879)
+-   [bugfix] Fix missing newline at end of file (#3896)
+-   [bugfix] allow-empty-functions option of [`no-empty`](https://palantir.github.io/tslint/rules/no-empty/) rule is now properly respecting empty methods (#3897)
+-   [bugfix][`no-magic-numbers`](https://palantir.github.io/tslint/rules/no-magic-numbers/) - support for negative zero (#3903)
+-   [bugfix] Handle tsconfig.json errors without using JSON.stringify (#3908)
+-   [bugfix] Fix CI: [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) test failure; typescript@next failure (#4019)
+-   [bugfix] Fix edge case in [`no-console`](https://palantir.github.io/tslint/rules/no-console/) rule (#4041)
+-   [docs] Fix typos in the [`no-floating-promises`](https://palantir.github.io/tslint/rules/no-floating-promises/) rule docs. (#3886)
+-   [docs] Updated [`prefer-while`](https://palantir.github.io/tslint/rules/prefer-while/) docs to be semantically correct (#3888)
+-   [docs] Fix link to configuration page (#3891)
+-   [docs] Fix docs typo (#3898)
+-   [docs] Fix docs typo (#3910)
+-   [enhancement] Turn on strictPropertyInitialization for src/ and test/ (#3924)
+-   [enhancement] Use Buffer.allocUnsafe instead of the deprecated new Buffer() (#3985)
+-   [enhancement] Improve [`radix`](https://palantir.github.io/tslint/rules/radix/) rule checks (#3901)
+-   [enhancement] Output +/- on diff so added/removed empty lines are visible. (#3973)
+-   [rule-change][`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) now always considers peer dependencies (#3875)
 
 Thanks to our contributors!
 
-- Achim Weimert
-- BB9z
-- Blair Zajac
-- Chia-Lun Wu (Leo)
-- Ethan
-- Janis Koehr
-- Josh Goldberg
-- Julian Verdurmen
-- Lucas Sloan
-- Mark Vincze
-- Martin Möhwald
-- Oliver Joseph Ash
-- Pichest Wongsiripiphat
-- Rafael Santana
-- Ruben Bridgewater
-- Ryan Waskiewicz
-- Sehrope Sarkuni
-- Suchan Lee
-- Victor Belozyorov
-- aervin_
-- cwgorman
-- felipeissa
-- jishi9
+-   Bowen Ni
+-   Peter Safranek
+-   Saugat Acharya
+-   Jason Mendes
+-   Ryan Waskiewicz
+-   Dariusz Rumiński
+-   Xinhu Liu
+-   Rado Kirov
+-   aervin\_
+-   Josh Goldberg
+-   mertdeg2
+-   Jason Killian
+-   Adrian Leonhard
+-   david-cannady
+-   Andy Russell
+-   Tibor Blenessy
+-   Andrew Crites
+-   Pavel Birukov
+-   shalomdotnet
 
+## v5.10.0
 
-v5.9.1
----
+## :tada: Features
+
+-   [new-rule][`prefer-while`](https://palantir.github.io/tslint/rules/prefer-while/) (#3750)
+-   [new-fixer][`comment-format`](https://palantir.github.io/tslint/rules/comment-format/) (#3845)
+-   [new-rule-option] `"allow-empty-functions"` for [`no-empty`](https://palantir.github.io/tslint/rules/no-empty/) rule (#3624)
+-   [new-rule-option] New options for [`promise-function-async`](https://palantir.github.io/tslint/rules/promise-function-async/) specifying what kinds of functions to check (#3807)
+
+## :hammer_and_wrench: Bugfixes & enhancements
+
+-   [bugfix][`file-header`](https://palantir.github.io/tslint/rules/file-header/) rule plays nice with [`no-trailing-whitespace`](https://palantir.github.io/tslint/rules/no-trailing-whitespace/) rule (#3802)
+-   [bugfix][`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/) rule allows square bracket property access (#3610)
+-   [bugfix][`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) no longer marks native JSX elements as unsafe (#3699)
+-   [enhancement][`file-header`](https://palantir.github.io/tslint/rules/file-header/) auto-fixes use '!' character to ensure header stays above imports (#3741)
+-   [enhancement] Better error messages if a rule crashes (#3836)
+-   [enhancement] Better error messages when no valid rules are specified (#3729)
+-   [enhancement] Better lint messages for unused imports in [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) rule (#3831)
+-   [docs] Improve documentation of cli flag --project (#3703)
+-   [docs] Added short rationales for about thirty rules (#3734)
+-   [docs] Added optional capability to provide code examples in rules' metadata (#3602)
+-   [docs] Many small docs fixes and tweaks from many great contributors!
+
+Thanks to our contributors!
+
+-   Achim Weimert
+-   BB9z
+-   Blair Zajac
+-   Chia-Lun Wu (Leo)
+-   Ethan
+-   Janis Koehr
+-   Josh Goldberg
+-   Julian Verdurmen
+-   Lucas Sloan
+-   Mark Vincze
+-   Martin Möhwald
+-   Oliver Joseph Ash
+-   Pichest Wongsiripiphat
+-   Rafael Santana
+-   Ruben Bridgewater
+-   Ryan Waskiewicz
+-   Sehrope Sarkuni
+-   Suchan Lee
+-   Victor Belozyorov
+-   aervin\_
+-   cwgorman
+-   felipeissa
+-   jishi9
+
+## v5.9.1
 
 ## :hammer_and_wrench: Bugfixes
 
-- [bugfix] Removed extraneous deprecation warning produced when using `tslint:recommended` or `tslint:latest` by disabling `typeof-compare` in these rulesets. (#3639)
-- [bugfix] Resolve directories as absolute paths when validating custom `rulesDirectory` paths, which fixes usage with tslint-loader. (#3640)
+-   [bugfix] Removed extraneous deprecation warning produced when using `tslint:recommended` or `tslint:latest` by disabling `typeof-compare` in these rulesets. (#3639)
+-   [bugfix] Resolve directories as absolute paths when validating custom `rulesDirectory` paths, which fixes usage with tslint-loader. (#3640)
 
-v5.9.0
----
+## v5.9.0
 
 ## :warning: Deprecations
 
-- [deprecation] Several utility functions from `src/language/utils.ts` have been deprecated (#3476)
-- [deprecation] Linting non-existent files now outputs a warning. This will be an error in TSLint 6. (#3313)
+-   [deprecation] Several utility functions from `src/language/utils.ts` have been deprecated (#3476)
+-   [deprecation] Linting non-existent files now outputs a warning. This will be an error in TSLint 6. (#3313)
 
 ## Configuration inheritance changes
 
@@ -138,96 +132,95 @@ and treat all errors as warnings instead of errors.
 
 For more details, see the relevant PRs:
 
-- Override `defaultSeverity` defined in extended configs (#3449)
-- Inherit defaultSeverity and apply it to preceding base configs (#3530)
+-   Override `defaultSeverity` defined in extended configs (#3449)
+-   Inherit defaultSeverity and apply it to preceding base configs (#3530)
 
 ## :tada: Features
 
-- [feature] Support yaml configuration files (#1598) (#3433)
-- [new-fixer] [`file-header`](https://palantir.github.io/tslint/rules/file-header/) (#3475)
-- [new-rule] [`no-dynamic-delete`](https://palantir.github.io/tslint/rules/no-dynamic-delete/) (#3573)
-- [new-rule] [`prefer-readonly`](https://palantir.github.io/tslint/rules/prefer-readonly/) (#2896)
-- [new-rule] [`newline-per-chained-call`](https://palantir.github.io/tslint/rules/newline-per-chained-call/) (#3278)
-- [new-rule-option] `"temporalDeadZone"` for [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) to ignore shadowing in the temporal dead zone of classes, parameters, enums and variables declared with `let` or `const`
-(#3389)
-- [new-rule-option] `"shorthand-first"` for [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/) (#3607)
-- [new-rule-option] Add support for an ignore pattern for [`max-line-length`](https://palantir.github.io/tslint/rules/max-line-length/) (#3099)
+-   [feature] Support yaml configuration files (#1598) (#3433)
+-   [new-fixer][`file-header`](https://palantir.github.io/tslint/rules/file-header/) (#3475)
+-   [new-rule][`no-dynamic-delete`](https://palantir.github.io/tslint/rules/no-dynamic-delete/) (#3573)
+-   [new-rule][`prefer-readonly`](https://palantir.github.io/tslint/rules/prefer-readonly/) (#2896)
+-   [new-rule][`newline-per-chained-call`](https://palantir.github.io/tslint/rules/newline-per-chained-call/) (#3278)
+-   [new-rule-option] `"temporalDeadZone"` for [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) to ignore shadowing in the temporal dead zone of classes, parameters, enums and variables declared with `let` or `const`
+    (#3389)
+-   [new-rule-option] `"shorthand-first"` for [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/) (#3607)
+-   [new-rule-option] Add support for an ignore pattern for [`max-line-length`](https://palantir.github.io/tslint/rules/max-line-length/) (#3099)
 
 ## :hammer_and_wrench: Bugfixes & enhancements
 
-- [bugfix] Update commander.js dependency to prevent users from transitively installing a buggy 2.12.0 release (#3510)
-- [bugfix] `--project` excludes all files of external dependencies (#3320)
-- [bugfix] Show errors when `tsconfig.json` is invalid (#3410)
-- [bugfix] [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) don't crash on malformed package.json (#3373)
-- [bugfix] [`strict-type-predicates`](https://palantir.github.io/tslint/rules/strict-type-predicates/) allows comparing typeof result with non-literals (#3542)
-- [bugfix] [`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) fixed crash on unhandled tag (#3414)
-- [bugfix] [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/) fixed regression that effectively disabled the rule with `\r\n` line breaks (#3427)
-- [bugfix] [`curly`](https://palantir.github.io/tslint/rules/curly/) fixer now correctly handles comments (#3473)
-- [bugfix] [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) fixed false-positive with namespaced types (#3487)
-- [bugfix] Removed potentailly dangerous fixer for [`no-any`](https://palantir.github.io/tslint/rules/no-any/) (#3486)
-- [bugfix] [`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) fixed false negatives for types with numeric keys (#3468)
-- [bugfix] [`callable-types`](https://palantir.github.io/tslint/rules/callable-types/) adds parentheses when fixing a type literal inside an array type (#3440)
-- [bugfix] [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) allows spreading an `any` value into an object (#3439)
-- [bugfix] no unnecessary whitespace before argument in callback functions fixed with [`arrow-parens`](https://palantir.github.io/tslint/rules/arrow-parens) fixer (#3618)
-- [bugfix] [`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/) false negative with index signature named like a variable (#3385)
-- [bugfix] [`whitespace`](https://palantir.github.io/tslint/rules/whitespace) rule checks property declarations if `"check-decl"` is enabled (#3546)
-- [bugfix] Using ternary operator for calling super() now passes [`no-duplicate-super`](https://palantir.github.io/tslint/rules/no-duplicate-super) rule. (#3544)
-- [bugfix] [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) now excludes declaration files and ambient modules (#3387)
-- [bugfix] [`no-duplicate-imports`](https://palantir.github.io/tslint/rules/no-duplicate-imports) Allow duplicate imports from separate ambient module declarations (#3398)
-- [bugfix] [`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) correctly recognises classes extending Promise (#3383)
-- [bugfix] [`prefer-conditional-expression`](https://palantir.github.io/tslint/rules/prefer-conditional-expression/): don't repeat error on nested if statements (#3528)
-- [bugfix] [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/): don't require documentation on methods in object literals (#3532)
-- [bugfix] [`one-line`](https://palantir.github.io/tslint/rules/one-line/) fixed crash on syntax error in class or interface (#3538)
-- [bugfix] [`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) allow `@template` tag if it has a description (#3415)
-- [bugfix] Fix condition for deprecation of [`typeof-compare`](https://palantir.github.io/tslint/rules/typeof-compare) (#3429)
-- [enhancement] Better error message for files not contained in the project (#3313)
-- [enhancement] `"properties"` option for [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/) rule now checks getter and setter accessors. (#3497)
-- [enhancement] [`no-magic-numbers`](https://palantir.github.io/tslint/rules/no-magic-numbers) ignores parseInt radix parameter (#3536)
-- [enhancement] Avoid duplicate I/O when using `--project` option (#3313)
-- [enhancement] clicking the filename in `stylish`-formatter's output jumps to the first failure in that file. (#3491)
-- [enhancement] [`ban-comma-operator`](https://palantir.github.io/tslint/rules/ban-comma-operator/) ignores comma operator inside for-loop incrementor (#3485)
-- [enhancement] [`space-within-parens`](https://palantir.github.io/tslint/rules/space-within-parens/) updated to always allow empty parentheses `()`. (#3513)
-- [enhancement] Better error message syntax for [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/) modifier lists (#3379)
-- [enhancement] Improve failure message & docs for [`ban-comma-operator`](https://palantir.github.io/tslint/rules/ban-comma-operator/) (#3384)
-- [enhancement] Output code warnings in yellow instead of red for codeFrame formatter (#3402)
-- [enhancement] Converted [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs) rule to use a function instead of a walker (#3466)
-- [docs] [`ban-comma-operator`](https://palantir.github.io/tslint/rules/ban-comma-operator/): fix metadata, list as "functionality" rule (#3612)
-- [docs] Enhance [`no-use-before-declare`](https://palantir.github.io/tslint/rules/no-use-before-declare/) documentation to clarify the rule's status (#3520)
-- [docs] Enhance [`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) options documentation (#3519)
-- [docs] Add `hasFix` metadata for the [`indent`](https://palantir.github.io/tslint/rules/indent) rule (#3529)
-- [docs] Clearer rule description for [`no-irregular-whitespace`](https://palantir.github.io/tslint/rules/no-irregular-whitespace) (#3627)
+-   [bugfix] Update commander.js dependency to prevent users from transitively installing a buggy 2.12.0 release (#3510)
+-   [bugfix] `--project` excludes all files of external dependencies (#3320)
+-   [bugfix] Show errors when `tsconfig.json` is invalid (#3410)
+-   [bugfix][`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) don't crash on malformed package.json (#3373)
+-   [bugfix][`strict-type-predicates`](https://palantir.github.io/tslint/rules/strict-type-predicates/) allows comparing typeof result with non-literals (#3542)
+-   [bugfix][`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) fixed crash on unhandled tag (#3414)
+-   [bugfix][`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/) fixed regression that effectively disabled the rule with `\r\n` line breaks (#3427)
+-   [bugfix][`curly`](https://palantir.github.io/tslint/rules/curly/) fixer now correctly handles comments (#3473)
+-   [bugfix][`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) fixed false-positive with namespaced types (#3487)
+-   [bugfix] Removed potentailly dangerous fixer for [`no-any`](https://palantir.github.io/tslint/rules/no-any/) (#3486)
+-   [bugfix][`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) fixed false negatives for types with numeric keys (#3468)
+-   [bugfix][`callable-types`](https://palantir.github.io/tslint/rules/callable-types/) adds parentheses when fixing a type literal inside an array type (#3440)
+-   [bugfix][`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) allows spreading an `any` value into an object (#3439)
+-   [bugfix] no unnecessary whitespace before argument in callback functions fixed with [`arrow-parens`](https://palantir.github.io/tslint/rules/arrow-parens) fixer (#3618)
+-   [bugfix][`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/) false negative with index signature named like a variable (#3385)
+-   [bugfix][`whitespace`](https://palantir.github.io/tslint/rules/whitespace) rule checks property declarations if `"check-decl"` is enabled (#3546)
+-   [bugfix] Using ternary operator for calling super() now passes [`no-duplicate-super`](https://palantir.github.io/tslint/rules/no-duplicate-super) rule. (#3544)
+-   [bugfix][`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) now excludes declaration files and ambient modules (#3387)
+-   [bugfix][`no-duplicate-imports`](https://palantir.github.io/tslint/rules/no-duplicate-imports) Allow duplicate imports from separate ambient module declarations (#3398)
+-   [bugfix][`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) correctly recognises classes extending Promise (#3383)
+-   [bugfix][`prefer-conditional-expression`](https://palantir.github.io/tslint/rules/prefer-conditional-expression/): don't repeat error on nested if statements (#3528)
+-   [bugfix][`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/): don't require documentation on methods in object literals (#3532)
+-   [bugfix][`one-line`](https://palantir.github.io/tslint/rules/one-line/) fixed crash on syntax error in class or interface (#3538)
+-   [bugfix][`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) allow `@template` tag if it has a description (#3415)
+-   [bugfix] Fix condition for deprecation of [`typeof-compare`](https://palantir.github.io/tslint/rules/typeof-compare) (#3429)
+-   [enhancement] Better error message for files not contained in the project (#3313)
+-   [enhancement] `"properties"` option for [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/) rule now checks getter and setter accessors. (#3497)
+-   [enhancement][`no-magic-numbers`](https://palantir.github.io/tslint/rules/no-magic-numbers) ignores parseInt radix parameter (#3536)
+-   [enhancement] Avoid duplicate I/O when using `--project` option (#3313)
+-   [enhancement] clicking the filename in `stylish`-formatter's output jumps to the first failure in that file. (#3491)
+-   [enhancement][`ban-comma-operator`](https://palantir.github.io/tslint/rules/ban-comma-operator/) ignores comma operator inside for-loop incrementor (#3485)
+-   [enhancement][`space-within-parens`](https://palantir.github.io/tslint/rules/space-within-parens/) updated to always allow empty parentheses `()`. (#3513)
+-   [enhancement] Better error message syntax for [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/) modifier lists (#3379)
+-   [enhancement] Improve failure message & docs for [`ban-comma-operator`](https://palantir.github.io/tslint/rules/ban-comma-operator/) (#3384)
+-   [enhancement] Output code warnings in yellow instead of red for codeFrame formatter (#3402)
+-   [enhancement] Converted [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs) rule to use a function instead of a walker (#3466)
+-   [docs][`ban-comma-operator`](https://palantir.github.io/tslint/rules/ban-comma-operator/): fix metadata, list as "functionality" rule (#3612)
+-   [docs] Enhance [`no-use-before-declare`](https://palantir.github.io/tslint/rules/no-use-before-declare/) documentation to clarify the rule's status (#3520)
+-   [docs] Enhance [`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) options documentation (#3519)
+-   [docs] Add `hasFix` metadata for the [`indent`](https://palantir.github.io/tslint/rules/indent) rule (#3529)
+-   [docs] Clearer rule description for [`no-irregular-whitespace`](https://palantir.github.io/tslint/rules/no-irregular-whitespace) (#3627)
 
 Thanks to our contributors!
 
-- Klaus Meinhardt
-- Josh Goldberg
-- Chris Barr
-- Nathan Shively-Sanders
-- Jeremy Morton
-- Sergey Koshechkin
-- Daniel Kucal
-- Eric Smekens
-- Johannes Choo
-- Elena Vilchik
-- Eugene Timokhov
-- Carlo Bottiglieri
-- reduckted
-- Glavin Wiechert
-- jbsingh
-- Mateusz Witkowski
-- HideDev
-- Bruno Lemos
-- aervin_
-- Roman
-- Ryan Waskiewicz
+-   Klaus Meinhardt
+-   Josh Goldberg
+-   Chris Barr
+-   Nathan Shively-Sanders
+-   Jeremy Morton
+-   Sergey Koshechkin
+-   Daniel Kucal
+-   Eric Smekens
+-   Johannes Choo
+-   Elena Vilchik
+-   Eugene Timokhov
+-   Carlo Bottiglieri
+-   reduckted
+-   Glavin Wiechert
+-   jbsingh
+-   Mateusz Witkowski
+-   HideDev
+-   Bruno Lemos
+-   aervin\_
+-   Roman
+-   Ryan Waskiewicz
 
-v5.8.0
----
+## v5.8.0
 
 ## :warning: Deprecations
 
-- [deprecation] [`typeof-compare`](https://palantir.github.io/tslint/rules/typeof-compare/) is deprecated because typescript already does that check (#3286)
-- [deprecation] CLI argument `--type-check` is no longer necessary and will be removed in the next major version (#3322)
+-   [deprecation][`typeof-compare`](https://palantir.github.io/tslint/rules/typeof-compare/) is deprecated because typescript already does that check (#3286)
+-   [deprecation] CLI argument `--type-check` is no longer necessary and will be removed in the next major version (#3322)
 
 ## Updates to `tslint:latest` configuration
 
@@ -243,493 +236,485 @@ v5.8.0
 
 ## :tada: Features
 
-- [feature] Added `linterOptions` configuration field to `tslint.json`, which supports a list of `exclude` globs to disable linting for a subset of files (#2409)
-- [new-rule] [`no-return-await`](https://palantir.github.io/tslint/rules/no-return-await/) (#3233)
-- [new-rule] [`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) (#2754)
-- [new-rule] [`no-duplicate-switch-case`](https://palantir.github.io/tslint/rules/no-duplicate-switch-case/) (#2937)
-- [new-rule] [`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) (#3343)
-- [new-rule] [`no-unnecessary-class`](https://palantir.github.io/tslint/rules/no-unnecessary-class/) (#3119)
-- [new-rule] [`ban-comma-operator`](https://palantir.github.io/tslint/rules/ban-comma-operator/) (#3250)
-- [new-fixer] [`one-line`](https://palantir.github.io/tslint/rules/one-line/) (#3200)
-- [new-fixer] [`curly`](https://palantir.github.io/tslint/rules/curly/) (#3262)
-- [new-rule-option] [`jsdoc-format`](https://palantir.github.io/tslint/rules/jsdoc-format/) adds option `"check-multiline-start"` to enforce the first line of a multiline JSDoc comment to be empty. (#3181)
-- [new-rule-option] [`trailing-comma`](https://palantir.github.io/tslint/rules/trailing-comma/) adds option `"esSpecCompliant"` to make it compatible with the ES spec regarding trailing commas after object/array rest and rest parameters. (#3176)
-- [new-rule-option] `"check-parameter-property"` option for [`member-access`](https://palantir.github.io/tslint/rules/member-access/) rule (#3325)
-- [new-rule-option] `"strict-bound-class-methods"` option for [`semicolon`](https://palantir.github.io/tslint/rules/semicolon/) rule (#3294)
-- [new-rule-option] `"grouped-imports"` option for [`ordered-imports`](https://palantir.github.io/tslint/rules/ordered-imports/) rule (#3138)
-- [new-rule-option] `"ignore-blank-lines"` option for [`no-trailing-whitespace`](https://palantir.github.io/tslint/rules/no-trailing-whitespace/) rule (#3346)
-- [new-rule-option] `"never"` option for [`object-literal-shorthand`](https://palantir.github.io/tslint/rules/object-literal-shorthand/) disallows shorthand notation (#3268)
-- [new-rule-option] `"exclude-class-expressions"` option for [`max-classes-per-file`](https://palantir.github.io/tslint/rules/max-classes-per-file/) rule (#3281)
-- [new-rule-option] [`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) supports a whitelist of types to ignore (#3257)
-- [new-rule-option] `"module-source-path"` for [`ordered-imports`](https://palantir.github.io/tslint/rules/ordered-imports/) allows sorting imports by trailing end of path (#3178)
-- [new-formatter] JUnit (#3194)
+-   [feature] Added `linterOptions` configuration field to `tslint.json`, which supports a list of `exclude` globs to disable linting for a subset of files (#2409)
+-   [new-rule][`no-return-await`](https://palantir.github.io/tslint/rules/no-return-await/) (#3233)
+-   [new-rule][`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) (#2754)
+-   [new-rule][`no-duplicate-switch-case`](https://palantir.github.io/tslint/rules/no-duplicate-switch-case/) (#2937)
+-   [new-rule][`no-implicit-dependencies`](https://palantir.github.io/tslint/rules/no-implicit-dependencies/) (#3343)
+-   [new-rule][`no-unnecessary-class`](https://palantir.github.io/tslint/rules/no-unnecessary-class/) (#3119)
+-   [new-rule][`ban-comma-operator`](https://palantir.github.io/tslint/rules/ban-comma-operator/) (#3250)
+-   [new-fixer][`one-line`](https://palantir.github.io/tslint/rules/one-line/) (#3200)
+-   [new-fixer][`curly`](https://palantir.github.io/tslint/rules/curly/) (#3262)
+-   [new-rule-option][`jsdoc-format`](https://palantir.github.io/tslint/rules/jsdoc-format/) adds option `"check-multiline-start"` to enforce the first line of a multiline JSDoc comment to be empty. (#3181)
+-   [new-rule-option][`trailing-comma`](https://palantir.github.io/tslint/rules/trailing-comma/) adds option `"esSpecCompliant"` to make it compatible with the ES spec regarding trailing commas after object/array rest and rest parameters. (#3176)
+-   [new-rule-option] `"check-parameter-property"` option for [`member-access`](https://palantir.github.io/tslint/rules/member-access/) rule (#3325)
+-   [new-rule-option] `"strict-bound-class-methods"` option for [`semicolon`](https://palantir.github.io/tslint/rules/semicolon/) rule (#3294)
+-   [new-rule-option] `"grouped-imports"` option for [`ordered-imports`](https://palantir.github.io/tslint/rules/ordered-imports/) rule (#3138)
+-   [new-rule-option] `"ignore-blank-lines"` option for [`no-trailing-whitespace`](https://palantir.github.io/tslint/rules/no-trailing-whitespace/) rule (#3346)
+-   [new-rule-option] `"never"` option for [`object-literal-shorthand`](https://palantir.github.io/tslint/rules/object-literal-shorthand/) disallows shorthand notation (#3268)
+-   [new-rule-option] `"exclude-class-expressions"` option for [`max-classes-per-file`](https://palantir.github.io/tslint/rules/max-classes-per-file/) rule (#3281)
+-   [new-rule-option][`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) supports a whitelist of types to ignore (#3257)
+-   [new-rule-option] `"module-source-path"` for [`ordered-imports`](https://palantir.github.io/tslint/rules/ordered-imports/) allows sorting imports by trailing end of path (#3178)
+-   [new-formatter] JUnit (#3194)
 
 ## :hammer_and_wrench: Bugfixes & enhancements
 
-- [bugfix] [`no-empty-interface`](https://palantir.github.io/tslint/rules/no-empty-interface/) allows providing type arguments for extended type (#3260)
-- [bugfix] Fixed line switches to not disable failures in the next line following the disabled line (#3177)
-- [bugfix] [`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/) handles union return types in async functions (#3298)
-- [bugfix] [`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) checks correct constructor overload (#3203)
-- [bugfix] [`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/) declared return type takes precedence over contextual type (#3298)
-- [bugfix] Correctly mark `inputFilePath` as an optional parameter in `Configuration.findConfiguration()` (#3195)
-- [bugfix] [`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/) fixed regressions: once again allows anything if return type is `any` (#3298)
-- [bugfix] [`only-arrow-functions`](https://palantir.github.io/tslint/rules/only-arrow-functions/) allow function if `this` is used in parameter initializer (#3315)
-- [bugfix] [`no-conditional-assignment`](https://palantir.github.io/tslint/rules/no-conditional-assignment/): exclude intentional assignments, e.g. inside functions (#2629)
-- [bugfix] [`no-angle-bracket-type-assertion`](https://palantir.github.io/tslint/rules/no-angle-bracket-type-assertion/) fixer adds parentheses when necessary (#3301)
-- [bugfix] [`no-angle-bracket-type-assertion`](https://palantir.github.io/tslint/rules/no-angle-bracket-type-assertion/) fixed order when autofixing consecutive assertions (#3301)
-- [bugfix] `vso` formatter no longer duplicates output for fixed failures (#3348)
-- [bugfix] [`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/): Allow negation of method (#3349)
-- [bugfix] [`arrow-parens`](https://palantir.github.io/tslint/rules/arrow-parens/) with option `"ban-single-arg-parens"` no longer produces invalid code when fixed (#3247)
-- [bugfix] Fixed regression where the lookup of `tslint.json` stopped at the current directory. (#3309)
-- [bugfix] `--test` works correctly with any `compilerOptions.target` (#3296)
-- [bugfix] `whitepace` handles files with BOM and other irregular whitespace (#3305)
-- [bugfix] [`callable-types`](https://palantir.github.io/tslint/rules/callable-types/) auto fix produces invalid results (#3342)
-- [bugfix] [`no-string-literal`](https://palantir.github.io/tslint/rules/no-string-literal/) correctly fix property names with leading underscores (#3184)
-- [bugfix] [`variable-name`](https://palantir.github.io/tslint/rules/variable-name/) fixed crash on empty variable name (#3292)
-- [bugfix] [`trailing-comma`](https://palantir.github.io/tslint/rules/trailing-comma/) fixed crash on arrow function without parens (#3246)
-- [bugfix] Fix [`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/) for anonymous/arrow generic functions (#3085)
-- [bugfix] Removed warning printed to console when using the [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) along with the `noUnusedLocals` and `noUnusedParameters` compiler options (#3227)
-- [bugfix] [`no-invalid-this`](https://palantir.github.io/tslint/rules/no-invalid-this/) ignores functions with a `this` param (#3267)
-- [enhancement] Sort failures by line and character for formatters (#3345)
-- [enhancement] [`import-blacklist`](https://palantir.github.io/tslint/rules/import-blacklist/) also checks exports and dynamic imports (#3258)
-- [enhancement] [`no-conditional-assignment`](https://palantir.github.io/tslint/rules/no-conditional-assignment/) added check for conditional (ternary) expressions (#2629)
-- [enhancement] Allow [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/) to list doc tags that mark a node as not requiring a documentation body. Tags can also provide a regexp matcher to validate that their contents are docs-valid. (#2415)
-- [enhancement] [`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) enforces that `for-await-of` is only used with `AsyncIterable` (#3297)
-- [enhancement] [`one-line`](https://palantir.github.io/tslint/rules/one-line/) checks type alias declarations (#3200)
-- [enhancement] [`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) checks object destructuring (#3318)
-- [enhancement] [`no-submodule-imports`](https://palantir.github.io/tslint/rules/no-submodule-imports/) also checks exports (#3258)
-- [enhancement] [`restrict-plus-operands`](https://palantir.github.io/tslint/rules/restrict-plus-operands/): More specific error message when arguments include strings (#3220)
-- [enhancement] [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) checks more expressions, for example destructuring, `yield`, property initializer (#3196)
-- [enhancement] [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): allow grouping of object properties via additional blank lines when using alphabetical ordering. (#3191)
-- [enhancement] Migrated CLI from using `colors` module to `chalk` module (#3171)
-- [enhancement] [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) applies the ignorePattern to imports (#3187)
+-   [bugfix][`no-empty-interface`](https://palantir.github.io/tslint/rules/no-empty-interface/) allows providing type arguments for extended type (#3260)
+-   [bugfix] Fixed line switches to not disable failures in the next line following the disabled line (#3177)
+-   [bugfix][`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/) handles union return types in async functions (#3298)
+-   [bugfix][`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) checks correct constructor overload (#3203)
+-   [bugfix][`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/) declared return type takes precedence over contextual type (#3298)
+-   [bugfix] Correctly mark `inputFilePath` as an optional parameter in `Configuration.findConfiguration()` (#3195)
+-   [bugfix][`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/) fixed regressions: once again allows anything if return type is `any` (#3298)
+-   [bugfix][`only-arrow-functions`](https://palantir.github.io/tslint/rules/only-arrow-functions/) allow function if `this` is used in parameter initializer (#3315)
+-   [bugfix][`no-conditional-assignment`](https://palantir.github.io/tslint/rules/no-conditional-assignment/): exclude intentional assignments, e.g. inside functions (#2629)
+-   [bugfix][`no-angle-bracket-type-assertion`](https://palantir.github.io/tslint/rules/no-angle-bracket-type-assertion/) fixer adds parentheses when necessary (#3301)
+-   [bugfix][`no-angle-bracket-type-assertion`](https://palantir.github.io/tslint/rules/no-angle-bracket-type-assertion/) fixed order when autofixing consecutive assertions (#3301)
+-   [bugfix] `vso` formatter no longer duplicates output for fixed failures (#3348)
+-   [bugfix][`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/): Allow negation of method (#3349)
+-   [bugfix][`arrow-parens`](https://palantir.github.io/tslint/rules/arrow-parens/) with option `"ban-single-arg-parens"` no longer produces invalid code when fixed (#3247)
+-   [bugfix] Fixed regression where the lookup of `tslint.json` stopped at the current directory. (#3309)
+-   [bugfix] `--test` works correctly with any `compilerOptions.target` (#3296)
+-   [bugfix] `whitepace` handles files with BOM and other irregular whitespace (#3305)
+-   [bugfix][`callable-types`](https://palantir.github.io/tslint/rules/callable-types/) auto fix produces invalid results (#3342)
+-   [bugfix][`no-string-literal`](https://palantir.github.io/tslint/rules/no-string-literal/) correctly fix property names with leading underscores (#3184)
+-   [bugfix][`variable-name`](https://palantir.github.io/tslint/rules/variable-name/) fixed crash on empty variable name (#3292)
+-   [bugfix][`trailing-comma`](https://palantir.github.io/tslint/rules/trailing-comma/) fixed crash on arrow function without parens (#3246)
+-   [bugfix] Fix [`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/) for anonymous/arrow generic functions (#3085)
+-   [bugfix] Removed warning printed to console when using the [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) along with the `noUnusedLocals` and `noUnusedParameters` compiler options (#3227)
+-   [bugfix][`no-invalid-this`](https://palantir.github.io/tslint/rules/no-invalid-this/) ignores functions with a `this` param (#3267)
+-   [enhancement] Sort failures by line and character for formatters (#3345)
+-   [enhancement][`import-blacklist`](https://palantir.github.io/tslint/rules/import-blacklist/) also checks exports and dynamic imports (#3258)
+-   [enhancement][`no-conditional-assignment`](https://palantir.github.io/tslint/rules/no-conditional-assignment/) added check for conditional (ternary) expressions (#2629)
+-   [enhancement] Allow [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/) to list doc tags that mark a node as not requiring a documentation body. Tags can also provide a regexp matcher to validate that their contents are docs-valid. (#2415)
+-   [enhancement][`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) enforces that `for-await-of` is only used with `AsyncIterable` (#3297)
+-   [enhancement][`one-line`](https://palantir.github.io/tslint/rules/one-line/) checks type alias declarations (#3200)
+-   [enhancement][`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) checks object destructuring (#3318)
+-   [enhancement][`no-submodule-imports`](https://palantir.github.io/tslint/rules/no-submodule-imports/) also checks exports (#3258)
+-   [enhancement][`restrict-plus-operands`](https://palantir.github.io/tslint/rules/restrict-plus-operands/): More specific error message when arguments include strings (#3220)
+-   [enhancement][`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/) checks more expressions, for example destructuring, `yield`, property initializer (#3196)
+-   [enhancement][`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): allow grouping of object properties via additional blank lines when using alphabetical ordering. (#3191)
+-   [enhancement] Migrated CLI from using `colors` module to `chalk` module (#3171)
+-   [enhancement][`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) applies the ignorePattern to imports (#3187)
 
 Thanks to our contributors!
 
-- Klaus Meinhardt
-- Charles Samborski
-- Donald Pipowitch
-- Josh Goldberg
-- mmkal
-- Erik
-- Csaba Miklos
-- Dominik Moritz
-- Khalid Saifullah
-- Lukas Spieß
-- Merott Movahedi
-- Bowen Ni
-- ksvitkovsky
-- Hutson Betts
-- Caleb Eggensperger
-- Brent Erickson
-- Trivikram
-- Brandon Furtwangler
-- Pavel Zet
-- aervin_
-- Holger Jeromin
-- Danny Guo
-- Jeremy Morton
-- Cyril Gandon
-- Andy Hanson
-- yadan
+-   Klaus Meinhardt
+-   Charles Samborski
+-   Donald Pipowitch
+-   Josh Goldberg
+-   mmkal
+-   Erik
+-   Csaba Miklos
+-   Dominik Moritz
+-   Khalid Saifullah
+-   Lukas Spieß
+-   Merott Movahedi
+-   Bowen Ni
+-   ksvitkovsky
+-   Hutson Betts
+-   Caleb Eggensperger
+-   Brent Erickson
+-   Trivikram
+-   Brandon Furtwangler
+-   Pavel Zet
+-   aervin\_
+-   Holger Jeromin
+-   Danny Guo
+-   Jeremy Morton
+-   Cyril Gandon
+-   Andy Hanson
+-   yadan
 
-v5.7.0
----
+## v5.7.0
 
 ## :tada: New rules, options, and fixers
 
-- [new-rule] [`no-parameter-reassignment`](https://palantir.github.io/tslint/rules/no-parameter-reassignment/) (#3045)
-- [new-rule-option]: [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): Add `match-declaration-order` option (#2829)
-- [new-rule-option] `check-type-operator` for [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/) rule (#3083)
-- [new-rule-option] [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/): Add `check-rest-spread` option (#3089)
+-   [new-rule][`no-parameter-reassignment`](https://palantir.github.io/tslint/rules/no-parameter-reassignment/) (#3045)
+-   [new-rule-option]: [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): Add `match-declaration-order` option (#2829)
+-   [new-rule-option] `check-type-operator` for [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/) rule (#3083)
+-   [new-rule-option][`whitespace`](https://palantir.github.io/tslint/rules/whitespace/): Add `check-rest-spread` option (#3089)
 
 ## :hammer_and_wrench: Bugfixes & enhancements
 
-- [api] `AbstractRule#applyWithFunction` allows additional parameter that is passed through to `walkFn` (#3140)
-- [api] `AbstractRule#applyWithFunction` has better type checking for its type parameter (#2660)
-- [bugfix] [`member-access`](https://palantir.github.io/tslint/rules/member-access/) autofix now correcly inserts `public` keyword after decorators (#3162)
-- [bugfix] [`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/) correctly handle `catch` without binding parameter introduced in `typescript@2.5.1` (#3151)
-- [bugfix] [`no-invalid-template-strings`](https://palantir.github.io/tslint/rules/no-invalid-template-strings/) allows backslash-prefixed template expressions  (#3116)
-- [bugfix] [`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) no longer shows errors on imports and exports (#3141)
-- [bugfix] [`deprecation`](https://palantir.github.io/tslint/rules/deprecation/): fix false positive when calling a function or method where another overload is deprecated (#2883)
-- [bugfix] [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/): fixed `"check-separator"` for trivial `for` cases. (#3132)
-- [bugfix] [`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) prevent spreading `this` as it is not allowed by the compiler (#3126)
-- [bugfix] `msbuild` formatter uses backslashes in paths on Windows (#3145)
-- [bugfix] [`no-namespace`](https://palantir.github.io/tslint/rules/no-namespace/) ignores global augmentation (#3161)
-- [enhancement] remove superfluous empty lines on tslint output. (#3121)
-- [enhancement] [`no-submodule-imports`](https://palantir.github.io/tslint/rules/no-submodule-imports/) allows whitelisting of submodules like `@angular/core/testing` (#3129)
-- [enhancement] custom lint rules will be resolved using node's path resolution to allow for loaders like `ts-node` (#3108)
-- [enhancement] [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/) no longer requires `"single"` or `"double"` to be the first option. The rule defaults to `"double"` if none is specified. (#3114)
-- [enhancement] [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) autofix removes trailing comments of imports (#3156)
-- [enhancement] [`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) allows certain necessary assertions to prevent type widening (#3120)
+-   [api] `AbstractRule#applyWithFunction` allows additional parameter that is passed through to `walkFn` (#3140)
+-   [api] `AbstractRule#applyWithFunction` has better type checking for its type parameter (#2660)
+-   [bugfix][`member-access`](https://palantir.github.io/tslint/rules/member-access/) autofix now correcly inserts `public` keyword after decorators (#3162)
+-   [bugfix][`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/) correctly handle `catch` without binding parameter introduced in `typescript@2.5.1` (#3151)
+-   [bugfix][`no-invalid-template-strings`](https://palantir.github.io/tslint/rules/no-invalid-template-strings/) allows backslash-prefixed template expressions (#3116)
+-   [bugfix][`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) no longer shows errors on imports and exports (#3141)
+-   [bugfix][`deprecation`](https://palantir.github.io/tslint/rules/deprecation/): fix false positive when calling a function or method where another overload is deprecated (#2883)
+-   [bugfix][`whitespace`](https://palantir.github.io/tslint/rules/whitespace/): fixed `"check-separator"` for trivial `for` cases. (#3132)
+-   [bugfix][`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) prevent spreading `this` as it is not allowed by the compiler (#3126)
+-   [bugfix] `msbuild` formatter uses backslashes in paths on Windows (#3145)
+-   [bugfix][`no-namespace`](https://palantir.github.io/tslint/rules/no-namespace/) ignores global augmentation (#3161)
+-   [enhancement] remove superfluous empty lines on tslint output. (#3121)
+-   [enhancement][`no-submodule-imports`](https://palantir.github.io/tslint/rules/no-submodule-imports/) allows whitelisting of submodules like `@angular/core/testing` (#3129)
+-   [enhancement] custom lint rules will be resolved using node's path resolution to allow for loaders like `ts-node` (#3108)
+-   [enhancement][`quotemark`](https://palantir.github.io/tslint/rules/quotemark/) no longer requires `"single"` or `"double"` to be the first option. The rule defaults to `"double"` if none is specified. (#3114)
+-   [enhancement][`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) autofix removes trailing comments of imports (#3156)
+-   [enhancement][`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) allows certain necessary assertions to prevent type widening (#3120)
 
 Thanks to our contributors!
 
-- Paul Gschwendtner
-- Andy Hanson
-- ksvitkovsky
-- Santi Albo
-- aervin
-- Junle Li
-- Joscha Feth
-- WiseBird
-- Caleb Eggensperger
-- WGroenestein
-- Bowen Ni
+-   Paul Gschwendtner
+-   Andy Hanson
+-   ksvitkovsky
+-   Santi Albo
+-   aervin
+-   Junle Li
+-   Joscha Feth
+-   WiseBird
+-   Caleb Eggensperger
+-   WGroenestein
+-   Bowen Ni
 
-v5.6.0
----
+## v5.6.0
 
 ## :tada: New rules, options, and fixers
 
-- [new-rule] [`no-duplicate-imports`](https://palantir.github.io/tslint/rules/no-duplicate-imports/) (#3075)
-- [new-rule] [`no-submodule-imports`](https://palantir.github.io/tslint/rules/no-submodule-imports/) (#3091)
-- [new-rule] [`space-within-parens`](https://palantir.github.io/tslint/rules/space-within-parens/) (#2959)
-- [new-fixer] [`member-access`](https://palantir.github.io/tslint/rules/member-access/) (#2969)
-- [new-fixer] [`no-null-keyword`](https://palantir.github.io/tslint/rules/no-null-keyword/): fix `x == null` to `x == undefined` (#2802)
-- [new-rule-option] [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) let's you optionally ignore certain kinds of declarations (#3030)
-- [new-rule-option] [`prefer-conditional-expression`](https://palantir.github.io/tslint/rules/prefer-conditional-expression/) adds `check-else-if` (#2963)
+-   [new-rule][`no-duplicate-imports`](https://palantir.github.io/tslint/rules/no-duplicate-imports/) (#3075)
+-   [new-rule][`no-submodule-imports`](https://palantir.github.io/tslint/rules/no-submodule-imports/) (#3091)
+-   [new-rule][`space-within-parens`](https://palantir.github.io/tslint/rules/space-within-parens/) (#2959)
+-   [new-fixer][`member-access`](https://palantir.github.io/tslint/rules/member-access/) (#2969)
+-   [new-fixer][`no-null-keyword`](https://palantir.github.io/tslint/rules/no-null-keyword/): fix `x == null` to `x == undefined` (#2802)
+-   [new-rule-option][`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) let's you optionally ignore certain kinds of declarations (#3030)
+-   [new-rule-option][`prefer-conditional-expression`](https://palantir.github.io/tslint/rules/prefer-conditional-expression/) adds `check-else-if` (#2963)
 
 ## :hammer_and_wrench: Bugfixes & enhancements
 
-- [bugfix] [`array-type`](https://palantir.github.io/tslint/rules/array-type/): consider `this` to be simple type (#2982)
-- [bugfix] [`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) accepts not only union types but also intersection types with Promise-like types (#2987)
-- [bugfix] [`callable-types`](https://palantir.github.io/tslint/rules/callable-types/): don't remove export modifier of interfaces (#2962)
-- [bugfix] [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/): Only checks variables at the file-level. (#2950)
-- [bugfix] [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/): Uses correct visibility of variables. (#2950)
-- [bugfix] [`no-floating-promises`](https://palantir.github.io/tslint/rules/no-floating-promises/): recognize rejection handler passed as second argument to `promise.then()` (#3048)
-- [bugfix] [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) don't warn for shadowed type parameter on static class members (#3030)
-- [bugfix] [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) fixed false positive with key name in index signature (#3030)
-- [bugfix] [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) fixed false positive with parameter inside function decorator (#3030)
-- [bugfix] [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): allow truthyness and falsyness checks (#3008)
-- [bugfix] [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) fixed crash when using destructuring (#3058)
-- [bugfix] [`one-line`](https://palantir.github.io/tslint/rules/one-line/) correctly handles multiline type parameters (#3004)
-- [bugfix] [`prefer-for-of`](https://palantir.github.io/tslint/rules/prefer-for-of/) fixed false positives when array is modified, e.g. `arr[i]++` (#3044)
-- [bugfix] [`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) adds parens when fixing arrow function return (#3026)
-- [bugfix] [`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) permit functions as first argument to Object.assign (#3098)
-- [bugfix] [`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/) Handle default exports of functions without names like anonymous functions (fixes #3040) (#3053)
-- [bugfix] Fixed an issue where, at runtime, the module `./test/parse` could not be located due after consumers had run `yarn clean` (#3072)
-- [enhancement] [`no-null-keyword`](https://palantir.github.io/tslint/rules/no-null-keyword/) allows strict comparison (#2802)
-- [enhancement] [`no-switch-case-fall-through`](https://palantir.github.io/tslint/rules/no-switch-case-fall-through/) matches `// falls through` comments case insensitive and allows trailing text (#2983)
-- [enhancement] [`ordered-imports`](https://palantir.github.io/tslint/rules/ordered-imports/): support importEqualsDeclaration (#3102)
-- [enhancement] Added NaN and (+/-)Infinity as numbers to [`no-inferrable-types`](https://palantir.github.io/tslint/rules/no-inferrable-types/) (#2885)
-- [enhancement] Improved CLI error message when no filenames are specified (#3066)
-- [rule-change] [`prefer-conditional-expression`](https://palantir.github.io/tslint/rules/prefer-conditional-expression/): ignore `if-else-if` by default. Use the new `"check-else-if"` option to check nested if statements (#2963)
+-   [bugfix][`array-type`](https://palantir.github.io/tslint/rules/array-type/): consider `this` to be simple type (#2982)
+-   [bugfix][`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) accepts not only union types but also intersection types with Promise-like types (#2987)
+-   [bugfix][`callable-types`](https://palantir.github.io/tslint/rules/callable-types/): don't remove export modifier of interfaces (#2962)
+-   [bugfix][`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/): Only checks variables at the file-level. (#2950)
+-   [bugfix][`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/): Uses correct visibility of variables. (#2950)
+-   [bugfix][`no-floating-promises`](https://palantir.github.io/tslint/rules/no-floating-promises/): recognize rejection handler passed as second argument to `promise.then()` (#3048)
+-   [bugfix][`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) don't warn for shadowed type parameter on static class members (#3030)
+-   [bugfix][`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) fixed false positive with key name in index signature (#3030)
+-   [bugfix][`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) fixed false positive with parameter inside function decorator (#3030)
+-   [bugfix][`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): allow truthyness and falsyness checks (#3008)
+-   [bugfix][`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) fixed crash when using destructuring (#3058)
+-   [bugfix][`one-line`](https://palantir.github.io/tslint/rules/one-line/) correctly handles multiline type parameters (#3004)
+-   [bugfix][`prefer-for-of`](https://palantir.github.io/tslint/rules/prefer-for-of/) fixed false positives when array is modified, e.g. `arr[i]++` (#3044)
+-   [bugfix][`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) adds parens when fixing arrow function return (#3026)
+-   [bugfix][`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) permit functions as first argument to Object.assign (#3098)
+-   [bugfix][`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/) Handle default exports of functions without names like anonymous functions (fixes #3040) (#3053)
+-   [bugfix] Fixed an issue where, at runtime, the module `./test/parse` could not be located due after consumers had run `yarn clean` (#3072)
+-   [enhancement][`no-null-keyword`](https://palantir.github.io/tslint/rules/no-null-keyword/) allows strict comparison (#2802)
+-   [enhancement][`no-switch-case-fall-through`](https://palantir.github.io/tslint/rules/no-switch-case-fall-through/) matches `// falls through` comments case insensitive and allows trailing text (#2983)
+-   [enhancement][`ordered-imports`](https://palantir.github.io/tslint/rules/ordered-imports/): support importEqualsDeclaration (#3102)
+-   [enhancement] Added NaN and (+/-)Infinity as numbers to [`no-inferrable-types`](https://palantir.github.io/tslint/rules/no-inferrable-types/) (#2885)
+-   [enhancement] Improved CLI error message when no filenames are specified (#3066)
+-   [rule-change][`prefer-conditional-expression`](https://palantir.github.io/tslint/rules/prefer-conditional-expression/): ignore `if-else-if` by default. Use the new `"check-else-if"` option to check nested if statements (#2963)
 
 Thanks to our contributors!
 
-- Klaus Meinhardt
-- Julian Verdurmen
-- Alexandre Alonso
-- Josh Goldberg
-- ksvitkovsky
-- Daisuke Yokomoto
-- Andrii Dieiev
-- Florent Suc
-- Jason Killian
-- Amin Pakseresht
-- reduckted
-- vilicvane
-- Russell Briggs
-- Andy Hanson
-- Leo Liang
-- Dan Homola
-- BehindTheMath
-- David Golightly
-- aervin
-- Daniel Kucal
-- Ika
-- Chris Barr
+-   Klaus Meinhardt
+-   Julian Verdurmen
+-   Alexandre Alonso
+-   Josh Goldberg
+-   ksvitkovsky
+-   Daisuke Yokomoto
+-   Andrii Dieiev
+-   Florent Suc
+-   Jason Killian
+-   Amin Pakseresht
+-   reduckted
+-   vilicvane
+-   Russell Briggs
+-   Andy Hanson
+-   Leo Liang
+-   Dan Homola
+-   BehindTheMath
+-   David Golightly
+-   aervin
+-   Daniel Kucal
+-   Ika
+-   Chris Barr
 
-v5.5.0
----
+## v5.5.0
 
-__Editor's note__: This release features an important bugfix for overlapping fixes when using `--project` and `--fix` (#2864).
+**Editor's note**: This release features an important bugfix for overlapping fixes when using `--project` and `--fix` (#2864).
 
 ## :tada: New rules and options
 
-- [new-rule-option] [`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/): Add `enum-members` option (#2911)
-- [new-rule] [`no-this-assignment`](https://palantir.github.io/tslint/rules/no-this-assignment/) (#2931)
+-   [new-rule-option][`completed-docs`](https://palantir.github.io/tslint/rules/completed-docs/): Add `enum-members` option (#2911)
+-   [new-rule][`no-this-assignment`](https://palantir.github.io/tslint/rules/no-this-assignment/) (#2931)
 
 ## :hammer_and_wrench: Bugfixes & enhancements
 
-- [bugfix] [`encoding`](https://palantir.github.io/tslint/rules/encoding/) closes files correctly (#2958)
-- [bugfix] [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/) fix whitespace `"check-module"` to properly lint and fix errors  (#2401) (#2825)
-- [bugfix]: [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/): now correctly handles dynamic imports introduced in typescript@2.4.0 (#2924)
-- [bugfix] [`switch-final-break`](https://palantir.github.io/tslint/rules/switch-final-break/): don't fail if break jumps to a label outside of the switch (#2914)
-- [bugfix] [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/): exempt `this` parameter (#2598)
-- [bugfix] [`prefer-for-of`](https://palantir.github.io/tslint/rules/prefer-for-of/) correctly handles variable scopes and other unrelated identifiers (#2984)
-- [bugfix] Don't leave blank lines when [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) autofix removes whole import (#2901)
-- [cli] restore `-v` option (#2926)
-- [enhancement] Print stack trace of exceptions (#2890)
-- [enhancement] Added allow-empty-catch option to [`no-empty`](https://palantir.github.io/tslint/rules/no-empty/) (#2886)
-- [enhancement] [`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/): handle destructuring in for-of loop initializer as if `{"destructuring": "all"}` was specified (#2904)
-- [enhancement] [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/): added checks for other shadowing declarations, e.g. interfaces, classes, type parameters, imports, etc. (#2598)
-- [rule-change] [`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) no longer fails for declarations in the same scope, e.g. `var foo; var foo;`. Use the rule [`no-duplicate-variable`](https://palantir.github.io/tslint/rules/no-duplicate-variable/) to find such errors. (#2598)
+-   [bugfix][`encoding`](https://palantir.github.io/tslint/rules/encoding/) closes files correctly (#2958)
+-   [bugfix][`whitespace`](https://palantir.github.io/tslint/rules/whitespace/) fix whitespace `"check-module"` to properly lint and fix errors (#2401) (#2825)
+-   [bugfix]: [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/): now correctly handles dynamic imports introduced in typescript@2.4.0 (#2924)
+-   [bugfix][`switch-final-break`](https://palantir.github.io/tslint/rules/switch-final-break/): don't fail if break jumps to a label outside of the switch (#2914)
+-   [bugfix][`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/): exempt `this` parameter (#2598)
+-   [bugfix][`prefer-for-of`](https://palantir.github.io/tslint/rules/prefer-for-of/) correctly handles variable scopes and other unrelated identifiers (#2984)
+-   [bugfix] Don't leave blank lines when [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) autofix removes whole import (#2901)
+-   [cli] restore `-v` option (#2926)
+-   [enhancement] Print stack trace of exceptions (#2890)
+-   [enhancement] Added allow-empty-catch option to [`no-empty`](https://palantir.github.io/tslint/rules/no-empty/) (#2886)
+-   [enhancement][`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/): handle destructuring in for-of loop initializer as if `{"destructuring": "all"}` was specified (#2904)
+-   [enhancement][`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/): added checks for other shadowing declarations, e.g. interfaces, classes, type parameters, imports, etc. (#2598)
+-   [rule-change][`no-shadowed-variable`](https://palantir.github.io/tslint/rules/no-shadowed-variable/) no longer fails for declarations in the same scope, e.g. `var foo; var foo;`. Use the rule [`no-duplicate-variable`](https://palantir.github.io/tslint/rules/no-duplicate-variable/) to find such errors. (#2598)
 
 Thanks to our contributors!
 
-- Klaus Meinhardt
-- Josh Goldberg
-- Petr Kosikhin
-- Pablo Núñez
-- Benny Neugebauer
-- Radon Rosborough
-- reduckted
-- Chris Barr
-- Julian Verdurmen
+-   Klaus Meinhardt
+-   Josh Goldberg
+-   Petr Kosikhin
+-   Pablo Núñez
+-   Benny Neugebauer
+-   Radon Rosborough
+-   reduckted
+-   Chris Barr
+-   Julian Verdurmen
 
-v5.4.3
----
-
-## :hammer_and_wrench: Bugfixes
-
-- [bugfix] Fixed regression with empty `--out` file (#2867)
-- [bugfix] [`unified-signatures`](https://palantir.github.io/tslint/rules/unified-signatures/): Don't suggest to unify rest parameters. (#2874)
-- [bugfix] [`binary-expression-operand-order`](https://palantir.github.io/tslint/rules/binary-expression-operand-order/): Allow if both sides of the binary expression are literals. (#2873)
-- [bugfix] Restore compatibility with typescript@2.1 and 2.2 for [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/), [`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/) and [`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) (#2893)
-- [docs] [`no-string-literal`](https://palantir.github.io/tslint/rules/no-string-literal/): Fix documentation (#2875)
-
-v5.4.2
----
+## v5.4.3
 
 ## :hammer_and_wrench: Bugfixes
 
-- [bugfix] Restored support for multiple `--exclude` options in the CLI (#2855)
-- [bugfix] Restored support for `--version` CLI option (#2857)
+-   [bugfix] Fixed regression with empty `--out` file (#2867)
+-   [bugfix][`unified-signatures`](https://palantir.github.io/tslint/rules/unified-signatures/): Don't suggest to unify rest parameters. (#2874)
+-   [bugfix][`binary-expression-operand-order`](https://palantir.github.io/tslint/rules/binary-expression-operand-order/): Allow if both sides of the binary expression are literals. (#2873)
+-   [bugfix] Restore compatibility with typescript@2.1 and 2.2 for [`whitespace`](https://palantir.github.io/tslint/rules/whitespace/), [`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/) and [`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) (#2893)
+-   [docs][`no-string-literal`](https://palantir.github.io/tslint/rules/no-string-literal/): Fix documentation (#2875)
 
-v5.4.1
----
+## v5.4.2
 
 ## :hammer_and_wrench: Bugfixes
 
-- [bugfix] Fixed regression in `--exclude` CLI option when using `--project` (#2852)
+-   [bugfix] Restored support for multiple `--exclude` options in the CLI (#2855)
+-   [bugfix] Restored support for `--version` CLI option (#2857)
 
-v5.4.0
----
+## v5.4.1
+
+## :hammer_and_wrench: Bugfixes
+
+-   [bugfix] Fixed regression in `--exclude` CLI option when using `--project` (#2852)
+
+## v5.4.0
 
 ## :star: Non-breaking API changes
 
-- `--type-check` only checks for errors before linting is no longer required to enable rules that use the type checker. You only need to supply `--project` now.
+-   `--type-check` only checks for errors before linting is no longer required to enable rules that use the type checker. You only need to supply `--project` now.
 
 ## :tada: New rules, options, and fixers
 
-- [new-rule] [`switch-final-break`](https://palantir.github.io/tslint/rules/switch-final-break/) (#2804)
-- [new-rule] [`use-default-type-parameter`](https://palantir.github.io/tslint/rules/use-default-type-parameter/) (#2253)
-- [new-rule] [`binary-expression-operand-order`](https://palantir.github.io/tslint/rules/binary-expression-operand-order/) (#2805)
-- [new-rule-option] [`ban`](https://palantir.github.io/tslint/rules/ban/) new options format: allows to specify an optional explanation message for function bans, banning nested methods and using a wildcard for object of a method ban (#2547)
-- [new-rule-option] [`no-duplicate-variable`](https://palantir.github.io/tslint/rules/no-duplicate-variable/) adds `check-parameters` option to check if variable has the same name as a parameter (#2597)
-- [new-rule-option] [`curly`](https://palantir.github.io/tslint/rules/curly/): "as-needed" option (#2842)
-- [new-rule-option] [`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/) add option `"ignore-static"` (#2751)
-- [new-rule-option] [`strict-boolean-expressions`](https://palantir.github.io/tslint/rules/strict-boolean-expressions/) adds `allow-boolean-or-undefined` (#2820)
-- [new-fixer] [`object-literal-shorthand`](https://palantir.github.io/tslint/rules/object-literal-shorthand/) can fix longhand methods (#2558)
+-   [new-rule][`switch-final-break`](https://palantir.github.io/tslint/rules/switch-final-break/) (#2804)
+-   [new-rule][`use-default-type-parameter`](https://palantir.github.io/tslint/rules/use-default-type-parameter/) (#2253)
+-   [new-rule][`binary-expression-operand-order`](https://palantir.github.io/tslint/rules/binary-expression-operand-order/) (#2805)
+-   [new-rule-option][`ban`](https://palantir.github.io/tslint/rules/ban/) new options format: allows to specify an optional explanation message for function bans, banning nested methods and using a wildcard for object of a method ban (#2547)
+-   [new-rule-option][`no-duplicate-variable`](https://palantir.github.io/tslint/rules/no-duplicate-variable/) adds `check-parameters` option to check if variable has the same name as a parameter (#2597)
+-   [new-rule-option][`curly`](https://palantir.github.io/tslint/rules/curly/): "as-needed" option (#2842)
+-   [new-rule-option][`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/) add option `"ignore-static"` (#2751)
+-   [new-rule-option][`strict-boolean-expressions`](https://palantir.github.io/tslint/rules/strict-boolean-expressions/) adds `allow-boolean-or-undefined` (#2820)
+-   [new-fixer][`object-literal-shorthand`](https://palantir.github.io/tslint/rules/object-literal-shorthand/) can fix longhand methods (#2558)
 
 ## :hammer_and_wrench: Bugfixes & enhancements
 
-- [bugfix] [`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) allows constructor, function and method calls and more as first argument to `Object.assign` (#2828)
-- [bugfix] [`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/) walker skips past the parent if it is a cast or parenthesized expression (#2838)
-- [bugfix] [`object-literal-shorthand`](https://palantir.github.io/tslint/rules/object-literal-shorthand/): fixed suggestion for generator functions (#2558)
-- [bugfix] Fixed issue with case sensitivity of [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) rule on Windows (#2819)
-- [bugfix] don't crash `tslint --project` if `allowJs` is set in tsconfig.json (#2823)
-- [bugfix] [`align`](https://palantir.github.io/tslint/rules/align/) with option `"members"`: check members of class expressions; don't check semicolons in classes (#2668)
-- [bugfix] [`no-inferred-empty-object-type`](https://palantir.github.io/tslint/rules/no-inferred-empty-object-type/): fix stack overflow (#2762)
-- [bugfix] [`semicolon`](https://palantir.github.io/tslint/rules/semicolon/): don't warn about unnecesary semicolon when it is actually needed, e.g. when followed by type assertion or template string (#2655)
-- [bugfix] [`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/): Ignore async arrow function with no parentheses (#2833)
-- [bugfix]: [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): Don't fail on `continue label;` (#2830)
-- [bugfix] [`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/): Allow unbound method to be used as a condition (#2834)
-- [bugfix] [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): Allow to switch on a value of type `any` (#2836)
-- [bugfix] [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): Don't mark `declare global {}` as an unsafe any. (#2839)
-- [bugfix] [`indent`](https://palantir.github.io/tslint/rules/indent/) now checks indentation of expressions inside template strings (#2826)
-- [enhancement] `--project` (or `-p`) enables rules that require the type checker. `--type-check` only checks for errors before linting is no longer required (#2773)
-- [enhancement] [`deprecation`](https://palantir.github.io/tslint/rules/deprecation/): error message includes deprecation text if available (#2748)
-- [enhancement] [`cyclomatic-complexity`](https://palantir.github.io/tslint/rules/cyclomatic-complexity/): Don't count empty switch case(#2743)
-- [enhancement] [`strict-boolean-expressions`](https://palantir.github.io/tslint/rules/strict-boolean-expressions/): Allow `any`, and `true` and `false` literal types (#2758)
-- [enhancement] [`no-floating-promises`](https://palantir.github.io/tslint/rules/no-floating-promises/): Allow 'promise.catch()' (#2774)
-- [enhancement] [`comment-format`](https://palantir.github.io/tslint/rules/comment-format/) no longer excludes comments with triple slash from linting except `/// <reference path="..."/>` (#2616)
-- [enhancement] [`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/): lint more locations where return value is used. (#2828)
-- [enhancement] [`semicolon`](https://palantir.github.io/tslint/rules/semicolon/): option `"never"` is now spec compliant (#2655)
-- [enhancement] [`object-literal-shorthand`](https://palantir.github.io/tslint/rules/object-literal-shorthand/) handles async functions correctly (#2558)
-- [enhancement] `--test` CLI option: allow passing path to tslint.json (#2784)
-- [enhancement] Use commander instead of optimist for CLI arguments (#2689)
-- [enhancement] [`strict-type-predicates`](https://palantir.github.io/tslint/rules/strict-type-predicates/): warn if strictNullChecks is not enabled (#2786)
+-   [bugfix][`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) allows constructor, function and method calls and more as first argument to `Object.assign` (#2828)
+-   [bugfix][`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/) walker skips past the parent if it is a cast or parenthesized expression (#2838)
+-   [bugfix][`object-literal-shorthand`](https://palantir.github.io/tslint/rules/object-literal-shorthand/): fixed suggestion for generator functions (#2558)
+-   [bugfix] Fixed issue with case sensitivity of [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) rule on Windows (#2819)
+-   [bugfix] don't crash `tslint --project` if `allowJs` is set in tsconfig.json (#2823)
+-   [bugfix][`align`](https://palantir.github.io/tslint/rules/align/) with option `"members"`: check members of class expressions; don't check semicolons in classes (#2668)
+-   [bugfix][`no-inferred-empty-object-type`](https://palantir.github.io/tslint/rules/no-inferred-empty-object-type/): fix stack overflow (#2762)
+-   [bugfix][`semicolon`](https://palantir.github.io/tslint/rules/semicolon/): don't warn about unnecesary semicolon when it is actually needed, e.g. when followed by type assertion or template string (#2655)
+-   [bugfix][`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/): Ignore async arrow function with no parentheses (#2833)
+-   [bugfix]: [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): Don't fail on `continue label;` (#2830)
+-   [bugfix][`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/): Allow unbound method to be used as a condition (#2834)
+-   [bugfix][`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): Allow to switch on a value of type `any` (#2836)
+-   [bugfix][`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): Don't mark `declare global {}` as an unsafe any. (#2839)
+-   [bugfix][`indent`](https://palantir.github.io/tslint/rules/indent/) now checks indentation of expressions inside template strings (#2826)
+-   [enhancement] `--project` (or `-p`) enables rules that require the type checker. `--type-check` only checks for errors before linting is no longer required (#2773)
+-   [enhancement][`deprecation`](https://palantir.github.io/tslint/rules/deprecation/): error message includes deprecation text if available (#2748)
+-   [enhancement][`cyclomatic-complexity`](https://palantir.github.io/tslint/rules/cyclomatic-complexity/): Don't count empty switch case(#2743)
+-   [enhancement][`strict-boolean-expressions`](https://palantir.github.io/tslint/rules/strict-boolean-expressions/): Allow `any`, and `true` and `false` literal types (#2758)
+-   [enhancement][`no-floating-promises`](https://palantir.github.io/tslint/rules/no-floating-promises/): Allow 'promise.catch()' (#2774)
+-   [enhancement][`comment-format`](https://palantir.github.io/tslint/rules/comment-format/) no longer excludes comments with triple slash from linting except `/// <reference path="..."/>` (#2616)
+-   [enhancement][`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/): lint more locations where return value is used. (#2828)
+-   [enhancement][`semicolon`](https://palantir.github.io/tslint/rules/semicolon/): option `"never"` is now spec compliant (#2655)
+-   [enhancement][`object-literal-shorthand`](https://palantir.github.io/tslint/rules/object-literal-shorthand/) handles async functions correctly (#2558)
+-   [enhancement] `--test` CLI option: allow passing path to tslint.json (#2784)
+-   [enhancement] Use commander instead of optimist for CLI arguments (#2689)
+-   [enhancement][`strict-type-predicates`](https://palantir.github.io/tslint/rules/strict-type-predicates/): warn if strictNullChecks is not enabled (#2786)
 
 Thanks to our contributors!
 
-- Klaus Meinhardt
-- Manuel Lopez
-- Andy Hanson
-- Piotr Tomiak
+-   Klaus Meinhardt
+-   Manuel Lopez
+-   Andy Hanson
+-   Piotr Tomiak
 
-v5.3.2
----
+## v5.3.2
 
-- [bugfix] Fixes `not a directory` error (#2813)
+-   [bugfix] Fixes `not a directory` error (#2813)
 
-v5.3.0
----
+## v5.3.0
 
 ## This change may require a change to tslint.json
 
-- [enhancement] [`prefer-switch`](https://palantir.github.io/tslint/rules/prefer-switch/): Change default `min-cases` to 3. (#2669)
+-   [enhancement][`prefer-switch`](https://palantir.github.io/tslint/rules/prefer-switch/): Change default `min-cases` to 3. (#2669)
 
 ## :tada: Features & enhancements
 
-- [new-cli-option] cli: Add `outputAbsolutePaths` option (#2667)
-- [new-rule] [`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) (#2624)
-- [new-rule] [`encoding`](https://palantir.github.io/tslint/rules/encoding/) (#2368)
-- [new-rule] [`prefer-conditional-expression`](https://palantir.github.io/tslint/rules/prefer-conditional-expression/) (#2363)
-- [new-rule-option] [`indent`](https://palantir.github.io/tslint/rules/indent/) support indent size (#2723)
-- [new-rule-option] [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/) adds `ignore-case` (#2592)
-- [new-rule-option] [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/): Add `avoid-template` option (#2766)
-- [new-rule-option] [`await-promise`](https://palantir.github.io/tslint/rules/await-promise): What's considered a "Promise" is now configurable. (#2661)
-- [new-fixer] [`indent`](https://palantir.github.io/tslint/rules/indent/) (#2723)
-- [new-fixer] [`typedef-whitespace`](https://palantir.github.io/tslint/rules/typedef-whitespace/) (#2718)
-- [enhancement] better error messages in [`variable-name`](https://palantir.github.io/tslint/rules/variable-name/) (#2672)
-- [enhancement] [`typedef`](https://palantir.github.io/tslint/rules/typedef/): Use name or parameters for error location (#2460)
-- [enhancement] [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): check shorthand properties (#2592)
-- [enhancement] [`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/): Handle `get`/`set` accessor (#2700)
-- [enhancement] [`typedef-whitespace`](https://palantir.github.io/tslint/rules/typedef-whitespace/) added checks for arrow function, call and construct signature (#2718)
-- [enhancement] [`no-object-literal-type-assertion`](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/): Allow cast to `any` (#2671)
-- [enhancement] cli: `-p` option handles directories (#2756)
-- [develop] testing rules with type information is enabled when a `tsconfig.json` is found next to `tslint.json` (#2769)
-- [configuration] deprecate mixed case tslint.json (#2713)
-- [bugfix] [`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/): Treat a return type `void | undefined` same as `void` (#2731)
-- [bugfix] [`no-unnecessary-initializer`](https://palantir.github.io/tslint/rules/no-unnecessary-initializer/): Handle `BindingElement` anywhere, not just in a `VariableDeclaration`. (#2707)
-- [bugfix] [`jsdoc-format`](https://palantir.github.io/tslint/rules/jsdoc-format/): correctly handle alignment in files with BOM (#2619)
-- [bugfix] [`jsdoc-format`](https://palantir.github.io/tslint/rules/jsdoc-format/): don't treat empty comments (`/**/`) as jsdoc (#2619)
-- [bugfix] [`typedef-whitespace`](https://palantir.github.io/tslint/rules/typedef-whitespace/) don't warn for leading whitespace if token is preceded by line break (#2718)
-- [bugfix] Make "completed-docs" rule respect "public" privacy (or lack thereof) (#2749)
-- [bugfix] [`jsdoc-format`](https://palantir.github.io/tslint/rules/jsdoc-format/): fixed error position if line ends with `\r\n` (#2619)
-- [bugfix] [`prefer-switch`](https://palantir.github.io/tslint/rules/prefer-switch/): add missing checks for some expressions (#2686)
-- [bugfix] [`prefer-template`](https://palantir.github.io/tslint/rules/prefer-template/): Allow `"a" + "b" + "c"`. (#2741)
-- [bugfix] [`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/): fix false positive with variable declared outside of for-of or for-in (#2760)
-- [bugfix] `--project`: fix file matching with relative path to `tsconfig.json` (#2688)
-- [bugfix] [`no-default-export`](https://palantir.github.io/tslint/rules/no-default-export/): correctly handle `export default abstract class {...}` (#2630)
-- [bugfix] [`no-mergeable-namespace`](https://palantir.github.io/tslint/rules/no-mergeable-namespace/): display correct line in error message (#2656)
-- [bugfix] [`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): handle object spread correctly (#2592)
-- [bugfix] Consistently output absolute/relative paths (#2667)
-- [bugfix] [`await-promise`](https://palantir.github.io/tslint/rules/await-promise): Consider types derived from a Promise in union types too. (#2661)
-- [bugfix] [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): Fix bug where number literal in type position was flagged as an unsafe `any`. (#2712)
-- [api] Deprecate `Lint.Utils.objectify` (#2764)
+-   [new-cli-option] cli: Add `outputAbsolutePaths` option (#2667)
+-   [new-rule][`prefer-object-spread`](https://palantir.github.io/tslint/rules/prefer-object-spread/) (#2624)
+-   [new-rule][`encoding`](https://palantir.github.io/tslint/rules/encoding/) (#2368)
+-   [new-rule][`prefer-conditional-expression`](https://palantir.github.io/tslint/rules/prefer-conditional-expression/) (#2363)
+-   [new-rule-option][`indent`](https://palantir.github.io/tslint/rules/indent/) support indent size (#2723)
+-   [new-rule-option][`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/) adds `ignore-case` (#2592)
+-   [new-rule-option][`quotemark`](https://palantir.github.io/tslint/rules/quotemark/): Add `avoid-template` option (#2766)
+-   [new-rule-option][`await-promise`](https://palantir.github.io/tslint/rules/await-promise): What's considered a "Promise" is now configurable. (#2661)
+-   [new-fixer][`indent`](https://palantir.github.io/tslint/rules/indent/) (#2723)
+-   [new-fixer][`typedef-whitespace`](https://palantir.github.io/tslint/rules/typedef-whitespace/) (#2718)
+-   [enhancement] better error messages in [`variable-name`](https://palantir.github.io/tslint/rules/variable-name/) (#2672)
+-   [enhancement][`typedef`](https://palantir.github.io/tslint/rules/typedef/): Use name or parameters for error location (#2460)
+-   [enhancement][`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): check shorthand properties (#2592)
+-   [enhancement][`space-before-function-paren`](https://palantir.github.io/tslint/rules/space-before-function-paren/): Handle `get`/`set` accessor (#2700)
+-   [enhancement][`typedef-whitespace`](https://palantir.github.io/tslint/rules/typedef-whitespace/) added checks for arrow function, call and construct signature (#2718)
+-   [enhancement][`no-object-literal-type-assertion`](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/): Allow cast to `any` (#2671)
+-   [enhancement] cli: `-p` option handles directories (#2756)
+-   [develop] testing rules with type information is enabled when a `tsconfig.json` is found next to `tslint.json` (#2769)
+-   [configuration] deprecate mixed case tslint.json (#2713)
+-   [bugfix][`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/): Treat a return type `void | undefined` same as `void` (#2731)
+-   [bugfix][`no-unnecessary-initializer`](https://palantir.github.io/tslint/rules/no-unnecessary-initializer/): Handle `BindingElement` anywhere, not just in a `VariableDeclaration`. (#2707)
+-   [bugfix][`jsdoc-format`](https://palantir.github.io/tslint/rules/jsdoc-format/): correctly handle alignment in files with BOM (#2619)
+-   [bugfix][`jsdoc-format`](https://palantir.github.io/tslint/rules/jsdoc-format/): don't treat empty comments (`/**/`) as jsdoc (#2619)
+-   [bugfix][`typedef-whitespace`](https://palantir.github.io/tslint/rules/typedef-whitespace/) don't warn for leading whitespace if token is preceded by line break (#2718)
+-   [bugfix] Make "completed-docs" rule respect "public" privacy (or lack thereof) (#2749)
+-   [bugfix][`jsdoc-format`](https://palantir.github.io/tslint/rules/jsdoc-format/): fixed error position if line ends with `\r\n` (#2619)
+-   [bugfix][`prefer-switch`](https://palantir.github.io/tslint/rules/prefer-switch/): add missing checks for some expressions (#2686)
+-   [bugfix][`prefer-template`](https://palantir.github.io/tslint/rules/prefer-template/): Allow `"a" + "b" + "c"`. (#2741)
+-   [bugfix][`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/): fix false positive with variable declared outside of for-of or for-in (#2760)
+-   [bugfix] `--project`: fix file matching with relative path to `tsconfig.json` (#2688)
+-   [bugfix][`no-default-export`](https://palantir.github.io/tslint/rules/no-default-export/): correctly handle `export default abstract class {...}` (#2630)
+-   [bugfix][`no-mergeable-namespace`](https://palantir.github.io/tslint/rules/no-mergeable-namespace/): display correct line in error message (#2656)
+-   [bugfix][`object-literal-sort-keys`](https://palantir.github.io/tslint/rules/object-literal-sort-keys/): handle object spread correctly (#2592)
+-   [bugfix] Consistently output absolute/relative paths (#2667)
+-   [bugfix][`await-promise`](https://palantir.github.io/tslint/rules/await-promise): Consider types derived from a Promise in union types too. (#2661)
+-   [bugfix][`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/): Fix bug where number literal in type position was flagged as an unsafe `any`. (#2712)
+-   [api] Deprecate `Lint.Utils.objectify` (#2764)
 
 Thanks to our contributors!
-- Andy Hanson
-- Klaus Meinhardt
-- Martin Probst
-- Filipe Silva
-- walkerburgin
-- René Scheibe
 
-v5.2.0
----
+-   Andy Hanson
+-   Klaus Meinhardt
+-   Martin Probst
+-   Filipe Silva
+-   walkerburgin
+-   René Scheibe
 
-- [rule-change] [`no-console`](https://palantir.github.io/tslint/rules/no-console/) bans all console methods when no methods are specified (#2610)
-- [new-rule] [`no-object-literal-type-assertion`](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/) (#2580)
-- [new-rule] [`no-irregular-whitespace`](https://palantir.github.io/tslint/rules/no-irregular-whitespace/) (#2487)
-- [new-rule] [`prefer-switch`](https://palantir.github.io/tslint/rules/prefer-switch/) (#2331)
-- [new-rule] [`number-literal-format`](https://palantir.github.io/tslint/rules/number-literal-format/) (#2526)
-- [new-rule] [`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) (#2395)
-- [new-rule] [`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) (#2519)
-- [new-fixer] [`interface-over-type-literal`](https://palantir.github.io/tslint/rules/interface-over-type-literal/) (#2617)
-- [new-fixer] [`callable-types`](https://palantir.github.io/tslint/rules/callable-types/) (#2552)
-- [new-fixer] [`no-string-literal`](https://palantir.github.io/tslint/rules/no-string-literal/) (#2495)
-- [new-fixer] [`no-internal-module`](https://palantir.github.io/tslint/rules/no-internal-module/) (#2517)
-- [new-rule-option] [`align`](https://palantir.github.io/tslint/rules/align/) rule added `members` option, which checks alignment of methods and properties of classes, objects, interfaces, type literals and object destructuring (#2387)
-- [new-rule-option] [`align`](https://palantir.github.io/tslint/rules/align/) rule added `elements` option, which checks alignment of elements in array literals, array destructuring and tuple types (#2387)
-- [new-rule-option] [`trailing-comma`](https://palantir.github.io/tslint/rules/trailing-comma/) adds more granular options to specify trailing commas for arrays, objects, functions, type literals, imports, and exports (#2538)
-- [api] Deprecate `ScopeAwareRuleWalker` and `BlockScopeAwareRuleWalker`. (#2561)
-- [develop] added support for [error templates in rule tests](https://palantir.github.io/tslint/develop/testing-rules/) (#2481)
-- [bugfix] Fixes "Severity for rule not found" error (#2516)
-- [bugfix] [`no-unused-expression`](https://palantir.github.io/tslint/rules/no-unused-expression/): allow `void(0)` in addition to `void 0` and `void` in expression and statement position (#2645)
-- [bugfix] [`align`](https://palantir.github.io/tslint/rules/align/): fix false positive for files with BOM (#2642)
-- [bugfix] [`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/): Handle contextual types with ambiguous signatures; allow `any`; and handle async functions. (#2576)
-- [bugfix] [`semicolon`](https://palantir.github.io/tslint/rules/semicolon/): don't mark semicolon as unnecessary when the next statement is on the same line (#2591)
-- [bugfix] [`no-internal-module`](https://palantir.github.io/tslint/rules/no-internal-module/): no more false positives for global augmentation (#2517)
-- [bugfix] [`no-unnecessary-qualifier`](https://palantir.github.io/tslint/rules/no-unnecessary-qualifier/): no longer breaks when walking a function that references `arguments` (#2555)
-- [bugfix] [`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/) no longer shows warnings on ambient declarations (#2391)
-- [bugfix] [`callable-types`](https://palantir.github.io/tslint/rules/callable-types/): suggest correct fix for interfaces with type arguments (#2552)
-- [bugfix] [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/): fix regression with jsx attributes (#2605)
-- [bugfix] [`adjacent-overload-signatures`](https://palantir.github.io/tslint/rules/adjacent-overload-signatures/) handles functions ending in semicolon (#2412)
-- [bugfix] [`object-literal-key-quotes`](https://palantir.github.io/tslint/rules/object-literal-key-quotes/): correctly stringify numbers when fixing (#2515)
-- [bugfix] [`object-literal-key-quotes`](https://palantir.github.io/tslint/rules/object-literal-key-quotes/): does no longer require quotes for property names containing digits (#2515)
-- [enhancement] Failures in extended config files now indicate which file (#2588)
-- [enhancement] [`align`](https://palantir.github.io/tslint/rules/align/): Don't report 'statements are not aligned' for empty statements (#2653)
-- [enhancement] [`class-name`](https://palantir.github.io/tslint/rules/class-name/) now also checks class expressions (#2553)
-- [enhancement] `optionExamples`: Allow to use an options array directly instead of a string representation. (#2527)
-- [enhancement] `rulesDirectory` can now be resolved with Nodes resolve logic, if the directory contains an `index.js` (#2163) (#2358)
-- [enhancement] [`no-unused-expression`](https://palantir.github.io/tslint/rules/no-unused-expression/): narrow error location for comma separated expressions and conditional expressions (#2645)
-- [enhancement] [`no-string-literal`](https://palantir.github.io/tslint/rules/no-string-literal/) now handles escaped strings (#2495)
-- [enhancement] [`no-unnecessary-callback-wrapper`](https://palantir.github.io/tslint/rules/no-unnecessary-callback-wrapper/): Allow `x => x(x)` (#2524)
-- [enhancement] [`no-var-keyword`](https://palantir.github.io/tslint/rules/no-var-keyword/): Allow global var declarations (#2513)
+## v5.2.0
 
-Thanks to our contributors!
-- Andy Hanson
-- Alex Eagle
-- Donald Pipowitch
-- Klaus Meinhardt
-- Gord P
-- Andy
-- Quentin
-- Mitchell Wills
-- Vito
-- CSchulz
-- Josh Goldberg
-- Brian Olore
-- Manuel Lopez
-- James Clark
-
-v5.1.0
----
-
-- [new-rule] `no-invalid-template-strings` (#2332)
-- [new-rule] `no-sparse-arrays` (#2407)
-- [new-rule-option] `no-void-expression`: adds `ignore-arrow-function-shorthand` (#2445)
-- [api] `tslint:all` configuration (#2417)
-- [bugfix] In tslint:recommended move `no-reference-import` from `jsRules` to `rules` (#2441)
-- [bugfix] `no-unnecessary-callback-wrapper`: only check if callback is identifier, allow all other expressions (#2510)
-- [bugfix] `member-access`: Skip index signature, it can not have an access modifier (#2437)
-- [bugfix] `restrict-plus-operands` fixes regression where every assignment and comparison was checked (#2454)
-- [bugfix] `no-unnecessary-callback-wrapper`: allow async wrapper function (#2510)
-- [bugfix] `prefer-for-of`: No error if `delete` is used (#2458)
-- [bugfix] `radix`: don't warn for missing radix on method calls (#2352)
-- [bugfix] `no-use-before-declare`: Handle symbol with empty declarations list. (#2436)
-- [bugfix] `strict-type-predicates`: Check for construct signatures in `isFunction`. (#2479)
-- [enhancement] `strict-boolean-expressions`: When `--strictNullChecks` is turned off, `allow-null-union` and `allow-undefined-union` turn off "always truthy" errors. (#2373)
-- [enhancement] `radix`: added check for global.parseInt and window.parseInt (#2352)
-- [enhancement] `arrow-return-shorthand`: Improve failure message when return expression is an object literal (#2466)
+-   [rule-change][`no-console`](https://palantir.github.io/tslint/rules/no-console/) bans all console methods when no methods are specified (#2610)
+-   [new-rule][`no-object-literal-type-assertion`](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/) (#2580)
+-   [new-rule][`no-irregular-whitespace`](https://palantir.github.io/tslint/rules/no-irregular-whitespace/) (#2487)
+-   [new-rule][`prefer-switch`](https://palantir.github.io/tslint/rules/prefer-switch/) (#2331)
+-   [new-rule][`number-literal-format`](https://palantir.github.io/tslint/rules/number-literal-format/) (#2526)
+-   [new-rule][`deprecation`](https://palantir.github.io/tslint/rules/deprecation/) (#2395)
+-   [new-rule][`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) (#2519)
+-   [new-fixer][`interface-over-type-literal`](https://palantir.github.io/tslint/rules/interface-over-type-literal/) (#2617)
+-   [new-fixer][`callable-types`](https://palantir.github.io/tslint/rules/callable-types/) (#2552)
+-   [new-fixer][`no-string-literal`](https://palantir.github.io/tslint/rules/no-string-literal/) (#2495)
+-   [new-fixer][`no-internal-module`](https://palantir.github.io/tslint/rules/no-internal-module/) (#2517)
+-   [new-rule-option][`align`](https://palantir.github.io/tslint/rules/align/) rule added `members` option, which checks alignment of methods and properties of classes, objects, interfaces, type literals and object destructuring (#2387)
+-   [new-rule-option][`align`](https://palantir.github.io/tslint/rules/align/) rule added `elements` option, which checks alignment of elements in array literals, array destructuring and tuple types (#2387)
+-   [new-rule-option][`trailing-comma`](https://palantir.github.io/tslint/rules/trailing-comma/) adds more granular options to specify trailing commas for arrays, objects, functions, type literals, imports, and exports (#2538)
+-   [api] Deprecate `ScopeAwareRuleWalker` and `BlockScopeAwareRuleWalker`. (#2561)
+-   [develop] added support for [error templates in rule tests](https://palantir.github.io/tslint/develop/testing-rules/) (#2481)
+-   [bugfix] Fixes "Severity for rule not found" error (#2516)
+-   [bugfix][`no-unused-expression`](https://palantir.github.io/tslint/rules/no-unused-expression/): allow `void(0)` in addition to `void 0` and `void` in expression and statement position (#2645)
+-   [bugfix][`align`](https://palantir.github.io/tslint/rules/align/): fix false positive for files with BOM (#2642)
+-   [bugfix][`return-undefined`](https://palantir.github.io/tslint/rules/return-undefined/): Handle contextual types with ambiguous signatures; allow `any`; and handle async functions. (#2576)
+-   [bugfix][`semicolon`](https://palantir.github.io/tslint/rules/semicolon/): don't mark semicolon as unnecessary when the next statement is on the same line (#2591)
+-   [bugfix][`no-internal-module`](https://palantir.github.io/tslint/rules/no-internal-module/): no more false positives for global augmentation (#2517)
+-   [bugfix][`no-unnecessary-qualifier`](https://palantir.github.io/tslint/rules/no-unnecessary-qualifier/): no longer breaks when walking a function that references `arguments` (#2555)
+-   [bugfix][`prefer-const`](https://palantir.github.io/tslint/rules/prefer-const/) no longer shows warnings on ambient declarations (#2391)
+-   [bugfix][`callable-types`](https://palantir.github.io/tslint/rules/callable-types/): suggest correct fix for interfaces with type arguments (#2552)
+-   [bugfix][`quotemark`](https://palantir.github.io/tslint/rules/quotemark/): fix regression with jsx attributes (#2605)
+-   [bugfix][`adjacent-overload-signatures`](https://palantir.github.io/tslint/rules/adjacent-overload-signatures/) handles functions ending in semicolon (#2412)
+-   [bugfix][`object-literal-key-quotes`](https://palantir.github.io/tslint/rules/object-literal-key-quotes/): correctly stringify numbers when fixing (#2515)
+-   [bugfix][`object-literal-key-quotes`](https://palantir.github.io/tslint/rules/object-literal-key-quotes/): does no longer require quotes for property names containing digits (#2515)
+-   [enhancement] Failures in extended config files now indicate which file (#2588)
+-   [enhancement][`align`](https://palantir.github.io/tslint/rules/align/): Don't report 'statements are not aligned' for empty statements (#2653)
+-   [enhancement][`class-name`](https://palantir.github.io/tslint/rules/class-name/) now also checks class expressions (#2553)
+-   [enhancement] `optionExamples`: Allow to use an options array directly instead of a string representation. (#2527)
+-   [enhancement] `rulesDirectory` can now be resolved with Nodes resolve logic, if the directory contains an `index.js` (#2163) (#2358)
+-   [enhancement][`no-unused-expression`](https://palantir.github.io/tslint/rules/no-unused-expression/): narrow error location for comma separated expressions and conditional expressions (#2645)
+-   [enhancement][`no-string-literal`](https://palantir.github.io/tslint/rules/no-string-literal/) now handles escaped strings (#2495)
+-   [enhancement][`no-unnecessary-callback-wrapper`](https://palantir.github.io/tslint/rules/no-unnecessary-callback-wrapper/): Allow `x => x(x)` (#2524)
+-   [enhancement][`no-var-keyword`](https://palantir.github.io/tslint/rules/no-var-keyword/): Allow global var declarations (#2513)
 
 Thanks to our contributors!
-- Andy Hanson
-- bumbleblym
-- Klaus Meinhardt
-- Jonas Kello
-- Minko Gechev
-- Donald Pipowitch
 
-v5.0.0
----
+-   Andy Hanson
+-   Alex Eagle
+-   Donald Pipowitch
+-   Klaus Meinhardt
+-   Gord P
+-   Andy
+-   Quentin
+-   Mitchell Wills
+-   Vito
+-   CSchulz
+-   Josh Goldberg
+-   Brian Olore
+-   Manuel Lopez
+-   James Clark
+
+## v5.1.0
+
+-   [new-rule] `no-invalid-template-strings` (#2332)
+-   [new-rule] `no-sparse-arrays` (#2407)
+-   [new-rule-option] `no-void-expression`: adds `ignore-arrow-function-shorthand` (#2445)
+-   [api] `tslint:all` configuration (#2417)
+-   [bugfix] In tslint:recommended move `no-reference-import` from `jsRules` to `rules` (#2441)
+-   [bugfix] `no-unnecessary-callback-wrapper`: only check if callback is identifier, allow all other expressions (#2510)
+-   [bugfix] `member-access`: Skip index signature, it can not have an access modifier (#2437)
+-   [bugfix] `restrict-plus-operands` fixes regression where every assignment and comparison was checked (#2454)
+-   [bugfix] `no-unnecessary-callback-wrapper`: allow async wrapper function (#2510)
+-   [bugfix] `prefer-for-of`: No error if `delete` is used (#2458)
+-   [bugfix] `radix`: don't warn for missing radix on method calls (#2352)
+-   [bugfix] `no-use-before-declare`: Handle symbol with empty declarations list. (#2436)
+-   [bugfix] `strict-type-predicates`: Check for construct signatures in `isFunction`. (#2479)
+-   [enhancement] `strict-boolean-expressions`: When `--strictNullChecks` is turned off, `allow-null-union` and `allow-undefined-union` turn off "always truthy" errors. (#2373)
+-   [enhancement] `radix`: added check for global.parseInt and window.parseInt (#2352)
+-   [enhancement] `arrow-return-shorthand`: Improve failure message when return expression is an object literal (#2466)
+
+Thanks to our contributors!
+
+-   Andy Hanson
+-   bumbleblym
+-   Klaus Meinhardt
+-   Jonas Kello
+-   Minko Gechev
+-   Donald Pipowitch
+
+## v5.0.0
 
 ## :fire: Breaking changes
 
-- Minimum version of TypeScript version is now 2.1.0 (#2425)
-- The severity level of rules are now configurable and defaults to severity "error". This affects the output of formatters:
-    - [formatter] `msbuild` was outputting all failures as "warning".
-    - [formatter] `pmd` was outputting all failures as priority 1. Now, it uses _priority 3_ for "error" (default) and _priority 4_ for "warning"
-- [formatter] `json` changed the `fix` property to now contain either one replacement or an array of replacements (#2403)
-- `tslint:recommended` configuration updated with `tslint:latest` rules & options (#2424)
-- Removed `no-unused-new` rule, with logic moved into `no-unused-expression` (#2269)
-- `no-trailing-whitespace` now checks template strings by default. Use the new options `ignore-template-strings` to restore the old behavior. (#2359)
+-   Minimum version of TypeScript version is now 2.1.0 (#2425)
+-   The severity level of rules are now configurable and defaults to severity "error". This affects the output of formatters:
+    -   [formatter] `msbuild` was outputting all failures as "warning".
+    -   [formatter] `pmd` was outputting all failures as priority 1. Now, it uses _priority 3_ for "error" (default) and _priority 4_ for "warning"
+-   [formatter] `json` changed the `fix` property to now contain either one replacement or an array of replacements (#2403)
+-   `tslint:recommended` configuration updated with `tslint:latest` rules & options (#2424)
+-   Removed `no-unused-new` rule, with logic moved into `no-unused-expression` (#2269)
+-   `no-trailing-whitespace` now checks template strings by default. Use the new options `ignore-template-strings` to restore the old behavior. (#2359)
 
 ### API breaks for custom rules
 
-- Removed method `skip` from `RuleWalker` (#2313)
-- Removed all use of the TypeScript Language Service, use only Program APIs instead (#2235)
+-   Removed method `skip` from `RuleWalker` (#2313)
+-   Removed all use of the TypeScript Language Service, use only Program APIs instead (#2235)
 
-    - This means that some rules that previously worked without the type checker _now require it_. This includes:
-        - `no-unused-variable`
-        - `no-use-before-declare`
+    -   This means that some rules that previously worked without the type checker _now require it_. This includes:
 
-    - This breaks custom rule compilation. If your rule was not using the `ts.LanguageService` APIs, the migration is quite simple:
+        -   `no-unused-variable`
+        -   `no-use-before-declare`
+
+    -   This breaks custom rule compilation. If your rule was not using the `ts.LanguageService` APIs, the migration is quite simple:
 
     ```diff
     - public applyWithProgram(srcFile: ts.SourceFile, langSvc: ts.LanguageService): Lint.RuleFailure[] {
@@ -738,18 +723,18 @@ v5.0.0
     +     return this.applyWithWalker(new Walker(srcFile, this.getOptions(), program));
     ```
 
-    - N.B. If you are refactoring your custom rules, consider [these performance tips for writing custom rules](https://palantir.github.io/tslint/develop/custom-rules/performance.html).
+    -   N.B. If you are refactoring your custom rules, consider [these performance tips for writing custom rules](https://palantir.github.io/tslint/develop/custom-rules/performance.html).
 
-- Removed `createFix`. Replacements should be passed directly into addFailure. (#2403)
-- Removed deprecated `scanAllTokens` and `skippableTokenAwareRuleWalker` (#2370)
+-   Removed `createFix`. Replacements should be passed directly into addFailure. (#2403)
+-   Removed deprecated `scanAllTokens` and `skippableTokenAwareRuleWalker` (#2370)
 
 ## :tada: Notable features & enhancements
 
-- [feature] The severity level of rules are now individually configurable. Default severity can also be configured.  (#629, #345)
+-   [feature] The severity level of rules are now individually configurable. Default severity can also be configured. (#629, #345)
 
-    - Valid values for `severity`: `default` | `error | warn | warning | none | off`
-    - Valid values for `defaultSeverity`: `error | warn | warning | none | off`
-    - Old style:
+    -   Valid values for `severity`: `default` | `error | warn | warning | none | off`
+    -   Valid values for `defaultSeverity`: `error | warn | warning | none | off`
+    -   Old style:
 
     ```json
     {
@@ -761,7 +746,7 @@ v5.0.0
     }
     ```
 
-    - New style (in this example, `callable-types` outputs errors and `max-line-length` outputs warnings):
+    -   New style (in this example, `callable-types` outputs errors and `max-line-length` outputs warnings):
 
     ```json
     {
@@ -777,1243 +762,1150 @@ v5.0.0
     }
     ```
 
-- [new-rule] `prefer-template` (#2243)
-- [new-rule] `return-undefined` (#2251)
-- [new-rule] `no-reference-import` (#2273)
-- [new-rule] `no-unnecessary-callback-wrapper` (#2249)
-- [new-fixer] `linebreak-style` (#2394)
-- [new-fixer] `eofline` (#2393)
-
+-   [new-rule] `prefer-template` (#2243)
+-   [new-rule] `return-undefined` (#2251)
+-   [new-rule] `no-reference-import` (#2273)
+-   [new-rule] `no-unnecessary-callback-wrapper` (#2249)
+-   [new-fixer] `linebreak-style` (#2394)
+-   [new-fixer] `eofline` (#2393)
 
 ## Full list of changes
 
-- [api] Added class `OptionallyTypedRule`, which allows rule authors to write a rule that applies when typing is either enabled or disabled (#2300)
-- [bugfix] `prefer-function-over-method` now ignores abstract methods (#2307)
-- [bugfix] `arrow-parens` with option `ban-single-arg-parens` now correctly handles functions with return type annotation (#2265)
-- [bugfix] `prefer-function-over-method` exclude overload signatures (#2315)
-- [bugfix] `use-isnan` now applies only to comparison operators (#2317)
-- [bugfix] `file-header-rule` now handles single-line comments correctly (#2320)
-- [bugfix] `newline-before-return`: fix handling of blank lines between comments (#2321)
-- [bugfix] `trailing-comma` No longer enforce trailing commas in type parameters and tuple types (#2236)
-- [bugfix] `align` don't fix if it would remove code (#2379)
-- [bugfix] `unified-signatures` now recognizes rest parameters (#2342)
-- [bugfix] `no-inferrable-types` don't warn for inferrable type on readonly property (#2312)
-- [bugfix] `trailing-comma` no longer crashes on new without parentheses (e.g. `new Foo`) (#2389)
-- [bugfix] `semicolon` Ignore comments when checking for unnecessary semicolon (#2240)
-- [bugfix] `semicolon` Don't report unnecessary semicolon when followed by regex literal (#2240)
-- [bugfix] CLI: exit with 0 on type check errors when `--force` is specified (#2322)
-- [bugfix] CLI: `--test` now correctly strips single quotes from patterns on windows (#2322)
-- [bugfix] `prefer-const` only fix initialized variables (#2219)
-- [bugfix] `prefer-const` correctly handle variables shadowed by parameters and catched exceptions (#2219)
-- [bugfix] `prefer-const` don't warn if one variable in a for loop initializer can not be const (#2219)
-- [bugfix] `prefer-const` handle more cases in destructuring (#2219)
-- [bugfix] `no-unused-expression` allow comma separated assignments (#2269)
-- [chore] removed update-notifier dependency (#2262)
-- [development] allow rule tests to specify version requirement for typescript (#2323)
-- [enhancement] `ignore-properties` option of `no-inferrable-types` now also ignores parameter properties (#2312)
-- [enhancement] `unified-signatures` now displays line number of the overload to unify if there are more than 2 overloads (#2270)
-- [enhancement] `trailing-comma` New checks for CallSignature and NamedExports (#2236)
-- [enhancement] `semicolon` New check for export statements, function overloads and shorthand module declaration (#2240)
-- [enhancement] `semicolon` Report unnecessary semicolons in classes and in statement position (for option "always" too) (#2240)
-- [enhancement] `semicolon` check for semicolon after method overload (#2240)
-- [enhancement] `array-type` now consider `object`, `undefined` and `never` as simple types, allowing `object`, `undefined[]` and `never[]` (#1843)(#2353)
-- [enhancement] `align` check statement alignment for all blocks (#2379)
-- [enhancement] `align`check parameter alignment for all signatures (#2379)
-- [enhancement] `--test` can handle multiple paths at once (#2322)
-- [enhancement] `only-arrow-functions` allow functions that use `this` in the body (#2229)
-- [enhancement] CLI: print error when `--type-check` is used without `--project` (#2322)
-- [enhancement] CLI: don't print stack trace on type check error (#2322)
-- [enhancement] CLI: added `-p` as shorthand for `--project` to be consistent with `tsc` (#2322)
-- [enhancement] `prefer-const` show warnings for `var` (#2219)
-- [enhancement] `quotemark` fixer unescapes original quotemark (e.g. `'\''` -> `"'"`) (#2359)
-- [enhancement] `no-unused-expression` allow indirect eval `(0, eval)("");` (#2269)
-- [enhancement] `no-unused-expression` checking for unused new can now use option `allow-fast-null-checks` (#2269)
-- [enhancement] `no-unused-expression` find unused comma separated expressions in all locations of the code (#2269)
-- [enhancement] `no-unused-expression` find unused expressions inside void expression (#2269)
-- [new-config-option] Adds `defaultSeverity` with options `error`, `warning`, and `off`. (#2416)
-- [new-formatter] TAP formatter (#2325)
-- [new-rule-option] `no-unused-expression` adds option `allow-tagged-template` to allow tagged templates for side effects (#2269)
-- [new-rule-option] `no-unused-expression` adds option `allow-new` to allow `new` without using the new object (#2269)
-- [new-rule-option] `member-access` adds `no-public` option (#2247)
-- [new-rule-option] `curly` added option `ignore-same-line` (#2334)
-- [new-rule-option] `{destructuring: "all"}` to only warn if all variables in a destructuring can be const (#2219)
-- [new-rule-option] added `ignore-template-strings` to `no-trailing-whitespace` (#2359)
-- [rule-update] `array-type` now consider `undefined` and `never` as simple types, allowing `undefined[]` and `never[]` (#1843)
+-   [api] Added class `OptionallyTypedRule`, which allows rule authors to write a rule that applies when typing is either enabled or disabled (#2300)
+-   [bugfix] `prefer-function-over-method` now ignores abstract methods (#2307)
+-   [bugfix] `arrow-parens` with option `ban-single-arg-parens` now correctly handles functions with return type annotation (#2265)
+-   [bugfix] `prefer-function-over-method` exclude overload signatures (#2315)
+-   [bugfix] `use-isnan` now applies only to comparison operators (#2317)
+-   [bugfix] `file-header-rule` now handles single-line comments correctly (#2320)
+-   [bugfix] `newline-before-return`: fix handling of blank lines between comments (#2321)
+-   [bugfix] `trailing-comma` No longer enforce trailing commas in type parameters and tuple types (#2236)
+-   [bugfix] `align` don't fix if it would remove code (#2379)
+-   [bugfix] `unified-signatures` now recognizes rest parameters (#2342)
+-   [bugfix] `no-inferrable-types` don't warn for inferrable type on readonly property (#2312)
+-   [bugfix] `trailing-comma` no longer crashes on new without parentheses (e.g. `new Foo`) (#2389)
+-   [bugfix] `semicolon` Ignore comments when checking for unnecessary semicolon (#2240)
+-   [bugfix] `semicolon` Don't report unnecessary semicolon when followed by regex literal (#2240)
+-   [bugfix] CLI: exit with 0 on type check errors when `--force` is specified (#2322)
+-   [bugfix] CLI: `--test` now correctly strips single quotes from patterns on windows (#2322)
+-   [bugfix] `prefer-const` only fix initialized variables (#2219)
+-   [bugfix] `prefer-const` correctly handle variables shadowed by parameters and catched exceptions (#2219)
+-   [bugfix] `prefer-const` don't warn if one variable in a for loop initializer can not be const (#2219)
+-   [bugfix] `prefer-const` handle more cases in destructuring (#2219)
+-   [bugfix] `no-unused-expression` allow comma separated assignments (#2269)
+-   [chore] removed update-notifier dependency (#2262)
+-   [development] allow rule tests to specify version requirement for typescript (#2323)
+-   [enhancement] `ignore-properties` option of `no-inferrable-types` now also ignores parameter properties (#2312)
+-   [enhancement] `unified-signatures` now displays line number of the overload to unify if there are more than 2 overloads (#2270)
+-   [enhancement] `trailing-comma` New checks for CallSignature and NamedExports (#2236)
+-   [enhancement] `semicolon` New check for export statements, function overloads and shorthand module declaration (#2240)
+-   [enhancement] `semicolon` Report unnecessary semicolons in classes and in statement position (for option "always" too) (#2240)
+-   [enhancement] `semicolon` check for semicolon after method overload (#2240)
+-   [enhancement] `array-type` now consider `object`, `undefined` and `never` as simple types, allowing `object`, `undefined[]` and `never[]` (#1843)(#2353)
+-   [enhancement] `align` check statement alignment for all blocks (#2379)
+-   [enhancement] `align`check parameter alignment for all signatures (#2379)
+-   [enhancement] `--test` can handle multiple paths at once (#2322)
+-   [enhancement] `only-arrow-functions` allow functions that use `this` in the body (#2229)
+-   [enhancement] CLI: print error when `--type-check` is used without `--project` (#2322)
+-   [enhancement] CLI: don't print stack trace on type check error (#2322)
+-   [enhancement] CLI: added `-p` as shorthand for `--project` to be consistent with `tsc` (#2322)
+-   [enhancement] `prefer-const` show warnings for `var` (#2219)
+-   [enhancement] `quotemark` fixer unescapes original quotemark (e.g. `'\''` -> `"'"`) (#2359)
+-   [enhancement] `no-unused-expression` allow indirect eval `(0, eval)("");` (#2269)
+-   [enhancement] `no-unused-expression` checking for unused new can now use option `allow-fast-null-checks` (#2269)
+-   [enhancement] `no-unused-expression` find unused comma separated expressions in all locations of the code (#2269)
+-   [enhancement] `no-unused-expression` find unused expressions inside void expression (#2269)
+-   [new-config-option] Adds `defaultSeverity` with options `error`, `warning`, and `off`. (#2416)
+-   [new-formatter] TAP formatter (#2325)
+-   [new-rule-option] `no-unused-expression` adds option `allow-tagged-template` to allow tagged templates for side effects (#2269)
+-   [new-rule-option] `no-unused-expression` adds option `allow-new` to allow `new` without using the new object (#2269)
+-   [new-rule-option] `member-access` adds `no-public` option (#2247)
+-   [new-rule-option] `curly` added option `ignore-same-line` (#2334)
+-   [new-rule-option] `{destructuring: "all"}` to only warn if all variables in a destructuring can be const (#2219)
+-   [new-rule-option] added `ignore-template-strings` to `no-trailing-whitespace` (#2359)
+-   [rule-update] `array-type` now consider `undefined` and `never` as simple types, allowing `undefined[]` and `never[]` (#1843)
 
 Thanks to our contributors!
 
-- Brian Olore
-- Andy Hanson
-- @andy-ms
-- Chris Barr
-- Klaus Meinhardt
-- @bumbleblym
-- Josh Goldberg
-- James Clark
-- @vilic
-- Aleksandr Filatov
-- Matt Banz
-- Karol Janyst
-- Mike Deverell
-- Alexander James Phillips
-- Irfan Hudda
+-   Brian Olore
+-   Andy Hanson
+-   @andy-ms
+-   Chris Barr
+-   Klaus Meinhardt
+-   @bumbleblym
+-   Josh Goldberg
+-   James Clark
+-   @vilic
+-   Aleksandr Filatov
+-   Matt Banz
+-   Karol Janyst
+-   Mike Deverell
+-   Alexander James Phillips
+-   Irfan Hudda
 
-v4.5.1
----
+## v4.5.1
 
-- [enhancement] Updated recommended rules to include `ban-types` and `no-duplicate-super` (#2271)
-- [bugfix] `object-literal-key-quotes` handle negative number property name (#2273)
+-   [enhancement] Updated recommended rules to include `ban-types` and `no-duplicate-super` (#2271)
+-   [bugfix] `object-literal-key-quotes` handle negative number property name (#2273)
 
-v4.5.0
----
+## v4.5.0
 
-- [new-rule] `no-import-side-effect` (#2155)
-- [new-rule] `match-default-export-name` (#2117)
-- [new-rule] `no-non-null-assertion` (#2221)
-- [new-rule] `ban-types` (#2175)
-- [new-rule] `no-duplicate-super` (#2038)
-- [new-rule] `newline-before-return` (#2173)
-- [new-rule-option] `completed-docs` adds options for location, type, and privacy. Also adds interfaces, enums, types (#2095)
-- [new-rule-option] `no-inferrable-types` adds option  `ignore-properties` (#2178)
-- [new-rule-option] `typedef` adds options `object-destructuring` and `array-destructuring` options (#2146)
-- [new-rule-option] `member-ordering` adds option `alphabetize` (#2101)
-- [new-rule-option] `no-trailing-whitespace` adds option `ignore-jsdoc` (#2177)
-- [new-rule-option] `no-trailing-whitespace` adds option `ignore-comments` option (#2153)
-- [new-fixer] `no-inferrable-types` automatically remove inferrable type annotations (#2178)
-- [new-fixer] `no-any` (#2165)
-- [new-fixer] `noConsecutiveBlankLines` (#2201)
-- [new-fixer] `object-literal-shorthand` (#2165)
-- [bugfix] `no-switch-case-fallthrough` handle break, throw, continue and return nested in block, if-else and switch (#2218)
-- [bugfix] `no-switch-case-fallthrough` allow empty case clauses before default clause (#2218)
-- [bugfix] `no-mergeable-namespace` ignore property types that can't be merged (#2105)
-- [bugfix] `object-literal-key-quotes` no need to quote a float if its .toString() is the same. (#2144)
-- [bugfix] `no-consecutive-blank-lines` Correctly apply fixes at EOF (#2239)
-- [bugfix]: Fixes installation issue with node 7.5 (#2212)
-- [bugfix]: `quotemark` now handles escaped chars (#2224)
-- [enhancement] Don't exit when a rule requires type checking but type checking is not enabled (#2188)
-- [enhancement] `no-switch-case-fallthrough` allow single line comment `// falls through` (#2218)
-- [enhancement] `no-unbound-method` allows property access and binary expressions (#2143)
-- [api] Introduce `AbstractWalker` for performance (#2093)
-    - see [performance] (https://palantir.github.io/tslint/develop/custom-rules/performance.html) and [migration] (https://palantir.github.io/tslint/develop/custom-rules/migration.html) docs
+-   [new-rule] `no-import-side-effect` (#2155)
+-   [new-rule] `match-default-export-name` (#2117)
+-   [new-rule] `no-non-null-assertion` (#2221)
+-   [new-rule] `ban-types` (#2175)
+-   [new-rule] `no-duplicate-super` (#2038)
+-   [new-rule] `newline-before-return` (#2173)
+-   [new-rule-option] `completed-docs` adds options for location, type, and privacy. Also adds interfaces, enums, types (#2095)
+-   [new-rule-option] `no-inferrable-types` adds option `ignore-properties` (#2178)
+-   [new-rule-option] `typedef` adds options `object-destructuring` and `array-destructuring` options (#2146)
+-   [new-rule-option] `member-ordering` adds option `alphabetize` (#2101)
+-   [new-rule-option] `no-trailing-whitespace` adds option `ignore-jsdoc` (#2177)
+-   [new-rule-option] `no-trailing-whitespace` adds option `ignore-comments` option (#2153)
+-   [new-fixer] `no-inferrable-types` automatically remove inferrable type annotations (#2178)
+-   [new-fixer] `no-any` (#2165)
+-   [new-fixer] `noConsecutiveBlankLines` (#2201)
+-   [new-fixer] `object-literal-shorthand` (#2165)
+-   [bugfix] `no-switch-case-fallthrough` handle break, throw, continue and return nested in block, if-else and switch (#2218)
+-   [bugfix] `no-switch-case-fallthrough` allow empty case clauses before default clause (#2218)
+-   [bugfix] `no-mergeable-namespace` ignore property types that can't be merged (#2105)
+-   [bugfix] `object-literal-key-quotes` no need to quote a float if its .toString() is the same. (#2144)
+-   [bugfix] `no-consecutive-blank-lines` Correctly apply fixes at EOF (#2239)
+-   [bugfix]: Fixes installation issue with node 7.5 (#2212)
+-   [bugfix]: `quotemark` now handles escaped chars (#2224)
+-   [enhancement] Don't exit when a rule requires type checking but type checking is not enabled (#2188)
+-   [enhancement] `no-switch-case-fallthrough` allow single line comment `// falls through` (#2218)
+-   [enhancement] `no-unbound-method` allows property access and binary expressions (#2143)
+-   [api] Introduce `AbstractWalker` for performance (#2093)
+    -   see [performance](https://palantir.github.io/tslint/develop/custom-rules/performance.html) and [migration](https://palantir.github.io/tslint/develop/custom-rules/migration.html) docs
 
 Thanks to our contributors!
 
-- Andy Hanson
-- Stefan Reichel
-- Shlomi Assaf
-- Josh Goldberg
-- Minko Gechev
-- Irfan Hudda
-- Klaus Meinhardt
-- Martin Probst
-- Naoto Usuyama
-- Caleb Eggensperger
-- Arturs Vonda
-- Joscha Feth
-- Moritz
-- Alexander Rusakov
-- Alex Ryan
-- Andy
-- Yuichi Nukiyama
+-   Andy Hanson
+-   Stefan Reichel
+-   Shlomi Assaf
+-   Josh Goldberg
+-   Minko Gechev
+-   Irfan Hudda
+-   Klaus Meinhardt
+-   Martin Probst
+-   Naoto Usuyama
+-   Caleb Eggensperger
+-   Arturs Vonda
+-   Joscha Feth
+-   Moritz
+-   Alexander Rusakov
+-   Alex Ryan
+-   Andy
+-   Yuichi Nukiyama
 
-v4.4.2
----
+## v4.4.2
 
-* [bugfix] `whitespace` rule caused false positive on EOF (#2131)
-* [bugfix] WebStorm fails because `json` formatter parameter has extra space (#2132)
+-   [bugfix] `whitespace` rule caused false positive on EOF (#2131)
+-   [bugfix] WebStorm fails because `json` formatter parameter has extra space (#2132)
 
-v4.4.1
----
+## v4.4.1
 
-* [bugfix] errant space in recommended ruleset (couldn't find `no-misused-new`)
+-   [bugfix] errant space in recommended ruleset (couldn't find `no-misused-new`)
 
-v4.4.0
----
+## v4.4.0
 
-* [new-rule] `arrow-return-shorthand` (#1972)
-* [new-rule] `no-unbound-method` (#2089)
-* [new-rule] `no-boolean-literal-compare` (#2013)
-* [new-rule] `no-unsafe-any` (#2047)
-* [new-rule] `no-unnecessary-qualifier` (#2008)
-* [new-rule] `no-unnecessary-initializer` (#2106)
-* [new-rule] `await-promise` (#2102)
-* [new-rule] `no-floating-promises` (#1632)
-* [new-rule] `strict-type-predicates` (#2046)
-* [new-rule] `no-misused-new` (#1963)
-* [new-rule] `prefer-method-signature` (#2028)
-* [new-rule] `prefer-function-over-method` (#2037)
-* [new-rule-option] `allow-fast-null-checks` added to `no-unused-expression` (#1638)
-* [new-rule-option] `comment-format-rule` adds `ignore-words` and `ignore-pattern` options (#1757)
-* [new-rule-option] `whitespace` adds `check-preblock` option (#2002)
-* [new-rule-option] `strict-boolean-expressions` adds `allow-null-union`, `allow-undefined-union`, `allow-string`, and `allow-number` and  (#2033)
-* [new-fixer] `align` (#2097)
-* [new-fixer] `no-trailing-whitespace` (#2060)
-* [bugfix] `no-magic-numbers` false positive on default parameter values (#2004)
-* [bugfix] `no-empty-interface` allow empty interface with 2 or more parents (#2070)
-* [bugfix] `no-trailing-whitespace` fixed for comments and EOF (#2060)
-* [bugfix] `no-empty` no longer fails for private or protected constructor (#1976)
-* [bugfix] `tslint:disable`/`tslint-enable` now handles multiple rules and fixes what code is enabled/disabled (#2061)
-* [bugfix] `no-inferrable-types` now validates property declarations (#2081)
-* [bugfix] `unified-signatures` false positive (#2016)
-* [bugfix] `whitespace` finds all whitespace errors in JsxExpressions and TemplateExpressions (#2036)
-* [bugfix] `comment-format` no more false positives in JsxText (#2036)
-* [enhancement] `--test` option now accepts glob (#2079)
+-   [new-rule] `arrow-return-shorthand` (#1972)
+-   [new-rule] `no-unbound-method` (#2089)
+-   [new-rule] `no-boolean-literal-compare` (#2013)
+-   [new-rule] `no-unsafe-any` (#2047)
+-   [new-rule] `no-unnecessary-qualifier` (#2008)
+-   [new-rule] `no-unnecessary-initializer` (#2106)
+-   [new-rule] `await-promise` (#2102)
+-   [new-rule] `no-floating-promises` (#1632)
+-   [new-rule] `strict-type-predicates` (#2046)
+-   [new-rule] `no-misused-new` (#1963)
+-   [new-rule] `prefer-method-signature` (#2028)
+-   [new-rule] `prefer-function-over-method` (#2037)
+-   [new-rule-option] `allow-fast-null-checks` added to `no-unused-expression` (#1638)
+-   [new-rule-option] `comment-format-rule` adds `ignore-words` and `ignore-pattern` options (#1757)
+-   [new-rule-option] `whitespace` adds `check-preblock` option (#2002)
+-   [new-rule-option] `strict-boolean-expressions` adds `allow-null-union`, `allow-undefined-union`, `allow-string`, and `allow-number` and (#2033)
+-   [new-fixer] `align` (#2097)
+-   [new-fixer] `no-trailing-whitespace` (#2060)
+-   [bugfix] `no-magic-numbers` false positive on default parameter values (#2004)
+-   [bugfix] `no-empty-interface` allow empty interface with 2 or more parents (#2070)
+-   [bugfix] `no-trailing-whitespace` fixed for comments and EOF (#2060)
+-   [bugfix] `no-empty` no longer fails for private or protected constructor (#1976)
+-   [bugfix] `tslint:disable`/`tslint-enable` now handles multiple rules and fixes what code is enabled/disabled (#2061)
+-   [bugfix] `no-inferrable-types` now validates property declarations (#2081)
+-   [bugfix] `unified-signatures` false positive (#2016)
+-   [bugfix] `whitespace` finds all whitespace errors in JsxExpressions and TemplateExpressions (#2036)
+-   [bugfix] `comment-format` no more false positives in JsxText (#2036)
+-   [enhancement] `--test` option now accepts glob (#2079)
 
 Thanks to our contributors!
 
-* Alexander Rusakov
-* Andrii Dieiev
-* @andy-ms
-* Andy Hanson
-* Josh Goldberg
-* Kei Son
-* Klaus Meinhardt
-* Krati Ahuja
-* Martin Probst
-* Mohsen Azimi
-* Romke van der Meulen
-* cameron-mcateer
+-   Alexander Rusakov
+-   Andrii Dieiev
+-   @andy-ms
+-   Andy Hanson
+-   Josh Goldberg
+-   Kei Son
+-   Klaus Meinhardt
+-   Krati Ahuja
+-   Martin Probst
+-   Mohsen Azimi
+-   Romke van der Meulen
+-   cameron-mcateer
 
-v4.3.1
----
+## v4.3.1
 
-* [bugfix] Fix back-compat break. Allow formattersDirectory === null (#1997)
+-   [bugfix] Fix back-compat break. Allow formattersDirectory === null (#1997)
 
-v4.3.0
----
+## v4.3.0
 
-* **Enabled additional rules in `tslint:latest` configuration** (#1981)
-* [new-rule] `space-before-function-paren` (#1897)
-* [new-rule] `typeof-compare` (#1927)
-* [new-rule] `import-spacing` (#1935)
-* [new-rule] `unified-signatures` (#1944)
-* [new-fixer] `object-literal-key-quotes` (#1953)
-* [new-fixer] `no-angle-bracket-type-assertion` (#1979)
-* [bugfix] `adjacent-overload-signature` now handles static/computed function names (#1831)
-* [bugfix] `file-header` now handles files with only comments (#1913)
-* [bugfix] `no-consecutive-blank-lines` now allows blank lines in template strings (#1886)
-* [bugfix] `object-literal-key-quotes` no longer throws exception when using rest operator (#1916)
-* [bugfix] `restrict-plus-operands` no longer shows false positive in ternary operation (#1925)
-* [bugfix] `prefer-for-of` now handles nested `for` loops with reused iterator (#1926)
-* [bugfix] Exit gracefully when `tsconfig.json` passed as `--project` argument doens't have files (#1933)
-* [bugfix] `object-literal-key-quotes` now handles shorthand and spread properties (#1945)
-* [bugfix] `arrow-parens` Allow binding patterns `([x, y]) => ...` and `({x, y}) => ...` to have parens (#1958)
-* [bugfix] `semicolon` fixer now handles comma separator in interfaces and indicates failure when commas are using in interfaces (#1856)
-* [bugfix] `only-arrow-functions` option `allow-named-functions` now allows function declarations (#1961)
-* [bugfix] `prefer-for-of` no longer shows false positive when array is in parentheses (#1986)
-* [bugfix] `prefer-const` now works for TypeScript versions < 2.1.0 (#1989)
-* [enhancement] `member-access` narrow location of error (#1964)
+-   **Enabled additional rules in `tslint:latest` configuration** (#1981)
+-   [new-rule] `space-before-function-paren` (#1897)
+-   [new-rule] `typeof-compare` (#1927)
+-   [new-rule] `import-spacing` (#1935)
+-   [new-rule] `unified-signatures` (#1944)
+-   [new-fixer] `object-literal-key-quotes` (#1953)
+-   [new-fixer] `no-angle-bracket-type-assertion` (#1979)
+-   [bugfix] `adjacent-overload-signature` now handles static/computed function names (#1831)
+-   [bugfix] `file-header` now handles files with only comments (#1913)
+-   [bugfix] `no-consecutive-blank-lines` now allows blank lines in template strings (#1886)
+-   [bugfix] `object-literal-key-quotes` no longer throws exception when using rest operator (#1916)
+-   [bugfix] `restrict-plus-operands` no longer shows false positive in ternary operation (#1925)
+-   [bugfix] `prefer-for-of` now handles nested `for` loops with reused iterator (#1926)
+-   [bugfix] Exit gracefully when `tsconfig.json` passed as `--project` argument doens't have files (#1933)
+-   [bugfix] `object-literal-key-quotes` now handles shorthand and spread properties (#1945)
+-   [bugfix] `arrow-parens` Allow binding patterns `([x, y]) => ...` and `({x, y}) => ...` to have parens (#1958)
+-   [bugfix] `semicolon` fixer now handles comma separator in interfaces and indicates failure when commas are using in interfaces (#1856)
+-   [bugfix] `only-arrow-functions` option `allow-named-functions` now allows function declarations (#1961)
+-   [bugfix] `prefer-for-of` no longer shows false positive when array is in parentheses (#1986)
+-   [bugfix] `prefer-const` now works for TypeScript versions < 2.1.0 (#1989)
+-   [enhancement] `member-access` narrow location of error (#1964)
 
 Thanks to our contributors!
 
-* Andrii Dieiev
-* @andy-ms
-* Andy Hanson
-* Josh Goldberg
-* Klaus Meinhardt
-* Linda_pp
-* Mohsen Azimi
-* Victor Grigoriu
-* Yuichi Nukiyama
-* cameron-mcateer
+-   Andrii Dieiev
+-   @andy-ms
+-   Andy Hanson
+-   Josh Goldberg
+-   Klaus Meinhardt
+-   Linda_pp
+-   Mohsen Azimi
+-   Victor Grigoriu
+-   Yuichi Nukiyama
+-   cameron-mcateer
 
-v4.2.0
----
+## v4.2.0
 
-* [new-rule] `no-string-throw` (#1878)
-* [new-rule] `no-empty-interface` (#1889)
-* [new-rule] `interface-over-type-literal` (#1890)
-* [new-rule] `callable-types` (#1891)
-* [new-rule] `no-void-expression` (#1903)
-* [new-rule-option] `ban-single-arg-parens` added to `arrow-parens` (#1893)
-* [bugfix] `prefer-const` handles destructuring arrays (#1894), destructuring objects (#1906), and forward references (#1908)
-* [bugfix] Don't error for misplaced braces for 'else' in `one-line` rule (#1866)
-* [bugfix] `no-shadowed-variable` now identifies shadowed `for` iterator (#1816)
-* [bugfix] `object-literal-key-quotes` now includes function names (#1874)
-* [bugfix] error when EOF comes after `disable-next-line` comment (#1902)
-
-Thanks to our contributors!
-
-* Andrew Scott
-* @andy-ms
-* Andy Hanson
-* James Booth
-* Klaus Meinhardt
-* Vladimir Matveev
-
-v4.1.1
----
-
-* [bugfix] `typedef` rule was showing false positive for `catch` clause (#1887)
-
-v4.1.0
----
-
-* [new-rule] `prefer-const` (#1801)
-* [new-rule] `strict-boolean-expressions` (#1820)
-* [new-rule] `no-magic-numbers` (#1799)
-* [new-rule] `import-blacklist` (#1841)
-* [new-rule] `promise-functions-async` (#1779)
-* [new-rule] `no-inferred-empty-object-type`: a type must be specified when using a generic class/function/etc (#1821)
-* [new-rule-option] `allow-named-functions` added to `only-arrow-functions` (#1857)
-* [new-fixer] `prefer-const` (#1801)
-* [new-fixer] `quotemark` (#1790)
-* [new-formatter] `code-frame` formatter shows you the error in context (#1819)
-* [enhancement] `no-internal-module` failures highlight less text (#1781)
-* [enhancement] Avoid auto-fixing errors that would result in compilation errors for rules that use type-check (#1608)
-* [rule-change] `only-arrow-functions` will allow functions with a `this` parameter (#1597)
-* [bugfix] `no-use-before-declare` false positive on named import (#1620)
-* [bugfix] `prefer-for-of` was showing false positive when the element is assigned (#1813)
-* [bugfix] The command line argument `type-check` was swallowing the next argument (#1783)
-* [bugfix] `tslint:disable-line` was re-enabling `tslint:disable` (#1634)
-* [bugfix] `adjacent-overload-signatures` did not work for constructors (#1800)
-* [bugfix] `checkstyle` formatter was reporting errors under one file (#1811)
-* [bugfix] `trailing-comma` was applied to parameter lists (#1775)
-* [api] CLI logic moved into API friendly class (#1688)
+-   [new-rule] `no-string-throw` (#1878)
+-   [new-rule] `no-empty-interface` (#1889)
+-   [new-rule] `interface-over-type-literal` (#1890)
+-   [new-rule] `callable-types` (#1891)
+-   [new-rule] `no-void-expression` (#1903)
+-   [new-rule-option] `ban-single-arg-parens` added to `arrow-parens` (#1893)
+-   [bugfix] `prefer-const` handles destructuring arrays (#1894), destructuring objects (#1906), and forward references (#1908)
+-   [bugfix] Don't error for misplaced braces for 'else' in `one-line` rule (#1866)
+-   [bugfix] `no-shadowed-variable` now identifies shadowed `for` iterator (#1816)
+-   [bugfix] `object-literal-key-quotes` now includes function names (#1874)
+-   [bugfix] error when EOF comes after `disable-next-line` comment (#1902)
 
 Thanks to our contributors!
 
-* Alex Eagle
-* Andrii Dieiev
-* Andy Hanson
-* Art Chaidarun
-* Donald Pipowitch
-* Feisal Ahmad
-* Josh Goldberg
-* Klaus Meinhardt
-* Maciej Sypień
-* Mohsen Azimi
-* Ryan Lester
-* Simon Schick
-* Subhash Sharma
-* Timothy Slatcher
-* Yaroslav Admin
-* Yuichi Nukiyama
-* tdsmithATabc
-* @wmrowan
+-   Andrew Scott
+-   @andy-ms
+-   Andy Hanson
+-   James Booth
+-   Klaus Meinhardt
+-   Vladimir Matveev
 
-v4.0.2
----
+## v4.1.1
 
-* [enhancement] Don't exit when a rule can't be found. Print as a warning instead (#1771)
-* [api-change] Allow 3rd party apps to see exception when the config is invalid (#1764)
-* [bugfix] Don't flag a property named as empty string as not needing quotes in an object literal (#1762)
-* [bugfix] Report correct number of fixes done by --fix (#1767)
-* [bugfix] Fix false positives and exceptions in `prefer-for-of` (#1758)
-* [bugfix] Fix `adjacent-overload-signatures` false positive when a static function has the same name (#1772)
+-   [bugfix] `typedef` rule was showing false positive for `catch` clause (#1887)
 
-Thanks to our contributors!
-* @gustavderdrache
+## v4.1.0
 
-v4.0.1
----
-
-* [bugfix] Removed `no-unused-variable` rule from recommended config, as it was causing spurious deprecation warnings.
-
-v4.0.0-dev.2
----
-
-* Include latest v4.0.0 changes
-
-v4.0.0
----
-
-* **BREAKING CHANGES**
-    * [api-change] Minor changes to the library API. See this PR for changes and upgrade instructions (#1720)
-    * [removed-rule] Removed `no-unreachable` rule; covered by compiler (#661)
-    * [enhancement] Changed order of applied configuration files for the `extends` array to make it more intuitive. (#1503)
-    * [enhancement] Changed TypeScript peer dependency to >= 2.0.0 (#1710)
-* [new-rule] `completed-docs` rule added (#1644)
-* [new-fixer] `ordered-imports` auto fixed (#1640)
-* [new-fixer] `arrow-parens` auto fixed (#1731)
-* [rule-change] `indent` rule now ignores template strings (#1611)
-* [new-rule-option] `object-literal-key-quotes` adds the options `consistent` and `consistent-as-needed` (#1733)
-* [enhancement] `--fix` option added to automatically fix selected rules (#1697)
-* [enhancement] Updated recommend rules (#1717)
-* [enhancement] `adjacent-overload-signatures` now works with classes, source files, modules, and namespaces (#1707)
-* [enhancement] Users are notified if they are using an old TSLint version (#1696)
-* [bugfix] Lint `.jsx` files if `jsRules` are configured (#1714)
-* [bugfix] Command line glob patterns now handle single quotes (#1679)
-
-Thanks to our contributors!
-* Andrii Dieiev
-* Andy
-* Chris Barr
-* Davie Schoots
-* Jordan Hawker
-* Josh Goldberg
-* Stepan Riha
-* Yuichi Nukiyama
-
-v4.0.0-dev.1
----
-
-* **BREAKING CHANGES**
-    * [enhancement] The `semicolon` rule now disallows semicolons in multi-line bound class methods
-         (to get the v3 behavior, use the `ignore-bound-class-methods` option) (#1643)
-    * [removed-rule] Removed `use-strict` rule (#678)
-    * [removed-rule] Removed `label-undefined` rule; covered by compiler (#1614)
-    * [enhancement] Renamed `no-constructor-vars` to `no-parameter-properties` (#1296)
-    * [rule-change] The `orderedImports` rule now sorts relative modules below non-relative modules (#1640)
-* **Deprecated**
-    * [deprecated] `no-unused-variable` rule. This is checked by the TypeScript v2 compiler using the flags [`--noUnusedParameters` and `--noUnusedLocals`](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#flag-unused-declarations-with---nounusedparameters-and---nounusedlocals). (#1481)
-* [enhancement] Lint .js files (#1515)
-* [new-fixer] `no-var-keyword` replaces `var` with `let` (#1547)
-* [new-fixer] `trailing-comma` auto fixed (#1546)
-* [new-fixer] `no-unused-variable` auto fixed for imports (#1568)
-* [new-fixer] `semicolon` auto fixed (#1423)
-* [new-rule] `max-classes-per-file` rule added (#1666)
-* [new-rule-option] `no-consecutive-blank-lines` rule now accepts a number value indicating max blank lines (#1650)
-* [new-rule-option] `ordered-imports` rule option `import-sources-order` accepts value `any` (#1602)
-* [bugfix] `no-empty` rule fixed when parameter has readonly modifier
-* [bugfix] `no-namespace` rule: do not flag nested or .d.ts namespaces (#1571)
+-   [new-rule] `prefer-const` (#1801)
+-   [new-rule] `strict-boolean-expressions` (#1820)
+-   [new-rule] `no-magic-numbers` (#1799)
+-   [new-rule] `import-blacklist` (#1841)
+-   [new-rule] `promise-functions-async` (#1779)
+-   [new-rule] `no-inferred-empty-object-type`: a type must be specified when using a generic class/function/etc (#1821)
+-   [new-rule-option] `allow-named-functions` added to `only-arrow-functions` (#1857)
+-   [new-fixer] `prefer-const` (#1801)
+-   [new-fixer] `quotemark` (#1790)
+-   [new-formatter] `code-frame` formatter shows you the error in context (#1819)
+-   [enhancement] `no-internal-module` failures highlight less text (#1781)
+-   [enhancement] Avoid auto-fixing errors that would result in compilation errors for rules that use type-check (#1608)
+-   [rule-change] `only-arrow-functions` will allow functions with a `this` parameter (#1597)
+-   [bugfix] `no-use-before-declare` false positive on named import (#1620)
+-   [bugfix] `prefer-for-of` was showing false positive when the element is assigned (#1813)
+-   [bugfix] The command line argument `type-check` was swallowing the next argument (#1783)
+-   [bugfix] `tslint:disable-line` was re-enabling `tslint:disable` (#1634)
+-   [bugfix] `adjacent-overload-signatures` did not work for constructors (#1800)
+-   [bugfix] `checkstyle` formatter was reporting errors under one file (#1811)
+-   [bugfix] `trailing-comma` was applied to parameter lists (#1775)
+-   [api] CLI logic moved into API friendly class (#1688)
 
 Thanks to our contributors!
 
-* Alex Eagle
-* Andrii Dieiev
-* Ben Coveney
-* Boris Aranovich
-* Chris Barr
-* Cyril Gandon
-* Evgeniy Zhukovskiy
-* Jay Anslow
-* Kunal Marwaha
-* Martin Probst
-* Mingye Wang
-* Raghav Katyal
-* Sean Dawson
-* Yuichi Nukiyama
-* jakpaw
+-   Alex Eagle
+-   Andrii Dieiev
+-   Andy Hanson
+-   Art Chaidarun
+-   Donald Pipowitch
+-   Feisal Ahmad
+-   Josh Goldberg
+-   Klaus Meinhardt
+-   Maciej Sypień
+-   Mohsen Azimi
+-   Ryan Lester
+-   Simon Schick
+-   Subhash Sharma
+-   Timothy Slatcher
+-   Yaroslav Admin
+-   Yuichi Nukiyama
+-   tdsmithATabc
+-   @wmrowan
 
-v4.0.0-dev.0
----
+## v4.0.2
 
-* **BREAKING CHANGES**
-    * [enhancement] Drop support for configuration via package.json (#1579)
-    * [removed-rule] Removed `no-duplicate-key` rule; covered by compiler (#1109)
-    * [enhancement] Call formatter once for all file results. Format output may be different (#656)
-    * [rule-change] `trailing-comma` supports function declarations, expressions, and types (#1486)
-    * [rule-change] `object-literal-sort-keys` now sorts quoted keys (#1529)
-    * [rule-change] `semicolon` now processes type aliases (#1475)
-    * [rule-change] `no-var-keyword` now rejects `export var` statements (#1256)
-    * [rule-change] `semicolon` now requires semicolon for function declaration with no body (#1447)
-* [new-formatter] `fileslist` formatter writes a list of files with errors without position or error type specifics (#1558)
-* [new-rule] `cyclomaticComplexity`, enforces a threshold of cyclomatic complexity.] (#1464)
-* [new-rule] `prefer-for-of`, which errors when `for(var x of y)` can be used instead of `for(var i = 0; i < y.length; i++)` (#1335)
-* [new-rule] `array-type`, which can require using either `T[]' or 'Array<T>' for arrays (#1498)
-* [rule-change] `object-literal-sort-keys` checks multiline objects only (#1642)
-* [rule-change] `ban` rule now can ban global functions (#327)
-* [bugfix] always write lint result, even if using formatter (#1353)
-* [bugfix] npm run test:bin fails on Windows (#1635)
-* [bugfix] Don't enforce trailing spaces on newlines in typedef-whitespace rule (#1531)
-* [bugfix] `jsdoc` rule should not match arbitrary comments (#1543)
-* [bugfix] `one-line` rule errors when declaring wildcard ambient modules (#1425)
+-   [enhancement] Don't exit when a rule can't be found. Print as a warning instead (#1771)
+-   [api-change] Allow 3rd party apps to see exception when the config is invalid (#1764)
+-   [bugfix] Don't flag a property named as empty string as not needing quotes in an object literal (#1762)
+-   [bugfix] Report correct number of fixes done by --fix (#1767)
+-   [bugfix] Fix false positives and exceptions in `prefer-for-of` (#1758)
+-   [bugfix] Fix `adjacent-overload-signatures` false positive when a static function has the same name (#1772)
 
 Thanks to our contributors!
 
-* Alex Eagle
-* Andrii Dieiev
-* Andy Hanson
-* Ben Coveney
-* Boris Aranovich
-* Chris Barr
-* Christian Dreher
-* Claas Augner
-* Josh Goldberg
-* Martin Probst
-* Mike Deverell
-* Nina Hartmann
-* Satoshi Amemiya
-* Scott Wu
-* Steve Van Opstal
-* Umar Bolatov
-* Vladimir Matveev
-* Yui
+-   @gustavderdrache
 
-v3.15.1
----
+## v4.0.1
 
-* Enabled additional rules in `tslint:latest` configuration (#1506)
+-   [bugfix] Removed `no-unused-variable` rule from recommended config, as it was causing spurious deprecation warnings.
 
-v3.15.0
----
+## v4.0.0-dev.2
 
-* Stable release containing changes from the last dev release (v3.15.0-dev.0)
+-   Include latest v4.0.0 changes
 
-v3.15.0-dev.0
----
+## v4.0.0
 
-* [enhancement] Rules can automatically fix errors (#1423)
-* [enhancement] Better error messages for invalid source files (#1480)
-* [new-rule] `adjacent-overload-signatures` rule (#1426)
-* [new-rule] `file-header` rule (#1441)
-* [new-rule] `object-literal-shorthand` rule (#1488)
-* [new-rule-option] `allow-declarations` option for `only-arrow-functions` rule (#1452)
-* [new-rule-option] `import-sources-order` option for `ordered-imports` rule (#1466)
-* [bugfix] `arrow-parens` rule handles async and generics (#1446, #1479)
-* [bugfix] `comment-format` rule ignores tslint control comments (#1473)
-* [bugfix] Fix `no-shadowed-variable` rule false positives (#1482)
+-   **BREAKING CHANGES**
+    -   [api-change] Minor changes to the library API. See this PR for changes and upgrade instructions (#1720)
+    -   [removed-rule] Removed `no-unreachable` rule; covered by compiler (#661)
+    -   [enhancement] Changed order of applied configuration files for the `extends` array to make it more intuitive. (#1503)
+    -   [enhancement] Changed TypeScript peer dependency to >= 2.0.0 (#1710)
+-   [new-rule] `completed-docs` rule added (#1644)
+-   [new-fixer] `ordered-imports` auto fixed (#1640)
+-   [new-fixer] `arrow-parens` auto fixed (#1731)
+-   [rule-change] `indent` rule now ignores template strings (#1611)
+-   [new-rule-option] `object-literal-key-quotes` adds the options `consistent` and `consistent-as-needed` (#1733)
+-   [enhancement] `--fix` option added to automatically fix selected rules (#1697)
+-   [enhancement] Updated recommend rules (#1717)
+-   [enhancement] `adjacent-overload-signatures` now works with classes, source files, modules, and namespaces (#1707)
+-   [enhancement] Users are notified if they are using an old TSLint version (#1696)
+-   [bugfix] Lint `.jsx` files if `jsRules` are configured (#1714)
+-   [bugfix] Command line glob patterns now handle single quotes (#1679)
 
 Thanks to our contributors!
-* @apacala
-* @danvk
-* @DovydasNavickas
-* @glen-84
-* @IllusionMH
-* @JoshuaKGoldberg
-* @markwongsk
-* @rakatyal
-* @rhysd
-* @ScottSWu
-* @YuichiNukiyama
 
-v3.14.0
----
+-   Andrii Dieiev
+-   Andy
+-   Chris Barr
+-   Davie Schoots
+-   Jordan Hawker
+-   Josh Goldberg
+-   Stepan Riha
+-   Yuichi Nukiyama
 
-* Stable release containing changes from the last dev releases (v3.14.0-dev.0, v3.14.0-dev.1)
+## v4.0.0-dev.1
 
-v3.14.0-dev.1
----
-
-* [new-rule] `arrow-parens` rule (#777)
-* [new-rule] `max-file-line-count` rule (#1360)
-* [new-rule] `no-unsafe-finally` rule (#1349)
-* [new-rule] `no-for-in-array` rule (#1380)
-* [new-rule] `object-literal-key-quotes` rule (#1364)
-* [enhancement] Better `ban` rule failure messages (#1385)
-* [enhancement] New stylish formatter (#1406)
-
-Thanks to our contributors!
-* @chrismbarr
-* @danvk
-* @gjuchault
-* @lowkay
-* @ScottSWu
-* @YuichiNukiyama
-
-v3.14.0-dev.0
----
-
-* [enhancement] Add optional type information to rules (#1323)
+-   **BREAKING CHANGES**
+    -   [enhancement] The `semicolon` rule now disallows semicolons in multi-line bound class methods
+        (to get the v3 behavior, use the `ignore-bound-class-methods` option) (#1643)
+    -   [removed-rule] Removed `use-strict` rule (#678)
+    -   [removed-rule] Removed `label-undefined` rule; covered by compiler (#1614)
+    -   [enhancement] Renamed `no-constructor-vars` to `no-parameter-properties` (#1296)
+    -   [rule-change] The `orderedImports` rule now sorts relative modules below non-relative modules (#1640)
+-   **Deprecated**
+    -   [deprecated] `no-unused-variable` rule. This is checked by the TypeScript v2 compiler using the flags [`--noUnusedParameters` and `--noUnusedLocals`](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#flag-unused-declarations-with---nounusedparameters-and---nounusedlocals). (#1481)
+-   [enhancement] Lint .js files (#1515)
+-   [new-fixer] `no-var-keyword` replaces `var` with `let` (#1547)
+-   [new-fixer] `trailing-comma` auto fixed (#1546)
+-   [new-fixer] `no-unused-variable` auto fixed for imports (#1568)
+-   [new-fixer] `semicolon` auto fixed (#1423)
+-   [new-rule] `max-classes-per-file` rule added (#1666)
+-   [new-rule-option] `no-consecutive-blank-lines` rule now accepts a number value indicating max blank lines (#1650)
+-   [new-rule-option] `ordered-imports` rule option `import-sources-order` accepts value `any` (#1602)
+-   [bugfix] `no-empty` rule fixed when parameter has readonly modifier
+-   [bugfix] `no-namespace` rule: do not flag nested or .d.ts namespaces (#1571)
 
 Thanks to our contributors!
-* @ScottSWu
 
-v3.13.0
----
+-   Alex Eagle
+-   Andrii Dieiev
+-   Ben Coveney
+-   Boris Aranovich
+-   Chris Barr
+-   Cyril Gandon
+-   Evgeniy Zhukovskiy
+-   Jay Anslow
+-   Kunal Marwaha
+-   Martin Probst
+-   Mingye Wang
+-   Raghav Katyal
+-   Sean Dawson
+-   Yuichi Nukiyama
+-   jakpaw
 
-* Stable release containing changes from the last dev release (v3.13.0-dev.0)
+## v4.0.0-dev.0
 
-v3.13.0-dev.0
----
-
-* [new-rule] `ordered-imports` rule (#1325)
-* [enhancement] MPEG transport stream files are ignored by the CLI (#1357)
-
-Thanks to our contributors!
-* @chrismbarr
-* @corydeppen
-* @danvk
-* @janaagaard75
-* @mprobst
-
-v3.12.0-dev.2
----
-
-* [enhancement] Support TypeScript v2.0.0-dev builds
-
-v3.12.1
----
-
-* Stable release containing changes from the last dev release (v3.12.0-dev.1)
-
-v3.12.0-dev.1
----
-
-* [bugfix] Fix null reference bug in typedef rule (#1345)
-
-v3.12.0
----
-
-* Stable release containing changes from the last dev release (v3.12.0-dev.0)
-
-v3.12.0-dev.0
----
-
-* [new-rule] `only-arrow-functions` rule (#1318)
-* [new-rule] `no-unused-new` rule (#1316)
-* [new-rule-option] `arrow-call-signature` option for `typedef` rule (#1284)
-* [enhancement] Metadata for every rule (#1311)
-* [enhancement] `typedef` rule is more flexible about the location of typedefs for arrow functions (#1176)
-* [enhancement] Failure messages are clearer and more consistent for many rules (#1303, #1307, #1309)
-* [bugfix] `no-consecutive-blank-lines` now handles lines with only whitespace correctly (#1249)
-* [bugfix] Correctly load `.json` config files that have a BOM (#1338)
+-   **BREAKING CHANGES**
+    -   [enhancement] Drop support for configuration via package.json (#1579)
+    -   [removed-rule] Removed `no-duplicate-key` rule; covered by compiler (#1109)
+    -   [enhancement] Call formatter once for all file results. Format output may be different (#656)
+    -   [rule-change] `trailing-comma` supports function declarations, expressions, and types (#1486)
+    -   [rule-change] `object-literal-sort-keys` now sorts quoted keys (#1529)
+    -   [rule-change] `semicolon` now processes type aliases (#1475)
+    -   [rule-change] `no-var-keyword` now rejects `export var` statements (#1256)
+    -   [rule-change] `semicolon` now requires semicolon for function declaration with no body (#1447)
+-   [new-formatter] `fileslist` formatter writes a list of files with errors without position or error type specifics (#1558)
+-   [new-rule] `cyclomaticComplexity`, enforces a threshold of cyclomatic complexity.] (#1464)
+-   [new-rule] `prefer-for-of`, which errors when `for(var x of y)` can be used instead of `for(var i = 0; i < y.length; i++)` (#1335)
+-   [new-rule] `array-type`, which can require using either `T[]' or 'Array<T>' for arrays (#1498)
+-   [rule-change] `object-literal-sort-keys` checks multiline objects only (#1642)
+-   [rule-change] `ban` rule now can ban global functions (#327)
+-   [bugfix] always write lint result, even if using formatter (#1353)
+-   [bugfix] npm run test:bin fails on Windows (#1635)
+-   [bugfix] Don't enforce trailing spaces on newlines in typedef-whitespace rule (#1531)
+-   [bugfix] `jsdoc` rule should not match arbitrary comments (#1543)
+-   [bugfix] `one-line` rule errors when declaring wildcard ambient modules (#1425)
 
 Thanks to our contributors!
-* @allannienhuis
-* @arnaudvalle
-* @bencoveney
-* @chrismbarr
-* @corydeppen
-* @HamletDRC
-* @JoshuaKGoldberg
-* @timbrown81
-* @tomduncalf
-* @YuichiNukiyama
 
-v3.11.0
----
+-   Alex Eagle
+-   Andrii Dieiev
+-   Andy Hanson
+-   Ben Coveney
+-   Boris Aranovich
+-   Chris Barr
+-   Christian Dreher
+-   Claas Augner
+-   Josh Goldberg
+-   Martin Probst
+-   Mike Deverell
+-   Nina Hartmann
+-   Satoshi Amemiya
+-   Scott Wu
+-   Steve Van Opstal
+-   Umar Bolatov
+-   Vladimir Matveev
+-   Yui
 
-* Stable release containing changes from the last dev release (v3.11.0-dev.0)
+## v3.15.1
 
-v3.11.0-dev.0
----
+-   Enabled additional rules in `tslint:latest` configuration (#1506)
 
-* [new-rule] `linebreak-style` rule (#123)
-* [new-rule] `no-mergeable-namespace` rule (#843)
-* [enhancement] Add built-in configurations (#1261)
-* [enhancement] New vso formatter (#1281)
-* [new-rule-option] `ignore-interfaces` option for `semicolon` rule (#1233)
-* [bugfix] `no-default-export` rule handles more default export cases (#1241)
+## v3.15.0
 
-Thanks to our contributors!
-* @cgwrench
-* @HamletDRC
-* @lijunle
-* @paldepind
-* @patsissons
-* @schmuli
-* @YuichiNukiyama
+-   Stable release containing changes from the last dev release (v3.15.0-dev.0)
 
-v3.10.2
----
+## v3.15.0-dev.0
 
-* Stable release containing changes from the last dev release (v3.10.0-dev.2)
-
-v3.10.0-dev.2
----
-
-* [bugfix] `member-ordering` rule doesn't crash on methods in class expressions (#1252)
-* [bugfix] `ban` rule handles chained methods appropriately (#1234)
+-   [enhancement] Rules can automatically fix errors (#1423)
+-   [enhancement] Better error messages for invalid source files (#1480)
+-   [new-rule] `adjacent-overload-signatures` rule (#1426)
+-   [new-rule] `file-header` rule (#1441)
+-   [new-rule] `object-literal-shorthand` rule (#1488)
+-   [new-rule-option] `allow-declarations` option for `only-arrow-functions` rule (#1452)
+-   [new-rule-option] `import-sources-order` option for `ordered-imports` rule (#1466)
+-   [bugfix] `arrow-parens` rule handles async and generics (#1446, #1479)
+-   [bugfix] `comment-format` rule ignores tslint control comments (#1473)
+-   [bugfix] Fix `no-shadowed-variable` rule false positives (#1482)
 
 Thanks to our contributors!
-* @marines
 
-v3.10.1
----
+-   @apacala
+-   @danvk
+-   @DovydasNavickas
+-   @glen-84
+-   @IllusionMH
+-   @JoshuaKGoldberg
+-   @markwongsk
+-   @rakatyal
+-   @rhysd
+-   @ScottSWu
+-   @YuichiNukiyama
 
-* Stable release containing changes from the last dev release (v3.10.0-dev.1)
+## v3.14.0
 
-v3.10.0-dev.1
----
+-   Stable release containing changes from the last dev releases (v3.14.0-dev.0, v3.14.0-dev.1)
 
-* [bugfix] `member-ordering` rule doesn't crash on methods in object literals (#1243)
+## v3.14.0-dev.1
 
-v3.10.0
----
-
-* Stable release containing changes from the last dev release (v3.10.0-dev.0)
-
-v3.10.0-dev.0
----
-
-* [new-rule] `new-parens` rule (#1177)
-* [new-rule] `no-default-export` rule (#1182)
-* [new-rule-option] `order: ...` option for `member-ordering` rule (#1208)
-* [new-rule-option] "ignore-for-loop" option for `one-variable-per-declaration` rule (#1204)
-* [enhancement] "no-this-in-function-in-method" option renamed to "check-function-in-method" (#1203)
-* [bugfix] `semicolon` rule checks export statements (#1155)
-
-Thanks to our contributors!
-* @chrismbarr
-* @HamletDRC
-* @larshp
-* @patsissons
-* @YuichiNukiyama
-
-v3.9.0
----
-
-* Stable release containing changes from the last dev release (v3.9.0-dev.0)
-
-v3.9.0-dev.0
----
-
-* [new-rule] `no-namespace` rule (#1133)
-* [new-rule] `one-variable-per-declaration` rule (#525)
-* [new-rule-option] "ignore-params" option for `no-inferrable-types` rule (#1190)
-* [new-rule-option] "no-this-in-function-in-method" option for `no-invalid-this` rule (#1179)
-* [enhancement] Single line enable/disable comments (#144)
-* [enhancement] Resolve `extends` packages relative to location of configuration file (#1171)
-* [enhancement] `Linter` class will throw an error if configuration is of an invalid type (#1167)
-* [bugfix] `use-isnan` allows assaignments to `NaN` (#1054)
-* [bugfix] `no-unreachable` handles allows hoisted type aliases (#564)
-* [bugfix] `member-ordering` rule now checks constructors (#1158)
-* [bugfix] `--test` CLI command works correctly with specifiying custom rules (#1195)
+-   [new-rule] `arrow-parens` rule (#777)
+-   [new-rule] `max-file-line-count` rule (#1360)
+-   [new-rule] `no-unsafe-finally` rule (#1349)
+-   [new-rule] `no-for-in-array` rule (#1380)
+-   [new-rule] `object-literal-key-quotes` rule (#1364)
+-   [enhancement] Better `ban` rule failure messages (#1385)
+-   [enhancement] New stylish formatter (#1406)
 
 Thanks to our contributors!
-* @abierbaum
-* @HamletDRC
-* @inthemill
-* @janslow
-* @JoshuaKGoldberg
-* @mprobst
-* @patsissions
-* @YuichiNukiyama
 
-v3.8.1
----
+-   @chrismbarr
+-   @danvk
+-   @gjuchault
+-   @lowkay
+-   @ScottSWu
+-   @YuichiNukiyama
 
-* Stable release containing changes from the last dev release (v3.8.0-dev.1)
+## v3.14.0-dev.0
 
-v3.8.0-dev.1
----
-
-* [bugfix] Allow JS directives at the start of constructors, getters, and setters (#1159)
-* [bugfix] Remove accidentally included performance profiles from published NPM artifact (#1160)
-
-v3.8.0
----
-
-* Stable release containing changes from the last dev release (v3.8.0-dev.0)
-
-v3.8.0-dev.0
----
-
-* [new-rule] `no-invalid-this` rule (#1105)
-* [new-rule] `use-isnan` rule (#1054)
-* [new-rule] `no-reference` rule (#1139)
-* [new-rule-option] "allow-pascal-case" option for `variable-name` rule (#1079)
-* [enhancement] Comments now allowed in `tslint.json` files (#1129)
-* [enhancement] Smarter `trailing-comma` behavior (#1122)
-* [enhancement] `semicolon` rule more lenient with arrow-function class members (#1076)
-* [enhancement] Allow enabling/disabling rules with `//` comments (#1134)
-* [enhancement] New checkstyle formatter (#250)
-* [enhancement] Clearer message for `no-var-keyword` rule (#1124)
-* [bugfix] Loaded configurations are not cached (#1128)
-* [bugfix] Allow JS directives at the start of class methods (#1144)
+-   [enhancement] Add optional type information to rules (#1323)
 
 Thanks to our contributors!
-* @AndyMoreland
-* @chrismbarr
-* @HamletDRC
-* @JoshuaKGoldberg
-* @sshev
-* @unional
 
-v3.7.4
----
+-   @ScottSWu
 
-* Stable release containing changes from the last dev release (v3.7.0-dev.5)
+## v3.13.0
 
-v3.7.0-dev.5
----
+-   Stable release containing changes from the last dev release (v3.13.0-dev.0)
 
-* [bugfix] Allow JS directives in namespaces (#1115)
+## v3.13.0-dev.0
 
-v3.7.3
----
-
-* Stable release containing changes from the last dev release (v3.7.0-dev.4)
-
-v3.7.0-dev.4
----
-
-* [bugfix] Downgrade `findup-sync` dependency (#1108)
-
-v3.7.2
----
-
-* Stable release containing changes from the last dev release (v3.7.0-dev.3)
-
-v3.7.0-dev.3
----
-
-* [bugfix] `findConfigurationPath` always returns an absolute path (#1093)
-* [bugfix] Update `findup-sync` dependency (#1080)
-* [bugfix] `declare global` no longer triggers `no-internal-module` rule (#1069)
-* [bugfix] Valid JS directives no longer trigger `no-unused-expression` rule (#1050)
-
-v3.7.1
----
-* Stable release containing changes from the last dev release
-
-v3.7.0-dev.2
----
-
-* [bugfix] Improve handling of paths provided via the -c CLI option (#1083)
-
-v3.7.0
----
-
-* Stable release containing changes from the last dev release
-
-v3.7.0-dev.1
----
-
-* [enhancement] `extends` field for `tslint.json` files (#997)
-* [enhancement] `--force` CLI option (#1059)
-* [enhancement] Improve how `Linter` class handles configurations with a `rulesDirectory` field (#1035)
-* [new-rule] `no-angle-bracket-type-assertion` rule (#639)
-* [new-rule-option] "allow-undefined-check" option for `triple-equals` rule (#602)
-* [new-rule-option] "always-prefix" and "never-prefix" option for `interface-name` rule (#512)
+-   [new-rule] `ordered-imports` rule (#1325)
+-   [enhancement] MPEG transport stream files are ignored by the CLI (#1357)
 
 Thanks to our contributors!
-* @Arnavion
-* @chrismbarr
-* @ChrisPearce
-* @JoshuaKGoldberg
-* @patsissonso
-* @sasidhar
-* @unional
-* @vvakame
 
-v3.6.0
----
+-   @chrismbarr
+-   @corydeppen
+-   @danvk
+-   @janaagaard75
+-   @mprobst
 
-* Stable release containing changes from the last dev release
+## v3.12.0-dev.2
 
-v3.6.0-dev.1
----
+-   [enhancement] Support TypeScript v2.0.0-dev builds
 
-* [enhancement] Add `--exclude` CLI option (#915)
-* [bugfix] Fix `no-shadowed-variable` rule handling of standalone blocks (#1021)
-* [deprecation] Configuration through `package.json` files (#1020)
-* [API] Export additional configuration methods from top-level "tslint" module (#1009)
+## v3.12.1
 
-Thanks to our contributors!
-* @blakeembrey
-* @hamhut1066
-* @meowtec
+-   Stable release containing changes from the last dev release (v3.12.0-dev.1)
 
-v3.5.0
----
+## v3.12.0-dev.1
 
-* Stable release containing changes from the last dev release
+-   [bugfix] Fix null reference bug in typedef rule (#1345)
 
-v3.5.0-dev.1
----
+## v3.12.0
 
-* [new-rule-option] "ignore-pattern" option for `no-unused-variable` rule (#314)
-* [bugfix] Fix occassional crash in `no-string-literal` rule (#906)
-* [enhancement] Tweak behavior of `member-ordering` rule with regards to arrow function types in interfaces (#226)
+-   Stable release containing changes from the last dev release (v3.12.0-dev.0)
+
+## v3.12.0-dev.0
+
+-   [new-rule] `only-arrow-functions` rule (#1318)
+-   [new-rule] `no-unused-new` rule (#1316)
+-   [new-rule-option] `arrow-call-signature` option for `typedef` rule (#1284)
+-   [enhancement] Metadata for every rule (#1311)
+-   [enhancement] `typedef` rule is more flexible about the location of typedefs for arrow functions (#1176)
+-   [enhancement] Failure messages are clearer and more consistent for many rules (#1303, #1307, #1309)
+-   [bugfix] `no-consecutive-blank-lines` now handles lines with only whitespace correctly (#1249)
+-   [bugfix] Correctly load `.json` config files that have a BOM (#1338)
 
 Thanks to our contributors!
-* @arusakov
-* @Pajn
 
-v3.4.0
----
+-   @allannienhuis
+-   @arnaudvalle
+-   @bencoveney
+-   @chrismbarr
+-   @corydeppen
+-   @HamletDRC
+-   @JoshuaKGoldberg
+-   @timbrown81
+-   @tomduncalf
+-   @YuichiNukiyama
 
-* Stable release containing changes from the last two dev releases
+## v3.11.0
 
-v3.4.0-dev.2
----
+-   Stable release containing changes from the last dev release (v3.11.0-dev.0)
 
-* [new-rule-option] "arrow-parameter" option for `typedef` rule (#333)
-* [new-rule-option] "never" option for `semicolon` rule (#363)
-* [new-rule-option] "onespace" setting for `typedef-whitespace` rule (#888)
-* [new-rule-option] `typedef-whitespace` rule can now check spacing on right side of typdef colon (#888)
-* [enhancement] `member-ordering` rule treats arrow functions as methods (#226)
-* [bugfix] Handle spaces before typedefs correctly in `typedef-whitespace` rule (#955)
-* [bugfix] `label-position` rule now allows labels on `for-of` loops (#959)
+## v3.11.0-dev.0
 
-Thanks to our contributors!
-* @b0r3as
-* @ChaseMoskal
-* @Pajn
-* @pe8ter
-* @tomduncalf
-
-v3.4.0-dev.1
----
-
-* [enhancement] Revamped testing system (#620)
-  * Writing tests for rules is now much simpler with a linter DSL.
-    See exisitng tests in `test/rules/**/*.ts.lint` for examples.
-* [enhancement] New msbuild formatter (#947)
-* [bugfix] Fix handling of multiline literals in `trailing-comma` rule (#856)
-* [bugfix] `one-line` rule correctly checks space between `catch` and opening brace (#925)
-* [bugfix] `one-line` rule correctly checks multiline variable declarations (#935)
-* [new-rule-option] New option `check-finally` for `one-line` rule (#925)
-* __BREAKING CHANGES__
-  * [bugfix] Report error when a rule in the config file is not found (#598)
+-   [new-rule] `linebreak-style` rule (#123)
+-   [new-rule] `no-mergeable-namespace` rule (#843)
+-   [enhancement] Add built-in configurations (#1261)
+-   [enhancement] New vso formatter (#1281)
+-   [new-rule-option] `ignore-interfaces` option for `semicolon` rule (#1233)
+-   [bugfix] `no-default-export` rule handles more default export cases (#1241)
 
 Thanks to our contributors!
-* @mmv
-* @pe8ter
 
-v3.3.0
----
+-   @cgwrench
+-   @HamletDRC
+-   @lijunle
+-   @paldepind
+-   @patsissons
+-   @schmuli
+-   @YuichiNukiyama
 
-* [bugfix] Tweak TSLint build so TSLint works with typescript@next (#926)
+## v3.10.2
 
-v3.3.0-dev.1
----
+-   Stable release containing changes from the last dev release (v3.10.0-dev.2)
 
-* [bugfix] Correctly handle more than one custom rules directory (#928)
+## v3.10.0-dev.2
 
-v3.2.2
----
+-   [bugfix] `member-ordering` rule doesn't crash on methods in class expressions (#1252)
+-   [bugfix] `ban` rule handles chained methods appropriately (#1234)
 
-* Stable release containing changes from the last dev release
+Thanks to our contributors!
 
-v3.2.2-dev.1
----
+-   @marines
 
-* [enhancement] Throw an error if a path to a directory of custom rules is invalid (#910)
-* [new-rule-option] "jsx-single" and "jsx-double" options for `quotemark` rule (#673)
-* [bugfix] Handle paths to directories of custom rules more accurately
-* [bugfix] `no-unused-expression` rule handles `await` statements correctly (#887)
+## v3.10.1
 
-v3.2.1
----
+-   Stable release containing changes from the last dev release (v3.10.0-dev.1)
 
-* Stable release containing changes from the last dev release
+## v3.10.0-dev.1
 
-v3.2.1-dev.1
----
+-   [bugfix] `member-ordering` rule doesn't crash on methods in object literals (#1243)
 
-* [enhancement] automatically generate a `tslint.json` file with new `--init` CLI command (#717)
-* [bugfix] `no-var-keyword` rule detects the use of `var` in all types of `for` loops (#855)
+## v3.10.0
 
-v3.2.0
----
+-   Stable release containing changes from the last dev release (v3.10.0-dev.0)
 
-* Stable release containing changes from last two dev releases
+## v3.10.0-dev.0
 
-v3.2.0-dev.2
----
+-   [new-rule] `new-parens` rule (#1177)
+-   [new-rule] `no-default-export` rule (#1182)
+-   [new-rule-option] `order: ...` option for `member-ordering` rule (#1208)
+-   [new-rule-option] "ignore-for-loop" option for `one-variable-per-declaration` rule (#1204)
+-   [enhancement] "no-this-in-function-in-method" option renamed to "check-function-in-method" (#1203)
+-   [bugfix] `semicolon` rule checks export statements (#1155)
 
-* [bugfix] formatters are now exported correctly to work with TS 1.8 (#863)
+Thanks to our contributors!
 
-v3.2.0-dev.1
----
+-   @chrismbarr
+-   @HamletDRC
+-   @larshp
+-   @patsissons
+-   @YuichiNukiyama
 
-* [bugfix] fixed bug in how custom rules directories are registered (#844)
-* [enhancement] better support for globs in CLI (#827)
-* [new-rule] `no-null-keyword` rule (#722)
+## v3.9.0
 
-v3.1.1
----
+-   Stable release containing changes from the last dev release (v3.9.0-dev.0)
 
-* Bump TypeScript peer dependency to `>= 1.7.3` due to `const enum` incompatibility (#832)
+## v3.9.0-dev.0
 
-v3.1.0
----
+-   [new-rule] `no-namespace` rule (#1133)
+-   [new-rule] `one-variable-per-declaration` rule (#525)
+-   [new-rule-option] "ignore-params" option for `no-inferrable-types` rule (#1190)
+-   [new-rule-option] "no-this-in-function-in-method" option for `no-invalid-this` rule (#1179)
+-   [enhancement] Single line enable/disable comments (#144)
+-   [enhancement] Resolve `extends` packages relative to location of configuration file (#1171)
+-   [enhancement] `Linter` class will throw an error if configuration is of an invalid type (#1167)
+-   [bugfix] `use-isnan` allows assaignments to `NaN` (#1054)
+-   [bugfix] `no-unreachable` handles allows hoisted type aliases (#564)
+-   [bugfix] `member-ordering` rule now checks constructors (#1158)
+-   [bugfix] `--test` CLI command works correctly with specifiying custom rules (#1195)
 
-* [bugfix] build with TS v1.7.3 to fix null pointer exception (#832)
-* [bugfix] fixed false positive in `no-require-imports` rule (#816)
+Thanks to our contributors!
 
-v3.1.0-dev.1
----
+-   @abierbaum
+-   @HamletDRC
+-   @inthemill
+-   @janslow
+-   @JoshuaKGoldberg
+-   @mprobst
+-   @patsissions
+-   @YuichiNukiyama
 
-* [bugfix] fixed `no-shadowed-variable` false positives when handling destructuring in function params (#727)
-* [enhancement] `rulesDirectory` in `tslint.json` now supports multiple file paths (#795)
+## v3.8.1
 
-v3.0.0
----
+-   Stable release containing changes from the last dev release (v3.8.0-dev.1)
 
-* [bugfix] `member-access` rule now handles object literals and get/set accessors properly (#801)
-    * New rule options: `check-accessor` and `check-constructor`
-* All the changes from the following releases, including some **breaking changes**:
-    * `3.0.0-dev.3`
-    * `3.0.0-dev.2`
-    * `3.0.0-dev.1`
-    * `2.6.0-dev.2`
-    * `2.6.0-dev.1`
+## v3.8.0-dev.1
 
-v3.0.0-dev.3
----
+-   [bugfix] Allow JS directives at the start of constructors, getters, and setters (#1159)
+-   [bugfix] Remove accidentally included performance profiles from published NPM artifact (#1160)
 
-* TypeScript is now a peerDependency (#791)
-* [bugfix] `no-unused-variable` rule with `react` option works with self-closing JSX tags (#776)
-* [bugfix] `use-strict` bugfix (#544)
+## v3.8.0
 
-v3.0.0-dev.2
----
+-   Stable release containing changes from the last dev release (v3.8.0-dev.0)
 
-* [new-rule-option] "react" option for `no-unused-variable` rule (#698, #725)
-* [bugfix] Fix how `Linter` is exported from "tslint" module (#760)
-* [bugfix] `no-use-before-declare` rule doesn't crash on uncompilable code (#763)
+## v3.8.0-dev.0
 
-v3.0.0-dev.1
----
+-   [new-rule] `no-invalid-this` rule (#1105)
+-   [new-rule] `use-isnan` rule (#1054)
+-   [new-rule] `no-reference` rule (#1139)
+-   [new-rule-option] "allow-pascal-case" option for `variable-name` rule (#1079)
+-   [enhancement] Comments now allowed in `tslint.json` files (#1129)
+-   [enhancement] Smarter `trailing-comma` behavior (#1122)
+-   [enhancement] `semicolon` rule more lenient with arrow-function class members (#1076)
+-   [enhancement] Allow enabling/disabling rules with `//` comments (#1134)
+-   [enhancement] New checkstyle formatter (#250)
+-   [enhancement] Clearer message for `no-var-keyword` rule (#1124)
+-   [bugfix] Loaded configurations are not cached (#1128)
+-   [bugfix] Allow JS directives at the start of class methods (#1144)
 
-* **BREAKING CHANGES**
-    * Rearchitect TSLint to use external modules instead of merged namespaces (#726)
-        * Dependencies need to be handled differently now by custom rules and formatters
-        * See the [PR](https://github.com/palantir/tslint/pull/726) for full details about this change
-    * `no-trailing-comma` rule removed, it is replaced by the `trailing-comma` rule (#687)
-    * Rename `sort-object-literal-keys` rule to `object-literal-sort-keys` (#304, #537)
-    * `Lint.abstract()` has been removed (#700)
-* [new-rule] `trailing-comma` rule (#557, #687)
-* [new-rule-option] "ban-keywords" option for `variable-name` rule (#735, #748)
-* [bugfix] `typedef` rule now handles `for-of` loops correctly (#743)
-* [bugfix] Handle tslint.json utf-8 files which have a BOM correctly (#90)
+Thanks to our contributors!
 
-v2.6.0-dev.2
----
+-   @AndyMoreland
+-   @chrismbarr
+-   @HamletDRC
+-   @JoshuaKGoldberg
+-   @sshev
+-   @unional
 
-* Upgrade TypeScript compiler to `v1.7.0-dev.20151003`
-* [bugfix] `no-unused-expression` rule now handles yield expressions properly (#706)
+## v3.7.4
 
-v2.6.0-dev.1
----
+-   Stable release containing changes from the last dev release (v3.7.0-dev.5)
 
-* Upgrade TypeScript compiler to `v1.7.0-dev.20150924`
+## v3.7.0-dev.5
 
-v2.5.1
----
+-   [bugfix] Allow JS directives in namespaces (#1115)
 
-* [new-rule] no-inferrable-types rule (#676)
-* [new-rule-option] "avoid-escape" option for quotemark rule (#543)
-* [bugfix] type declaration for tslint external module #686
-* [enhancement] `AbstractRule` and `AbstractFormatter` are now abstract classes (#631)
-    * Note: `Lint.abstract()` is now deprecated
+## v3.7.3
 
-v2.5.0
----
+-   Stable release containing changes from the last dev release (v3.7.0-dev.4)
 
-* Use TypeScript compiler `v1.6.2`
-* [bugfixes] #637, #642, #650, #652
-* [bugfixes] fix various false positives in `no-unused-variable` rule (#570, #613, #663)
-* Update project setup for latest VSCode (#662)
+## v3.7.0-dev.4
 
-v2.5.0-beta
----
+-   [bugfix] Downgrade `findup-sync` dependency (#1108)
 
-* Use TypeScript compiler `v1.6.0-beta`
-* [bugfix] Fix `no-internal-module` false positives on nested namespaces (#600)
-* [docs] Add documentation for `sort-object-literal-keys` rule
-
-v2.5.0-dev.5
----
-
-* Upgrade TypeScript compiler to `v1.7.0-dev.20150828`
-* [bugfix] Handle .tsx files appropriately (#597, #558)
+## v3.7.2
 
-v2.5.0-dev.4
----
-
-* Upgrade TypeScript compiler to `v1.6.0-dev.20150825`
-
-v2.5.0-dev.3
----
+-   Stable release containing changes from the last dev release (v3.7.0-dev.3)
 
-* Upgrade TypeScript compiler to `v1.6.0-dev.20150821`
+## v3.7.0-dev.3
 
-v2.5.0-dev.2
----
+-   [bugfix] `findConfigurationPath` always returns an absolute path (#1093)
+-   [bugfix] Update `findup-sync` dependency (#1080)
+-   [bugfix] `declare global` no longer triggers `no-internal-module` rule (#1069)
+-   [bugfix] Valid JS directives no longer trigger `no-unused-expression` rule (#1050)
 
-* Upgrade TypeScript compiler to `v1.6.0-dev.20150811`
-* [bug] fix `whitespace` false positive in JSX elements (#559)
+## v3.7.1
 
-v2.5.0-dev.1
----
-
-* Upgrade TypeScript compiler to `v1.6.0-dev.20150805`
-* [enhancement] Support `.tsx` syntax (#490)
-
-v2.4.5
----
-
-* [bugfix] fix false positives on `no-shadowed-variable` rule (#500)
-* [enhancement] add `allow-trailing-underscore` option to `variable-name` rule
-
-v2.4.4
----
-
-* [bugfix] remove "typescript" block from package.json (#606)
-
-v2.4.3
----
+-   Stable release containing changes from the last dev release
 
-* [new-rule] `no-conditional-assignment` (#507)
-* [new-rule] `member-access` (#552)
-* [new-rule] `no-internal-module` (#513)
-* [bugfix] small fixes to `sample.tslint.json` (#545)
-* [bugfix] fix README docs for quotemark and indent (#523)
-* [enhancement] update `findup-sync` and `underscore.string` dependencies
-* [enhancement] add `"typescript"` field to `package.json` (#560)
-* [enhancement] small improvements to CLI help text
-* [enhancement] expose raw failures array in the JS API (#477)
-
-v2.4.2
----
-
-* [bug] remove npm-shrinkwrap.json from the published package
+## v3.7.0-dev.2
 
-v2.4.0
----
+-   [bugfix] Improve handling of paths provided via the -c CLI option (#1083)
 
-* Upgraded Typescript compiler to 1.5.3
-* [bugs] #332, #493, #509, #483
-* [bug] fix error message in `no-var-keyword` rule
-* [enhancement] CI tests are now run on node v0.12 in addition to v0.10
-* **BREAKING**
-    * `-f` option removed from CLI
+## v3.7.0
 
-v2.3.1-beta
----
+-   Stable release containing changes from the last dev release
 
-* [bugs] #137 #434 #451 #456
-* [new-rule] `no-require-imports` disallows `require()` style imports
-* [new-rule] `no-shadowed-variable` moves over shadowed variable checking from `no-duplicate-variable` into its own rule
-* **BREAKING**
-    * `no-duplicate-variable` now only checks for duplicates within the same block scope; enable `no-shadowed-variable` to get duplicate-variable checking across block scopes
-* [enhancement] `no-duplicate-variable`, `no-shadowed-variable`, and `no-use-before-declare` now support ES6 destructuring
-* [enhancement] tslint CLI now uses a default configuration if no config file is found
+## v3.7.0-dev.1
 
-v2.3.0-beta
----
+-   [enhancement] `extends` field for `tslint.json` files (#997)
+-   [enhancement] `--force` CLI option (#1059)
+-   [enhancement] Improve how `Linter` class handles configurations with a `rulesDirectory` field (#1035)
+-   [new-rule] `no-angle-bracket-type-assertion` rule (#639)
+-   [new-rule-option] "allow-undefined-check" option for `triple-equals` rule (#602)
+-   [new-rule-option] "always-prefix" and "never-prefix" option for `interface-name` rule (#512)
 
-* [bugs] #401 #367 #324 #352
-* [new-rule] `no-var-keyword` disallows `var` in favor of `let` and `const`
-* [new-rule] `sort-object-literal-keys` forces object-literal keys to be sorted alphabetically
-* Add support for ES6 destructuring and module syntax (affects `variable-name`, `no-use-before-declare`, `whitespace` and `no-unused-variable`)
-* Add support for ES6 for-of and spread operator syntax
-* Use tsconfig.json & JSCS in the build system
+Thanks to our contributors!
 
-v2.2.0-beta
----
+-   @Arnavion
+-   @chrismbarr
+-   @ChrisPearce
+-   @JoshuaKGoldberg
+-   @patsissonso
+-   @sasidhar
+-   @unional
+-   @vvakame
 
-* Upgraded Typescript compiler to 1.5.0-beta
-* **BREAKING CHANGES**
-    * due to changes to the typescript compiler API, old custom rules may no longer work and may need to be rewritten
-    * the JSON formatter's line and character positions are now back to being 0-indexed instead of 1-indexed
-* [bugs] #328 #334 #319 #351 #365 #254
-* [bug] fixes for tslint behavior around template strings (fixes #357, #349, #332, and more)
-* [new-rule] `align` rule now enforces vertical alignment on parameters, arguments, and statements
-* [new-rule] `switch-default` enforces a `default` case in `switch` statements
-* [feature] `no-duplicate-variable` rule now additionally checks if function parameters have been shadowed
-* Additional fixes to existing rules to work as before with the typescript 1.5 compiler
+## v3.6.0
 
-v2.1.1
----
-
-* [bugs] #292 #293 #295 #301 #302
-* Some internal refactoring
-* Added Windows CI testing (appveyor)
+-   Stable release containing changes from the last dev release
 
-v2.1.0
----
+## v3.6.0-dev.1
 
-* Fix crash on Windows
+-   [enhancement] Add `--exclude` CLI option (#915)
+-   [bugfix] Fix `no-shadowed-variable` rule handling of standalone blocks (#1021)
+-   [deprecation] Configuration through `package.json` files (#1020)
+-   [API] Export additional configuration methods from top-level "tslint" module (#1009)
 
-v2.0.1
----
+Thanks to our contributors!
 
-* Upgraded Typescript compiler to 1.4
-* **BREAKING CHANGES**
-    * typedef rule options were modified:
-        * index-signature removed as no longer necessary
-        * property-signature renamed to property-declaration
-        * variable-declarator renamed to variable-declaration
-        * member-variable-declarator renamed to member-variable-declaration
-    * typedef-whitespace rule options were modified:
-        * catch-clause was removed as invalid
-        * further options were added, see readme for more details
-    * due to changes to the typescript compiler API, old custom rules may no longer work and may need to be rewritten
-    * the JSON formatter's line and character positions are now 1-indexed instead of 0-indexed
-
-v1.2.0
----
-
-* [bug] #245
-
-v1.0.1
----
-
-* [bug] #238
-
-v1.0.0
----
-
-* upgrade TypeScript compiler to 1.3
-* **BREAKING CHANGES**
-    * all error messages now start with a lower-case character and do not end with a period
-    * all rule options are consistent in nomenclature. The `typedef` and `typedef-whitespace` rules now take in hyphenated options
-    * `unused-variables` rule cannot find unused private variables defined in the constructor due to a bug in 1.3 compiler
-    * `indent` rule has changed to only check for tabs or spaces and not enforce indentation levels
-
-v0.4.12
----
-
-* multiple files with -f on cli
-* config file search starts with input file
-
-v0.4.11
----
-
-* [bugs] #136, #163
-* internal refactors
-
-v0.4.10
----
-
-* [bugs] #138, #145, #146, #148
-
-v0.4.9
----
-
-* [new-rule] `no-any` disallows all uses of `any`
-* [bug] `/* tslint:disable */` now disables semicolon rule as well
-* [bug] delete operator no longer results in a false positive for `no-unused-expression`
-
-v0.4.8
----
-
-* [new-rule] `no-var-requires` disallows require statements not part of an import statement
-* [new-rule] `typedef` rule also checks for member variables
-* [bug] `no-unused-variable` no longer triggers false positives for class members labeled only `static`
-* [bug] `no-unused-expression` no longer triggers false positives for `"use strict";` expressions
-* [bug] `use-strict` works correctly on function declarations
-* [bug] config file is now discoverable from other drives on Windows
-
-v0.4.7
----
-
-* [new-rule] added `no-unused-expression` rule which disallows unused expression statements
-* [feature] the `check-operator` option for the `whitespace` rule now checks whitespace around the => token
-* [bug] `no-use-before-declare-rule` no longer triggers false positives for member variables of classes used before the class is declared
-* [bug] semicolon at end of file no longer triggers false positives for `whitespace` rule
-* [bug] hoisted functions no longer cause false positives for the `no-unreachable` rule
-* [bug] the rule loader no longer transforms/ignores the leading and trailing underscores and dashes of rule names in the config file
-* [bug] `export import` statements no longer false positives for `no-unused-variable-rule`
-* [docs] added documentation for creating custom rules and formatters
-* [docs] added sample `tslint.json` file, under `docs/sample.tslint.json`
-
-v0.4.6
----
-
-* [build] migrated build to use `grunt-ts` instead of `grunt-typescript`
-* [feature] `package.json` now contains a `tslintConfig` paramater to allow users to specify the location of the configuration file there
-* [feature] tslint now searches for the configuration file in the user's home directory if not found in the current path
-* [bug] unbraced conditionals no longer cause false positives for the `no-unreachable` rule
-
-v0.4.5
----
-
-* [feature] `no-unused-variable` no longer checks parameters by default. Parameters are now only checked if the `check-parameters` option is set.
-* [bug] `no-unused-variable` parameter check no longer fails on variable argument parameters (like ...args) and on cases where the parameters are broken up by newlines.
-
-v0.4.4
----
-
-* [bug] `no-unused-variable` validates function parameters and constructor methods
-* [bug] `no-empty` and `no-trailing-comma` rules handle empty objects
-
-v0.4.3
----
-
-* [new-rule] `no-unused-variable`
-* [new-rule] `no-trailing-comma`
-* [new-rule] `no-use-before-declare`
-* [feature] support `--version` in CLI
-* [feature] expose rule names to custom formatters
-* [feature] add `verbose` formatter
-* [bug] `no-empty` allows constructors with member declaration parameters
-* [bug] CLI supports `--help`
-* [bug] `max-line-length` allows CRLF endings
+-   @blakeembrey
+-   @hamhut1066
+-   @meowtec
+
+## v3.5.0
+
+-   Stable release containing changes from the last dev release
+
+## v3.5.0-dev.1
+
+-   [new-rule-option] "ignore-pattern" option for `no-unused-variable` rule (#314)
+-   [bugfix] Fix occassional crash in `no-string-literal` rule (#906)
+-   [enhancement] Tweak behavior of `member-ordering` rule with regards to arrow function types in interfaces (#226)
+
+Thanks to our contributors!
+
+-   @arusakov
+-   @Pajn
+
+## v3.4.0
+
+-   Stable release containing changes from the last two dev releases
+
+## v3.4.0-dev.2
+
+-   [new-rule-option] "arrow-parameter" option for `typedef` rule (#333)
+-   [new-rule-option] "never" option for `semicolon` rule (#363)
+-   [new-rule-option] "onespace" setting for `typedef-whitespace` rule (#888)
+-   [new-rule-option] `typedef-whitespace` rule can now check spacing on right side of typdef colon (#888)
+-   [enhancement] `member-ordering` rule treats arrow functions as methods (#226)
+-   [bugfix] Handle spaces before typedefs correctly in `typedef-whitespace` rule (#955)
+-   [bugfix] `label-position` rule now allows labels on `for-of` loops (#959)
+
+Thanks to our contributors!
+
+-   @b0r3as
+-   @ChaseMoskal
+-   @Pajn
+-   @pe8ter
+-   @tomduncalf
+
+## v3.4.0-dev.1
+
+-   [enhancement] Revamped testing system (#620)
+    -   Writing tests for rules is now much simpler with a linter DSL.
+        See exisitng tests in `test/rules/**/*.ts.lint` for examples.
+-   [enhancement] New msbuild formatter (#947)
+-   [bugfix] Fix handling of multiline literals in `trailing-comma` rule (#856)
+-   [bugfix] `one-line` rule correctly checks space between `catch` and opening brace (#925)
+-   [bugfix] `one-line` rule correctly checks multiline variable declarations (#935)
+-   [new-rule-option] New option `check-finally` for `one-line` rule (#925)
+-   **BREAKING CHANGES**
+    -   [bugfix] Report error when a rule in the config file is not found (#598)
+
+Thanks to our contributors!
+
+-   @mmv
+-   @pe8ter
+
+## v3.3.0
+
+-   [bugfix] Tweak TSLint build so TSLint works with typescript@next (#926)
+
+## v3.3.0-dev.1
+
+-   [bugfix] Correctly handle more than one custom rules directory (#928)
+
+## v3.2.2
+
+-   Stable release containing changes from the last dev release
+
+## v3.2.2-dev.1
+
+-   [enhancement] Throw an error if a path to a directory of custom rules is invalid (#910)
+-   [new-rule-option] "jsx-single" and "jsx-double" options for `quotemark` rule (#673)
+-   [bugfix] Handle paths to directories of custom rules more accurately
+-   [bugfix] `no-unused-expression` rule handles `await` statements correctly (#887)
+
+## v3.2.1
+
+-   Stable release containing changes from the last dev release
+
+## v3.2.1-dev.1
+
+-   [enhancement] automatically generate a `tslint.json` file with new `--init` CLI command (#717)
+-   [bugfix] `no-var-keyword` rule detects the use of `var` in all types of `for` loops (#855)
+
+## v3.2.0
+
+-   Stable release containing changes from last two dev releases
+
+## v3.2.0-dev.2
+
+-   [bugfix] formatters are now exported correctly to work with TS 1.8 (#863)
+
+## v3.2.0-dev.1
+
+-   [bugfix] fixed bug in how custom rules directories are registered (#844)
+-   [enhancement] better support for globs in CLI (#827)
+-   [new-rule] `no-null-keyword` rule (#722)
+
+## v3.1.1
+
+-   Bump TypeScript peer dependency to `>= 1.7.3` due to `const enum` incompatibility (#832)
+
+## v3.1.0
+
+-   [bugfix] build with TS v1.7.3 to fix null pointer exception (#832)
+-   [bugfix] fixed false positive in `no-require-imports` rule (#816)
+
+## v3.1.0-dev.1
+
+-   [bugfix] fixed `no-shadowed-variable` false positives when handling destructuring in function params (#727)
+-   [enhancement] `rulesDirectory` in `tslint.json` now supports multiple file paths (#795)
+
+## v3.0.0
+
+-   [bugfix] `member-access` rule now handles object literals and get/set accessors properly (#801)
+    -   New rule options: `check-accessor` and `check-constructor`
+-   All the changes from the following releases, including some **breaking changes**:
+    -   `3.0.0-dev.3`
+    -   `3.0.0-dev.2`
+    -   `3.0.0-dev.1`
+    -   `2.6.0-dev.2`
+    -   `2.6.0-dev.1`
+
+## v3.0.0-dev.3
+
+-   TypeScript is now a peerDependency (#791)
+-   [bugfix] `no-unused-variable` rule with `react` option works with self-closing JSX tags (#776)
+-   [bugfix] `use-strict` bugfix (#544)
+
+## v3.0.0-dev.2
+
+-   [new-rule-option] "react" option for `no-unused-variable` rule (#698, #725)
+-   [bugfix] Fix how `Linter` is exported from "tslint" module (#760)
+-   [bugfix] `no-use-before-declare` rule doesn't crash on uncompilable code (#763)
+
+## v3.0.0-dev.1
+
+-   **BREAKING CHANGES**
+    -   Rearchitect TSLint to use external modules instead of merged namespaces (#726)
+        -   Dependencies need to be handled differently now by custom rules and formatters
+        -   See the [PR](https://github.com/palantir/tslint/pull/726) for full details about this change
+    -   `no-trailing-comma` rule removed, it is replaced by the `trailing-comma` rule (#687)
+    -   Rename `sort-object-literal-keys` rule to `object-literal-sort-keys` (#304, #537)
+    -   `Lint.abstract()` has been removed (#700)
+-   [new-rule] `trailing-comma` rule (#557, #687)
+-   [new-rule-option] "ban-keywords" option for `variable-name` rule (#735, #748)
+-   [bugfix] `typedef` rule now handles `for-of` loops correctly (#743)
+-   [bugfix] Handle tslint.json utf-8 files which have a BOM correctly (#90)
+
+## v2.6.0-dev.2
+
+-   Upgrade TypeScript compiler to `v1.7.0-dev.20151003`
+-   [bugfix] `no-unused-expression` rule now handles yield expressions properly (#706)
+
+## v2.6.0-dev.1
+
+-   Upgrade TypeScript compiler to `v1.7.0-dev.20150924`
+
+## v2.5.1
+
+-   [new-rule] no-inferrable-types rule (#676)
+-   [new-rule-option] "avoid-escape" option for quotemark rule (#543)
+-   [bugfix] type declaration for tslint external module #686
+-   [enhancement] `AbstractRule` and `AbstractFormatter` are now abstract classes (#631)
+    -   Note: `Lint.abstract()` is now deprecated
+
+## v2.5.0
+
+-   Use TypeScript compiler `v1.6.2`
+-   [bugfixes] #637, #642, #650, #652
+-   [bugfixes] fix various false positives in `no-unused-variable` rule (#570, #613, #663)
+-   Update project setup for latest VSCode (#662)
+
+## v2.5.0-beta
+
+-   Use TypeScript compiler `v1.6.0-beta`
+-   [bugfix] Fix `no-internal-module` false positives on nested namespaces (#600)
+-   [docs] Add documentation for `sort-object-literal-keys` rule
+
+## v2.5.0-dev.5
+
+-   Upgrade TypeScript compiler to `v1.7.0-dev.20150828`
+-   [bugfix] Handle .tsx files appropriately (#597, #558)
+
+## v2.5.0-dev.4
+
+-   Upgrade TypeScript compiler to `v1.6.0-dev.20150825`
+
+## v2.5.0-dev.3
+
+-   Upgrade TypeScript compiler to `v1.6.0-dev.20150821`
+
+## v2.5.0-dev.2
+
+-   Upgrade TypeScript compiler to `v1.6.0-dev.20150811`
+-   [bug] fix `whitespace` false positive in JSX elements (#559)
+
+## v2.5.0-dev.1
+
+-   Upgrade TypeScript compiler to `v1.6.0-dev.20150805`
+-   [enhancement] Support `.tsx` syntax (#490)
+
+## v2.4.5
+
+-   [bugfix] fix false positives on `no-shadowed-variable` rule (#500)
+-   [enhancement] add `allow-trailing-underscore` option to `variable-name` rule
+
+## v2.4.4
+
+-   [bugfix] remove "typescript" block from package.json (#606)
+
+## v2.4.3
+
+-   [new-rule] `no-conditional-assignment` (#507)
+-   [new-rule] `member-access` (#552)
+-   [new-rule] `no-internal-module` (#513)
+-   [bugfix] small fixes to `sample.tslint.json` (#545)
+-   [bugfix] fix README docs for quotemark and indent (#523)
+-   [enhancement] update `findup-sync` and `underscore.string` dependencies
+-   [enhancement] add `"typescript"` field to `package.json` (#560)
+-   [enhancement] small improvements to CLI help text
+-   [enhancement] expose raw failures array in the JS API (#477)
+
+## v2.4.2
+
+-   [bug] remove npm-shrinkwrap.json from the published package
+
+## v2.4.0
+
+-   Upgraded Typescript compiler to 1.5.3
+-   [bugs] #332, #493, #509, #483
+-   [bug] fix error message in `no-var-keyword` rule
+-   [enhancement] CI tests are now run on node v0.12 in addition to v0.10
+-   **BREAKING**
+    -   `-f` option removed from CLI
+
+## v2.3.1-beta
+
+-   [bugs] #137 #434 #451 #456
+-   [new-rule] `no-require-imports` disallows `require()` style imports
+-   [new-rule] `no-shadowed-variable` moves over shadowed variable checking from `no-duplicate-variable` into its own rule
+-   **BREAKING**
+    -   `no-duplicate-variable` now only checks for duplicates within the same block scope; enable `no-shadowed-variable` to get duplicate-variable checking across block scopes
+-   [enhancement] `no-duplicate-variable`, `no-shadowed-variable`, and `no-use-before-declare` now support ES6 destructuring
+-   [enhancement] tslint CLI now uses a default configuration if no config file is found
+
+## v2.3.0-beta
+
+-   [bugs] #401 #367 #324 #352
+-   [new-rule] `no-var-keyword` disallows `var` in favor of `let` and `const`
+-   [new-rule] `sort-object-literal-keys` forces object-literal keys to be sorted alphabetically
+-   Add support for ES6 destructuring and module syntax (affects `variable-name`, `no-use-before-declare`, `whitespace` and `no-unused-variable`)
+-   Add support for ES6 for-of and spread operator syntax
+-   Use tsconfig.json & JSCS in the build system
+
+## v2.2.0-beta
+
+-   Upgraded Typescript compiler to 1.5.0-beta
+-   **BREAKING CHANGES**
+    -   due to changes to the typescript compiler API, old custom rules may no longer work and may need to be rewritten
+    -   the JSON formatter's line and character positions are now back to being 0-indexed instead of 1-indexed
+-   [bugs] #328 #334 #319 #351 #365 #254
+-   [bug] fixes for tslint behavior around template strings (fixes #357, #349, #332, and more)
+-   [new-rule] `align` rule now enforces vertical alignment on parameters, arguments, and statements
+-   [new-rule] `switch-default` enforces a `default` case in `switch` statements
+-   [feature] `no-duplicate-variable` rule now additionally checks if function parameters have been shadowed
+-   Additional fixes to existing rules to work as before with the typescript 1.5 compiler
+
+## v2.1.1
+
+-   [bugs] #292 #293 #295 #301 #302
+-   Some internal refactoring
+-   Added Windows CI testing (appveyor)
+
+## v2.1.0
+
+-   Fix crash on Windows
+
+## v2.0.1
+
+-   Upgraded Typescript compiler to 1.4
+-   **BREAKING CHANGES**
+    -   typedef rule options were modified:
+        -   index-signature removed as no longer necessary
+        -   property-signature renamed to property-declaration
+        -   variable-declarator renamed to variable-declaration
+        -   member-variable-declarator renamed to member-variable-declaration
+    -   typedef-whitespace rule options were modified:
+        -   catch-clause was removed as invalid
+        -   further options were added, see readme for more details
+    -   due to changes to the typescript compiler API, old custom rules may no longer work and may need to be rewritten
+    -   the JSON formatter's line and character positions are now 1-indexed instead of 0-indexed
+
+## v1.2.0
+
+-   [bug] #245
+
+## v1.0.1
+
+-   [bug] #238
+
+## v1.0.0
+
+-   upgrade TypeScript compiler to 1.3
+-   **BREAKING CHANGES**
+    -   all error messages now start with a lower-case character and do not end with a period
+    -   all rule options are consistent in nomenclature. The `typedef` and `typedef-whitespace` rules now take in hyphenated options
+    -   `unused-variables` rule cannot find unused private variables defined in the constructor due to a bug in 1.3 compiler
+    -   `indent` rule has changed to only check for tabs or spaces and not enforce indentation levels
+
+## v0.4.12
+
+-   multiple files with -f on cli
+-   config file search starts with input file
+
+## v0.4.11
+
+-   [bugs] #136, #163
+-   internal refactors
+
+## v0.4.10
+
+-   [bugs] #138, #145, #146, #148
+
+## v0.4.9
+
+-   [new-rule] `no-any` disallows all uses of `any`
+-   [bug] `/* tslint:disable */` now disables semicolon rule as well
+-   [bug] delete operator no longer results in a false positive for `no-unused-expression`
+
+## v0.4.8
+
+-   [new-rule] `no-var-requires` disallows require statements not part of an import statement
+-   [new-rule] `typedef` rule also checks for member variables
+-   [bug] `no-unused-variable` no longer triggers false positives for class members labeled only `static`
+-   [bug] `no-unused-expression` no longer triggers false positives for `"use strict";` expressions
+-   [bug] `use-strict` works correctly on function declarations
+-   [bug] config file is now discoverable from other drives on Windows
+
+## v0.4.7
+
+-   [new-rule] added `no-unused-expression` rule which disallows unused expression statements
+-   [feature] the `check-operator` option for the `whitespace` rule now checks whitespace around the => token
+-   [bug] `no-use-before-declare-rule` no longer triggers false positives for member variables of classes used before the class is declared
+-   [bug] semicolon at end of file no longer triggers false positives for `whitespace` rule
+-   [bug] hoisted functions no longer cause false positives for the `no-unreachable` rule
+-   [bug] the rule loader no longer transforms/ignores the leading and trailing underscores and dashes of rule names in the config file
+-   [bug] `export import` statements no longer false positives for `no-unused-variable-rule`
+-   [docs] added documentation for creating custom rules and formatters
+-   [docs] added sample `tslint.json` file, under `docs/sample.tslint.json`
+
+## v0.4.6
+
+-   [build] migrated build to use `grunt-ts` instead of `grunt-typescript`
+-   [feature] `package.json` now contains a `tslintConfig` paramater to allow users to specify the location of the configuration file there
+-   [feature] tslint now searches for the configuration file in the user's home directory if not found in the current path
+-   [bug] unbraced conditionals no longer cause false positives for the `no-unreachable` rule
+
+## v0.4.5
+
+-   [feature] `no-unused-variable` no longer checks parameters by default. Parameters are now only checked if the `check-parameters` option is set.
+-   [bug] `no-unused-variable` parameter check no longer fails on variable argument parameters (like ...args) and on cases where the parameters are broken up by newlines.
+
+## v0.4.4
+
+-   [bug] `no-unused-variable` validates function parameters and constructor methods
+-   [bug] `no-empty` and `no-trailing-comma` rules handle empty objects
+
+## v0.4.3
+
+-   [new-rule] `no-unused-variable`
+-   [new-rule] `no-trailing-comma`
+-   [new-rule] `no-use-before-declare`
+-   [feature] support `--version` in CLI
+-   [feature] expose rule names to custom formatters
+-   [feature] add `verbose` formatter
+-   [bug] `no-empty` allows constructors with member declaration parameters
+-   [bug] CLI supports `--help`
+-   [bug] `max-line-length` allows CRLF endings

--- a/README.md
+++ b/README.md
@@ -2,60 +2,57 @@
 [![Downloads](http://img.shields.io/npm/dm/tslint.svg)](https://npmjs.org/package/tslint)
 [![Circle CI](https://circleci.com/gh/palantir/tslint.svg?style=svg)](https://circleci.com/gh/palantir/tslint)
 
-TSLint
-======
+# TSLint
 
 TSLint is an extensible static analysis tool that checks [TypeScript](https://github.com/Microsoft/TypeScript) code for readability, maintainability, and functionality errors. It is widely supported across modern editors & build systems and can be customized with your own lint rules, configurations, and formatters.
 
 TSLint supports:
 
-- an extensive set of core rules
-- custom lint rules
-- custom formatters (failure reporters)
-- inline disabling and enabling of rules with comment flags in source code
-- configuration presets (`tslint:latest`, `tslint-react`, etc.) and plugin composition
-- automatic fixing of formatting & style violations
-- integration with [MSBuild](https://github.com/joshuakgoldberg/tslint.msbuild), [Grunt](https://github.com/palantir/grunt-tslint), [Gulp](https://github.com/panuhorsmalahti/gulp-tslint), [Atom](https://github.com/AtomLinter/linter-tslint), [Eclipse](https://github.com/palantir/eclipse-tslint), [Emacs](http://flycheck.org), [Sublime](https://packagecontrol.io/packages/SublimeLinter-contrib-tslint), [Vim](https://github.com/scrooloose/syntastic), [Visual Studio 2015](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.WebAnalyzer), [Visual Studio 2017](https://marketplace.visualstudio.com/items?itemName=RichNewman.TypeScriptAnalyzer), [Visual Studio code](https://marketplace.visualstudio.com/items?itemName=eg2.tslint), [WebStorm](https://www.jetbrains.com/webstorm/help/tslint.html) and [more](https://palantir.github.io/tslint/usage/third-party-tools/)
+-   an extensive set of core rules
+-   custom lint rules
+-   custom formatters (failure reporters)
+-   inline disabling and enabling of rules with comment flags in source code
+-   configuration presets (`tslint:latest`, `tslint-react`, etc.) and plugin composition
+-   automatic fixing of formatting & style violations
+-   integration with [MSBuild](https://github.com/joshuakgoldberg/tslint.msbuild), [Grunt](https://github.com/palantir/grunt-tslint), [Gulp](https://github.com/panuhorsmalahti/gulp-tslint), [Atom](https://github.com/AtomLinter/linter-tslint), [Eclipse](https://github.com/palantir/eclipse-tslint), [Emacs](http://flycheck.org), [Sublime](https://packagecontrol.io/packages/SublimeLinter-contrib-tslint), [Vim](https://github.com/scrooloose/syntastic), [Visual Studio 2015](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.WebAnalyzer), [Visual Studio 2017](https://marketplace.visualstudio.com/items?itemName=RichNewman.TypeScriptAnalyzer), [Visual Studio code](https://marketplace.visualstudio.com/items?itemName=eg2.tslint), [WebStorm](https://www.jetbrains.com/webstorm/help/tslint.html) and [more](https://palantir.github.io/tslint/usage/third-party-tools/)
 
-Installation & Usage
-------------
+## Installation & Usage
 
 Please refer to the full installation & usage documentation on the [TSLint website](https://palantir.github.io/tslint/). There, you'll find information about
-- [configuration](https://palantir.github.io/tslint/usage/configuration/),
-- [core rules](https://palantir.github.io/tslint/rules/),
-- [core formatters](https://palantir.github.io/tslint/formatters/), and
-- [customization of TSLint](https://palantir.github.io/tslint/develop/custom-rules/).
-- [inline disabling and enabling of rules with comment flags](https://palantir.github.io/tslint/usage/rule-flags/)
 
-Custom Rules & Plugins
-------------
+-   [configuration](https://palantir.github.io/tslint/usage/configuration/),
+-   [core rules](https://palantir.github.io/tslint/rules/),
+-   [core formatters](https://palantir.github.io/tslint/formatters/), and
+-   [customization of TSLint](https://palantir.github.io/tslint/develop/custom-rules/).
+-   [inline disabling and enabling of rules with comment flags](https://palantir.github.io/tslint/usage/rule-flags/)
+
+## Custom Rules & Plugins
 
 #### Custom rule sets from Palantir
 
-- [tslint-react](https://github.com/palantir/tslint-react) - Lint rules related to React & JSX.
-- [tslint-blueprint](https://github.com/palantir/tslint-blueprint) - Lint rules to enforce best practices with [blueprintjs libraries](https://github.com/palantir/blueprint)
+-   [tslint-react](https://github.com/palantir/tslint-react) - Lint rules related to React & JSX.
+-   [tslint-blueprint](https://github.com/palantir/tslint-blueprint) - Lint rules to enforce best practices with [blueprintjs libraries](https://github.com/palantir/blueprint)
 
 #### Custom rule sets from the community
 
 If we don't have all the rules you're looking for, you can either write your own [custom rules](https://palantir.github.io/tslint/develop/custom-rules/) or use rules implementations developed by the community. The repos below are a good source of custom rules:
 
-- [ESLint rules for TSLint](https://github.com/buzinas/tslint-eslint-rules) - Improve your TSLint with the missing ESLint Rules
-- [tslint-microsoft-contrib](https://github.com/Microsoft/tslint-microsoft-contrib) - A set of TSLint rules used on some Microsoft projects
-- [codelyzer](https://github.com/mgechev/codelyzer) - A set of tslint rules for static code analysis of Angular TypeScript projects
-- [vrsource-tslint-rules](https://github.com/vrsource/vrsource-tslint-rules)
-- [tslint-immutable](https://github.com/jonaskello/tslint-immutable) - TSLint rules to disable mutation in TypeScript
-- [tslint-consistent-codestyle](https://github.com/ajafff/tslint-consistent-codestyle) - TSLint rules to enforce consistent code style in TypeScript
-- [tslint-sonarts](https://github.com/SonarSource/SonarTS) - Bug-finding rules based on advanced code models to spot hard to find errors in TypeScript
-- [tslint-clean-code](https://github.com/Glavin001/tslint-clean-code) - A set of TSLint rules inspired by the Clean Code handbook
-- [rxjs-tslint-rules](https://github.com/cartant/rxjs-tslint-rules) - TSLint rules for RxJS 
+-   [ESLint rules for TSLint](https://github.com/buzinas/tslint-eslint-rules) - Improve your TSLint with the missing ESLint Rules
+-   [tslint-microsoft-contrib](https://github.com/Microsoft/tslint-microsoft-contrib) - A set of TSLint rules used on some Microsoft projects
+-   [codelyzer](https://github.com/mgechev/codelyzer) - A set of tslint rules for static code analysis of Angular TypeScript projects
+-   [vrsource-tslint-rules](https://github.com/vrsource/vrsource-tslint-rules)
+-   [tslint-immutable](https://github.com/jonaskello/tslint-immutable) - TSLint rules to disable mutation in TypeScript
+-   [tslint-consistent-codestyle](https://github.com/ajafff/tslint-consistent-codestyle) - TSLint rules to enforce consistent code style in TypeScript
+-   [tslint-sonarts](https://github.com/SonarSource/SonarTS) - Bug-finding rules based on advanced code models to spot hard to find errors in TypeScript
+-   [tslint-clean-code](https://github.com/Glavin001/tslint-clean-code) - A set of TSLint rules inspired by the Clean Code handbook
+-   [rxjs-tslint-rules](https://github.com/cartant/rxjs-tslint-rules) - TSLint rules for RxJS
 
-Development
------------
+## Development
 
 Prerequisites:
 
-- `node` v7+
-- `yarn` v1.0+
+-   `node` v7+
+-   `yarn` v1.0+
 
 #### Quick Start
 
@@ -66,15 +63,14 @@ yarn compile
 yarn test
 ```
 
-Creating a new release
-----------------------
+## Creating a new release
 
 1. Bump the version number in `package.json` and `src/linter.ts`
 2. Add release notes in `CHANGELOG.md`
     - Use `./scripts/generate-changelog.js` (after building it with `tsc -p scripts`) to generate the changelog diff. This script expects a [Github.com personal access token](https://github.com/settings/tokens) to exist at `~/github_token.txt` with "repo" permissions.
-4. Commit with message `Prepare release <version>`
-5. Push your branch to GitHub and make a PR
-6. Once your PR is merged, wait for the tests to pass on CircleCI for develop
-7. Create a "Release" on GitHub with the proper tag version and notes from the changelog.
+3. Commit with message `Prepare release <version>`
+4. Push your branch to GitHub and make a PR
+5. Once your PR is merged, wait for the tests to pass on CircleCI for develop
+6. Create a "Release" on GitHub with the proper tag version and notes from the changelog.
     - The tag should be identical to the version in `package.json`
-8. Run `yarn run publish:local`
+7. Run `yarn run publish:local`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,16 @@
 environment:
-  matrix:
-  - nodejs_version: "4.1.2"
-  - nodejs_version: "5.7"
-  - nodejs_version: "6.1"
+    matrix:
+        - nodejs_version: "4.1.2"
+        - nodejs_version: "5.7"
+        - nodejs_version: "6.1"
 
 install:
-  - ps: Install-Product node $env:nodejs_version
-  - npm install
+    - ps: Install-Product node $env:nodejs_version
+    - npm install
 
 test_script:
-  - node --version
-  - npm --version
-  - npm run verify
+    - node --version
+    - npm --version
+    - npm run verify
 
 build: off

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "lint:from-bin": "node bin/tslint --project test/tsconfig.json --format stylish",
         "precommit": "npm-run-all precommit:prettier",
         "precommit:prettier": "pretty-quick --staged",
-        "prettier": "prettier --write ./**/*.{js,ts,css,scss,json,md,yml} --ignore-path ./.prettierignore",
+        "prettier": "prettier --write ./**/*.{js,ts,css,scss,md,yml} --ignore-path ./.prettierignore",
         "publish:local": "./scripts/npmPublish.sh",
         "test": "npm-run-all test:pre -p test:mocha test:rules",
         "test:pre": "cd ./test/config && npm install --no-save",

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -29,7 +29,10 @@ export const rules = {
     "ban-types": {
         options: [
             ["Object", "Avoid using the `Object` type. Did you mean `object`?"],
-            ["Function", "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."],
+            [
+                "Function",
+                "Avoid using the `Function` type. Prefer a specific function type, like `() => void`.",
+            ],
             ["Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?"],
             ["Number", "Avoid using the `Number` type. Did you mean `number`?"],
             ["String", "Avoid using the `String` type. Did you mean `string`?"],
@@ -38,10 +41,13 @@ export const rules = {
     },
     "ban-ts-ignore": true,
     "member-access": [true, "check-accessor", "check-constructor", "check-parameter-property"],
-    "member-ordering": [true, {
-        "order": "statics-first",
-        "alphabetize": true,
-    }],
+    "member-ordering": [
+        true,
+        {
+            order: "statics-first",
+            alphabetize: true,
+        },
+    ],
     "no-any": true,
     "no-empty-interface": true,
     "no-import-side-effect": true,
@@ -58,7 +64,7 @@ export const rules = {
     "prefer-for-of": true,
     "prefer-readonly": true,
     "promise-function-async": true,
-    "typedef": [
+    typedef: [
         true,
         "call-signature",
         "arrow-call-signature",
@@ -73,14 +79,14 @@ export const rules = {
         {
             "call-signature": "nospace",
             "index-signature": "nospace",
-            "parameter": "nospace",
+            parameter: "nospace",
             "property-declaration": "nospace",
             "variable-declaration": "nospace",
         },
         {
             "call-signature": "onespace",
             "index-signature": "onespace",
-            "parameter": "onespace",
+            parameter: "onespace",
             "property-declaration": "onespace",
             "variable-declaration": "onespace",
         },
@@ -91,8 +97,8 @@ export const rules = {
     "await-promise": true,
     // "ban": no sensible default
     "ban-comma-operator": true,
-    "curly": true,
-    "forin": true,
+    curly: true,
+    forin: true,
     // "import-blacklist": no sensible default
     "label-position": true,
     "no-arg": true,
@@ -103,10 +109,7 @@ export const rules = {
     "no-debugger": true,
     "no-duplicate-super": true,
     "no-duplicate-switch-case": true,
-    "no-duplicate-variable": [
-        true,
-        "check-parameters",
-    ],
+    "no-duplicate-variable": [true, "check-parameters"],
     "no-dynamic-delete": true,
     "no-empty": true,
     "no-eval": true,
@@ -135,7 +138,7 @@ export const rules = {
     "no-var-keyword": true,
     "no-void-expression": true,
     "prefer-conditional-expression": true,
-    "radix": true,
+    radix: true,
     "restrict-plus-operands": true,
     "strict-boolean-expressions": true,
     "strict-type-predicates": true,
@@ -147,8 +150,8 @@ export const rules = {
     // Maintainability
 
     "cyclomatic-complexity": true,
-    "eofline": true,
-    "indent": [true, "spaces"],
+    eofline: true,
+    indent: [true, "spaces"],
     "linebreak-style": [true, "LF"],
     "max-classes-per-file": [true, 1],
     "max-file-line-count": [true, 1000],
@@ -162,38 +165,30 @@ export const rules = {
     "no-trailing-whitespace": true,
     "object-literal-sort-keys": true,
     "prefer-const": true,
-    "trailing-comma": [true, {
-        "esSpecCompliant": true,
-        "multiline": "always",
-        "singleline": "never",
-    }],
+    "trailing-comma": [
+        true,
+        {
+            esSpecCompliant: true,
+            multiline: "always",
+            singleline: "never",
+        },
+    ],
 
     // Style
 
-    "align": [
-        true,
-        "parameters",
-        "arguments",
-        "statements",
-        "elements",
-        "members",
-    ],
+    align: [true, "parameters", "arguments", "statements", "elements", "members"],
     "array-type": [true, "array-simple"],
     "arrow-parens": true,
     "arrow-return-shorthand": [true, "multiline"],
     "binary-expression-operand-order": true,
     "callable-types": true,
     "class-name": true,
-    "comment-format": [
-        true,
-        "check-space",
-        "check-uppercase",
-    ],
+    "comment-format": [true, "check-space", "check-uppercase"],
     "comment-type": [true, "singleline", "multiline", "doc", "directive"],
     "completed-docs": true,
     // "file-header": No sensible default
-    "deprecation": true,
-    "encoding": true,
+    deprecation: true,
+    encoding: true,
     "file-name-casing": [true, "camel-case"],
     "import-spacing": true,
     "increment-decrement": true,
@@ -226,41 +221,38 @@ export const rules = {
         "check-whitespace",
     ],
     "one-variable-per-declaration": true,
-    "ordered-imports": [true, {
-        "import-sources-order": "case-insensitive",
-        "named-imports-order": "case-insensitive",
-        "module-source-path": "full",
-    }],
+    "ordered-imports": [
+        true,
+        {
+            "import-sources-order": "case-insensitive",
+            "named-imports-order": "case-insensitive",
+            "module-source-path": "full",
+        },
+    ],
     "prefer-function-over-method": true,
     "prefer-method-signature": true,
     "prefer-object-spread": true,
     "prefer-switch": true,
     "prefer-template": true,
     "prefer-while": true,
-    "quotemark": [
-        true,
-        "double",
-        "avoid-escape",
-        "avoid-template",
-    ],
+    quotemark: [true, "double", "avoid-escape", "avoid-template"],
     "return-undefined": true,
-    "semicolon": [true, "always"],
-    "space-before-function-paren": [true, {
-        "anonymous": "never",
-        "asyncArrow": "always",
-        "constructor": "never",
-        "method": "never",
-        "named": "never",
-    }],
+    semicolon: [true, "always"],
+    "space-before-function-paren": [
+        true,
+        {
+            anonymous: "never",
+            asyncArrow: "always",
+            constructor: "never",
+            method: "never",
+            named: "never",
+        },
+    ],
     "space-within-parens": [true, 0],
     "switch-final-break": true,
     "type-literal-delimiter": true,
-    "variable-name": [
-        true,
-        "ban-keywords",
-        "check-format",
-    ],
-    "whitespace": [
+    "variable-name": [true, "ban-keywords", "check-format"],
+    whitespace: [
         true,
         "check-branch",
         "check-decl",
@@ -275,8 +267,15 @@ export const rules = {
     ],
 };
 
-export const RULES_EXCLUDED_FROM_ALL_CONFIG =
-    ["ban", "fileHeader", "importBlacklist", "noInvalidThis", "noSwitchCaseFallThrough", "typeofCompare", "noUnusedVariable"];
+export const RULES_EXCLUDED_FROM_ALL_CONFIG = [
+    "ban",
+    "fileHeader",
+    "importBlacklist",
+    "noInvalidThis",
+    "noSwitchCaseFallThrough",
+    "typeofCompare",
+    "noUnusedVariable",
+];
 
 // Exclude typescript-only rules from jsRules, otherwise it's identical.
 export const jsRules: { [key: string]: any } = {};

--- a/src/configs/latest.ts
+++ b/src/configs/latest.ts
@@ -19,12 +19,8 @@
 // tslint:disable:object-literal-key-quotes
 export const rules = {
     // added in v5.1
-    "align": {
-        options: [
-            "parameters",
-            "statements",
-            "members",
-        ],
+    align: {
+        options: ["parameters", "statements", "members"],
     },
     "no-invalid-template-strings": true,
     "no-sparse-arrays": true,
@@ -37,10 +33,7 @@ export const rules = {
     "prefer-object-spread": true,
 
     // added in v5.4
-    "no-duplicate-variable": [
-        true,
-        "check-parameters",
-    ],
+    "no-duplicate-variable": [true, "check-parameters"],
 
     // added in v5.5
     "no-this-assignment": true,
@@ -51,7 +44,7 @@ export const rules = {
     "no-submodule-imports": true,
 
     // added in v5.7
-    "whitespace": {
+    whitespace: {
         options: [
             "check-branch",
             "check-decl",

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -17,11 +17,8 @@
 
 export const rules = {
     "adjacent-overload-signatures": true,
-    "align": {
-        options: [
-            "parameters",
-            "statements",
-        ],
+    align: {
+        options: ["parameters", "statements"],
     },
     "array-type": {
         options: ["array-simple"],
@@ -31,7 +28,10 @@ export const rules = {
     "ban-types": {
         options: [
             ["Object", "Avoid using the `Object` type. Did you mean `object`?"],
-            ["Function", "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."],
+            [
+                "Function",
+                "Avoid using the `Function` type. Prefer a specific function type, like `() => void`.",
+            ],
             ["Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?"],
             ["Number", "Avoid using the `Number` type. Did you mean `number`?"],
             ["String", "Avoid using the `String` type. Did you mean `string`?"],
@@ -43,12 +43,12 @@ export const rules = {
     "comment-format": {
         options: ["check-space"],
     },
-    "curly": true,
+    curly: true,
     "cyclomatic-complexity": false,
-    "eofline": true,
-    "forin": true,
+    eofline: true,
+    forin: true,
     "import-spacing": true,
-    "indent":  {
+    indent: {
         options: ["spaces"],
     },
     "interface-name": {
@@ -120,10 +120,7 @@ export const rules = {
         options: ["ignore-for-loop"],
     },
     "only-arrow-functions": {
-        options: [
-            "allow-declarations",
-            "allow-named-functions",
-        ],
+        options: ["allow-declarations", "allow-named-functions"],
     },
     "ordered-imports": {
         options: {
@@ -134,14 +131,11 @@ export const rules = {
     },
     "prefer-const": true,
     "prefer-for-of": true,
-    "quotemark": {
-        options: [
-            "double",
-            "avoid-escape",
-        ],
+    quotemark: {
+        options: ["double", "avoid-escape"],
     },
-    "radix": true,
-    "semicolon": {
+    radix: true,
+    semicolon: {
         options: ["always"],
     },
     "space-before-function-paren": {
@@ -163,20 +157,20 @@ export const rules = {
     "triple-equals": {
         options: ["allow-null-check"],
     },
-    "typedef": false,
+    typedef: false,
     "typedef-whitespace": {
         options: [
             {
                 "call-signature": "nospace",
                 "index-signature": "nospace",
-                "parameter": "nospace",
+                parameter: "nospace",
                 "property-declaration": "nospace",
                 "variable-declaration": "nospace",
             },
             {
                 "call-signature": "onespace",
                 "index-signature": "onespace",
-                "parameter": "onespace",
+                parameter: "onespace",
                 "property-declaration": "onespace",
                 "variable-declaration": "onespace",
             },
@@ -186,13 +180,9 @@ export const rules = {
     "unified-signatures": true,
     "use-isnan": true,
     "variable-name": {
-        options: [
-            "ban-keywords",
-            "check-format",
-            "allow-pascal-case",
-        ],
+        options: ["ban-keywords", "check-format", "allow-pascal-case"],
     },
-    "whitespace": {
+    whitespace: {
         options: [
             "check-branch",
             "check-decl",
@@ -204,18 +194,15 @@ export const rules = {
     },
 };
 export const jsRules = {
-    "align": {
-        options: [
-            "parameters",
-            "statements",
-        ],
+    align: {
+        options: ["parameters", "statements"],
     },
     "class-name": true,
-    "curly": true,
-    "eofline": true,
-    "forin": true,
+    curly: true,
+    eofline: true,
+    forin: true,
     "import-spacing": true,
-    "indent":  {
+    indent: {
         options: ["spaces"],
     },
     "jsdoc-format": true,
@@ -257,14 +244,11 @@ export const jsRules = {
     "one-variable-per-declaration": {
         options: ["ignore-for-loop"],
     },
-    "quotemark": {
-        options: [
-            "double",
-            "avoid-escape",
-        ],
+    quotemark: {
+        options: ["double", "avoid-escape"],
     },
-    "radix": true,
-    "semicolon": {
+    radix: true,
+    semicolon: {
         options: ["always"],
     },
     "space-before-function-paren": {
@@ -287,13 +271,9 @@ export const jsRules = {
     },
     "use-isnan": true,
     "variable-name": {
-        options: [
-            "ban-keywords",
-            "check-format",
-            "allow-pascal-case",
-        ],
+        options: ["ban-keywords", "check-format", "allow-pascal-case"],
     },
-    "whitespace": {
+    whitespace: {
         options: [
             "check-branch",
             "check-decl",

--- a/src/formatters/checkstyleFormatter.ts
+++ b/src/formatters/checkstyleFormatter.ts
@@ -43,8 +43,9 @@ export class Formatter extends AbstractFormatter {
         let output = '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">';
 
         if (failures.length !== 0) {
-            const failuresSorted = failures.sort(
-                (a, b) => a.getFileName().localeCompare(b.getFileName()));
+            const failuresSorted = failures.sort((a, b) =>
+                a.getFileName().localeCompare(b.getFileName()),
+            );
             let previousFilename: string | null = null;
             for (const failure of failuresSorted) {
                 const severity = failure.getRuleSeverity();
@@ -55,8 +56,10 @@ export class Formatter extends AbstractFormatter {
                     previousFilename = failure.getFileName();
                     output += `<file name="${this.escapeXml(failure.getFileName())}">`;
                 }
-                output += `<error line="${failure.getStartPosition().getLineAndCharacter().line + 1}" `;
-                output += `column="${failure.getStartPosition().getLineAndCharacter().character + 1}" `;
+                output += `<error line="${failure.getStartPosition().getLineAndCharacter().line +
+                    1}" `;
+                output += `column="${failure.getStartPosition().getLineAndCharacter().character +
+                    1}" `;
                 output += `severity="${severity}" `;
                 output += `message="${this.escapeXml(failure.getFailure())}" `;
                 // checkstyle parser wants "source" to have structure like <anything>dot<category>dot<type>

--- a/src/formatters/codeFrameFormatter.ts
+++ b/src/formatters/codeFrameFormatter.ts
@@ -67,7 +67,10 @@ export class Formatter extends AbstractFormatter {
             }
 
             let failureString = failure.getFailure();
-            failureString = failure.getRuleSeverity() === "warning" ? chalk.yellow(failureString) : chalk.red(failureString);
+            failureString =
+                failure.getRuleSeverity() === "warning"
+                    ? chalk.yellow(failureString)
+                    : chalk.red(failureString);
 
             // Rule
             let ruleName = failure.getRuleName();

--- a/src/formatters/jsonFormatter.ts
+++ b/src/formatters/jsonFormatter.ts
@@ -54,7 +54,7 @@ export class Formatter extends AbstractFormatter {
     /* tslint:enable:object-literal-sort-keys */
 
     public format(failures: RuleFailure[]): string {
-        const failuresJSON = failures.map((failure) => failure.toJson());
+        const failuresJSON = failures.map(failure => failure.toJson());
         return JSON.stringify(failuresJSON);
     }
 }

--- a/src/formatters/junitFormatter.ts
+++ b/src/formatters/junitFormatter.ts
@@ -46,8 +46,9 @@ export class Formatter extends AbstractFormatter {
         let output = '<?xml version="1.0" encoding="utf-8"?><testsuites package="tslint">';
 
         if (failures.length !== 0) {
-            const failuresSorted = failures.sort(
-                (a, b) => a.getFileName().localeCompare(b.getFileName()));
+            const failuresSorted = failures.sort((a, b) =>
+                a.getFileName().localeCompare(b.getFileName()),
+            );
             let previousFilename: string | null = null;
             for (const failure of failuresSorted) {
                 const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();

--- a/src/formatters/msbuildFormatter.ts
+++ b/src/formatters/msbuildFormatter.ts
@@ -40,7 +40,8 @@ export class Formatter extends AbstractFormatter {
             const camelizedRule = camelize(failure.getRuleName());
 
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
-            const positionTuple = `(${lineAndCharacter.line + 1},${lineAndCharacter.character + 1})`;
+            const positionTuple = `(${lineAndCharacter.line + 1},${lineAndCharacter.character +
+                1})`;
             const severity = failure.getRuleSeverity();
 
             return `${fileName}${positionTuple}: ${severity} ${camelizedRule}: ${failureString}`;

--- a/src/formatters/pmdFormatter.ts
+++ b/src/formatters/pmdFormatter.ts
@@ -38,10 +38,11 @@ export class Formatter extends AbstractFormatter {
     /* tslint:enable:object-literal-sort-keys */
 
     public format(failures: RuleFailure[]): string {
-        let output = "<pmd version=\"tslint\">";
+        let output = '<pmd version="tslint">';
 
         for (const failure of failures) {
-            const failureString = failure.getFailure()
+            const failureString = failure
+                .getFailure()
                 .replace(/&/g, "&amp;")
                 .replace(/</g, "&lt;")
                 .replace(/>/g, "&gt;")

--- a/src/formatters/stylishFormatter.ts
+++ b/src/formatters/stylishFormatter.ts
@@ -55,8 +55,8 @@ export class Formatter extends AbstractFormatter {
             return [];
         }
         const outputLines: string[] = [];
-        const positionMaxSize       = this.getPositionMaxSize(failures);
-        const ruleMaxSize           = this.getRuleMaxSize(failures);
+        const positionMaxSize = this.getPositionMaxSize(failures);
+        const ruleMaxSize = this.getRuleMaxSize(failures);
 
         let currentFile: string | undefined;
 
@@ -73,19 +73,20 @@ export class Formatter extends AbstractFormatter {
             }
 
             let failureString = failure.getFailure();
-            failureString     = chalk.yellow(failureString);
+            failureString = chalk.yellow(failureString);
 
             // Rule
             let ruleName = failure.getRuleName();
-            ruleName     = this.pad(ruleName, ruleMaxSize);
-            ruleName     = chalk.grey(ruleName);
+            ruleName = this.pad(ruleName, ruleMaxSize);
+            ruleName = chalk.grey(ruleName);
 
             // Lines
             positionTuple = this.pad(positionTuple, positionMaxSize);
 
-            positionTuple = failure.getRuleSeverity() === "warning"
-                ? chalk.blue(`${failure.getRuleSeverity().toUpperCase()}: ${positionTuple}`)
-                : chalk.red(`${failure.getRuleSeverity().toUpperCase()}: ${positionTuple}`);
+            positionTuple =
+                failure.getRuleSeverity() === "warning"
+                    ? chalk.blue(`${failure.getRuleSeverity().toUpperCase()}: ${positionTuple}`)
+                    : chalk.red(`${failure.getRuleSeverity().toUpperCase()}: ${positionTuple}`);
 
             // Output
             const output = `${positionTuple}  ${ruleName}  ${failureString}`;
@@ -107,7 +108,8 @@ export class Formatter extends AbstractFormatter {
         for (const failure of failures) {
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
 
-            const positionSize = `${lineAndCharacter.line + 1}:${lineAndCharacter.character + 1}`.length;
+            const positionSize = `${lineAndCharacter.line + 1}:${lineAndCharacter.character + 1}`
+                .length;
 
             if (positionSize > positionMaxSize) {
                 positionMaxSize = positionSize;

--- a/src/formatters/tapFormatter.ts
+++ b/src/formatters/tapFormatter.ts
@@ -26,7 +26,8 @@ export class Formatter extends AbstractFormatter {
     public static metadata: IFormatterMetadata = {
         formatterName: "tap",
         description: "Formats output as TAP stream.",
-        descriptionDetails: "Provides error messages output in TAP13 format which can be consumed by any TAP formatter.",
+        descriptionDetails:
+            "Provides error messages output in TAP13 format which can be consumed by any TAP formatter.",
         sample: Utils.dedent`
             TAP version 13
             1..1
@@ -50,9 +51,7 @@ export class Formatter extends AbstractFormatter {
         let output: string[] = ["TAP version 13"];
 
         if (failures.length === 0) {
-            output = output.concat([
-                "1..0 # SKIP No failures",
-            ]);
+            output = output.concat(["1..0 # SKIP No failures"]);
         } else {
             output = output.concat([`1..${failures.length}`]).concat(this.mapToMessages(failures));
         }
@@ -84,6 +83,5 @@ export class Formatter extends AbstractFormatter {
                     rawLines: ${failureRaw}
                   ...`;
         });
-
     }
 }

--- a/src/formatters/tapFormatter.ts
+++ b/src/formatters/tapFormatter.ts
@@ -50,11 +50,10 @@ export class Formatter extends AbstractFormatter {
     public format(failures: RuleFailure[]): string {
         let output: string[] = ["TAP version 13"];
 
-        if (failures.length === 0) {
-            output = output.concat(["1..0 # SKIP No failures"]);
-        } else {
-            output = output.concat([`1..${failures.length}`]).concat(this.mapToMessages(failures));
-        }
+        output =
+            failures.length === 0
+                ? output.concat(["1..0 # SKIP No failures"])
+                : output.concat([`1..${failures.length}`]).concat(this.mapToMessages(failures));
 
         return `${output.join("\n")}\n`;
     }

--- a/src/formatters/verboseFormatter.ts
+++ b/src/formatters/verboseFormatter.ts
@@ -24,7 +24,8 @@ export class Formatter extends AbstractFormatter {
     public static metadata: IFormatterMetadata = {
         formatterName: "verbose",
         description: "The human-readable formatter which includes the rule name in messages.",
-        descriptionDetails: "The output is the same as the prose formatter with the rule name included",
+        descriptionDetails:
+            "The output is the same as the prose formatter with the rule name included",
         sample: "ERROR: (semicolon) myFile.ts[1, 14]: Missing semicolon",
         consumer: "human",
     };
@@ -42,10 +43,12 @@ export class Formatter extends AbstractFormatter {
             const ruleName = failure.getRuleName();
 
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
-            const positionTuple = `[${lineAndCharacter.line + 1}, ${lineAndCharacter.character + 1}]`;
+            const positionTuple = `[${lineAndCharacter.line + 1}, ${lineAndCharacter.character +
+                1}]`;
 
-            return `${failure.getRuleSeverity().toUpperCase()}: (${ruleName}) ${fileName}${positionTuple}: ${failureString}`;
+            return `${failure
+                .getRuleSeverity()
+                .toUpperCase()}: (${ruleName}) ${fileName}${positionTuple}: ${failureString}`;
         });
-
     }
 }

--- a/src/formatters/vsoFormatter.ts
+++ b/src/formatters/vsoFormatter.ts
@@ -29,7 +29,8 @@ export class Formatter extends AbstractFormatter {
         descriptionDetails: Utils.dedent`
             Integrates with Visual Studio Online and Team Foundation Server by outputting errors
             as 'warning' logging commands.`,
-        sample: "##vso[task.logissue type=warning;sourcepath=myFile.ts;linenumber=1;columnnumber=14;code=semicolon;]Missing semicolon",
+        sample:
+            "##vso[task.logissue type=warning;sourcepath=myFile.ts;linenumber=1;columnnumber=14;code=semicolon;]Missing semicolon",
         consumer: "machine",
     };
     /* tslint:enable:object-literal-sort-keys */

--- a/src/language/formatter/formatter.ts
+++ b/src/language/formatter/formatter.ts
@@ -47,7 +47,7 @@ export interface IFormatterMetadata {
 export type ConsumerType = "human" | "machine";
 
 export interface FormatterConstructor {
-    new(): IFormatter;
+    new (): IFormatter;
 }
 
 export interface IFormatter {

--- a/src/language/rule/abstractRule.ts
+++ b/src/language/rule/abstractRule.ts
@@ -20,7 +20,7 @@ import * as ts from "typescript";
 import { IWalker, WalkContext } from "../walker";
 import { IOptions, IRule, IRuleMetadata, RuleFailure, RuleSeverity } from "./rule";
 
-export type NoInfer<T> = T & {[K in keyof T]: T[K]};
+export type NoInfer<T> = T & { [K in keyof T]: T[K] };
 
 export abstract class AbstractRule implements IRule {
     public static metadata: IRuleMetadata;
@@ -49,8 +49,15 @@ export abstract class AbstractRule implements IRule {
         return this.ruleSeverity !== "off";
     }
 
-    protected applyWithFunction(sourceFile: ts.SourceFile, walkFn: (ctx: WalkContext<void>) => void): RuleFailure[];
-    protected applyWithFunction<T>(sourceFile: ts.SourceFile, walkFn: (ctx: WalkContext<T>) => void, options: NoInfer<T>): RuleFailure[];
+    protected applyWithFunction(
+        sourceFile: ts.SourceFile,
+        walkFn: (ctx: WalkContext<void>) => void,
+    ): RuleFailure[];
+    protected applyWithFunction<T>(
+        sourceFile: ts.SourceFile,
+        walkFn: (ctx: WalkContext<T>) => void,
+        options: NoInfer<T>,
+    ): RuleFailure[];
     protected applyWithFunction<T, U>(
         sourceFile: ts.SourceFile,
         walkFn: (ctx: WalkContext<T>, programOrChecker: U) => void,
@@ -73,5 +80,7 @@ export abstract class AbstractRule implements IRule {
      * Failures will be filtered based on `tslint:disable` comments by tslint.
      * This method now does nothing.
      */
-    protected filterFailures(failures: RuleFailure[]) { return failures; }
+    protected filterFailures(failures: RuleFailure[]) {
+        return failures;
+    }
 }

--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -22,7 +22,7 @@ import { IWalker } from "../walker";
 
 export interface RuleConstructor {
     metadata: IRuleMetadata;
-    new(options: IOptions): IRule;
+    new (options: IOptions): IRule;
 }
 
 export interface IRuleMetadata {
@@ -171,11 +171,15 @@ export class Replacement {
 
     public static applyAll(content: string, replacements: Replacement[]) {
         // sort in reverse so that diffs are properly applied
-        replacements.sort((a, b) => b.end !== a.end ? b.end - a.end : b.start - a.start);
+        replacements.sort((a, b) => (b.end !== a.end ? b.end - a.end : b.start - a.start));
         return replacements.reduce((text, r) => r.apply(text), content);
     }
 
-    public static replaceNode(node: ts.Node, text: string, sourceFile?: ts.SourceFile): Replacement {
+    public static replaceNode(
+        node: ts.Node,
+        text: string,
+        sourceFile?: ts.SourceFile,
+    ): Replacement {
         return this.replaceFromTo(node.getStart(sourceFile), node.getEnd(), text);
     }
 
@@ -202,7 +206,11 @@ export class Replacement {
     }
 
     public apply(content: string) {
-        return content.substring(0, this.start) + this.text + content.substring(this.start + this.length);
+        return (
+            content.substring(0, this.start) +
+            this.text +
+            content.substring(this.start + this.length)
+        );
     }
 
     public toJson(): ReplacementJson {
@@ -217,8 +225,10 @@ export class Replacement {
 }
 
 export class RuleFailurePosition {
-    constructor(private readonly position: number, private readonly lineAndCharacter: ts.LineAndCharacter) {
-    }
+    constructor(
+        private readonly position: number,
+        private readonly lineAndCharacter: ts.LineAndCharacter,
+    ) {}
 
     public getPosition() {
         return this.position;
@@ -240,9 +250,11 @@ export class RuleFailurePosition {
         const ll = this.lineAndCharacter;
         const rr = ruleFailurePosition.lineAndCharacter;
 
-        return this.position === ruleFailurePosition.position
-            && ll.line === rr.line
-            && ll.character === rr.character;
+        return (
+            this.position === ruleFailurePosition.position &&
+            ll.line === rr.line &&
+            ll.character === rr.character
+        );
     }
 }
 
@@ -263,13 +275,14 @@ export class RuleFailure {
         return a.startPosition.getPosition() - b.startPosition.getPosition();
     }
 
-    constructor(private readonly sourceFile: ts.SourceFile,
-                start: number,
-                end: number,
-                private readonly failure: string,
-                private readonly ruleName: string,
-                private readonly fix?: Fix) {
-
+    constructor(
+        private readonly sourceFile: ts.SourceFile,
+        start: number,
+        end: number,
+        private readonly failure: string,
+        private readonly ruleName: string,
+        private readonly fix?: Fix,
+    ) {
         this.fileName = sourceFile.fileName;
         this.startPosition = this.createFailurePosition(start);
         this.endPosition = this.createFailurePosition(end);
@@ -321,7 +334,12 @@ export class RuleFailure {
         return {
             endPosition: this.endPosition.toJson(),
             failure: this.failure,
-            fix: this.fix === undefined ? undefined : Array.isArray(this.fix) ? this.fix.map((r) => r.toJson()) : this.fix.toJson(),
+            fix:
+                this.fix === undefined
+                    ? undefined
+                    : Array.isArray(this.fix)
+                        ? this.fix.map(r => r.toJson())
+                        : this.fix.toJson(),
             name: this.fileName,
             ruleName: this.ruleName,
             ruleSeverity: this.ruleSeverity.toUpperCase(),
@@ -330,10 +348,12 @@ export class RuleFailure {
     }
 
     public equals(ruleFailure: RuleFailure) {
-        return this.failure  === ruleFailure.getFailure()
-            && this.fileName === ruleFailure.getFileName()
-            && this.startPosition.equals(ruleFailure.getStartPosition())
-            && this.endPosition.equals(ruleFailure.getEndPosition());
+        return (
+            this.failure === ruleFailure.getFailure() &&
+            this.fileName === ruleFailure.getFileName() &&
+            this.startPosition.equals(ruleFailure.getStartPosition()) &&
+            this.endPosition.equals(ruleFailure.getEndPosition())
+        );
     }
 
     private createFailurePosition(position: number) {

--- a/src/language/rule/typedRule.ts
+++ b/src/language/rule/typedRule.ts
@@ -22,7 +22,6 @@ import { AbstractRule } from "./abstractRule";
 import { ITypedRule, RuleFailure } from "./rule";
 
 export abstract class TypedRule extends AbstractRule implements ITypedRule {
-
     public apply(): RuleFailure[] {
         // if no program is given to the linter, show an error
         showWarningOnce(`Warning: The '${this.ruleName}' rule requires type information.`);

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -16,19 +16,32 @@
  */
 
 import * as path from "path";
-import { isBlockScopedVariableDeclarationList, isIdentifier, isPrefixUnaryExpression } from "tsutils";
+import {
+    isBlockScopedVariableDeclarationList,
+    isIdentifier,
+    isPrefixUnaryExpression,
+} from "tsutils";
 import * as ts from "typescript";
 
 import { IDisabledInterval, RuleFailure } from "./rule/rule";
 
 export function getSourceFile(fileName: string, source: string): ts.SourceFile {
     const normalizedName = path.normalize(fileName).replace(/\\/g, "/");
-    return ts.createSourceFile(normalizedName, source, ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+    return ts.createSourceFile(
+        normalizedName,
+        source,
+        ts.ScriptTarget.ES5,
+        /*setParentNodes*/ true,
+    );
 }
 
 /** @deprecated See IDisabledInterval. */
-export function doesIntersect(failure: RuleFailure, disabledIntervals: IDisabledInterval[]): boolean { // tslint:disable-line deprecation
-    return disabledIntervals.some((interval) => {
+export function doesIntersect(
+    failure: RuleFailure,
+    disabledIntervals: IDisabledInterval[],
+): boolean {
+    // tslint:disable-line deprecation
+    return disabledIntervals.some(interval => {
         const maxStart = Math.max(interval.startPosition, failure.getStartPosition().getPosition());
         const minEnd = Math.min(interval.endPosition, failure.getEndPosition().getPosition());
         return maxStart <= minEnd;
@@ -40,13 +53,15 @@ export function doesIntersect(failure: RuleFailure, disabledIntervals: IDisabled
  *
  * @deprecated use `hasModifier` from `tsutils`
  */
-export function hasModifier(modifiers: ts.ModifiersArray | undefined, ...modifierKinds: ts.SyntaxKind[]): boolean {
+export function hasModifier(
+    modifiers: ts.ModifiersArray | undefined,
+    ...modifierKinds: ts.SyntaxKind[]
+): boolean {
     if (modifiers === undefined || modifierKinds.length === 0) {
         return false;
     }
 
-    return modifiers.some(
-        (m) => modifierKinds.some((k) => m.kind === k));
+    return modifiers.some(m => modifierKinds.some(k => m.kind === k));
 }
 
 /**
@@ -55,10 +70,15 @@ export function hasModifier(modifiers: ts.ModifiersArray | undefined, ...modifie
  *
  * @deprecated use `isBlockScopedVariableDeclarationList` from `tsutils`
  */
-export function isBlockScopedVariable(node: ts.VariableDeclaration | ts.VariableStatement): boolean {
+export function isBlockScopedVariable(
+    node: ts.VariableDeclaration | ts.VariableStatement,
+): boolean {
     if (node.kind === ts.SyntaxKind.VariableDeclaration) {
         const parent = node.parent!;
-        return parent.kind === ts.SyntaxKind.CatchClause || isBlockScopedVariableDeclarationList(parent);
+        return (
+            parent.kind === ts.SyntaxKind.CatchClause ||
+            isBlockScopedVariableDeclarationList(parent)
+        );
     } else {
         return isBlockScopedVariableDeclarationList(node.declarationList);
     }
@@ -68,11 +88,13 @@ export function isBlockScopedVariable(node: ts.VariableDeclaration | ts.Variable
 export function isBlockScopedBindingElement(node: ts.BindingElement): boolean {
     const variableDeclaration = getBindingElementVariableDeclaration(node); // tslint:disable-line:deprecation
     // if no variable declaration, it must be a function param, which is block scoped
-    return (variableDeclaration === null) || isBlockScopedVariable(variableDeclaration); // tslint:disable-line:deprecation
+    return variableDeclaration === null || isBlockScopedVariable(variableDeclaration); // tslint:disable-line:deprecation
 }
 
 /** @deprecated use `getDeclarationOfBindingElement` from `tsutils` */
-export function getBindingElementVariableDeclaration(node: ts.BindingElement): ts.VariableDeclaration | null {
+export function getBindingElementVariableDeclaration(
+    node: ts.BindingElement,
+): ts.VariableDeclaration | null {
     let currentParent = node.parent! as ts.Node;
     while (currentParent.kind !== ts.SyntaxKind.VariableDeclaration) {
         if (currentParent.parent === undefined) {
@@ -91,7 +113,7 @@ export function getBindingElementVariableDeclaration(node: ts.BindingElement): t
  * @deprecated use `getChildOfKind` from `tsutils`
  */
 export function childOfKind(node: ts.Node, kind: ts.SyntaxKind): ts.Node | undefined {
-    return node.getChildren().find((child) => child.kind === kind);
+    return node.getChildren().find(child => child.kind === kind);
 }
 
 /**
@@ -121,8 +143,10 @@ export function ancestorWhere<T extends ts.Node = ts.Node>(
 export function isAssignment(node: ts.Node) {
     if (node.kind === ts.SyntaxKind.BinaryExpression) {
         const binaryExpression = node as ts.BinaryExpression;
-        return binaryExpression.operatorToken.kind >= ts.SyntaxKind.FirstAssignment
-            && binaryExpression.operatorToken.kind <= ts.SyntaxKind.LastAssignment;
+        return (
+            binaryExpression.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+            binaryExpression.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+        );
     } else {
         return false;
     }
@@ -210,55 +234,65 @@ export function unwrapParentheses(node: ts.Expression) {
 
 /** @deprecated use `isFunctionScopeBoundary` from `tsutils` */
 export function isScopeBoundary(node: ts.Node): boolean {
-    return node.kind === ts.SyntaxKind.FunctionDeclaration
-        || node.kind === ts.SyntaxKind.FunctionExpression
-        || node.kind === ts.SyntaxKind.PropertyAssignment
-        || node.kind === ts.SyntaxKind.ShorthandPropertyAssignment
-        || node.kind === ts.SyntaxKind.MethodDeclaration
-        || node.kind === ts.SyntaxKind.Constructor
-        || node.kind === ts.SyntaxKind.ModuleDeclaration
-        || node.kind === ts.SyntaxKind.ArrowFunction
-        || node.kind === ts.SyntaxKind.ParenthesizedExpression
-        || node.kind === ts.SyntaxKind.ClassDeclaration
-        || node.kind === ts.SyntaxKind.ClassExpression
-        || node.kind === ts.SyntaxKind.InterfaceDeclaration
-        || node.kind === ts.SyntaxKind.GetAccessor
-        || node.kind === ts.SyntaxKind.SetAccessor
-        || node.kind === ts.SyntaxKind.SourceFile && ts.isExternalModule(node as ts.SourceFile);
+    return (
+        node.kind === ts.SyntaxKind.FunctionDeclaration ||
+        node.kind === ts.SyntaxKind.FunctionExpression ||
+        node.kind === ts.SyntaxKind.PropertyAssignment ||
+        node.kind === ts.SyntaxKind.ShorthandPropertyAssignment ||
+        node.kind === ts.SyntaxKind.MethodDeclaration ||
+        node.kind === ts.SyntaxKind.Constructor ||
+        node.kind === ts.SyntaxKind.ModuleDeclaration ||
+        node.kind === ts.SyntaxKind.ArrowFunction ||
+        node.kind === ts.SyntaxKind.ParenthesizedExpression ||
+        node.kind === ts.SyntaxKind.ClassDeclaration ||
+        node.kind === ts.SyntaxKind.ClassExpression ||
+        node.kind === ts.SyntaxKind.InterfaceDeclaration ||
+        node.kind === ts.SyntaxKind.GetAccessor ||
+        node.kind === ts.SyntaxKind.SetAccessor ||
+        (node.kind === ts.SyntaxKind.SourceFile && ts.isExternalModule(node as ts.SourceFile))
+    );
 }
 
 /** @deprecated use `isBlockScopeBoundary` from `tsutils` */
 export function isBlockScopeBoundary(node: ts.Node): boolean {
-    return isScopeBoundary(node) // tslint:disable-line:deprecation
-        || node.kind === ts.SyntaxKind.Block
-        || isLoop(node) // tslint:disable-line:deprecation
-        || node.kind === ts.SyntaxKind.WithStatement
-        || node.kind === ts.SyntaxKind.SwitchStatement
-        || node.parent !== undefined
-            && (node.parent.kind === ts.SyntaxKind.TryStatement
-            || node.parent.kind === ts.SyntaxKind.IfStatement);
+    return (
+        isScopeBoundary(node) || // tslint:disable-line:deprecation
+        node.kind === ts.SyntaxKind.Block ||
+        isLoop(node) || // tslint:disable-line:deprecation
+        node.kind === ts.SyntaxKind.WithStatement ||
+        node.kind === ts.SyntaxKind.SwitchStatement ||
+        (node.parent !== undefined &&
+            (node.parent.kind === ts.SyntaxKind.TryStatement ||
+                node.parent.kind === ts.SyntaxKind.IfStatement))
+    );
 }
 
 /** @deprecated use `isIterationStatement` from `tsutils` or `typescript` */
 export function isLoop(node: ts.Node): node is ts.IterationStatement {
-   return node.kind === ts.SyntaxKind.DoStatement
-        || node.kind === ts.SyntaxKind.WhileStatement
-        || node.kind === ts.SyntaxKind.ForStatement
-        || node.kind === ts.SyntaxKind.ForInStatement
-        || node.kind === ts.SyntaxKind.ForOfStatement;
+    return (
+        node.kind === ts.SyntaxKind.DoStatement ||
+        node.kind === ts.SyntaxKind.WhileStatement ||
+        node.kind === ts.SyntaxKind.ForStatement ||
+        node.kind === ts.SyntaxKind.ForInStatement ||
+        node.kind === ts.SyntaxKind.ForOfStatement
+    );
 }
 
 /**
  * @returns Whether node is a numeric expression.
  */
 export function isNumeric(node: ts.Expression) {
-    while (isPrefixUnaryExpression(node) &&
-           (node.operator === ts.SyntaxKind.PlusToken || node.operator === ts.SyntaxKind.MinusToken)) {
+    while (
+        isPrefixUnaryExpression(node) &&
+        (node.operator === ts.SyntaxKind.PlusToken || node.operator === ts.SyntaxKind.MinusToken)
+    ) {
         node = node.operand;
     }
 
-    return node.kind === ts.SyntaxKind.NumericLiteral ||
-        isIdentifier(node) && (node.text === "NaN" || node.text === "Infinity");
+    return (
+        node.kind === ts.SyntaxKind.NumericLiteral ||
+        (isIdentifier(node) && (node.text === "NaN" || node.text === "Infinity"))
+    );
 }
 
 export interface TokenPosition {
@@ -269,8 +303,17 @@ export interface TokenPosition {
     /** The end of the token */
     end: number;
 }
-export type ForEachTokenCallback = (fullText: string, kind: ts.SyntaxKind, pos: TokenPosition, parent: ts.Node) => void;
-export type ForEachCommentCallback = (fullText: string, kind: ts.SyntaxKind, pos: TokenPosition) => void;
+export type ForEachTokenCallback = (
+    fullText: string,
+    kind: ts.SyntaxKind,
+    pos: TokenPosition,
+    parent: ts.Node,
+) => void;
+export type ForEachCommentCallback = (
+    fullText: string,
+    kind: ts.SyntaxKind,
+    pos: TokenPosition,
+) => void;
 export type FilterCallback = (node: ts.Node) => boolean;
 
 /**
@@ -285,7 +328,12 @@ export type FilterCallback = (node: ts.Node) => boolean;
  *
  * @deprecated use `forEachToken` or `forEachTokenWithTrivia` from `tsutils`
  */
-export function forEachToken(node: ts.Node, skipTrivia: boolean, cb: ForEachTokenCallback, filter?: FilterCallback) {
+export function forEachToken(
+    node: ts.Node,
+    skipTrivia: boolean,
+    cb: ForEachTokenCallback,
+    filter?: FilterCallback,
+) {
     // this function will most likely be called with SourceFile anyways, so there is no need for an additional parameter
     const sourceFile = node.getSourceFile();
     const fullText = sourceFile.text;
@@ -302,10 +350,12 @@ export function forEachToken(node: ts.Node, skipTrivia: boolean, cb: ForEachToke
     }
 
     function iterateChildren(child: ts.Node): void {
-        if (child.kind < ts.SyntaxKind.FirstNode ||
+        if (
+            child.kind < ts.SyntaxKind.FirstNode ||
             // for backwards compatibility to typescript 2.0.10
             // JsxText was no Token, but a Node in that version
-            child.kind === ts.SyntaxKind.JsxText) {
+            child.kind === ts.SyntaxKind.JsxText
+        ) {
             // we found a token, tokens have no children, stop recursing here
             return callback(child);
         }
@@ -324,13 +374,23 @@ export function forEachToken(node: ts.Node, skipTrivia: boolean, cb: ForEachToke
             // we only have to handle trivia before each token, because there is nothing after EndOfFileToken
             handleTrivia!(token.pos, tokenStart, token);
         }
-        return cb(fullText, token.kind, {tokenStart, fullStart: token.pos, end: token.end}, token.parent!);
+        return cb(
+            fullText,
+            token.kind,
+            { tokenStart, fullStart: token.pos, end: token.end },
+            token.parent!,
+        );
     }
 }
 
 function createTriviaHandler(sourceFile: ts.SourceFile, cb: ForEachTokenCallback) {
     const fullText = sourceFile.text;
-    const scanner = ts.createScanner(sourceFile.languageVersion, false, sourceFile.languageVariant, fullText);
+    const scanner = ts.createScanner(
+        sourceFile.languageVersion,
+        false,
+        sourceFile.languageVariant,
+        fullText,
+    );
     /**
      * Scan the specified range to get all trivia tokens.
      * This includes trailing trivia of the last token and the leading trivia of the current token
@@ -347,7 +407,12 @@ function createTriviaHandler(sourceFile: ts.SourceFile, cb: ForEachTokenCallback
         do {
             const kind = scanner.scan();
             position = scanner.getTextPos();
-            cb(fullText, kind, {tokenStart: scanner.getTokenPos(), end: position, fullStart: start}, parent);
+            cb(
+                fullText,
+                kind,
+                { tokenStart: scanner.getTokenPos(), end: position, fullStart: start },
+                parent,
+            );
         } while (position < end);
     }
 
@@ -365,14 +430,19 @@ export function forEachComment(node: ts.Node, cb: ForEachCommentCallback) {
        forEachToken also does intentionally not pay attention to the correct comment ownership of nodes as it always
        scans all trivia before each token, which could include trailing comments of the previous token.
        Comment onwership is done right in this function*/
-    return forEachToken(node, true, (fullText, tokenKind, pos, parent) => { // tslint:disable-line:deprecation
+    return forEachToken(node, true, (fullText, tokenKind, pos, parent) => {
+        // tslint:disable-line:deprecation
         // don't search for comments inside JsxText
         if (canHaveLeadingTrivia(tokenKind, parent)) {
             // Comments before the first token (pos.fullStart === 0) are all considered leading comments, so no need for special treatment
             const comments = ts.getLeadingCommentRanges(fullText, pos.fullStart);
             if (comments !== undefined) {
                 for (const comment of comments) {
-                    cb(fullText, comment.kind, {fullStart: pos.fullStart, tokenStart: comment.pos, end: comment.end});
+                    cb(fullText, comment.kind, {
+                        fullStart: pos.fullStart,
+                        tokenStart: comment.pos,
+                        end: comment.end,
+                    });
                 }
             }
         }
@@ -380,7 +450,11 @@ export function forEachComment(node: ts.Node, cb: ForEachCommentCallback) {
             const comments = ts.getTrailingCommentRanges(fullText, pos.end);
             if (comments !== undefined) {
                 for (const comment of comments) {
-                    cb(fullText, comment.kind, {fullStart: pos.fullStart, tokenStart: comment.pos, end: comment.end});
+                    cb(fullText, comment.kind, {
+                        fullStart: pos.fullStart,
+                        tokenStart: comment.pos,
+                        end: comment.end,
+                    });
                 }
             }
         }
@@ -395,7 +469,10 @@ function canHaveLeadingTrivia(tokenKind: ts.SyntaxKind, parent: ts.Node): boolea
 
         case ts.SyntaxKind.OpenBraceToken:
             // before a JsxExpression inside a JsxElement's body can only be other JsxChild, but no trivia
-            return parent.kind !== ts.SyntaxKind.JsxExpression || parent.parent!.kind !== ts.SyntaxKind.JsxElement;
+            return (
+                parent.kind !== ts.SyntaxKind.JsxExpression ||
+                parent.parent!.kind !== ts.SyntaxKind.JsxElement
+            );
 
         case ts.SyntaxKind.LessThanToken:
             switch (parent.kind) {
@@ -423,7 +500,10 @@ function canHaveTrailingTrivia(tokenKind: ts.SyntaxKind, parent: ts.Node): boole
 
         case ts.SyntaxKind.CloseBraceToken:
             // after a JsxExpression inside a JsxElement's body can only be other JsxChild, but no trivia
-            return parent.kind !== ts.SyntaxKind.JsxExpression || parent.parent!.kind !== ts.SyntaxKind.JsxElement;
+            return (
+                parent.kind !== ts.SyntaxKind.JsxExpression ||
+                parent.parent!.kind !== ts.SyntaxKind.JsxElement
+            );
 
         case ts.SyntaxKind.GreaterThanToken:
             switch (parent.kind) {
@@ -451,8 +531,10 @@ function canHaveTrailingTrivia(tokenKind: ts.SyntaxKind, parent: ts.Node): boole
  *                 This value is typically obtained from `node.getFullStart()` or `node.getEnd()`
  */
 export function hasCommentAfterPosition(text: string, position: number): boolean {
-    return ts.getTrailingCommentRanges(text, position) !== undefined ||
-           ts.getLeadingCommentRanges(text, position) !== undefined;
+    return (
+        ts.getTrailingCommentRanges(text, position) !== undefined ||
+        ts.getLeadingCommentRanges(text, position) !== undefined
+    );
 }
 
 export interface EqualsKind {
@@ -476,14 +558,20 @@ export function getEqualsKind(node: ts.BinaryOperatorToken): EqualsKind | undefi
 }
 
 export function isStrictNullChecksEnabled(options: ts.CompilerOptions): boolean {
-    return options.strictNullChecks === true ||
-        (options.strict === true && options.strictNullChecks !== false);
+    return (
+        options.strictNullChecks === true ||
+        (options.strict === true && options.strictNullChecks !== false)
+    );
 }
 
-export function isNegativeNumberLiteral(node: ts.Node): node is ts.PrefixUnaryExpression & { operand: ts.NumericLiteral } {
-    return isPrefixUnaryExpression(node) &&
+export function isNegativeNumberLiteral(
+    node: ts.Node,
+): node is ts.PrefixUnaryExpression & { operand: ts.NumericLiteral } {
+    return (
+        isPrefixUnaryExpression(node) &&
         node.operator === ts.SyntaxKind.MinusToken &&
-        node.operand.kind === ts.SyntaxKind.NumericLiteral;
+        node.operand.kind === ts.SyntaxKind.NumericLiteral
+    );
 }
 
 /** Wrapper for compatibility with typescript@<2.3.1 */

--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -38,9 +38,9 @@ export function getSourceFile(fileName: string, source: string): ts.SourceFile {
 /** @deprecated See IDisabledInterval. */
 export function doesIntersect(
     failure: RuleFailure,
+    // tslint:disable-next-line:deprecation
     disabledIntervals: IDisabledInterval[],
 ): boolean {
-    // tslint:disable-line deprecation
     return disabledIntervals.some(interval => {
         const maxStart = Math.max(interval.startPosition, failure.getStartPosition().getPosition());
         const minEnd = Math.min(interval.endPosition, failure.getEndPosition().getPosition());
@@ -430,8 +430,8 @@ export function forEachComment(node: ts.Node, cb: ForEachCommentCallback) {
        forEachToken also does intentionally not pay attention to the correct comment ownership of nodes as it always
        scans all trivia before each token, which could include trailing comments of the previous token.
        Comment onwership is done right in this function*/
+    // tslint:disable-next-line:deprecation
     return forEachToken(node, true, (fullText, tokenKind, pos, parent) => {
-        // tslint:disable-line:deprecation
         // don't search for comments inside JsxText
         if (canHaveLeadingTrivia(tokenKind, parent)) {
             // Comments before the first token (pos.fullStart === 0) are all considered leading comments, so no need for special treatment
@@ -439,9 +439,9 @@ export function forEachComment(node: ts.Node, cb: ForEachCommentCallback) {
             if (comments !== undefined) {
                 for (const comment of comments) {
                     cb(fullText, comment.kind, {
+                        end: comment.end,
                         fullStart: pos.fullStart,
                         tokenStart: comment.pos,
-                        end: comment.end,
                     });
                 }
             }
@@ -451,9 +451,9 @@ export function forEachComment(node: ts.Node, cb: ForEachCommentCallback) {
             if (comments !== undefined) {
                 for (const comment of comments) {
                     cb(fullText, comment.kind, {
+                        end: comment.end,
                         fullStart: pos.fullStart,
                         tokenStart: comment.pos,
-                        end: comment.end,
                     });
                 }
             }

--- a/src/language/walker/blockScopeAwareRuleWalker.ts
+++ b/src/language/walker/blockScopeAwareRuleWalker.ts
@@ -36,7 +36,9 @@ export abstract class BlockScopeAwareRuleWalker<T, U> extends ScopeAwareRuleWalk
         super(sourceFile, options);
 
         // initialize with global scope if file is not a module
-        this.blockScopeStack = ts.isExternalModule(sourceFile) ? [] : [this.createBlockScope(sourceFile)];
+        this.blockScopeStack = ts.isExternalModule(sourceFile)
+            ? []
+            : [this.createBlockScope(sourceFile)];
     }
 
     public abstract createBlockScope(node: ts.Node): U;

--- a/src/language/walker/programAwareRuleWalker.ts
+++ b/src/language/walker/programAwareRuleWalker.ts
@@ -23,7 +23,11 @@ import { RuleWalker } from "./ruleWalker";
 export class ProgramAwareRuleWalker extends RuleWalker {
     private readonly typeChecker: ts.TypeChecker;
 
-    constructor(sourceFile: ts.SourceFile, options: IOptions, private readonly program: ts.Program) {
+    constructor(
+        sourceFile: ts.SourceFile,
+        options: IOptions,
+        private readonly program: ts.Program,
+    ) {
         super(sourceFile, options);
 
         this.typeChecker = program.getTypeChecker();

--- a/src/language/walker/ruleWalker.ts
+++ b/src/language/walker/ruleWalker.ts
@@ -66,8 +66,8 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
 
     /** @deprecated Prefer `addFailureAt` and its variants. */
     public createFailure(start: number, width: number, failure: string, fix?: Fix): RuleFailure {
-        const from = (start > this.limit) ? this.limit : start;
-        const to = ((start + width) > this.limit) ? this.limit : (start + width);
+        const from = start > this.limit ? this.limit : start;
+        const to = start + width > this.limit ? this.limit : start + width;
         return new RuleFailure(this.sourceFile, from, to, failure, this.ruleName, fix);
     }
 
@@ -89,7 +89,12 @@ export class RuleWalker extends SyntaxWalker implements IWalker {
 
     /** Add a failure using a node's span. */
     public addFailureAtNode(node: ts.Node, failure: string, fix?: Fix) {
-        this.addFailureAt(node.getStart(this.sourceFile), node.getWidth(this.sourceFile), failure, fix);
+        this.addFailureAt(
+            node.getStart(this.sourceFile),
+            node.getWidth(this.sourceFile),
+            failure,
+            fix,
+        );
     }
 
     public createReplacement(start: number, length: number, text: string): Replacement {

--- a/src/language/walker/syntaxWalker.ts
+++ b/src/language/walker/syntaxWalker.ts
@@ -698,6 +698,6 @@ export class SyntaxWalker {
     }
 
     protected walkChildren(node: ts.Node) {
-        ts.forEachChild(node, (child) => this.visitNode(child));
+        ts.forEachChild(node, child => this.visitNode(child));
     }
 }

--- a/src/language/walker/walkContext.ts
+++ b/src/language/walker/walkContext.ts
@@ -22,7 +22,11 @@ import { Fix, RuleFailure } from "../rule/rule";
 export class WalkContext<T> {
     public readonly failures: RuleFailure[] = [];
 
-    constructor(public readonly sourceFile: ts.SourceFile, public readonly ruleName: string, public readonly options: T) {}
+    constructor(
+        public readonly sourceFile: ts.SourceFile,
+        public readonly ruleName: string,
+        public readonly options: T,
+    ) {}
 
     /** Add a failure with any arbitrary span. Prefer `addFailureAtNode` if possible. */
     public addFailureAt(start: number, width: number, failure: string, fix?: Fix) {
@@ -32,7 +36,14 @@ export class WalkContext<T> {
     public addFailure(start: number, end: number, failure: string, fix?: Fix) {
         const fileLength = this.sourceFile.end;
         this.failures.push(
-            new RuleFailure(this.sourceFile, Math.min(start, fileLength), Math.min(end, fileLength), failure, this.ruleName, fix),
+            new RuleFailure(
+                this.sourceFile,
+                Math.min(start, fileLength),
+                Math.min(end, fileLength),
+                failure,
+                this.ruleName,
+                fix,
+            ),
         );
     }
 

--- a/src/rules/adjacentOverloadSignaturesRule.ts
+++ b/src/rules/adjacentOverloadSignaturesRule.ts
@@ -28,7 +28,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
-        rationale: "Improves readability and organization by grouping naturally related items together.",
+        rationale:
+            "Improves readability and organization by grouping naturally related items together.",
         type: "typescript",
         typescriptOnly: true,
     };
@@ -55,9 +56,19 @@ function walk(ctx: Lint.WalkContext<void>): void {
             case ts.SyntaxKind.InterfaceDeclaration:
             case ts.SyntaxKind.ClassDeclaration:
             case ts.SyntaxKind.TypeLiteral: {
-                const { members } = node as ts.InterfaceDeclaration | ts.ClassDeclaration | ts.TypeLiteralNode;
-                addFailures(getMisplacedOverloads<ts.TypeElement | ts.ClassElement>(members, (member) =>
-                    utils.isSignatureDeclaration(member) ? getOverloadKey(member) : undefined));
+                const { members } = node as
+                    | ts.InterfaceDeclaration
+                    | ts.ClassDeclaration
+                    | ts.TypeLiteralNode;
+                addFailures(
+                    getMisplacedOverloads<ts.TypeElement | ts.ClassElement>(
+                        members,
+                        member =>
+                            utils.isSignatureDeclaration(member)
+                                ? getOverloadKey(member)
+                                : undefined,
+                    ),
+                );
             }
         }
 
@@ -65,8 +76,15 @@ function walk(ctx: Lint.WalkContext<void>): void {
     });
 
     function visitStatements(statements: ReadonlyArray<ts.Statement>): void {
-        addFailures(getMisplacedOverloads(statements, (statement) =>
-            utils.isFunctionDeclaration(statement) && statement.name !== undefined ? statement.name.text : undefined));
+        addFailures(
+            getMisplacedOverloads(
+                statements,
+                statement =>
+                    utils.isFunctionDeclaration(statement) && statement.name !== undefined
+                        ? statement.name.text
+                        : undefined,
+            ),
+        );
     }
 
     function addFailures(misplacedOverloads: ReadonlyArray<ts.SignatureDeclaration>): void {
@@ -79,7 +97,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
 /** 'getOverloadName' may return undefined for nodes that cannot be overloads, e.g. a `const` declaration. */
 function getMisplacedOverloads<T extends ts.Node>(
     overloads: ReadonlyArray<T>,
-    getKey: (node: T) => string | undefined): ts.SignatureDeclaration[] {
+    getKey: (node: T) => string | undefined,
+): ts.SignatureDeclaration[] {
     const result: ts.SignatureDeclaration[] = [];
     let lastKey: string | undefined;
     const seen = new Set<string>();
@@ -91,7 +110,7 @@ function getMisplacedOverloads<T extends ts.Node>(
         const key = getKey(node);
         if (key !== undefined) {
             if (seen.has(key) && lastKey !== key) {
-                result.push(node as any as ts.SignatureDeclaration);
+                result.push((node as any) as ts.SignatureDeclaration);
             }
             seen.add(key);
             lastKey = key;
@@ -118,7 +137,9 @@ export function getOverloadKey(node: ts.SignatureDeclaration): string | undefine
     return (computed ? "0" : "1") + (isStatic ? "0" : "1") + name;
 }
 
-function getOverloadInfo(node: ts.SignatureDeclaration): string | { name: string; computed?: boolean } | undefined {
+function getOverloadInfo(
+    node: ts.SignatureDeclaration,
+): string | { name: string; computed?: boolean } | undefined {
     switch (node.kind) {
         case ts.SyntaxKind.ConstructSignature:
         case ts.SyntaxKind.Constructor:
@@ -136,7 +157,9 @@ function getOverloadInfo(node: ts.SignatureDeclaration): string | { name: string
                     return name.text;
                 case ts.SyntaxKind.ComputedPropertyName:
                     const { expression } = name;
-                    return utils.isLiteralExpression(expression) ? expression.text : { name: expression.getText(), computed: true };
+                    return utils.isLiteralExpression(expression)
+                        ? expression.text
+                        : { name: expression.getText(), computed: true };
                 default:
                     return utils.isLiteralExpression(name) ? name.text : undefined;
             }

--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -58,7 +58,13 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "array",
             items: {
                 type: "string",
-                enum: [OPTION_ARGUMENTS, OPTION_ELEMENTS, OPTION_MEMBERS, OPTION_PARAMETERS, OPTION_STATEMENTS],
+                enum: [
+                    OPTION_ARGUMENTS,
+                    OPTION_ELEMENTS,
+                    OPTION_MEMBERS,
+                    OPTION_PARAMETERS,
+                    OPTION_STATEMENTS,
+                ],
             },
             minLength: 1,
             maxLength: 5,
@@ -72,13 +78,15 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_SUFFIX = " are not aligned";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new AlignWalker(sourceFile, this.ruleName, {
-            arguments: this.ruleArguments.indexOf(OPTION_ARGUMENTS) !== -1,
-            elements: this.ruleArguments.indexOf(OPTION_ELEMENTS) !== -1,
-            members: this.ruleArguments.indexOf(OPTION_MEMBERS) !== -1,
-            parameters: this.ruleArguments.indexOf(OPTION_PARAMETERS) !== -1,
-            statements: this.ruleArguments.indexOf(OPTION_STATEMENTS) !== -1,
-        }));
+        return this.applyWithWalker(
+            new AlignWalker(sourceFile, this.ruleName, {
+                arguments: this.ruleArguments.indexOf(OPTION_ARGUMENTS) !== -1,
+                elements: this.ruleArguments.indexOf(OPTION_ELEMENTS) !== -1,
+                members: this.ruleArguments.indexOf(OPTION_MEMBERS) !== -1,
+                parameters: this.ruleArguments.indexOf(OPTION_PARAMETERS) !== -1,
+                statements: this.ruleArguments.indexOf(OPTION_STATEMENTS) !== -1,
+            }),
+        );
     }
 }
 
@@ -86,17 +94,23 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
             if (this.options.statements && isBlockLike(node)) {
-                this.checkAlignment(node.statements.filter((s) => s.kind !== ts.SyntaxKind.EmptyStatement), OPTION_STATEMENTS);
+                this.checkAlignment(
+                    node.statements.filter(s => s.kind !== ts.SyntaxKind.EmptyStatement),
+                    OPTION_STATEMENTS,
+                );
             } else {
                 switch (node.kind) {
                     case ts.SyntaxKind.NewExpression:
                         if ((node as ts.NewExpression).arguments === undefined) {
                             break;
                         }
-                        // falls through
+                    // falls through
                     case ts.SyntaxKind.CallExpression:
                         if (this.options.arguments) {
-                            this.checkAlignment((node as ts.CallExpression | ts.NewExpression).arguments!, OPTION_ARGUMENTS);
+                            this.checkAlignment(
+                                (node as ts.CallExpression | ts.NewExpression).arguments!,
+                                OPTION_ARGUMENTS,
+                            );
                         }
                         break;
                     case ts.SyntaxKind.FunctionDeclaration:
@@ -110,35 +124,52 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
                     case ts.SyntaxKind.FunctionType:
                     case ts.SyntaxKind.ConstructorType:
                         if (this.options.parameters) {
-                            this.checkAlignment((node as ts.SignatureDeclaration).parameters, OPTION_PARAMETERS);
+                            this.checkAlignment(
+                                (node as ts.SignatureDeclaration).parameters,
+                                OPTION_PARAMETERS,
+                            );
                         }
                         break;
                     case ts.SyntaxKind.ArrayLiteralExpression:
                     case ts.SyntaxKind.ArrayBindingPattern:
                         if (this.options.elements) {
-                            this.checkAlignment((node as ts.ArrayBindingOrAssignmentPattern).elements, OPTION_ELEMENTS);
+                            this.checkAlignment(
+                                (node as ts.ArrayBindingOrAssignmentPattern).elements,
+                                OPTION_ELEMENTS,
+                            );
                         }
                         break;
                     case ts.SyntaxKind.TupleType:
                         if (this.options.elements) {
-                            this.checkAlignment((node as ts.TupleTypeNode).elementTypes, OPTION_ELEMENTS);
+                            this.checkAlignment(
+                                (node as ts.TupleTypeNode).elementTypes,
+                                OPTION_ELEMENTS,
+                            );
                         }
                         break;
                     case ts.SyntaxKind.ObjectLiteralExpression:
                         if (this.options.members) {
-                            this.checkAlignment((node as ts.ObjectLiteralExpression).properties, OPTION_MEMBERS);
+                            this.checkAlignment(
+                                (node as ts.ObjectLiteralExpression).properties,
+                                OPTION_MEMBERS,
+                            );
                         }
                         break;
                     case ts.SyntaxKind.ObjectBindingPattern:
                         if (this.options.members) {
-                            this.checkAlignment((node as ts.ObjectBindingPattern).elements, OPTION_MEMBERS);
+                            this.checkAlignment(
+                                (node as ts.ObjectBindingPattern).elements,
+                                OPTION_MEMBERS,
+                            );
                         }
                         break;
                     case ts.SyntaxKind.ClassDeclaration:
                     case ts.SyntaxKind.ClassExpression:
                         if (this.options.members) {
                             this.checkAlignment(
-                                (node as ts.ClassLikeDeclaration).members.filter((m) => m.kind !== ts.SyntaxKind.SemicolonClassElement),
+                                (node as ts.ClassLikeDeclaration).members.filter(
+                                    m => m.kind !== ts.SyntaxKind.SemicolonClassElement,
+                                ),
                                 OPTION_MEMBERS,
                             );
                         }
@@ -146,7 +177,10 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
                     case ts.SyntaxKind.InterfaceDeclaration:
                     case ts.SyntaxKind.TypeLiteral:
                         if (this.options.members) {
-                            this.checkAlignment((node as ts.InterfaceDeclaration | ts.TypeLiteralNode).members, OPTION_MEMBERS);
+                            this.checkAlignment(
+                                (node as ts.InterfaceDeclaration | ts.TypeLiteralNode).members,
+                                OPTION_MEMBERS,
+                            );
                         }
                 }
             }
@@ -175,11 +209,19 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
                 let fix: Lint.Fix | undefined;
                 if (diff >= 0) {
                     fix = Lint.Replacement.appendText(start, " ".repeat(diff));
-                } else if (node.pos <= start + diff && /^\s+$/.test(sourceFile.text.substring(start + diff, start))) {
+                } else if (
+                    node.pos <= start + diff &&
+                    /^\s+$/.test(sourceFile.text.substring(start + diff, start))
+                ) {
                     // only delete text if there is only whitespace
                     fix = Lint.Replacement.deleteText(start + diff, -diff);
                 }
-                this.addFailure(start, Math.max(node.end, start), kind + Rule.FAILURE_STRING_SUFFIX, fix);
+                this.addFailure(
+                    start,
+                    Math.max(node.end, start),
+                    kind + Rule.FAILURE_STRING_SUFFIX,
+                    fix,
+                );
             }
             line = pos.line;
         }
@@ -188,12 +230,15 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
     private getStart(node: ts.Node) {
         return node.kind !== ts.SyntaxKind.OmittedExpression
             ? node.getStart(this.sourceFile)
-            // find the comma token following the OmmitedExpression
-            : getNextToken(node, this.sourceFile)!.getStart(this.sourceFile);
+            : // find the comma token following the OmmitedExpression
+              getNextToken(node, this.sourceFile)!.getStart(this.sourceFile);
     }
 }
 
-function getLineAndCharacterWithoutBom(sourceFile: ts.SourceFile, pos: number): ts.LineAndCharacter {
+function getLineAndCharacterWithoutBom(
+    sourceFile: ts.SourceFile,
+    pos: number,
+): ts.LineAndCharacter {
     const result = ts.getLineAndCharacterOfPosition(sourceFile, pos);
     if (result.line === 0 && sourceFile.text[0] === "\uFEFF") {
         result.character -= 1;

--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -46,10 +46,14 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_ARRAY = "Array type using 'Array<T>' is forbidden. Use 'T[]' instead.";
-    public static FAILURE_STRING_GENERIC = "Array type using 'T[]' is forbidden. Use 'Array<T>' instead.";
-    public static FAILURE_STRING_ARRAY_SIMPLE = "Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.";
-    public static FAILURE_STRING_GENERIC_SIMPLE = "Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.";
+    public static FAILURE_STRING_ARRAY =
+        "Array type using 'Array<T>' is forbidden. Use 'T[]' instead.";
+    public static FAILURE_STRING_GENERIC =
+        "Array type using 'T[]' is forbidden. Use 'Array<T>' instead.";
+    public static FAILURE_STRING_ARRAY_SIMPLE =
+        "Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.";
+    public static FAILURE_STRING_GENERIC_SIMPLE =
+        "Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, this.ruleArguments[0] as Option);
@@ -71,14 +75,18 @@ function walk(ctx: Lint.WalkContext<Option>): void {
 
     function checkArrayType(node: ts.ArrayTypeNode): void {
         const { elementType, parent } = node;
-        if (option === "array" || option === "array-simple" && isSimpleType(elementType)) {
+        if (option === "array" || (option === "array-simple" && isSimpleType(elementType))) {
             return;
         }
 
-        const failureString = option === "generic" ? Rule.FAILURE_STRING_GENERIC : Rule.FAILURE_STRING_GENERIC_SIMPLE;
+        const failureString =
+            option === "generic" ? Rule.FAILURE_STRING_GENERIC : Rule.FAILURE_STRING_GENERIC_SIMPLE;
         const parens = elementType.kind === ts.SyntaxKind.ParenthesizedType ? 1 : 0;
         // Add a space if the type is preceded by 'as' and the node has no leading whitespace
-        const space = parens === 0 && parent!.kind === ts.SyntaxKind.AsExpression && node.getStart() === node.getFullStart();
+        const space =
+            parens === 0 &&
+            parent!.kind === ts.SyntaxKind.AsExpression &&
+            node.getStart() === node.getFullStart();
         const fix = [
             new Lint.Replacement(elementType.getStart(), parens, `${space ? " " : ""}Array<`),
             // Delete the square brackets and replace with an angle bracket
@@ -94,14 +102,22 @@ function walk(ctx: Lint.WalkContext<Option>): void {
             return;
         }
 
-        const failureString = option === "array" ? Rule.FAILURE_STRING_ARRAY : Rule.FAILURE_STRING_ARRAY_SIMPLE;
+        const failureString =
+            option === "array" ? Rule.FAILURE_STRING_ARRAY : Rule.FAILURE_STRING_ARRAY_SIMPLE;
         if (typeArguments === undefined || typeArguments.length === 0) {
             // Create an 'any' array
-            ctx.addFailureAtNode(node, failureString, Lint.Replacement.replaceFromTo(node.getStart(), node.getEnd(), "any[]"));
+            ctx.addFailureAtNode(
+                node,
+                failureString,
+                Lint.Replacement.replaceFromTo(node.getStart(), node.getEnd(), "any[]"),
+            );
             return;
         }
 
-        if (typeArguments.length !== 1 || (option === "array-simple" && !isSimpleType(typeArguments[0]))) {
+        if (
+            typeArguments.length !== 1 ||
+            (option === "array-simple" && !isSimpleType(typeArguments[0]))
+        ) {
             return;
         }
 
@@ -157,7 +173,11 @@ function isSimpleType(nodeType: ts.TypeNode): boolean {
                 case 0:
                     return true;
                 case 1:
-                    return typeName.kind === ts.SyntaxKind.Identifier && typeName.text === "Array" && isSimpleType(typeArguments[0]);
+                    return (
+                        typeName.kind === ts.SyntaxKind.Identifier &&
+                        typeName.text === "Array" &&
+                        isSimpleType(typeArguments[0])
+                    );
                 default:
                     return false;
             }

--- a/src/rules/arrowParensRule.ts
+++ b/src/rules/arrowParensRule.ts
@@ -46,8 +46,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_MISSING = "Parentheses are required around the parameters of an arrow function definition";
-    public static FAILURE_STRING_EXISTS = "Parentheses are prohibited around the parameter in this single parameter arrow function";
+    public static FAILURE_STRING_MISSING =
+        "Parentheses are required around the parameters of an arrow function definition";
+    public static FAILURE_STRING_EXISTS =
+        "Parentheses are prohibited around the parameter in this single parameter arrow function";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, {
@@ -72,10 +74,17 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 }
             } else if (ctx.options.banSingleArgParens) {
                 const closeParen = getChildOfKind(node, ts.SyntaxKind.CloseParenToken)!;
-                const charBeforeOpenParen = ctx.sourceFile.text.substring(openParen.pos - 1, openParen.pos);
+                const charBeforeOpenParen = ctx.sourceFile.text.substring(
+                    openParen.pos - 1,
+                    openParen.pos,
+                );
                 const replaceValue = charBeforeOpenParen.match(/[a-z]/i) !== null ? " " : "";
                 ctx.addFailureAtNode(node.parameters[0], Rule.FAILURE_STRING_EXISTS, [
-                    Lint.Replacement.replaceFromTo(openParen.pos, node.parameters[0].getStart(ctx.sourceFile), replaceValue),
+                    Lint.Replacement.replaceFromTo(
+                        openParen.pos,
+                        node.parameters[0].getStart(ctx.sourceFile),
+                        replaceValue,
+                    ),
                     Lint.Replacement.deleteFromTo(node.parameters[0].end, closeParen.end),
                 ]);
             }
@@ -86,16 +95,20 @@ function walk(ctx: Lint.WalkContext<Options>) {
 }
 
 function parensAreOptional(node: ts.ArrowFunction) {
-    return node.parameters.length === 1 &&
+    return (
+        node.parameters.length === 1 &&
         node.typeParameters === undefined &&
         node.type === undefined &&
-        isSimpleParameter(node.parameters[0]);
+        isSimpleParameter(node.parameters[0])
+    );
 }
 
 function isSimpleParameter(parameter: ts.ParameterDeclaration): boolean {
-    return parameter.name.kind === ts.SyntaxKind.Identifier
-        && parameter.dotDotDotToken === undefined
-        && parameter.initializer === undefined
-        && parameter.questionToken === undefined
-        && parameter.type === undefined;
+    return (
+        parameter.name.kind === ts.SyntaxKind.Identifier &&
+        parameter.dotDotDotToken === undefined &&
+        parameter.initializer === undefined &&
+        parameter.questionToken === undefined &&
+        parameter.type === undefined
+    );
 }

--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -36,10 +36,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "string",
             enum: [OPTION_MULTILINE],
         },
-        optionExamples: [
-            true,
-            [true, OPTION_MULTILINE],
-        ],
+        optionExamples: [true, [true, OPTION_MULTILINE]],
         rationale: Lint.Utils.dedent`
             It's unnecessary to include \`return\` and \`{}\` brackets in arrow lambdas.
             Leaving them out results in simpler and easier to read code.
@@ -51,12 +48,17 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING(isObjectLiteral: boolean): string {
-        const start = "This arrow function body can be simplified by omitting the curly braces and the keyword 'return'";
-        return start + (isObjectLiteral ? ", and wrapping the object literal in parentheses." : ".");
+        const start =
+            "This arrow function body can be simplified by omitting the curly braces and the keyword 'return'";
+        return (
+            start + (isObjectLiteral ? ", and wrapping the object literal in parentheses." : ".")
+        );
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, walk, { multiline: this.ruleArguments.indexOf(OPTION_MULTILINE) !== -1 });
+        return this.applyWithFunction(sourceFile, walk, {
+            multiline: this.ruleArguments.indexOf(OPTION_MULTILINE) !== -1,
+        });
     }
 }
 
@@ -65,20 +67,36 @@ interface Options {
 }
 
 function walk(ctx: Lint.WalkContext<Options>): void {
-    const { sourceFile, options: { multiline } } = ctx;
+    const {
+        sourceFile,
+        options: { multiline },
+    } = ctx;
     return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
         if (utils.isArrowFunction(node) && utils.isBlock(node.body)) {
             const expr = getSimpleReturnExpression(node.body);
-            if (expr !== undefined && (multiline || utils.isSameLine(sourceFile, node.body.getStart(sourceFile), node.body.end))) {
+            if (
+                expr !== undefined &&
+                (multiline ||
+                    utils.isSameLine(sourceFile, node.body.getStart(sourceFile), node.body.end))
+            ) {
                 const isObjectLiteral = expr.kind === ts.SyntaxKind.ObjectLiteralExpression;
-                ctx.addFailureAtNode(node.body, Rule.FAILURE_STRING(isObjectLiteral), createFix(node, node.body, expr, sourceFile.text));
+                ctx.addFailureAtNode(
+                    node.body,
+                    Rule.FAILURE_STRING(isObjectLiteral),
+                    createFix(node, node.body, expr, sourceFile.text),
+                );
             }
         }
         return ts.forEachChild(node, cb);
     });
 }
 
-function createFix(arrowFunction: ts.FunctionLikeDeclaration, body: ts.Block, expr: ts.Expression, text: string): Lint.Fix | undefined {
+function createFix(
+    arrowFunction: ts.FunctionLikeDeclaration,
+    body: ts.Block,
+    expr: ts.Expression,
+    text: string,
+): Lint.Fix | undefined {
     const statement = expr.parent!;
     const returnKeyword = utils.getChildOfKind(statement, ts.SyntaxKind.ReturnKeyword)!;
     const arrow = utils.getChildOfKind(arrowFunction, ts.SyntaxKind.EqualsGreaterThanToken)!;
@@ -86,21 +104,31 @@ function createFix(arrowFunction: ts.FunctionLikeDeclaration, body: ts.Block, ex
     const closeBrace = utils.getChildOfKind(body, ts.SyntaxKind.CloseBraceToken)!;
     const semicolon = utils.getChildOfKind(statement, ts.SyntaxKind.SemicolonToken);
 
-    const anyComments = hasComments(arrow) || hasComments(openBrace) || hasComments(statement) || hasComments(returnKeyword) ||
-        hasComments(expr) || (semicolon !== undefined && hasComments(semicolon)) || hasComments(closeBrace);
-    return anyComments ? undefined : [
-        // Object literal must be wrapped in `()`
-        ...(expr.kind === ts.SyntaxKind.ObjectLiteralExpression ? [
-            Lint.Replacement.appendText(expr.getStart(), "("),
-            Lint.Replacement.appendText(expr.getEnd(), ")"),
-        ] : []),
-        // " {"
-        Lint.Replacement.deleteFromTo(arrow.end, openBrace.end),
-        // "return "
-        Lint.Replacement.deleteFromTo(statement.getStart(), expr.getStart()),
-        // " }" (may include semicolon)
-        Lint.Replacement.deleteFromTo(expr.end, closeBrace.end),
-    ];
+    const anyComments =
+        hasComments(arrow) ||
+        hasComments(openBrace) ||
+        hasComments(statement) ||
+        hasComments(returnKeyword) ||
+        hasComments(expr) ||
+        (semicolon !== undefined && hasComments(semicolon)) ||
+        hasComments(closeBrace);
+    return anyComments
+        ? undefined
+        : [
+              // Object literal must be wrapped in `()`
+              ...(expr.kind === ts.SyntaxKind.ObjectLiteralExpression
+                  ? [
+                        Lint.Replacement.appendText(expr.getStart(), "("),
+                        Lint.Replacement.appendText(expr.getEnd(), ")"),
+                    ]
+                  : []),
+              // " {"
+              Lint.Replacement.deleteFromTo(arrow.end, openBrace.end),
+              // "return "
+              Lint.Replacement.deleteFromTo(statement.getStart(), expr.getStart()),
+              // " }" (may include semicolon)
+              Lint.Replacement.deleteFromTo(expr.end, closeBrace.end),
+          ];
 
     function hasComments(node: ts.Node): boolean {
         return hasCommentAfterPosition(text, node.getEnd());
@@ -109,7 +137,8 @@ function createFix(arrowFunction: ts.FunctionLikeDeclaration, body: ts.Block, ex
 
 /** Given `{ return x; }`, return `x`. */
 function getSimpleReturnExpression(block: ts.Block): ts.Expression | undefined {
-    return block.statements.length === 1 && block.statements[0].kind === ts.SyntaxKind.ReturnStatement
+    return block.statements.length === 1 &&
+        block.statements[0].kind === ts.SyntaxKind.ReturnStatement
         ? (block.statements[0] as ts.ReturnStatement).expression
         : undefined;
 }

--- a/src/rules/awaitPromiseRule.ts
+++ b/src/rules/awaitPromiseRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { isAwaitExpression, isForOfStatement, isTypeFlagSet, isTypeReference, isUnionOrIntersectionType } from "tsutils";
+import {
+    isAwaitExpression,
+    isForOfStatement,
+    isTypeFlagSet,
+    isTypeReference,
+    isUnionOrIntersectionType,
+} from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -35,7 +41,7 @@ export class Rule extends Lint.Rules.TypedRule {
             type: "list",
             listType: {
                 type: "array",
-                items: {type: "string"},
+                items: { type: "string" },
             },
         },
         optionExamples: [true, [true, "Thenable"]],
@@ -56,7 +62,7 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_FOR_AWAIT_OF = "Invalid 'for-await-of' of a non-AsyncIterable value.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        const promiseTypes = new Set(["Promise", ...this.ruleArguments as string[]]);
+        const promiseTypes = new Set(["Promise", ...(this.ruleArguments as string[])]);
         return this.applyWithFunction(sourceFile, walk, promiseTypes, program.getTypeChecker());
     }
 }
@@ -66,10 +72,16 @@ function walk(ctx: Lint.WalkContext<Set<string>>, tc: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, cb);
 
     function cb(node: ts.Node): void {
-        if (isAwaitExpression(node) && !containsType(tc.getTypeAtLocation(node.expression), isPromiseType)) {
+        if (
+            isAwaitExpression(node) &&
+            !containsType(tc.getTypeAtLocation(node.expression), isPromiseType)
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
-        } else if (isForOfStatement(node) && node.awaitModifier !== undefined &&
-                   !containsType(tc.getTypeAtLocation(node.expression), isAsyncIterable)) {
+        } else if (
+            isForOfStatement(node) &&
+            node.awaitModifier !== undefined &&
+            !containsType(tc.getTypeAtLocation(node.expression), isAsyncIterable)
+        ) {
             ctx.addFailureAtNode(node.expression, Rule.FAILURE_FOR_AWAIT_OF);
         }
         return ts.forEachChild(node, cb);
@@ -91,10 +103,10 @@ function containsType(type: ts.Type, predicate: (name: string) => boolean): bool
         return true;
     }
     if (isUnionOrIntersectionType(type)) {
-        return type.types.some((t) => containsType(t, predicate));
+        return type.types.some(t => containsType(t, predicate));
     }
     const bases = type.getBaseTypes();
-    return bases !== undefined && bases.some((t) => containsType(t, predicate));
+    return bases !== undefined && bases.some(t => containsType(t, predicate));
 }
 
 function isAsyncIterable(name: string) {

--- a/src/rules/banCommaOperatorRule.ts
+++ b/src/rules/banCommaOperatorRule.ts
@@ -25,7 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "ban-comma-operator",
         description: "Disallows the comma operator to be used.",
-        descriptionDetails: "[Read more about the comma operator here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator).",
+        descriptionDetails:
+            "[Read more about the comma operator here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator).",
         rationale: Lint.Utils.dedent`
             Using the comma operator can create a potential for many non-obvious bugs or lead to misunderstanding of code.
 
@@ -55,7 +56,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys max-line-length */
 
-    public static FAILURE_STRING = "Do not use comma operator here because it can be easily misunderstood or lead to unintended bugs.";
+    public static FAILURE_STRING =
+        "Do not use comma operator here because it can be easily misunderstood or lead to unintended bugs.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -64,7 +66,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.CommaToken && !isForLoopIncrementor(node)) {
+        if (
+            isBinaryExpression(node) &&
+            node.operatorToken.kind === ts.SyntaxKind.CommaToken &&
+            !isForLoopIncrementor(node)
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);
@@ -73,5 +79,8 @@ function walk(ctx: Lint.WalkContext<void>) {
 
 function isForLoopIncrementor(node: ts.Node) {
     const parent = node.parent!;
-    return parent.kind === ts.SyntaxKind.ForStatement && (parent as ts.ForStatement).incrementor === node;
+    return (
+        parent.kind === ts.SyntaxKind.ForStatement &&
+        (parent as ts.ForStatement).incrementor === node
+    );
 }

--- a/src/rules/banRule.ts
+++ b/src/rules/banRule.ts
@@ -61,13 +61,13 @@ export class Rule extends Lint.Rules.AbstractRule {
             listType: {
                 anyOf: [
                     {
-                        type: "string"
+                        type: "string",
                     },
                     {
                         type: "array",
                         items: { type: "string" },
                         minLength: 1,
-                        maxLength: 3
+                        maxLength: 3,
                     },
                     {
                         type: "object",
@@ -75,15 +75,15 @@ export class Rule extends Lint.Rules.AbstractRule {
                             name: {
                                 anyOf: [
                                     { type: "string" },
-                                    { type: "array", items: { type: "string" }, minLength: 1 }
-                                ]
+                                    { type: "array", items: { type: "string" }, minLength: 1 },
+                                ],
                             },
-                            message: { type: "string" }
+                            message: { type: "string" },
                         },
-                        required: ["name"]
-                    }
-                ]
-            }
+                        required: ["name"],
+                    },
+                ],
+            },
         },
         optionExamples: [
             [
@@ -93,11 +93,11 @@ export class Rule extends Lint.Rules.AbstractRule {
                 ["describe", "only"],
                 { name: ["it", "only"], message: "don't focus tests" },
                 { name: ["chai", "assert", "equal"], message: "Use 'strictEqual' instead." },
-                { name: ["*", "forEach"], message: "Use a regular for loop instead." }
-            ]
+                { name: ["*", "forEach"], message: "Use a regular for loop instead." },
+            ],
         ],
         type: "functionality",
-        typescriptOnly: false
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 
@@ -109,7 +109,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(
-            new BanFunctionWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments))
+            new BanFunctionWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)),
         );
     }
 }
@@ -143,7 +143,7 @@ function parseOptions(args: Array<string | string[] | OptionsInput>): Options {
                     methods.push({
                         message: arg.message,
                         name: arg.name[arg.name.length - 1],
-                        object: arg.name.slice(0, -1)
+                        object: arg.name.slice(0, -1),
                     });
             }
         }
@@ -184,7 +184,7 @@ class BanFunctionWalker extends Lint.AbstractWalker<Options> {
             ) {
                 this.addFailureAtNode(
                     expression,
-                    Rule.FAILURE_STRING_FACTORY(`${ban.object.join(".")}.${ban.name}`, ban.message)
+                    Rule.FAILURE_STRING_FACTORY(`${ban.object.join(".")}.${ban.name}`, ban.message),
                 );
                 break;
             }

--- a/src/rules/banTsIgnoreRule.ts
+++ b/src/rules/banTsIgnoreRule.ts
@@ -34,7 +34,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:disable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = 'Do not use "// @ts-ignore" comments because they suppress compilation errors.';
+    public static FAILURE_STRING =
+        'Do not use "// @ts-ignore" comments because they suppress compilation errors.';
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);

--- a/src/rules/banTypesRule.ts
+++ b/src/rules/banTypesRule.ts
@@ -51,7 +51,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING_FACTORY(typeName: string, messageAddition?: string) {
-        return `Don't use '${typeName}' as a type.${messageAddition !== undefined ? ` ${messageAddition}` : ""}`;
+        return `Don't use '${typeName}' as a type.${
+            messageAddition !== undefined ? ` ${messageAddition}` : ""
+        }`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -60,7 +62,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function parseOption([pattern, message]: [string, string | undefined]): Option {
-    return {message, pattern: new RegExp(`^${pattern}$`)};
+    return { message, pattern: new RegExp(`^${pattern}$`) };
 }
 
 function walk(ctx: Lint.WalkContext<Option[]>) {

--- a/src/rules/binaryExpressionOperandOrderRule.ts
+++ b/src/rules/binaryExpressionOperandOrderRule.ts
@@ -42,7 +42,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Literal expression should be on the right-hand side of a binary expression.";
+    public static FAILURE_STRING =
+        "Literal expression should be on the right-hand side of a binary expression.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -51,7 +52,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>): void {
     ts.forEachChild(ctx.sourceFile, function cb(node) {
-        if (isBinaryExpression(node) && isLiteral(node.left) && !isLiteral(node.right) && !isAllowedOrderedOperator(node)) {
+        if (
+            isBinaryExpression(node) &&
+            isLiteral(node.left) &&
+            !isLiteral(node.right) &&
+            !isAllowedOrderedOperator(node)
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         ts.forEachChild(node, cb);

--- a/src/rules/callableTypesRule.ts
+++ b/src/rules/callableTypesRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { getChildOfKind, isCallSignatureDeclaration, isIdentifier, isInterfaceDeclaration, isTypeLiteralNode } from "tsutils";
+import {
+    getChildOfKind,
+    isCallSignatureDeclaration,
+    isIdentifier,
+    isInterfaceDeclaration,
+    isTypeLiteralNode,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -24,7 +30,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "callable-types",
-        description: "An interface or literal type with just a call signature can be written as a function type.",
+        description:
+            "An interface or literal type with just a call signature can be written as a function type.",
         rationale: "style",
         optionsDescription: "Not configurable.",
         options: null,
@@ -45,19 +52,29 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if ((isInterfaceDeclaration(node) && noSupertype(node) || isTypeLiteralNode(node))
-            && node.members.length === 1) {
+        if (
+            ((isInterfaceDeclaration(node) && noSupertype(node)) || isTypeLiteralNode(node)) &&
+            node.members.length === 1
+        ) {
             const member = node.members[0];
-            if (isCallSignatureDeclaration(member) &&
+            if (
+                isCallSignatureDeclaration(member) &&
                 // avoid bad parse
-                member.type !== undefined) {
+                member.type !== undefined
+            ) {
                 const suggestion = renderSuggestion(member, node, ctx.sourceFile);
-                const fixStart = node.kind === ts.SyntaxKind.TypeLiteral
-                    ? node.getStart(ctx.sourceFile)
-                    : getChildOfKind(node, ts.SyntaxKind.InterfaceKeyword)!.getStart(ctx.sourceFile);
+                const fixStart =
+                    node.kind === ts.SyntaxKind.TypeLiteral
+                        ? node.getStart(ctx.sourceFile)
+                        : getChildOfKind(node, ts.SyntaxKind.InterfaceKeyword)!.getStart(
+                              ctx.sourceFile,
+                          );
                 ctx.addFailureAtNode(
                     member,
-                    Rule.FAILURE_STRING_FACTORY(node.kind === ts.SyntaxKind.TypeLiteral ? "Type literal" : "Interface", suggestion),
+                    Rule.FAILURE_STRING_FACTORY(
+                        node.kind === ts.SyntaxKind.TypeLiteral ? "Type literal" : "Interface",
+                        suggestion,
+                    ),
                     Lint.Replacement.replaceFromTo(fixStart, node.end, suggestion),
                 );
             }
@@ -78,10 +95,11 @@ function noSupertype(node: ts.InterfaceDeclaration): boolean {
     return isIdentifier(expr) && expr.text === "Function";
 }
 
-function renderSuggestion(call: ts.CallSignatureDeclaration,
-                          parent: ts.InterfaceDeclaration | ts.TypeLiteralNode,
-                          sourceFile: ts.SourceFile): string {
-
+function renderSuggestion(
+    call: ts.CallSignatureDeclaration,
+    parent: ts.InterfaceDeclaration | ts.TypeLiteralNode,
+    sourceFile: ts.SourceFile,
+): string {
     const start = call.getStart(sourceFile);
     const colonPos = call.type!.pos - 1 - start;
     const text = sourceFile.text.substring(start, call.end);
@@ -92,7 +110,10 @@ function renderSuggestion(call: ts.CallSignatureDeclaration,
     }
     if (parent.kind === ts.SyntaxKind.InterfaceDeclaration) {
         if (parent.typeParameters !== undefined) {
-            return `type${sourceFile.text.substring(parent.name.pos, parent.typeParameters.end + 1)} = ${suggestion}`;
+            return `type${sourceFile.text.substring(
+                parent.name.pos,
+                parent.typeParameters.end + 1,
+            )} = ${suggestion}`;
         } else {
             return `type ${parent.name.text} = ${suggestion}`;
         }

--- a/src/rules/classNameRule.ts
+++ b/src/rules/classNameRule.ts
@@ -51,8 +51,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isClassLikeDeclaration(node) && node.name !== undefined ||
-            isInterfaceDeclaration(node)) {
+        if (
+            (isClassLikeDeclaration(node) && node.name !== undefined) ||
+            isInterfaceDeclaration(node)
+        ) {
             if (!isPascalCased(node.name!.text)) {
                 ctx.addFailureAtNode(node.name!, Rule.FAILURE_STRING);
             }

--- a/src/rules/code-examples/arrowReturnShorthand.examples.ts
+++ b/src/rules/code-examples/arrowReturnShorthand.examples.ts
@@ -20,7 +20,8 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Enforces usage of the shorthand return syntax when an arrow function's body does not span multiple lines.",
+        description:
+            "Enforces usage of the shorthand return syntax when an arrow function's body does not span multiple lines.",
         config: Lint.Utils.dedent`
             "rules": { "arrow-return-shorthand": true }
         `,
@@ -38,7 +39,8 @@ export const codeExamples = [
        `,
     },
     {
-        description: "Enforces usage of the shorthand return syntax even when an arrow function's body spans multiple lines.",
+        description:
+            "Enforces usage of the shorthand return syntax even when an arrow function's body spans multiple lines.",
         config: Lint.Utils.dedent`
             "rules": { "arrow-return-shorthand": [true, "multiline"] }
         `,

--- a/src/rules/code-examples/objectLiteralSortKeys.examples.ts
+++ b/src/rules/code-examples/objectLiteralSortKeys.examples.ts
@@ -38,7 +38,8 @@ export const codeExamples = [
         `,
     },
     {
-        description: Lint.Utils.dedent`Requires that an object literal's keys be sorted by interface-definition.
+        description: Lint.Utils
+            .dedent`Requires that an object literal's keys be sorted by interface-definition.
             If there is no interface fallback to alphabetically.`,
         config: Lint.Utils.dedent`
             "rules": {

--- a/src/rules/code-examples/oneVariablePerDeclaration.examples.ts
+++ b/src/rules/code-examples/oneVariablePerDeclaration.examples.ts
@@ -33,7 +33,8 @@ export const codeExamples = [
        `,
     },
     {
-        description: "Disallows multiple variable definitions in the same declaration statement but allows them in for-loops.",
+        description:
+            "Disallows multiple variable definitions in the same declaration statement but allows them in for-loops.",
         config: Lint.Utils.dedent`
             "rules": { "one-variable-per-declaration": [true, "ignore-for-loop"] }
         `,

--- a/src/rules/code-examples/preferWhile.examples.ts
+++ b/src/rules/code-examples/preferWhile.examples.ts
@@ -20,7 +20,8 @@ import * as Lint from "../../index";
 // tslint:disable: object-literal-sort-keys
 export const codeExamples = [
     {
-        description: "Prefer `while` loops instead of `for` loops without an initializer and incrementor.",
+        description:
+            "Prefer `while` loops instead of `for` loops without an initializer and incrementor.",
         config: Lint.Utils.dedent`
             "rules": { "prefer-while": true }
         `,

--- a/src/rules/commentFormatRule.ts
+++ b/src/rules/commentFormatRule.ts
@@ -72,11 +72,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 anyOf: [
                     {
                         type: "string",
-                        enum: [
-                            "check-space",
-                            "check-lowercase",
-                            "check-uppercase",
-                        ],
+                        enum: ["check-space", "check-lowercase", "check-uppercase"],
                     },
                     {
                         type: "object",
@@ -101,8 +97,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         },
         optionExamples: [
             [true, "check-space", "check-uppercase"],
-            [true, "check-lowercase", {"ignore-words": ["TODO", "HACK"]}],
-            [true, "check-lowercase", {"ignore-pattern": "STD\\w{2,3}\\b"}],
+            [true, "check-lowercase", { "ignore-words": ["TODO", "HACK"] }],
+            [true, "check-lowercase", { "ignore-pattern": "STD\\w{2,3}\\b" }],
         ],
         type: "style",
         typescriptOnly: false,
@@ -113,8 +109,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static LOWERCASE_FAILURE = "comment must start with lowercase letter";
     public static UPPERCASE_FAILURE = "comment must start with uppercase letter";
     public static LEADING_SPACE_FAILURE = "comment must start with a space";
-    public static IGNORE_WORDS_FAILURE_FACTORY = (words: string[]): string => ` or the word(s): ${words.join(", ")}`;
-    public static IGNORE_PATTERN_FAILURE_FACTORY = (pattern: string): string => ` or its start must match the regex pattern "${pattern}"`;
+    public static IGNORE_WORDS_FAILURE_FACTORY = (words: string[]): string =>
+        ` or the word(s): ${words.join(", ")}`;
+    public static IGNORE_PATTERN_FAILURE_FACTORY = (pattern: string): string =>
+        ` or its start must match the regex pattern "${pattern}"`;
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, parseOptions(this.ruleArguments));
@@ -123,7 +121,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function parseOptions(options: Array<string | IExceptionsObject>): Options {
     return {
-        case: options.indexOf(OPTION_LOWERCASE) !== -1
+        case:
+            options.indexOf(OPTION_LOWERCASE) !== -1
                 ? Case.Lower
                 : options.indexOf(OPTION_UPPERCASE) !== -1
                     ? Case.Upper
@@ -134,7 +133,9 @@ function parseOptions(options: Array<string | IExceptionsObject>): Options {
     };
 }
 
-function composeExceptions(option?: string | IExceptionsObject): undefined | {exceptions: RegExp; failureSuffix: string} {
+function composeExceptions(
+    option?: string | IExceptionsObject,
+): undefined | { exceptions: RegExp; failureSuffix: string } {
     if (typeof option !== "object") {
         return undefined;
     }
@@ -149,7 +150,9 @@ function composeExceptions(option?: string | IExceptionsObject): undefined | {ex
     const ignoreWords = option["ignore-words"];
     if (ignoreWords !== undefined && ignoreWords.length !== 0) {
         return {
-            exceptions: new RegExp(`^\\s*(?:${ignoreWords.map((word) => escapeRegExp(word.trim())).join("|")})\\b`),
+            exceptions: new RegExp(
+                `^\\s*(?:${ignoreWords.map(word => escapeRegExp(word.trim())).join("|")})\\b`,
+            ),
             failureSuffix: Rule.IGNORE_WORDS_FAILURE_FACTORY(ignoreWords),
         };
     }
@@ -157,13 +160,16 @@ function composeExceptions(option?: string | IExceptionsObject): undefined | {ex
 }
 
 function walk(ctx: Lint.WalkContext<Options>) {
-    utils.forEachComment(ctx.sourceFile, (fullText, {kind, pos, end}) => {
+    utils.forEachComment(ctx.sourceFile, (fullText, { kind, pos, end }) => {
         let start = pos + 2;
-        if (kind !== ts.SyntaxKind.SingleLineCommentTrivia ||
+        if (
+            kind !== ts.SyntaxKind.SingleLineCommentTrivia ||
             // exclude empty comments
             start === end ||
             // exclude /// <reference path="...">
-            fullText[start] === "/" && ctx.sourceFile.referencedFiles.some((ref) => ref.pos >= pos && ref.end <= end)) {
+            (fullText[start] === "/" &&
+                ctx.sourceFile.referencedFiles.some(ref => ref.pos >= pos && ref.end <= end))
+        ) {
             return;
         }
         // skip all leading slashes
@@ -180,12 +186,16 @@ function walk(ctx: Lint.WalkContext<Options>) {
         }
 
         if (ctx.options.space && commentText[0] !== " ") {
-            ctx.addFailure(start, end, Rule.LEADING_SPACE_FAILURE, [ Lint.Replacement.appendText(start, " ") ]);
+            ctx.addFailure(start, end, Rule.LEADING_SPACE_FAILURE, [
+                Lint.Replacement.appendText(start, " "),
+            ]);
         }
 
-        if (ctx.options.case === Case.None ||
-            ctx.options.exceptions !== undefined && ctx.options.exceptions.test(commentText) ||
-            ENABLE_DISABLE_REGEX.test(commentText)) {
+        if (
+            ctx.options.case === Case.None ||
+            (ctx.options.exceptions !== undefined && ctx.options.exceptions.test(commentText)) ||
+            ENABLE_DISABLE_REGEX.test(commentText)
+        ) {
             return;
         }
 

--- a/src/rules/commentTypeRule.ts
+++ b/src/rules/commentTypeRule.ts
@@ -37,7 +37,6 @@ const DIRECTIVE_FAILURE = "triple-slash directives are not allowed";
 
 // Logic
 export class Rule extends Lint.Rules.AbstractRule {
-
     // tslint:disable:object-literal-sort-keys
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "comment-type",
@@ -57,11 +56,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             },
             uniqueItems: true,
         },
-        optionExamples: [
-            [true, "doc", "singleline"],
-            [true, "singleline"],
-            [true, "multiline"],
-        ],
+        optionExamples: [[true, "doc", "singleline"], [true, "singleline"], [true, "multiline"]],
         hasFix: false,
         type: "style",
         typescriptOnly: false,
@@ -70,16 +65,15 @@ export class Rule extends Lint.Rules.AbstractRule {
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, parseOptions(this.ruleArguments));
     }
-
 }
 
 function walk(ctx: Lint.WalkContext<Options>) {
-    utils.forEachComment(ctx.sourceFile, (fullText, {kind, pos, end}) => {
+    utils.forEachComment(ctx.sourceFile, (fullText, { kind, pos, end }) => {
         if (kind === ts.SyntaxKind.SingleLineCommentTrivia) {
             // directive
             if (fullText.slice(pos, pos + 3) === "///" && !ctx.options.has("directive")) {
                 ctx.addFailure(pos, end, DIRECTIVE_FAILURE);
-            // singleline
+                // singleline
             } else if (fullText.slice(pos, pos + 3) !== "///" && !ctx.options.has("singleline")) {
                 ctx.addFailure(pos, end, SINGLE_LINE_FAILURE);
             }
@@ -87,7 +81,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
             // doc
             if (fullText.slice(pos, pos + 3) === "/**" && !ctx.options.has("doc")) {
                 ctx.addFailure(pos, end, DOC_FAILURE);
-            // multiline
+                // multiline
             } else if (fullText.slice(pos, pos + 3) !== "/**" && !ctx.options.has("multiline")) {
                 ctx.addFailure(pos, end, MULTILINE_FAILURE);
             }

--- a/src/rules/completed-docs/classExclusion.ts
+++ b/src/rules/completed-docs/classExclusion.ts
@@ -19,7 +19,14 @@ import { hasModifier } from "tsutils";
 import * as ts from "typescript";
 
 import {
-    ALL, Location, LOCATION_INSTANCE, LOCATION_STATIC, Privacy, PRIVACY_PRIVATE, PRIVACY_PROTECTED, PRIVACY_PUBLIC,
+    ALL,
+    Location,
+    LOCATION_INSTANCE,
+    LOCATION_STATIC,
+    Privacy,
+    PRIVACY_PRIVATE,
+    PRIVACY_PROTECTED,
+    PRIVACY_PUBLIC,
 } from "../completedDocsRule";
 import { Exclusion } from "./exclusion";
 
@@ -33,9 +40,7 @@ export class ClassExclusion extends Exclusion<IClassExclusionDescriptor> {
     public readonly privacies: Set<Privacy> = this.createSet(this.descriptor.privacies);
 
     public excludes(node: ts.Node) {
-        return !(
-            this.shouldLocationBeDocumented(node)
-            && this.shouldPrivacyBeDocumented(node));
+        return !(this.shouldLocationBeDocumented(node) && this.shouldPrivacyBeDocumented(node));
     }
 
     private shouldLocationBeDocumented(node: ts.Node) {

--- a/src/rules/completed-docs/exclusion.ts
+++ b/src/rules/completed-docs/exclusion.ts
@@ -21,7 +21,7 @@ import { All, ALL } from "../completedDocsRule";
 import { ExclusionDescriptor } from "./exclusionDescriptors";
 
 export abstract class Exclusion<TDescriptor extends ExclusionDescriptor> {
-    public constructor(protected readonly descriptor: Partial<TDescriptor> = {}) { }
+    public constructor(protected readonly descriptor: Partial<TDescriptor> = {}) {}
 
     public abstract excludes(node: ts.Node): boolean;
 

--- a/src/rules/completed-docs/exclusionDescriptors.ts
+++ b/src/rules/completed-docs/exclusionDescriptors.ts
@@ -20,7 +20,10 @@ import { IBlockExclusionDescriptor } from "./blockExclusion";
 import { IClassExclusionDescriptor } from "./classExclusion";
 import { ITagExclusionDescriptor } from "./tagExclusion";
 
-export type ExclusionDescriptor = IBlockExclusionDescriptor | IClassExclusionDescriptor | ITagExclusionDescriptor;
+export type ExclusionDescriptor =
+    | IBlockExclusionDescriptor
+    | IClassExclusionDescriptor
+    | ITagExclusionDescriptor;
 
 export type InputExclusionDescriptor = boolean | ExclusionDescriptor;
 
@@ -28,6 +31,8 @@ export interface IExclusionDescriptors {
     [type: string /* DocType */]: ExclusionDescriptor;
 }
 
-export type IInputExclusionDescriptors = DocType | {
-    [type: string /* DocType */]: InputExclusionDescriptor;
-};
+export type IInputExclusionDescriptors =
+    | DocType
+    | {
+          [type: string /* DocType */]: InputExclusionDescriptor;
+      };

--- a/src/rules/completed-docs/exclusionFactory.ts
+++ b/src/rules/completed-docs/exclusionFactory.ts
@@ -44,7 +44,10 @@ export class ExclusionFactory {
 
         for (const docType in descriptors) {
             if (hasOwnProperty(descriptors, docType)) {
-                exclusionsMap.set(docType as DocType, this.createRequirementsForDocType(docType as DocType, descriptors[docType]));
+                exclusionsMap.set(
+                    docType as DocType,
+                    this.createRequirementsForDocType(docType as DocType, descriptors[docType]),
+                );
             }
         }
     }

--- a/src/rules/completed-docs/tagExclusion.ts
+++ b/src/rules/completed-docs/tagExclusion.ts
@@ -31,14 +31,14 @@ export interface IContentTags {
 }
 
 export class TagExclusion extends Exclusion<ITagExclusionDescriptor> {
-    private readonly contentTags: IContentTags = this.descriptor.tags === undefined
-        ? {}
-        : this.descriptor.tags.content;
+    private readonly contentTags: IContentTags =
+        this.descriptor.tags === undefined ? {} : this.descriptor.tags.content;
 
     private readonly existenceTags = new Set(
         this.descriptor.tags !== undefined && this.descriptor.tags.existence !== undefined
             ? this.descriptor.tags.existence
-            : undefined);
+            : undefined,
+    );
 
     public excludes(node: ts.Node) {
         const documentationNode = this.getDocumentationNode(node);
@@ -75,7 +75,7 @@ export class TagExclusion extends Exclusion<ITagExclusionDescriptor> {
             return [];
         }
 
-        const docMatches = nodeText.match((/\/\*\*\s*\n?([^\*]*(\*[^\/])?)*\*\//));
+        const docMatches = nodeText.match(/\/\*\*\s*\n?([^\*]*(\*[^\/])?)*\*\//);
         if (docMatches === null || docMatches.length === 0) {
             return [];
         }
@@ -85,15 +85,13 @@ export class TagExclusion extends Exclusion<ITagExclusionDescriptor> {
             return [];
         }
 
-        return lines
-            .map((line): [string, string] => {
+        return lines.map(
+            (line): [string, string] => {
                 const body = line.substring(line.indexOf("@"));
                 const firstSpaceIndex = body.search(/\s/);
 
-                return [
-                    body.substring(1, firstSpaceIndex),
-                    body.substring(firstSpaceIndex).trim(),
-                ];
-            });
+                return [body.substring(1, firstSpaceIndex), body.substring(firstSpaceIndex).trim()];
+            },
+        );
     }
 }

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -54,7 +54,8 @@ export const VISIBILITY_INTERNAL = "internal";
 
 export type All = typeof ALL;
 
-export type DocType = All
+export type DocType =
+    | All
     | typeof ARGUMENT_CLASSES
     | typeof ARGUMENT_ENUMS
     | typeof ARGUMENT_ENUM_MEMBERS
@@ -66,18 +67,15 @@ export type DocType = All
     | typeof ARGUMENT_TYPES
     | typeof ARGUMENT_VARIABLES;
 
-export type Location = All
-    | typeof LOCATION_INSTANCE
-    | typeof LOCATION_STATIC;
+export type Location = All | typeof LOCATION_INSTANCE | typeof LOCATION_STATIC;
 
-export type Privacy = All
+export type Privacy =
+    | All
     | typeof PRIVACY_PRIVATE
     | typeof PRIVACY_PROTECTED
     | typeof PRIVACY_PUBLIC;
 
-export type Visibility = All
-    | typeof VISIBILITY_EXPORTED
-    | typeof VISIBILITY_INTERNAL;
+export type Visibility = All | typeof VISIBILITY_EXPORTED | typeof VISIBILITY_INTERNAL;
 
 export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING_EXIST = "Documentation must exist for ";
@@ -90,10 +88,7 @@ export class Rule extends Lint.Rules.TypedRule {
                 [TAGS_FOR_CONTENT]: {
                     see: ".*",
                 },
-                [TAGS_FOR_EXISTENCE]: [
-                    "deprecated",
-                    "inheritdoc",
-                ],
+                [TAGS_FOR_EXISTENCE]: ["deprecated", "inheritdoc"],
             },
         },
         [ARGUMENT_PROPERTIES]: {
@@ -101,10 +96,7 @@ export class Rule extends Lint.Rules.TypedRule {
                 [TAGS_FOR_CONTENT]: {
                     see: ".*",
                 },
-                [TAGS_FOR_EXISTENCE]: [
-                    "deprecated",
-                    "inheritdoc",
-                ],
+                [TAGS_FOR_EXISTENCE]: ["deprecated", "inheritdoc"],
             },
         },
     };
@@ -128,11 +120,7 @@ export class Rule extends Lint.Rules.TypedRule {
                 },
             },
             [DESCRIPTOR_VISIBILITIES]: {
-                enum: [
-                    ALL,
-                    VISIBILITY_EXPORTED,
-                    VISIBILITY_INTERNAL,
-                ],
+                enum: [ALL, VISIBILITY_EXPORTED, VISIBILITY_INTERNAL],
                 type: "string",
             },
         },
@@ -158,20 +146,11 @@ export class Rule extends Lint.Rules.TypedRule {
                 },
             },
             [DESCRIPTOR_LOCATIONS]: {
-                enum: [
-                    ALL,
-                    LOCATION_INSTANCE,
-                    LOCATION_STATIC,
-                ],
+                enum: [ALL, LOCATION_INSTANCE, LOCATION_STATIC],
                 type: "string",
             },
             [DESCRIPTOR_PRIVACIES]: {
-                enum: [
-                    ALL,
-                    PRIVACY_PRIVATE,
-                    PRIVACY_PROTECTED,
-                    PRIVACY_PUBLIC,
-                ],
+                enum: [ALL, PRIVACY_PRIVATE, PRIVACY_PROTECTED, PRIVACY_PUBLIC],
                 type: "string",
             },
         },
@@ -301,7 +280,9 @@ export class Rule extends Lint.Rules.TypedRule {
         return this.applyWithFunction(sourceFile, walk, exclusionsMap, program.getTypeChecker());
     }
 
-    private getExclusionsMap(ruleArguments: Array<DocType | IInputExclusionDescriptors>): ExclusionsMap {
+    private getExclusionsMap(
+        ruleArguments: Array<DocType | IInputExclusionDescriptors>,
+    ): ExclusionsMap {
         if (ruleArguments.length === 0) {
             ruleArguments = [Rule.defaultArguments];
         }
@@ -372,7 +353,8 @@ function walk(context: Lint.WalkContext<ExclusionsMap>, typeChecker: ts.TypeChec
                 switch (node.parent!.kind) {
                     case ts.SyntaxKind.SourceFile:
                     case ts.SyntaxKind.ModuleBlock:
-                        for (const declaration of (node as ts.VariableStatement).declarationList.declarations) {
+                        for (const declaration of (node as ts.VariableStatement).declarationList
+                            .declarations) {
                             checkNode(declaration, ARGUMENT_VARIABLES, node);
                         }
                 }
@@ -388,7 +370,11 @@ function walk(context: Lint.WalkContext<ExclusionsMap>, typeChecker: ts.TypeChec
         return ts.forEachChild(node, cb);
     }
 
-    function checkNode(node: ts.NamedDeclaration, nodeType: DocType, requirementNode: ts.Node = node): void {
+    function checkNode(
+        node: ts.NamedDeclaration,
+        nodeType: DocType,
+        requirementNode: ts.Node = node,
+    ): void {
         const { name } = node;
         if (name === undefined) {
             return;
@@ -414,13 +400,27 @@ function walk(context: Lint.WalkContext<ExclusionsMap>, typeChecker: ts.TypeChec
         checkComments(node, describeNode(nodeType), comments, requirementNode);
     }
 
-    function checkComments(node: ts.Node, nodeDescriptor: string, comments: ts.SymbolDisplayPart[], requirementNode: ts.Node) {
-        if (comments.map((comment: ts.SymbolDisplayPart) => comment.text).join("").trim() === "") {
+    function checkComments(
+        node: ts.Node,
+        nodeDescriptor: string,
+        comments: ts.SymbolDisplayPart[],
+        requirementNode: ts.Node,
+    ) {
+        if (
+            comments
+                .map((comment: ts.SymbolDisplayPart) => comment.text)
+                .join("")
+                .trim() === ""
+        ) {
             addDocumentationFailure(node, nodeDescriptor, requirementNode);
         }
     }
 
-    function addDocumentationFailure(node: ts.Node, nodeType: string, requirementNode: ts.Node): void {
+    function addDocumentationFailure(
+        node: ts.Node,
+        nodeType: string,
+        requirementNode: ts.Node,
+    ): void {
         const start = node.getStart();
         const width = node.getText().split(/\r|\n/g)[0].length;
         const description = describeDocumentationFailure(requirementNode, nodeType);
@@ -433,7 +433,9 @@ function describeDocumentationFailure(node: ts.Node, nodeType: string): string {
     let description = Rule.FAILURE_STRING_EXIST;
 
     if (node.modifiers !== undefined) {
-        description += `${node.modifiers.map((modifier) => describeModifier(modifier.kind)).join(" ")} `;
+        description += `${node.modifiers
+            .map(modifier => describeModifier(modifier.kind))
+            .join(" ")} `;
     }
 
     return `${description}${nodeType}.`;

--- a/src/rules/curlyRule.ts
+++ b/src/rules/curlyRule.ts
@@ -15,12 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    isBlock,
-    isIfStatement,
-    isIterationStatement,
-    isSameLine,
-} from "tsutils";
+import { isBlock, isIfStatement, isIterationStatement, isSameLine } from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 import { codeExamples } from "./code-examples/curly.examples";
@@ -58,17 +53,10 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "array",
             items: {
                 type: "string",
-                enum: [
-                    OPTION_AS_NEEDED,
-                    OPTION_IGNORE_SAME_LINE,
-                ],
+                enum: [OPTION_AS_NEEDED, OPTION_IGNORE_SAME_LINE],
             },
         },
-        optionExamples: [
-            true,
-            [true, OPTION_IGNORE_SAME_LINE],
-            [true, OPTION_AS_NEEDED],
-        ],
+        optionExamples: [true, [true, OPTION_IGNORE_SAME_LINE], [true, OPTION_AS_NEEDED]],
         type: "functionality",
         typescriptOnly: false,
         hasFix: true,
@@ -76,7 +64,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_AS_NEEDED = "Block contains only one statement; remove the curly braces.";
+    public static FAILURE_STRING_AS_NEEDED =
+        "Block contains only one statement; remove the curly braces.";
     public static FAILURE_STRING_FACTORY(kind: string) {
         return `${kind} statements must be braced`;
     }
@@ -86,9 +75,11 @@ export class Rule extends Lint.Rules.AbstractRule {
             return this.applyWithFunction(sourceFile, walkAsNeeded);
         }
 
-        return this.applyWithWalker(new CurlyWalker(sourceFile, this.ruleName, {
-            ignoreSameLine: this.ruleArguments.indexOf(OPTION_IGNORE_SAME_LINE) !== -1,
-        }));
+        return this.applyWithWalker(
+            new CurlyWalker(sourceFile, this.ruleName, {
+                ignoreSameLine: this.ruleArguments.indexOf(OPTION_IGNORE_SAME_LINE) !== -1,
+            }),
+        );
     }
 }
 
@@ -103,9 +94,13 @@ function walkAsNeeded(ctx: Lint.WalkContext<void>): void {
 
 function isBlockUnnecessary(node: ts.Block): boolean {
     const parent = node.parent!;
-    if (node.statements.length !== 1) { return false; }
+    if (node.statements.length !== 1) {
+        return false;
+    }
     const statement = node.statements[0];
-    if (isIterationStatement(parent)) { return true; }
+    if (isIterationStatement(parent)) {
+        return true;
+    }
     /*
     Watch out for this case:
     if (so) {
@@ -114,10 +109,15 @@ function isBlockUnnecessary(node: ts.Block): boolean {
     } else
         bar();
     */
-    return isIfStatement(parent) && !(isIfStatement(statement)
-        && statement.elseStatement === undefined
-        && parent.thenStatement === node
-        && parent.elseStatement !== undefined);
+    return (
+        isIfStatement(parent) &&
+        !(
+            isIfStatement(statement) &&
+            statement.elseStatement === undefined &&
+            parent.thenStatement === node &&
+            parent.elseStatement !== undefined
+        )
+    );
 }
 
 class CurlyWalker extends Lint.AbstractWalker<Options> {
@@ -127,7 +127,10 @@ class CurlyWalker extends Lint.AbstractWalker<Options> {
                 this.checkStatement(node.statement, node, 0, node.end);
             } else if (isIfStatement(node)) {
                 this.checkStatement(node.thenStatement, node, 0);
-                if (node.elseStatement !== undefined && node.elseStatement.kind !== ts.SyntaxKind.IfStatement) {
+                if (
+                    node.elseStatement !== undefined &&
+                    node.elseStatement.kind !== ts.SyntaxKind.IfStatement
+                ) {
                     this.checkStatement(node.elseStatement, node, 5);
                 }
             }
@@ -136,20 +139,31 @@ class CurlyWalker extends Lint.AbstractWalker<Options> {
         return ts.forEachChild(sourceFile, cb);
     }
 
-    private checkStatement(statement: ts.Statement, node: ts.IterationStatement | ts.IfStatement, childIndex: number, end = statement.end) {
+    private checkStatement(
+        statement: ts.Statement,
+        node: ts.IterationStatement | ts.IfStatement,
+        childIndex: number,
+        end = statement.end,
+    ) {
         const sameLine = isSameLine(this.sourceFile, statement.pos, statement.end);
-        if (statement.kind !== ts.SyntaxKind.Block &&
-            !(this.options.ignoreSameLine && sameLine)) {
+        if (statement.kind !== ts.SyntaxKind.Block && !(this.options.ignoreSameLine && sameLine)) {
             const token = node.getChildAt(childIndex, this.sourceFile);
             const tokenText = ts.tokenToString(token.kind)!;
             this.addFailure(
-                token.end - tokenText.length, end, Rule.FAILURE_STRING_FACTORY(tokenText),
-                this.createMissingBraceFix(statement, node, sameLine));
+                token.end - tokenText.length,
+                end,
+                Rule.FAILURE_STRING_FACTORY(tokenText),
+                this.createMissingBraceFix(statement, node, sameLine),
+            );
         }
     }
 
     /** Generate the necessary replacement to add braces to a statement that needs them. */
-    private createMissingBraceFix(statement: ts.Statement, node: ts.IterationStatement | ts.IfStatement, sameLine: boolean) {
+    private createMissingBraceFix(
+        statement: ts.Statement,
+        node: ts.IterationStatement | ts.IfStatement,
+        sameLine: boolean,
+    ) {
         if (sameLine) {
             return [
                 Lint.Replacement.appendText(statement.pos, " {"),
@@ -157,16 +171,28 @@ class CurlyWalker extends Lint.AbstractWalker<Options> {
             ];
         } else {
             const match = /\n([\t ])/.exec(node.getFullText(this.sourceFile)); // determine which character to use (tab or space)
-            const indentation = match === null ?
-                "" :
-                // indentation should match start of statement
-                match[1].repeat(ts.getLineAndCharacterOfPosition(this.sourceFile, node.getStart(this.sourceFile)).character);
+            const indentation =
+                match === null
+                    ? ""
+                    : // indentation should match start of statement
+                      match[1].repeat(
+                          ts.getLineAndCharacterOfPosition(
+                              this.sourceFile,
+                              node.getStart(this.sourceFile),
+                          ).character,
+                      );
 
-            const maybeCarriageReturn = this.sourceFile.text[this.sourceFile.getLineEndOfPosition(node.pos) - 1] === "\r" ? "\r" : "";
+            const maybeCarriageReturn =
+                this.sourceFile.text[this.sourceFile.getLineEndOfPosition(node.pos) - 1] === "\r"
+                    ? "\r"
+                    : "";
 
             return [
                 Lint.Replacement.appendText(statement.pos, " {"),
-                Lint.Replacement.appendText(statement.end, `${maybeCarriageReturn}\n${indentation}}`),
+                Lint.Replacement.appendText(
+                    statement.end,
+                    `${maybeCarriageReturn}\n${indentation}}`,
+                ),
             ];
         }
     }

--- a/src/rules/cyclomaticComplexityRule.ts
+++ b/src/rules/cyclomaticComplexityRule.ts
@@ -20,7 +20,6 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 
 export class Rule extends Lint.Rules.AbstractRule {
-
     public static DEFAULT_THRESHOLD = 20;
     public static MINIMUM_THRESHOLD = 2;
 
@@ -59,8 +58,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING(expected: number, actual: number, name?: string): string {
-        return `The function${name === undefined ? "" : ` ${name}`} has a cyclomatic complexity of ` +
-            `${actual} which is higher than the threshold of ${expected}`;
+        return (
+            `The function${name === undefined ? "" : ` ${name}`} has a cyclomatic complexity of ` +
+            `${actual} which is higher than the threshold of ${expected}`
+        );
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -69,7 +70,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public isEnabled(): boolean {
         // Disable the rule if the option is provided but non-numeric or less than the minimum.
-        const isThresholdValid = typeof this.threshold === "number" && this.threshold >= Rule.MINIMUM_THRESHOLD;
+        const isThresholdValid =
+            typeof this.threshold === "number" && this.threshold >= Rule.MINIMUM_THRESHOLD;
         return super.isEnabled() && isThresholdValid;
     }
 
@@ -82,7 +84,9 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function walk(ctx: Lint.WalkContext<{ threshold: number }>): void {
-    const { options: { threshold } } = ctx;
+    const {
+        options: { threshold },
+    } = ctx;
     let complexity = 0;
 
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {

--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -110,12 +110,16 @@ function isDeclaration(identifier: ts.Identifier): boolean {
         case ts.SyntaxKind.ImportEqualsDeclaration:
             return (parent as ts.NamedDeclaration).name === identifier;
         case ts.SyntaxKind.PropertyAssignment:
-            return (parent as ts.PropertyAssignment).name === identifier &&
-                !isReassignmentTarget(identifier.parent!.parent as ts.ObjectLiteralExpression);
+            return (
+                (parent as ts.PropertyAssignment).name === identifier &&
+                !isReassignmentTarget(identifier.parent!.parent as ts.ObjectLiteralExpression)
+            );
         case ts.SyntaxKind.BindingElement:
             // return true for `b` in `const {a: b} = obj"`
-            return (parent as ts.BindingElement).name === identifier &&
-                (parent as ts.BindingElement).propertyName !== undefined;
+            return (
+                (parent as ts.BindingElement).name === identifier &&
+                (parent as ts.BindingElement).propertyName !== undefined
+            );
         default:
             return false;
     }
@@ -127,7 +131,8 @@ function getCallExpresion(node: ts.Expression): ts.CallLikeExpression | undefine
         node = parent;
         parent = node.parent!;
     }
-    return isTaggedTemplateExpression(parent) || (isCallExpression(parent) || isNewExpression(parent)) && parent.expression === node
+    return isTaggedTemplateExpression(parent) ||
+        ((isCallExpression(parent) || isNewExpression(parent)) && parent.expression === node)
         ? parent
         : undefined;
 }
@@ -144,8 +149,12 @@ function getDeprecation(node: ts.Identifier, tc: ts.TypeChecker): string | undef
     const parent = node.parent!;
     if (parent.kind === ts.SyntaxKind.BindingElement) {
         symbol = tc.getTypeAtLocation(parent.parent!).getProperty(node.text);
-    } else if (isPropertyAssignment(parent) && parent.name === node ||
-               isShorthandPropertyAssignment(parent) && parent.name === node && isReassignmentTarget(node)) {
+    } else if (
+        (isPropertyAssignment(parent) && parent.name === node) ||
+        (isShorthandPropertyAssignment(parent) &&
+            parent.name === node &&
+            isReassignmentTarget(node))
+    ) {
         symbol = tc.getPropertySymbolOfDestructuringAssignment(node);
     } else {
         symbol = tc.getSymbolAtLocation(node);
@@ -154,10 +163,12 @@ function getDeprecation(node: ts.Identifier, tc: ts.TypeChecker): string | undef
     if (symbol !== undefined && isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)) {
         symbol = tc.getAliasedSymbol(symbol);
     }
-    if (symbol === undefined ||
+    if (
+        symbol === undefined ||
         // if this is a CallExpression and the declaration is a function or method,
         // stop here to avoid collecting JsDoc of all overload signatures
-        callExpression !== undefined && isFunctionOrMethod(symbol.declarations)) {
+        (callExpression !== undefined && isFunctionOrMethod(symbol.declarations))
+    ) {
         return undefined;
     }
     return getSymbolDeprecation(symbol);
@@ -189,7 +200,9 @@ function getSignatureDeprecation(signature?: ts.Signature): string | undefined {
     }
 
     // for compatibility with typescript@<2.3.0
-    return signature.declaration === undefined ? undefined : getDeprecationFromDeclaration(signature.declaration);
+    return signature.declaration === undefined
+        ? undefined
+        : getDeprecationFromDeclaration(signature.declaration);
 }
 
 function getDeprecationFromDeclarations(declarations?: ts.Declaration[]): string | undefined {

--- a/src/rules/encodingRule.ts
+++ b/src/rules/encodingRule.ts
@@ -67,7 +67,13 @@ function detectEncoding(fileName: string): Encoding {
     const fd = fs.openSync(fileName, "r");
     const maxBytesRead = 3; // Only need 3 bytes to detect the encoding.
     const buffer = Buffer.allocUnsafe(maxBytesRead);
-    const bytesRead = fs.readSync(fd, buffer, /*offset*/ 0, /*length*/ maxBytesRead, /*position*/ 0);
+    const bytesRead = fs.readSync(
+        fd,
+        buffer,
+        /*offset*/ 0,
+        /*length*/ maxBytesRead,
+        /*position*/ 0,
+    );
     fs.closeSync(fd);
     return detectBufferEncoding(buffer, bytesRead);
 }

--- a/src/rules/eoflineRule.ts
+++ b/src/rules/eoflineRule.ts
@@ -25,7 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "eofline",
         description: "Ensures the file ends with a newline.",
         descriptionDetails: "Fix for single-line files is not supported.",
-        rationale: "It is a [standard convention](https://stackoverflow.com/q/729692/3124288) to end files with a newline.",
+        rationale:
+            "It is a [standard convention](https://stackoverflow.com/q/729692/3124288) to end files with a newline.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -38,17 +39,31 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const length = sourceFile.text.length;
-        if (length === 0 || // if the file is empty, it "ends with a newline", so don't return a failure
-            sourceFile.text[length - 1] === "\n") {
+        if (
+            length === 0 || // if the file is empty, it "ends with a newline", so don't return a failure
+            sourceFile.text[length - 1] === "\n"
+        ) {
             return [];
         }
 
         let fix: Lint.Fix | undefined;
         const lines = sourceFile.getLineStarts();
         if (lines.length > 1) {
-            fix = Lint.Replacement.appendText(length, sourceFile.text[lines[1] - 2] === "\r" ? "\r\n" : "\n");
+            fix = Lint.Replacement.appendText(
+                length,
+                sourceFile.text[lines[1] - 2] === "\r" ? "\r\n" : "\n",
+            );
         }
 
-        return [new Lint.RuleFailure(sourceFile, length, length, Rule.FAILURE_STRING, this.ruleName, fix)];
+        return [
+            new Lint.RuleFailure(
+                sourceFile,
+                length,
+                length,
+                Rule.FAILURE_STRING,
+                this.ruleName,
+                fix,
+            ),
+        ];
     }
 }

--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -36,23 +36,23 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "array",
             items: [
                 {
-                    type: "string"
+                    type: "string",
                 },
                 {
-                    type: "string"
+                    type: "string",
                 },
                 {
-                    type: "string"
-                }
+                    type: "string",
+                },
             ],
             additionalItems: false,
             minLength: 1,
-            maxLength: 3
+            maxLength: 3,
         },
         optionExamples: [[true, "Copyright \\d{4}", "Copyright 2018", ENFORCE_TRAILING_NEWLINE]],
         hasFix: true,
         type: "style",
-        typescriptOnly: false
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 
@@ -70,7 +70,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         let offset = text.startsWith("#!") ? text.indexOf("\n") : 0;
         // returns the text of the first comment or undefined
         const commentText = ts.forEachLeadingCommentRange(text, offset, (pos, end, kind) =>
-            text.substring(pos + 2, kind === ts.SyntaxKind.SingleLineCommentTrivia ? end : end - 2)
+            text.substring(pos + 2, kind === ts.SyntaxKind.SingleLineCommentTrivia ? end : end - 2),
         );
 
         if (commentText === undefined || !headerFormat.test(commentText)) {
@@ -89,8 +89,8 @@ export class Rule extends Lint.Rules.AbstractRule {
                               sourceFile,
                               textToInsert,
                               leadingNewlines,
-                              trailingNewlines
-                          )
+                              trailingNewlines,
+                          ),
                       )
                     : undefined;
             return [
@@ -100,8 +100,8 @@ export class Rule extends Lint.Rules.AbstractRule {
                     offset,
                     Rule.MISSING_HEADER_FAILURE_STRING,
                     this.ruleName,
-                    fix
-                )
+                    fix,
+                ),
             ];
         }
 
@@ -126,8 +126,8 @@ export class Rule extends Lint.Rules.AbstractRule {
                     offset,
                     Rule.MISSING_NEW_LINE_FAILURE_STRING,
                     this.ruleName,
-                    fix
-                )
+                    fix,
+                ),
             ];
         }
 
@@ -138,7 +138,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         sourceFile: ts.SourceFile,
         commentText: string,
         leadingNewlines = 1,
-        trailingNewlines = 1
+        trailingNewlines = 1,
     ) {
         const lineEnding = this.generateLineEnding(sourceFile);
         return (
@@ -149,7 +149,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 // but are working in files with \r\n line endings
                 // Trim trailing spaces to play nice with `no-trailing-whitespace` rule
                 ...commentText.split(/\r?\n/g).map(line => ` * ${line}`.replace(/\s+$/, "")),
-                " */"
+                " */",
             ].join(lineEnding) +
             lineEnding.repeat(trailingNewlines)
         );
@@ -163,7 +163,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     private doesNewLineEndingViolationExist(text: string, offset: number): boolean {
         const entireComment = ts.forEachLeadingCommentRange(text, offset, (pos, end) =>
-            text.substring(pos, end + 2)
+            text.substring(pos, end + 2),
         );
 
         const NEW_LINE_FOLLOWING_HEADER = /^.*((\r)?\n){2,}$/gm;

--- a/src/rules/fileNameCasingRule.ts
+++ b/src/rules/fileNameCasingRule.ts
@@ -100,7 +100,9 @@ export class Rule extends Lint.Rules.AbstractRule {
         const casing = this.ruleArguments[0] as Casing;
         const fileName = path.parse(sourceFile.fileName).name;
         if (!Rule.isCorrectCasing(fileName, casing)) {
-            return [new Lint.RuleFailure(sourceFile, 0, 0, Rule.FAILURE_STRING(casing), this.ruleName)];
+            return [
+                new Lint.RuleFailure(sourceFile, 0, 0, Rule.FAILURE_STRING(casing), this.ruleName),
+            ];
         }
 
         return [];

--- a/src/rules/forinRule.ts
+++ b/src/rules/forinRule.ts
@@ -50,7 +50,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "for (... in ...) statements must be filtered with an if statement";
+    public static FAILURE_STRING =
+        "for (... in ...) statements must be filtered with an if statement";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -66,16 +67,25 @@ function walk(ctx: Lint.WalkContext<void>) {
     });
 }
 
-function isFiltered({statements}: ts.Block): boolean {
+function isFiltered({ statements }: ts.Block): boolean {
     switch (statements.length) {
-        case 0: return true;
-        case 1: return statements[0].kind === ts.SyntaxKind.IfStatement;
+        case 0:
+            return true;
+        case 1:
+            return statements[0].kind === ts.SyntaxKind.IfStatement;
         default:
-            return statements[0].kind === ts.SyntaxKind.IfStatement && nodeIsContinue((statements[0] as ts.IfStatement).thenStatement);
+            return (
+                statements[0].kind === ts.SyntaxKind.IfStatement &&
+                nodeIsContinue((statements[0] as ts.IfStatement).thenStatement)
+            );
     }
 }
 
 function nodeIsContinue(node: ts.Node) {
-    return node.kind === ts.SyntaxKind.ContinueStatement ||
-        isBlock(node) && node.statements.length === 1 && node.statements[0].kind === ts.SyntaxKind.ContinueStatement;
+    return (
+        node.kind === ts.SyntaxKind.ContinueStatement ||
+        (isBlock(node) &&
+            node.statements.length === 1 &&
+            node.statements[0].kind === ts.SyntaxKind.ContinueStatement)
+    );
 }

--- a/src/rules/importSpacingRule.ts
+++ b/src/rules/importSpacingRule.ts
@@ -83,7 +83,10 @@ class Walker extends Lint.AbstractWalker<void> {
             this.addFailure(nodeStart, importClauseStart, Rule.TOO_MANY_SPACES_AFTER_IMPORT);
         }
 
-        const fromString = text.substring(importClauseEnd - nodeStart, moduleSpecifierStart - nodeStart);
+        const fromString = text.substring(
+            importClauseEnd - nodeStart,
+            moduleSpecifierStart - nodeStart,
+        );
 
         if (/from$/.test(fromString)) {
             this.addFailureAt(importClauseEnd, fromString.length, Rule.ADD_SPACE_AFTER_FROM);
@@ -125,7 +128,10 @@ class Walker extends Lint.AbstractWalker<void> {
         if (nodeStart + "import".length + 1 < moduleSpecifierStart) {
             this.addFailure(nodeStart, moduleSpecifierStart, Rule.TOO_MANY_SPACES_AFTER_IMPORT);
         } else if (nodeStart + "import".length === moduleSpecifierStart) {
-            this.addFailureAtNode(getChildOfKind(node, ts.SyntaxKind.ImportKeyword, this.sourceFile)!, Rule.ADD_SPACE_AFTER_IMPORT);
+            this.addFailureAtNode(
+                getChildOfKind(node, ts.SyntaxKind.ImportKeyword, this.sourceFile)!,
+                Rule.ADD_SPACE_AFTER_IMPORT,
+            );
         }
 
         if (LINE_BREAK_REGEX.test(node.getText())) {

--- a/src/rules/incrementDecrementRule.ts
+++ b/src/rules/incrementDecrementRule.ts
@@ -29,10 +29,7 @@ const OPTION_ALLOW_POST = "allow-post";
 export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         description: "Enforces using explicit += 1 or -= 1 operators.",
-        optionExamples: [
-            true,
-            [true, OPTION_ALLOW_POST],
-        ],
+        optionExamples: [true, [true, OPTION_ALLOW_POST]],
         options: {
             items: {
                 enum: [OPTION_ALLOW_POST],
@@ -56,7 +53,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
 
     public static FAILURE_STRING_FACTORY = (newOperatorText: string) =>
-        `Use an explicit ${newOperatorText} operator.`
+        `Use an explicit ${newOperatorText} operator.`;
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options: Options = {
@@ -68,7 +65,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function walk(context: Lint.WalkContext<Options>) {
-    function createReplacement(node: ts.PostfixUnaryExpression | ts.PrefixUnaryExpression, newOperatorText: string): Lint.Replacement {
+    function createReplacement(
+        node: ts.PostfixUnaryExpression | ts.PrefixUnaryExpression,
+        newOperatorText: string,
+    ): Lint.Replacement {
         let text = `${node.operand.getText(context.sourceFile)} ${newOperatorText}`;
 
         if (node.parent !== undefined && tsutils.isBinaryExpression(node.parent)) {
@@ -79,9 +79,7 @@ function walk(context: Lint.WalkContext<Options>) {
     }
 
     function complainOnNode(node: ts.PostfixUnaryExpression | ts.PrefixUnaryExpression) {
-        const newOperatorText = node.operator === ts.SyntaxKind.PlusPlusToken
-            ? "+= 1"
-            : "-= 1";
+        const newOperatorText = node.operator === ts.SyntaxKind.PlusPlusToken ? "+= 1" : "-= 1";
         const replacement = createReplacement(node, newOperatorText);
 
         const failure = Rule.FAILURE_STRING_FACTORY(newOperatorText);
@@ -112,6 +110,8 @@ function walk(context: Lint.WalkContext<Options>) {
     });
 }
 
-function isIncrementOrDecrementOperator(operator: ts.PostfixUnaryOperator | ts.PrefixUnaryOperator) {
+function isIncrementOrDecrementOperator(
+    operator: ts.PostfixUnaryOperator | ts.PrefixUnaryOperator,
+) {
     return operator === ts.SyntaxKind.PlusPlusToken || operator === ts.SyntaxKind.MinusMinusToken;
 }

--- a/src/rules/indentRule.ts
+++ b/src/rules/indentRule.ts
@@ -86,7 +86,9 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function parseOptions(ruleArguments: any[]): Options | undefined {
     const type = ruleArguments[0] as string;
-    if (type !== OPTION_USE_TABS && type !== OPTION_USE_SPACES) { return undefined; }
+    if (type !== OPTION_USE_TABS && type !== OPTION_USE_SPACES) {
+        return undefined;
+    }
 
     const size = ruleArguments[1] as number | undefined;
     return {
@@ -101,36 +103,57 @@ interface Options {
 }
 
 function walk(ctx: Lint.WalkContext<Options>): void {
-    const { sourceFile, options: { tabs, size } } = ctx;
+    const {
+        sourceFile,
+        options: { tabs, size },
+    } = ctx;
     const regExp = tabs ? new RegExp(" ".repeat(size === undefined ? 1 : size)) : /\t/;
-    const failure = Rule.FAILURE_STRING(tabs ? "tab" : size === undefined ? "space" : `${size} space`);
+    const failure = Rule.FAILURE_STRING(
+        tabs ? "tab" : size === undefined ? "space" : `${size} space`,
+    );
 
-    for (const {pos, contentLength} of getLineRanges(sourceFile)) {
-        if (contentLength === 0) { continue; }
+    for (const { pos, contentLength } of getLineRanges(sourceFile)) {
+        if (contentLength === 0) {
+            continue;
+        }
         const line = sourceFile.text.substr(pos, contentLength);
         let indentEnd = line.search(/\S/);
-        if (indentEnd === 0) { continue; }
+        if (indentEnd === 0) {
+            continue;
+        }
         if (indentEnd === -1) {
             indentEnd = contentLength;
         }
         const whitespace = line.slice(0, indentEnd);
-        if (!regExp.test(whitespace)) { continue; }
+        if (!regExp.test(whitespace)) {
+            continue;
+        }
         const token = getTokenAtPosition(sourceFile, pos)!;
-        if (token.kind !== ts.SyntaxKind.JsxText &&
-            (pos >= token.getStart(sourceFile) || isPositionInComment(sourceFile, pos, token))) {
+        if (
+            token.kind !== ts.SyntaxKind.JsxText &&
+            (pos >= token.getStart(sourceFile) || isPositionInComment(sourceFile, pos, token))
+        ) {
             continue;
         }
         ctx.addFailureAt(pos, indentEnd, failure, createFix(pos, whitespace, tabs, size));
     }
 }
 
-function createFix(lineStart: number, fullLeadingWhitespace: string, tabs: boolean, size?: number): Lint.Fix | undefined {
-    if (size === undefined) { return undefined; }
+function createFix(
+    lineStart: number,
+    fullLeadingWhitespace: string,
+    tabs: boolean,
+    size?: number,
+): Lint.Fix | undefined {
+    if (size === undefined) {
+        return undefined;
+    }
     const replaceRegExp = tabs
-        // we want to find every group of `size` spaces, plus up to one 'incomplete' group
-        ? new RegExp(`^( {${size}})+( {1,${size - 1}})?`, "g")
+        ? // we want to find every group of `size` spaces, plus up to one 'incomplete' group
+          new RegExp(`^( {${size}})+( {1,${size - 1}})?`, "g")
         : /\t/g;
-    const replacement = fullLeadingWhitespace.replace(replaceRegExp, (match) =>
-        (tabs ? "\t" : " ".repeat(size)).repeat(Math.ceil(match.length / size)));
+    const replacement = fullLeadingWhitespace.replace(replaceRegExp, match =>
+        (tabs ? "\t" : " ".repeat(size)).repeat(Math.ceil(match.length / size)),
+    );
     return new Lint.Replacement(lineStart, fullLeadingWhitespace.length, replacement);
 }

--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -49,12 +49,16 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_NO_PREFIX = 'interface name must not have an "I" prefix';
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, walk, { never: this.ruleArguments.indexOf(OPTION_NEVER) !== -1 });
+        return this.applyWithFunction(sourceFile, walk, {
+            never: this.ruleArguments.indexOf(OPTION_NEVER) !== -1,
+        });
     }
 }
 
 function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
-    const { options: { never } } = ctx;
+    const {
+        options: { never },
+    } = ctx;
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (utils.isInterfaceDeclaration(node)) {
             const { name } = node;

--- a/src/rules/interfaceOverTypeLiteralRule.ts
+++ b/src/rules/interfaceOverTypeLiteralRule.ts
@@ -24,7 +24,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "interface-over-type-literal",
         description: "Prefer an interface declaration over a type literal (`type T = { ... }`)",
-        rationale: "Interfaces are generally preferred over type literals because interfaces can be implemented, extended and merged.",
+        rationale:
+            "Interfaces are generally preferred over type literals because interfaces can be implemented, extended and merged.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/jsdocFormatRule.ts
+++ b/src/rules/jsdocFormatRule.ts
@@ -71,9 +71,13 @@ interface Options {
 }
 
 function walk(ctx: Lint.WalkContext<Options>) {
-    return utils.forEachComment(ctx.sourceFile, (fullText, {kind, pos, end}) => {
-        if (kind !== ts.SyntaxKind.MultiLineCommentTrivia ||
-            fullText[pos + 2] !== "*" || fullText[pos + 3] === "*" || fullText[pos + 3] === "/") {
+    return utils.forEachComment(ctx.sourceFile, (fullText, { kind, pos, end }) => {
+        if (
+            kind !== ts.SyntaxKind.MultiLineCommentTrivia ||
+            fullText[pos + 2] !== "*" ||
+            fullText[pos + 3] === "*" ||
+            fullText[pos + 3] === "/"
+        ) {
             return;
         }
         const lines = fullText.slice(pos + 3, end - 2).split("\n");
@@ -112,7 +116,6 @@ function walk(ctx: Lint.WalkContext<Options>) {
         if (lastLine.length !== alignColumn) {
             ctx.addFailure(lineStart, end, Rule.ALIGNMENT_FAILURE_STRING);
         }
-
     });
 }
 

--- a/src/rules/labelPositionRule.ts
+++ b/src/rules/labelPositionRule.ts
@@ -25,7 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "label-position",
         description: "Only allows labels in sensible locations.",
-        descriptionDetails: "This rule only allows labels to be on `do/for/while/switch` statements.",
+        descriptionDetails:
+            "This rule only allows labels to be on `do/for/while/switch` statements.",
         rationale: Lint.Utils.dedent`
             Labels in JavaScript only can be used in conjunction with \`break\` or \`continue\`,
             constructs meant to be used for loop flow control. While you can theoretically use

--- a/src/rules/linebreakStyleRule.ts
+++ b/src/rules/linebreakStyleRule.ts
@@ -47,7 +47,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_LF = `Expected linebreak to be '${OPTION_LINEBREAK_STYLE_LF}'`;
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, walk, this.ruleArguments.indexOf(OPTION_LINEBREAK_STYLE_CRLF) !== -1);
+        return this.applyWithFunction(
+            sourceFile,
+            walk,
+            this.ruleArguments.indexOf(OPTION_LINEBREAK_STYLE_CRLF) !== -1,
+        );
     }
 }
 
@@ -59,10 +63,20 @@ function walk(ctx: Lint.WalkContext<boolean>) {
         const lineEnd = lineStarts[i] - 1;
         if (sourceText[lineEnd - 1] === "\r") {
             if (!expectedCr) {
-                ctx.addFailure(lineStarts[i - 1], lineEnd - 1, Rule.FAILURE_LF, Lint.Replacement.deleteText(lineEnd - 1, 1));
+                ctx.addFailure(
+                    lineStarts[i - 1],
+                    lineEnd - 1,
+                    Rule.FAILURE_LF,
+                    Lint.Replacement.deleteText(lineEnd - 1, 1),
+                );
             }
         } else if (expectedCr) {
-            ctx.addFailure(lineStarts[i - 1], lineEnd, Rule.FAILURE_CRLF, Lint.Replacement.appendText(lineEnd, "\r"));
+            ctx.addFailure(
+                lineStarts[i - 1],
+                lineEnd,
+                Rule.FAILURE_CRLF,
+                Lint.Replacement.appendText(lineEnd, "\r"),
+            );
         }
     }
 }

--- a/src/rules/matchDefaultExportNameRule.ts
+++ b/src/rules/matchDefaultExportNameRule.ts
@@ -47,8 +47,11 @@ export class Rule extends Lint.Rules.TypedRule {
 
 function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker) {
     for (const statement of ctx.sourceFile.statements) {
-        if (!isImportDeclaration(statement) ||
-            statement.importClause === undefined || statement.importClause.name === undefined) {
+        if (
+            !isImportDeclaration(statement) ||
+            statement.importClause === undefined ||
+            statement.importClause.name === undefined
+        ) {
             continue;
         }
         const defaultImport = statement.importClause.name;
@@ -57,11 +60,18 @@ function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker) {
             continue;
         }
 
-        const {declarations} = tc.getAliasedSymbol(symbol);
+        const { declarations } = tc.getAliasedSymbol(symbol);
         if (declarations !== undefined && declarations.length !== 0) {
             const { name } = declarations[0] as ts.NamedDeclaration;
-            if (name !== undefined && name.kind === ts.SyntaxKind.Identifier && name.text !== defaultImport.text) {
-                ctx.addFailureAtNode(defaultImport, Rule.FAILURE_STRING(defaultImport.text, name.text));
+            if (
+                name !== undefined &&
+                name.kind === ts.SyntaxKind.Identifier &&
+                name.text !== defaultImport.text
+            ) {
+                ctx.addFailureAtNode(
+                    defaultImport,
+                    Rule.FAILURE_STRING(defaultImport.text, name.text),
+                );
             }
         }
     }

--- a/src/rules/maxClassesPerFileRule.ts
+++ b/src/rules/maxClassesPerFileRule.ts
@@ -27,7 +27,6 @@ interface Options {
 const OPTION_EXCLUDE_CLASS_EXPRESSIONS = "exclude-class-expressions";
 
 export class Rule extends Lint.Rules.AbstractRule {
-
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "max-classes-per-file",
@@ -70,14 +69,18 @@ export class Rule extends Lint.Rules.AbstractRule {
         const argument = this.ruleArguments[0] as number;
         const maxClasses = isNaN(argument) || argument > 0 ? argument : 1;
         return this.applyWithFunction(sourceFile, walk, {
-            excludeClassExpressions: this.ruleArguments.indexOf(OPTION_EXCLUDE_CLASS_EXPRESSIONS) !== -1,
+            excludeClassExpressions:
+                this.ruleArguments.indexOf(OPTION_EXCLUDE_CLASS_EXPRESSIONS) !== -1,
             maxClasses,
         });
     }
 }
 
 function walk(ctx: Lint.WalkContext<Options>): void {
-    const { sourceFile, options: { maxClasses, excludeClassExpressions } } = ctx;
+    const {
+        sourceFile,
+        options: { maxClasses, excludeClassExpressions },
+    } = ctx;
     let classes = 0;
     return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
         if (isClassDeclaration(node) || (!excludeClassExpressions && isClassExpression(node))) {

--- a/src/rules/maxFileLineCountRule.ts
+++ b/src/rules/maxFileLineCountRule.ts
@@ -38,12 +38,14 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING(lineCount: number, lineLimit: number) {
-        return `This file has ${lineCount} lines, which exceeds the maximum of ${lineLimit} lines allowed. ` +
-            "Consider breaking this file up into smaller parts";
+        return (
+            `This file has ${lineCount} lines, which exceeds the maximum of ${lineLimit} lines allowed. ` +
+            "Consider breaking this file up into smaller parts"
+        );
     }
 
     public isEnabled(): boolean {
-        return super.isEnabled() && this.ruleArguments[0] as number > 0;
+        return super.isEnabled() && (this.ruleArguments[0] as number) > 0;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -54,6 +56,14 @@ export class Rule extends Lint.Rules.AbstractRule {
         }
 
         const len = sourceFile.text.length;
-        return [new Lint.RuleFailure(sourceFile, len - 1, len, Rule.FAILURE_STRING(lineCount, lineLimit), this.ruleName)];
+        return [
+            new Lint.RuleFailure(
+                sourceFile,
+                len - 1,
+                len,
+                Rule.FAILURE_STRING(lineCount, lineLimit),
+                this.ruleName,
+            ),
+        ];
     }
 }

--- a/src/rules/maxLineLengthRule.ts
+++ b/src/rules/maxLineLengthRule.ts
@@ -56,8 +56,8 @@ export class Rule extends Lint.Rules.AbstractRule {
                     {
                         type: "object",
                         properties: {
-                            "limit": {type: "number"},
-                            "ignore-pattern": {type: "string"},
+                            limit: { type: "number" },
+                            "ignore-pattern": { type: "string" },
                         },
                         additionalProperties: false,
                     },
@@ -66,9 +66,16 @@ export class Rule extends Lint.Rules.AbstractRule {
             minLength: 1,
             maxLength: 2,
         },
-        optionExamples: [[true, 120], [true, {
-            "limit": 120,
-            "ignore-pattern": "^import |^export \{(.*?)\}"}]],
+        optionExamples: [
+            [true, 120],
+            [
+                true,
+                {
+                    limit: 120,
+                    "ignore-pattern": "^import |^export {(.*?)}",
+                },
+            ],
+        ],
         type: "maintainability",
         typescriptOnly: false,
     };
@@ -80,7 +87,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public isEnabled(): boolean {
         const limit = this.getRuleOptions().limit;
-        return super.isEnabled() && (limit > 0);
+        return super.isEnabled() && limit > 0;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -89,14 +96,14 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     private getRuleOptions(): MaxLineLengthRuleOptions {
         const argument = this.ruleArguments[0];
-        let options: MaxLineLengthRuleOptions = {limit: 0};
+        let options: MaxLineLengthRuleOptions = { limit: 0 };
         if (typeof argument === "number") {
             options.limit = argument;
         } else {
             options = argument as MaxLineLengthRuleOptions;
-            const ignorePattern = (argument as {[key: string]: string})["ignore-pattern"];
-            options.ignorePattern = (typeof ignorePattern === "string") ?
-                new RegExp((ignorePattern)) : undefined;
+            const ignorePattern = (argument as { [key: string]: string })["ignore-pattern"];
+            options.ignorePattern =
+                typeof ignorePattern === "string" ? new RegExp(ignorePattern) : undefined;
         }
         options.limit = Number(options.limit); // user can pass a string instead of number
         return options;
@@ -107,9 +114,13 @@ function walk(ctx: Lint.WalkContext<MaxLineLengthRuleOptions>) {
     const limit = ctx.options.limit;
     const ignorePattern = ctx.options.ignorePattern;
     for (const line of getLineRanges(ctx.sourceFile)) {
-        if (line.contentLength <= limit) { continue; }
+        if (line.contentLength <= limit) {
+            continue;
+        }
         const lineContent = ctx.sourceFile.text.substr(line.pos, line.contentLength);
-        if (ignorePattern !== undefined && ignorePattern.test(lineContent)) { continue; }
+        if (ignorePattern !== undefined && ignorePattern.test(lineContent)) {
+            continue;
+        }
         ctx.addFailureAt(line.pos, line.contentLength, Rule.FAILURE_STRING_FACTORY(limit));
     }
 }

--- a/src/rules/memberAccessRule.ts
+++ b/src/rules/memberAccessRule.ts
@@ -64,7 +64,12 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "array",
             items: {
                 type: "string",
-                enum: [OPTION_NO_PUBLIC, OPTION_CHECK_ACCESSOR, OPTION_CHECK_CONSTRUCTOR, OPTION_CHECK_PARAMETER_PROPERTY],
+                enum: [
+                    OPTION_NO_PUBLIC,
+                    OPTION_CHECK_ACCESSOR,
+                    OPTION_CHECK_CONSTRUCTOR,
+                    OPTION_CHECK_PARAMETER_PROPERTY,
+                ],
             },
             minLength: 0,
             maxLength: 4,
@@ -78,7 +83,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public static FAILURE_STRING_NO_PUBLIC = "'public' is implicit.";
 
-    public static FAILURE_STRING_FACTORY(memberType: string, memberName: string | undefined): string {
+    public static FAILURE_STRING_FACTORY(
+        memberType: string,
+        memberName: string | undefined,
+    ): string {
         memberName = memberName === undefined ? "" : ` '${memberName}'`;
         return `The ${memberType}${memberName} must be marked either 'private', 'public', or 'protected'`;
     }
@@ -91,7 +99,11 @@ export class Rule extends Lint.Rules.AbstractRule {
         let checkParameterProperty = options.indexOf(OPTION_CHECK_PARAMETER_PROPERTY) !== -1;
         if (noPublic) {
             if (checkAccessor || checkConstructor || checkParameterProperty) {
-                showWarningOnce(`Warning: ${this.ruleName} - If 'no-public' is present, it should be the only option.`);
+                showWarningOnce(
+                    `Warning: ${
+                        this.ruleName
+                    } - If 'no-public' is present, it should be the only option.`,
+                );
                 return [];
             }
             checkAccessor = checkConstructor = checkParameterProperty = true;
@@ -113,7 +125,11 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 if (shouldCheck(child)) {
                     check(child);
                 }
-                if (checkParameterProperty && isConstructorDeclaration(child) && child.body !== undefined) {
+                if (
+                    checkParameterProperty &&
+                    isConstructorDeclaration(child) &&
+                    child.body !== undefined
+                ) {
                     for (const param of child.parameters) {
                         if (isParameterProperty(param)) {
                             check(param);
@@ -141,27 +157,45 @@ function walk(ctx: Lint.WalkContext<Options>) {
     }
 
     function check(node: ts.ClassElement | ts.ParameterDeclaration): void {
-        if (hasModifier(node.modifiers, ts.SyntaxKind.ProtectedKeyword, ts.SyntaxKind.PrivateKeyword)) {
+        if (
+            hasModifier(
+                node.modifiers,
+                ts.SyntaxKind.ProtectedKeyword,
+                ts.SyntaxKind.PrivateKeyword,
+            )
+        ) {
             return;
         }
         const publicKeyword = getModifier(node, ts.SyntaxKind.PublicKeyword);
         if (noPublic && publicKeyword !== undefined) {
             // public is not optional for parameter property without the readonly modifier
-            if (node.kind !== ts.SyntaxKind.Parameter || hasModifier(node.modifiers, ts.SyntaxKind.ReadonlyKeyword)) {
+            if (
+                node.kind !== ts.SyntaxKind.Parameter ||
+                hasModifier(node.modifiers, ts.SyntaxKind.ReadonlyKeyword)
+            ) {
                 const start = publicKeyword.end - "public".length;
                 ctx.addFailure(
                     start,
                     publicKeyword.end,
                     Rule.FAILURE_STRING_NO_PUBLIC,
-                    Lint.Replacement.deleteFromTo(start, getNextToken(publicKeyword, ctx.sourceFile)!.getStart(ctx.sourceFile)),
+                    Lint.Replacement.deleteFromTo(
+                        start,
+                        getNextToken(publicKeyword, ctx.sourceFile)!.getStart(ctx.sourceFile),
+                    ),
                 );
             }
         }
         if (!noPublic && publicKeyword === undefined) {
-            const nameNode = node.kind === ts.SyntaxKind.Constructor
-                ? getChildOfKind(node, ts.SyntaxKind.ConstructorKeyword, ctx.sourceFile)!
-                : node.name !== undefined ? node.name : node;
-            const memberName = node.name !== undefined && node.name.kind === ts.SyntaxKind.Identifier ? node.name.text : undefined;
+            const nameNode =
+                node.kind === ts.SyntaxKind.Constructor
+                    ? getChildOfKind(node, ts.SyntaxKind.ConstructorKeyword, ctx.sourceFile)!
+                    : node.name !== undefined
+                        ? node.name
+                        : node;
+            const memberName =
+                node.name !== undefined && node.name.kind === ts.SyntaxKind.Identifier
+                    ? node.name.text
+                    : undefined;
             ctx.addFailureAtNode(
                 nameNode,
                 Rule.FAILURE_STRING_FACTORY(typeToString(node), memberName),
@@ -171,8 +205,14 @@ function walk(ctx: Lint.WalkContext<Options>) {
     }
 }
 
-function getInsertionPosition(member: ts.ClassElement | ts.ParameterDeclaration, sourceFile: ts.SourceFile): number {
-    const node = member.decorators === undefined ? member : getTokenAtPosition(member, member.decorators.end, sourceFile)!;
+function getInsertionPosition(
+    member: ts.ClassElement | ts.ParameterDeclaration,
+    sourceFile: ts.SourceFile,
+): number {
+    const node =
+        member.decorators === undefined
+            ? member
+            : getTokenAtPosition(member, member.decorators.end, sourceFile)!;
     return node.getStart(sourceFile);
 }
 

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -44,61 +44,72 @@ enum MemberKind {
 }
 
 const PRESETS = new Map<string, MemberCategoryJson[]>([
-    ["fields-first", [
-        "public-static-field",
-        "protected-static-field",
-        "private-static-field",
-        "public-instance-field",
-        "protected-instance-field",
-        "private-instance-field",
-        "constructor",
-        "public-static-method",
-        "protected-static-method",
-        "private-static-method",
-        "public-instance-method",
-        "protected-instance-method",
-        "private-instance-method",
-    ]],
-    ["instance-sandwich", [
-        "public-static-field",
-        "protected-static-field",
-        "private-static-field",
-        "public-instance-field",
-        "protected-instance-field",
-        "private-instance-field",
-        "constructor",
-        "public-instance-method",
-        "protected-instance-method",
-        "private-instance-method",
-        "public-static-method",
-        "protected-static-method",
-        "private-static-method",
-    ]],
-    ["statics-first", [
-        "public-static-field",
-        "public-static-method",
-        "protected-static-field",
-        "protected-static-method",
-        "private-static-field",
-        "private-static-method",
-        "public-instance-field",
-        "protected-instance-field",
-        "private-instance-field",
-        "constructor",
-        "public-instance-method",
-        "protected-instance-method",
-        "private-instance-method",
-    ]],
+    [
+        "fields-first",
+        [
+            "public-static-field",
+            "protected-static-field",
+            "private-static-field",
+            "public-instance-field",
+            "protected-instance-field",
+            "private-instance-field",
+            "constructor",
+            "public-static-method",
+            "protected-static-method",
+            "private-static-method",
+            "public-instance-method",
+            "protected-instance-method",
+            "private-instance-method",
+        ],
+    ],
+    [
+        "instance-sandwich",
+        [
+            "public-static-field",
+            "protected-static-field",
+            "private-static-field",
+            "public-instance-field",
+            "protected-instance-field",
+            "private-instance-field",
+            "constructor",
+            "public-instance-method",
+            "protected-instance-method",
+            "private-instance-method",
+            "public-static-method",
+            "protected-static-method",
+            "private-static-method",
+        ],
+    ],
+    [
+        "statics-first",
+        [
+            "public-static-field",
+            "public-static-method",
+            "protected-static-field",
+            "protected-static-method",
+            "private-static-field",
+            "private-static-method",
+            "public-instance-field",
+            "protected-instance-field",
+            "private-instance-field",
+            "constructor",
+            "public-instance-method",
+            "protected-instance-method",
+            "private-instance-method",
+        ],
+    ],
 ]);
 const PRESET_NAMES = Array.from(PRESETS.keys());
 
-const allMemberKindNames = mapDefined(Object.keys(MemberKind), (key) => {
+const allMemberKindNames = mapDefined(Object.keys(MemberKind), key => {
     const mk = (MemberKind as any)[key];
-    return typeof mk === "number" ? MemberKind[mk].replace(/[A-Z]/g, (cap) => `-${cap.toLowerCase()}`) : undefined;
+    return typeof mk === "number"
+        ? MemberKind[mk].replace(/[A-Z]/g, cap => `-${cap.toLowerCase()}`)
+        : undefined;
 });
 
 function namesMarkdown(names: string[]): string {
-    return names.map((name) => `* \`${name}\``).join("\n    ");
+    return names.map(name => `* \`${name}\``).join("\n    ");
 }
 
 const optionsDescription = Lint.Utils.dedent`
@@ -165,33 +176,39 @@ export class Rule extends Lint.Rules.AbstractRule {
         },
         optionExamples: [
             [true, { order: "fields-first" }],
-            [true, {
-                order: [
-                    "public-static-field",
-                    "public-instance-field",
-                    "public-constructor",
-                    "private-static-field",
-                    "private-instance-field",
-                    "private-constructor",
-                    "public-instance-method",
-                    "protected-instance-method",
-                    "private-instance-method",
-                ],
-            }],
-            [true, {
-                order: [
-                    {
-                        name: "static non-private",
-                        kinds: [
-                            "public-static-field",
-                            "protected-static-field",
-                            "public-static-method",
-                            "protected-static-method",
-                        ],
-                    },
-                    "constructor",
-                ],
-            }],
+            [
+                true,
+                {
+                    order: [
+                        "public-static-field",
+                        "public-instance-field",
+                        "public-constructor",
+                        "private-static-field",
+                        "private-instance-field",
+                        "private-constructor",
+                        "public-instance-method",
+                        "protected-instance-method",
+                        "private-instance-method",
+                    ],
+                },
+            ],
+            [
+                true,
+                {
+                    order: [
+                        {
+                            name: "static non-private",
+                            kinds: [
+                                "public-static-field",
+                                "protected-static-field",
+                                "public-static-method",
+                                "protected-static-method",
+                            ],
+                        },
+                        "constructor",
+                    ],
+                },
+            ],
         ],
         type: "typescript",
         typescriptOnly: false,
@@ -218,7 +235,6 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
-
     private readonly fixes: Array<[Lint.RuleFailure, Lint.Replacement]> = [];
 
     public walk(sourceFile: ts.SourceFile) {
@@ -231,7 +247,12 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
                 case ts.SyntaxKind.ClassExpression:
                 case ts.SyntaxKind.InterfaceDeclaration:
                 case ts.SyntaxKind.TypeLiteral:
-                    this.checkMembers((node as ts.ClassLikeDeclaration | ts.InterfaceDeclaration | ts.TypeLiteralNode).members);
+                    this.checkMembers(
+                        (node as
+                            | ts.ClassLikeDeclaration
+                            | ts.InterfaceDeclaration
+                            | ts.TypeLiteralNode).members,
+                    );
             }
         };
         ts.forEachChild(sourceFile, cb);
@@ -265,10 +286,12 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
                 const nodeType = this.rankName(rank);
                 const prevNodeType = this.rankName(prevRank);
                 const lowerRank = this.findLowerRank(members, rank);
-                const locationHint = lowerRank !== -1
-                    ? `after ${this.rankName(lowerRank)}s`
-                    : "at the beginning of the class/interface";
-                const errorLine1 = `Declaration of ${nodeType} not allowed after declaration of ${prevNodeType}. ` +
+                const locationHint =
+                    lowerRank !== -1
+                        ? `after ${this.rankName(lowerRank)}s`
+                        : "at the beginning of the class/interface";
+                const errorLine1 =
+                    `Declaration of ${nodeType} not allowed after declaration of ${prevNodeType}. ` +
                     `Instead, this should come ${locationHint}.`;
                 // add empty array as fix so we can add a replacement later. (fix itself is readonly)
                 this.addFailureAtNode(member, errorLine1, []);
@@ -284,7 +307,12 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
                     if (prevName !== undefined && caseInsensitiveLess(curName, prevName)) {
                         this.addFailureAtNode(
                             member.name,
-                            Rule.FAILURE_STRING_ALPHABETIZE(this.findLowerName(members, rank, curName), curName), []);
+                            Rule.FAILURE_STRING_ALPHABETIZE(
+                                this.findLowerName(members, rank, curName),
+                                curName,
+                            ),
+                            [],
+                        );
                         failureExists = true;
                     } else {
                         prevName = curName;
@@ -302,19 +330,23 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
 
                 // first, sort by member rank
                 const rankDiff = this.memberRank(a) - this.memberRank(b);
-                if (rankDiff !== 0) { return rankDiff; }
+                if (rankDiff !== 0) {
+                    return rankDiff;
+                }
                 // then lexicographically if alphabetize == true
                 if (this.options.alphabetize && a.name !== undefined && b.name !== undefined) {
                     const aName = nameString(a.name);
                     const bName = nameString(b.name);
                     const nameDiff = aName.localeCompare(bName);
-                    if (nameDiff !== 0) { return nameDiff; }
+                    if (nameDiff !== 0) {
+                        return nameDiff;
+                    }
                 }
                 // finally, sort by position in original NodeArray so the sort remains stable.
                 return ai - bi;
             });
             const splits = getSplitIndexes(members, this.sourceFile.text);
-            const sortedMembersText = sortedMemberIndexes.map((i) => {
+            const sortedMembersText = sortedMemberIndexes.map(i => {
                 const start = splits[i];
                 const end = splits[i + 1];
                 let nodeText = this.sourceFile.text.substring(start, end);
@@ -339,13 +371,21 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
             // it fixes all failures in this NodeArray, as TSLint doesn't handle duplicate Replacements.
             this.fixes.push([
                 arrayLast(this.failures),
-                Lint.Replacement.replaceFromTo(splits[0], arrayLast(splits), sortedMembersText.join("")),
+                Lint.Replacement.replaceFromTo(
+                    splits[0],
+                    arrayLast(splits),
+                    sortedMembersText.join(""),
+                ),
             ]);
         }
     }
 
     /** Finds the lowest name higher than 'targetName'. */
-    private findLowerName(members: ReadonlyArray<Member>, targetRank: Rank, targetName: string): string {
+    private findLowerName(
+        members: ReadonlyArray<Member>,
+        targetRank: Rank,
+        targetName: string,
+    ): string {
         for (const member of members) {
             if (member.name === undefined || this.memberRank(member) !== targetRank) {
                 continue;
@@ -375,7 +415,7 @@ class MemberOrderingWalker extends Lint.AbstractWalker<Options> {
         if (optionName === undefined) {
             return -1;
         }
-        return this.options.order.findIndex((category) => category.has(optionName));
+        return this.options.order.findIndex(category => category.has(optionName));
     }
 
     private rankName(rank: Rank): string {
@@ -391,7 +431,11 @@ function memberKindForConstructor(access: Access): MemberKind {
     return (MemberKind as any)[`${access}Constructor`] as MemberKind;
 }
 
-function memberKindForMethodOrField(access: Access, membership: "Static" | "Instance", kind: "Method" | "Field"): MemberKind {
+function memberKindForMethodOrField(
+    access: Access,
+    membership: "Static" | "Instance",
+    kind: "Method" | "Field",
+): MemberKind {
     return (MemberKind as any)[access + membership + kind] as MemberKind;
 }
 
@@ -411,9 +455,11 @@ function memberKindFromName(name: string): MemberKind[] {
 }
 
 function getMemberKind(member: Member): MemberKind | undefined {
-    const accessLevel =  hasModifier(member.modifiers, ts.SyntaxKind.PrivateKeyword) ? "private"
-        : hasModifier(member.modifiers, ts.SyntaxKind.ProtectedKeyword) ? "protected"
-        : "public";
+    const accessLevel = hasModifier(member.modifiers, ts.SyntaxKind.PrivateKeyword)
+        ? "private"
+        : hasModifier(member.modifiers, ts.SyntaxKind.ProtectedKeyword)
+            ? "protected"
+            : "public";
 
     switch (member.kind) {
         case ts.SyntaxKind.Constructor:
@@ -433,7 +479,9 @@ function getMemberKind(member: Member): MemberKind | undefined {
     }
 
     function methodOrField(isMethod: boolean) {
-        const membership = hasModifier(member.modifiers, ts.SyntaxKind.StaticKeyword) ? "Static" : "Instance";
+        const membership = hasModifier(member.modifiers, ts.SyntaxKind.StaticKeyword)
+            ? "Static"
+            : "Instance";
         return memberKindForMethodOrField(accessLevel, membership, isMethod ? "Method" : "Field");
     }
 }
@@ -441,7 +489,9 @@ function getMemberKind(member: Member): MemberKind | undefined {
 type MemberCategoryJson = { name: string; kinds: string[] } | string;
 class MemberCategory {
     constructor(readonly name: string, private readonly kinds: Set<MemberKind>) {}
-    public has(kind: MemberKind) { return this.kinds.has(kind); }
+    public has(kind: MemberKind) {
+        return this.kinds.has(kind);
+    }
 }
 
 type Member = ts.TypeElement | ts.ClassElement;
@@ -456,9 +506,12 @@ interface Options {
 
 function parseOptions(options: any[]): Options {
     const { order: orderJson, alphabetize } = getOptionsJson(options);
-    const order = orderJson.map((cat) => typeof cat === "string"
-        ? new MemberCategory(cat.replace(/-/g, " "), new Set(memberKindFromName(cat)))
-        : new MemberCategory(cat.name, new Set(flatMap(cat.kinds, memberKindFromName))));
+    const order = orderJson.map(
+        cat =>
+            typeof cat === "string"
+                ? new MemberCategory(cat.replace(/-/g, " "), new Set(memberKindFromName(cat)))
+                : new MemberCategory(cat.name, new Set(flatMap(cat.kinds, memberKindFromName))),
+    );
     return { order, alphabetize };
 }
 function getOptionsJson(allOptions: any[]): { order: MemberCategoryJson[]; alphabetize: boolean } {
@@ -466,13 +519,18 @@ function getOptionsJson(allOptions: any[]): { order: MemberCategoryJson[]; alpha
         throw new Error("Got empty options");
     }
 
-    const firstOption = allOptions[0] as { order: MemberCategoryJson[] | string; alphabetize?: boolean } | string;
+    const firstOption = allOptions[0] as
+        | { order: MemberCategoryJson[] | string; alphabetize?: boolean }
+        | string;
     if (typeof firstOption !== "object") {
         // Undocumented direct string option. Deprecate eventually.
         return { order: convertFromOldStyleOptions(allOptions), alphabetize: false }; // presume allOptions to be string[]
     }
 
-    return { order: categoryFromOption(firstOption[OPTION_ORDER]), alphabetize: firstOption[OPTION_ALPHABETIZE] === true };
+    return {
+        order: categoryFromOption(firstOption[OPTION_ORDER]),
+        alphabetize: firstOption[OPTION_ALPHABETIZE] === true,
+    };
 }
 function categoryFromOption(orderOption: MemberCategoryJson[] | string): MemberCategoryJson[] {
     if (Array.isArray(orderOption)) {
@@ -493,14 +551,29 @@ function categoryFromOption(orderOption: MemberCategoryJson[] | string): MemberC
 function convertFromOldStyleOptions(options: string[]): MemberCategoryJson[] {
     let categories: NameAndKinds[] = [{ name: "member", kinds: allMemberKindNames }];
     if (hasOption("variables-before-functions")) {
-        categories = splitOldStyleOptions(categories, (kind) => kind.includes("field"), "field", "method");
+        categories = splitOldStyleOptions(
+            categories,
+            kind => kind.includes("field"),
+            "field",
+            "method",
+        );
     }
     if (hasOption("static-before-instance")) {
-        categories = splitOldStyleOptions(categories, (kind) => kind.includes("static"), "static", "instance");
+        categories = splitOldStyleOptions(
+            categories,
+            kind => kind.includes("static"),
+            "static",
+            "instance",
+        );
     }
     if (hasOption("public-before-private")) {
         // 'protected' is considered public
-        categories = splitOldStyleOptions(categories, (kind) => !kind.includes("private"), "public", "private");
+        categories = splitOldStyleOptions(
+            categories,
+            kind => !kind.includes("private"),
+            "public",
+            "private",
+        );
     }
     return categories;
 
@@ -508,11 +581,20 @@ function convertFromOldStyleOptions(options: string[]): MemberCategoryJson[] {
         return options.indexOf(x) !== -1;
     }
 }
-interface NameAndKinds { name: string; kinds: string[]; }
-function splitOldStyleOptions(categories: NameAndKinds[], filter: (name: string) => boolean, a: string, b: string): NameAndKinds[] {
-    const newCategories: NameAndKinds[]  = [];
+interface NameAndKinds {
+    name: string;
+    kinds: string[];
+}
+function splitOldStyleOptions(
+    categories: NameAndKinds[],
+    filter: (name: string) => boolean,
+    a: string,
+    b: string,
+): NameAndKinds[] {
+    const newCategories: NameAndKinds[] = [];
     for (const cat of categories) {
-        const yes = []; const no = [];
+        const yes = [];
+        const no = [];
         for (const kind of cat.kinds) {
             if (filter(kind)) {
                 yes.push(kind);
@@ -571,7 +653,7 @@ function arrayFindLastIndex<T>(
     array: ArrayLike<T>,
     predicate: (el: T, elIndex: number, array: ArrayLike<T>) => boolean,
 ): number {
-    for (let i = array.length; i-- > 0;) {
+    for (let i = array.length; i-- > 0; ) {
         if (predicate(array[i], i, array)) {
             return i;
         }
@@ -584,9 +666,11 @@ function arrayFindLastIndex<T>(
  * See also Replacement.apply
  */
 function applyReplacementOffset(content: string, replacement: Lint.Replacement, offset: number) {
-    return content.substring(0, replacement.start - offset)
-        + replacement.text
-        + content.substring(replacement.start - offset + replacement.length);
+    return (
+        content.substring(0, replacement.start - offset) +
+        replacement.text +
+        content.substring(replacement.start - offset + replacement.length)
+    );
 }
 
 /**
@@ -602,7 +686,7 @@ function applyReplacementOffset(content: string, replacement: Lint.Replacement, 
  * if that comes first.
  */
 function getSplitIndexes(members: ts.NodeArray<Member>, text: string) {
-    const result = members.map((member) => getNextSplitIndex(text, member.getFullStart()));
+    const result = members.map(member => getNextSplitIndex(text, member.getFullStart()));
     result.push(getNextSplitIndex(text, arrayLast(members).getEnd()));
     return result;
 }
@@ -614,15 +698,15 @@ function getSplitIndexes(members: ts.NodeArray<Member>, text: string) {
  */
 function getNextSplitIndex(text: string, pos: number) {
     const enum CharacterCodes {
-        lineFeed = 0x0A,              // \n
-        carriageReturn = 0x0D,        // \r
-        formFeed = 0x0C,              // \f
-        tab = 0x09,                   // \t
-        verticalTab = 0x0B,           // \v
-        slash = 0x2F,                 // /
-        asterisk = 0x2A,              // *
-        space = 0x0020,   // " "
-        maxAsciiCharacter = 0x7F,
+        lineFeed = 0x0a, // \n
+        carriageReturn = 0x0d, // \r
+        formFeed = 0x0c, // \f
+        tab = 0x09, // \t
+        verticalTab = 0x0b, // \v
+        slash = 0x2f, // /
+        asterisk = 0x2a, // *
+        space = 0x0020, // " "
+        maxAsciiCharacter = 0x7f,
     }
     scan: while (pos >= 0 && pos < text.length) {
         const ch = text.charCodeAt(pos);
@@ -658,7 +742,10 @@ function getNextSplitIndex(text: string, pos: number) {
                         }
                     } else {
                         while (pos < text.length) {
-                            if (text.charCodeAt(pos) === CharacterCodes.asterisk && text.charCodeAt(pos + 1) === CharacterCodes.slash) {
+                            if (
+                                text.charCodeAt(pos) === CharacterCodes.asterisk &&
+                                text.charCodeAt(pos + 1) === CharacterCodes.slash
+                            ) {
                                 pos += 2;
                                 continue scan;
                             }
@@ -672,7 +759,7 @@ function getNextSplitIndex(text: string, pos: number) {
                 break scan;
             default:
                 // skip whitespace:
-                if (ch > CharacterCodes.maxAsciiCharacter && (ts.isWhiteSpaceLike(ch))) {
+                if (ch > CharacterCodes.maxAsciiCharacter && ts.isWhiteSpaceLike(ch)) {
                     pos++;
                     continue;
                 }

--- a/src/rules/memberOrderingRule.ts
+++ b/src/rules/memberOrderingRule.ts
@@ -528,8 +528,8 @@ function getOptionsJson(allOptions: any[]): { order: MemberCategoryJson[]; alpha
     }
 
     return {
-        order: categoryFromOption(firstOption[OPTION_ORDER]),
         alphabetize: firstOption[OPTION_ALPHABETIZE] === true,
+        order: categoryFromOption(firstOption[OPTION_ORDER]),
     };
 }
 function categoryFromOption(orderOption: MemberCategoryJson[] | string): MemberCategoryJson[] {

--- a/src/rules/newParensRule.ts
+++ b/src/rules/newParensRule.ts
@@ -42,7 +42,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (node.kind === ts.SyntaxKind.NewExpression && (node as ts.NewExpression).arguments === undefined) {
+        if (
+            node.kind === ts.SyntaxKind.NewExpression &&
+            (node as ts.NewExpression).arguments === undefined
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/newlineBeforeReturnRule.ts
+++ b/src/rules/newlineBeforeReturnRule.ts
@@ -36,7 +36,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Missing blank line before return";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NewlineBeforeReturnWalker(sourceFile, this.ruleName, undefined));
+        return this.applyWithWalker(
+            new NewlineBeforeReturnWalker(sourceFile, this.ruleName, undefined),
+        );
     }
 }
 
@@ -65,7 +67,8 @@ class NewlineBeforeReturnWalker extends Lint.AbstractWalker<void> {
         if (comments !== undefined) {
             // check for blank lines between comments
             for (let i = comments.length - 1; i >= 0; --i) {
-                const endLine = ts.getLineAndCharacterOfPosition(this.sourceFile, comments[i].end).line;
+                const endLine = ts.getLineAndCharacterOfPosition(this.sourceFile, comments[i].end)
+                    .line;
                 if (endLine < line - 1) {
                     return;
                 }

--- a/src/rules/newlinePerChainedCallRule.ts
+++ b/src/rules/newlinePerChainedCallRule.ts
@@ -53,11 +53,7 @@ class NewlinePerChainedCallWalker extends Lint.AbstractWalker<void> {
             if (
                 isCallExpression(node) &&
                 isPropertyAccessExpression(node.expression) &&
-                isSameLine(
-                    sourceFile,
-                    node.expression.expression.end,
-                    node.expression.name.pos,
-                ) &&
+                isSameLine(sourceFile, node.expression.expression.end, node.expression.name.pos) &&
                 hasChildCall(node.expression)
             ) {
                 this.addFailure(
@@ -74,10 +70,7 @@ class NewlinePerChainedCallWalker extends Lint.AbstractWalker<void> {
 
 function hasChildCall(node: ts.PropertyAccessExpression): boolean {
     let { expression } = node;
-    while (
-        isPropertyAccessExpression(expression) ||
-        isElementAccessExpression(expression)
-    ) {
+    while (isPropertyAccessExpression(expression) || isElementAccessExpression(expression)) {
         ({ expression } = expression);
     }
     return expression.kind === ts.SyntaxKind.CallExpression;

--- a/src/rules/noAngleBracketTypeAssertionRule.ts
+++ b/src/rules/noAngleBracketTypeAssertionRule.ts
@@ -38,7 +38,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.";
+    public static FAILURE_STRING =
+        "Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -48,7 +49,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (isTypeAssertion(node)) {
-            let {expression} = node;
+            let { expression } = node;
             const start = node.getStart(ctx.sourceFile);
             const addParens = needsParens(node);
             let replaceText = ` as ${node.type.getText(ctx.sourceFile)}${addParens ? ")" : ""}`;
@@ -58,7 +59,11 @@ function walk(ctx: Lint.WalkContext<void>) {
             }
             ctx.addFailure(start, node.end, Rule.FAILURE_STRING, [
                 Lint.Replacement.appendText(node.end, replaceText),
-                Lint.Replacement.replaceFromTo(start, expression.getStart(ctx.sourceFile), addParens ? "(" : ""),
+                Lint.Replacement.replaceFromTo(
+                    start,
+                    expression.getStart(ctx.sourceFile),
+                    addParens ? "(" : "",
+                ),
             ]);
             return cb(expression);
         }
@@ -68,6 +73,9 @@ function walk(ctx: Lint.WalkContext<void>) {
 
 function needsParens(node: ts.TypeAssertion): boolean {
     const parent = node.parent!;
-    return isBinaryExpression(parent) &&
-        (parent.operatorToken.kind === ts.SyntaxKind.AmpersandToken || parent.operatorToken.kind === ts.SyntaxKind.BarToken);
+    return (
+        isBinaryExpression(parent) &&
+        (parent.operatorToken.kind === ts.SyntaxKind.AmpersandToken ||
+            parent.operatorToken.kind === ts.SyntaxKind.BarToken)
+    );
 }

--- a/src/rules/noAnyRule.ts
+++ b/src/rules/noAnyRule.ts
@@ -46,7 +46,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.";
+    public static FAILURE_STRING =
+        "Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);

--- a/src/rules/noArgRule.ts
+++ b/src/rules/noArgRule.ts
@@ -46,9 +46,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isPropertyAccessExpression(node) &&
+        if (
+            isPropertyAccessExpression(node) &&
             node.name.text === "callee" &&
-            node.expression.kind === ts.SyntaxKind.Identifier && (node.expression as ts.Identifier).text === "arguments") {
+            node.expression.kind === ts.SyntaxKind.Identifier &&
+            (node.expression as ts.Identifier).text === "arguments"
+        ) {
             return ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/noBitwiseRule.ts
+++ b/src/rules/noBitwiseRule.ts
@@ -66,8 +66,10 @@ function walk(ctx: Lint.WalkContext<void>) {
                 case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
                     ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
-        } else if (node.kind === ts.SyntaxKind.PrefixUnaryExpression &&
-                   (node as ts.PrefixUnaryExpression).operator === ts.SyntaxKind.TildeToken) {
+        } else if (
+            node.kind === ts.SyntaxKind.PrefixUnaryExpression &&
+            (node as ts.PrefixUnaryExpression).operator === ts.SyntaxKind.TildeToken
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/noBooleanLiteralCompareRule.ts
+++ b/src/rules/noBooleanLiteralCompareRule.ts
@@ -40,7 +40,9 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING(negate: boolean) {
-        return `This expression is unnecessarily compared to a boolean. Just ${negate ? "negate it" : "use it directly"}.`;
+        return `This expression is unnecessarily compared to a boolean. Just ${
+            negate ? "negate it" : "use it directly"
+        }.`;
     }
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
@@ -53,7 +55,11 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
         if (utils.isBinaryExpression(node)) {
             const cmp = getBooleanComparison(node, checker);
             if (cmp !== undefined) {
-                ctx.addFailureAtNode(cmp.expression, Rule.FAILURE_STRING(cmp.negate), fix(node, cmp));
+                ctx.addFailureAtNode(
+                    cmp.expression,
+                    Rule.FAILURE_STRING(cmp.negate),
+                    fix(node, cmp),
+                );
             }
         }
         return ts.forEachChild(node, cb);
@@ -65,15 +71,22 @@ interface Compare {
     expression: ts.Expression;
 }
 
-function getBooleanComparison(node: ts.BinaryExpression, checker: ts.TypeChecker): Compare | undefined {
+function getBooleanComparison(
+    node: ts.BinaryExpression,
+    checker: ts.TypeChecker,
+): Compare | undefined {
     const cmp = deconstructComparison(node);
-    return cmp === undefined || !utils.isTypeFlagSet(checker.getTypeAtLocation(cmp.expression), ts.TypeFlags.Boolean) ? undefined : cmp;
+    return cmp === undefined ||
+        !utils.isTypeFlagSet(checker.getTypeAtLocation(cmp.expression), ts.TypeFlags.Boolean)
+        ? undefined
+        : cmp;
 }
 
 function fix(node: ts.BinaryExpression, { negate, expression }: Compare): Lint.Fix {
-    const deleted = node.left === expression
-        ? Lint.Replacement.deleteFromTo(node.left.end, node.end)
-        : Lint.Replacement.deleteFromTo(node.getStart(), node.right.getStart());
+    const deleted =
+        node.left === expression
+            ? Lint.Replacement.deleteFromTo(node.left.end, node.end)
+            : Lint.Replacement.deleteFromTo(node.getStart(), node.right.getStart());
     if (!negate) {
         return deleted;
     } else if (needsParenthesesForNegate(expression)) {
@@ -83,10 +96,7 @@ function fix(node: ts.BinaryExpression, { negate, expression }: Compare): Lint.F
             Lint.Replacement.appendText(node.getEnd(), ")"),
         ];
     } else {
-        return [
-            deleted,
-            Lint.Replacement.appendText(node.getStart(), "!"),
-        ];
+        return [deleted, Lint.Replacement.appendText(node.getStart(), "!")];
     }
 }
 

--- a/src/rules/noConditionalAssignmentRule.ts
+++ b/src/rules/noConditionalAssignmentRule.ts
@@ -25,7 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-conditional-assignment",
         description: "Disallows any type of assignment in conditionals.",
-        descriptionDetails: "This applies to `do-while`, `for`, `if`, and `while` statements and conditional (ternary) expressions.",
+        descriptionDetails:
+            "This applies to `do-while`, `for`, `if`, and `while` statements and conditional (ternary) expressions.",
         rationale: Lint.Utils.dedent`
             Assignments in conditionals are often typos:
             for example \`if (var1 = var2)\` instead of \`if (var1 == var2)\`.
@@ -90,7 +91,12 @@ function walk(ctx: Lint.WalkContext<void>) {
                 case ts.SyntaxKind.NonNullExpression:
                 case ts.SyntaxKind.AsExpression:
                 case ts.SyntaxKind.TypeAssertionExpression:
-                    return cb((node as ts.AssertionExpression | ts.NonNullExpression | ts.ParenthesizedExpression).expression);
+                    return cb(
+                        (node as
+                            | ts.AssertionExpression
+                            | ts.NonNullExpression
+                            | ts.ParenthesizedExpression).expression,
+                    );
                 case ts.SyntaxKind.PrefixUnaryExpression:
                     return cb((node as ts.PrefixUnaryExpression).operand);
                 default:

--- a/src/rules/noConsecutiveBlankLinesRule.ts
+++ b/src/rules/noConsecutiveBlankLinesRule.ts
@@ -65,7 +65,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const limit = this.ruleArguments[0] as number | undefined;
-        return this.applyWithFunction(sourceFile, walk, limit !== undefined ? limit : Rule.DEFAULT_ALLOWED_BLANKS);
+        return this.applyWithFunction(
+            sourceFile,
+            walk,
+            limit !== undefined ? limit : Rule.DEFAULT_ALLOWED_BLANKS,
+        );
     }
 }
 
@@ -76,7 +80,10 @@ function walk(ctx: Lint.WalkContext<number>) {
     let consecutiveBlankLines = 0;
 
     for (const line of utils.getLineRanges(ctx.sourceFile)) {
-        if (line.contentLength === 0 || sourceText.substr(line.pos, line.contentLength).search(/\S/) === -1) {
+        if (
+            line.contentLength === 0 ||
+            sourceText.substr(line.pos, line.contentLength).search(/\S/) === -1
+        ) {
             ++consecutiveBlankLines;
             if (consecutiveBlankLines === threshold) {
                 possibleFailures.push({
@@ -97,12 +104,19 @@ function walk(ctx: Lint.WalkContext<number>) {
     const failureString = Rule.FAILURE_STRING_FACTORY(ctx.options);
     const templateRanges = getTemplateRanges(ctx.sourceFile);
     for (const possibleFailure of possibleFailures) {
-        if (!templateRanges.some((template) => template.pos < possibleFailure.pos && possibleFailure.pos < template.end)) {
+        if (
+            !templateRanges.some(
+                template =>
+                    template.pos < possibleFailure.pos && possibleFailure.pos < template.end,
+            )
+        ) {
             ctx.addFailureAt(possibleFailure.pos, 1, failureString, [
                 Lint.Replacement.deleteFromTo(
                     // special handling for fixing blank lines at the end of the file
                     // to fix this we need to cut off the line break of the last allowed blank line, too
-                    possibleFailure.end === sourceText.length ? getStartOfLineBreak(sourceText, possibleFailure.pos) : possibleFailure.pos,
+                    possibleFailure.end === sourceText.length
+                        ? getStartOfLineBreak(sourceText, possibleFailure.pos)
+                        : possibleFailure.pos,
                     possibleFailure.end,
                 ),
             ]);
@@ -117,8 +131,10 @@ function getStartOfLineBreak(sourceText: string, pos: number) {
 export function getTemplateRanges(sourceFile: ts.SourceFile): ts.TextRange[] {
     const intervals: ts.TextRange[] = [];
     const cb = (node: ts.Node): void => {
-        if (node.kind >= ts.SyntaxKind.FirstTemplateToken &&
-            node.kind <= ts.SyntaxKind.LastTemplateToken) {
+        if (
+            node.kind >= ts.SyntaxKind.FirstTemplateToken &&
+            node.kind <= ts.SyntaxKind.LastTemplateToken
+        ) {
             intervals.push({
                 end: node.end,
                 pos: node.getStart(sourceFile),

--- a/src/rules/noConsoleRule.ts
+++ b/src/rules/noConsoleRule.ts
@@ -25,8 +25,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-console",
         description: "Bans the use of specified `console` methods.",
-        rationale: "In general, \`console\` methods aren't appropriate for production code.",
-        optionsDescription: "A list of method names to ban. If no method names are provided, all console methods are banned.",
+        rationale: "In general, `console` methods aren't appropriate for production code.",
+        optionsDescription:
+            "A list of method names to ban. If no method names are provided, all console methods are banned.",
         options: {
             type: "array",
             items: { type: "string" },
@@ -48,11 +49,12 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<string[]>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
-        if (isPropertyAccessExpression(node) &&
+        if (
+            isPropertyAccessExpression(node) &&
             isIdentifier(node.expression) &&
             node.expression.text === "console" &&
-            (ctx.options.length === 0 || ctx.options.indexOf(node.name.text) !== -1)) {
-
+            (ctx.options.length === 0 || ctx.options.indexOf(node.name.text) !== -1)
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY(node.name.text));
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/noConstructRule.ts
+++ b/src/rules/noConstructRule.ts
@@ -25,7 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-construct",
         description: "Disallows access to the constructors of `String`, `Number`, and `Boolean`.",
-        descriptionDetails: "Disallows constructor use such as `new Number(foo)` but does not disallow `Number(foo)`.",
+        descriptionDetails:
+            "Disallows constructor use such as `new Number(foo)` but does not disallow `Number(foo)`.",
         rationale: Lint.Utils.dedent`
             There is little reason to use \`String\`, \`Number\`, or \`Boolean\` as constructors.
             In almost all cases, the regular function-call version is more appropriate.
@@ -38,7 +39,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Forbidden constructor, use a literal or simple function call instead";
+    public static FAILURE_STRING =
+        "Forbidden constructor, use a literal or simple function call instead";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -52,7 +54,11 @@ function walk(ctx: Lint.WalkContext<void>) {
                 case "Boolean":
                 case "String":
                 case "Number":
-                    ctx.addFailure(node.getStart(ctx.sourceFile), node.expression.end, Rule.FAILURE_STRING);
+                    ctx.addFailure(
+                        node.getStart(ctx.sourceFile),
+                        node.expression.end,
+                        Rule.FAILURE_STRING,
+                    );
             }
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/noDebuggerRule.ts
+++ b/src/rules/noDebuggerRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-debugger",
         description: "Disallows `debugger` statements.",
-        rationale: "In general, \`debugger\` statements aren't appropriate for production code.",
+        rationale: "In general, `debugger` statements aren't appropriate for production code.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/noDefaultExportRule.ts
+++ b/src/rules/noDefaultExportRule.ts
@@ -53,9 +53,12 @@ function walk(ctx: Lint.WalkContext<void>) {
             if (!(statement as ts.ExportAssignment).isExportEquals) {
                 ctx.addFailureAtNode(statement.getChildAt(1, ctx.sourceFile), Rule.FAILURE_STRING);
             }
-        } else if (statement.modifiers !== undefined && statement.modifiers.length >= 2 &&
-                   statement.modifiers[0].kind === ts.SyntaxKind.ExportKeyword &&
-                   statement.modifiers[1].kind === ts.SyntaxKind.DefaultKeyword) {
+        } else if (
+            statement.modifiers !== undefined &&
+            statement.modifiers.length >= 2 &&
+            statement.modifiers[0].kind === ts.SyntaxKind.ExportKeyword &&
+            statement.modifiers[1].kind === ts.SyntaxKind.DefaultKeyword
+        ) {
             ctx.addFailureAtNode(statement.modifiers[1], Rule.FAILURE_STRING);
         }
     }

--- a/src/rules/noDuplicateImportsRule.ts
+++ b/src/rules/noDuplicateImportsRule.ts
@@ -48,7 +48,11 @@ function walk(ctx: Lint.WalkContext<void>): void {
     walkWorker(ctx, ctx.sourceFile.statements, new Set());
 }
 
-function walkWorker(ctx: Lint.WalkContext<void>, statements: ReadonlyArray<ts.Statement>, seen: Set<string>): void {
+function walkWorker(
+    ctx: Lint.WalkContext<void>,
+    statements: ReadonlyArray<ts.Statement>,
+    seen: Set<string>,
+): void {
     for (const statement of statements) {
         if (isImportDeclaration(statement) && isLiteralExpression(statement.moduleSpecifier)) {
             const { text } = statement.moduleSpecifier;
@@ -58,11 +62,19 @@ function walkWorker(ctx: Lint.WalkContext<void>, statements: ReadonlyArray<ts.St
             seen.add(text);
         }
 
-        if (isModuleDeclaration(statement) && statement.body !== undefined && statement.name.kind === ts.SyntaxKind.StringLiteral) {
+        if (
+            isModuleDeclaration(statement) &&
+            statement.body !== undefined &&
+            statement.name.kind === ts.SyntaxKind.StringLiteral
+        ) {
             // If this is a module augmentation, re-use `seen` since those imports could be moved outside.
             // If this is an ambient module, create a fresh `seen`
             // because they should have separate imports to avoid becoming augmentations.
-            walkWorker(ctx, (statement.body as ts.ModuleBlock).statements, ts.isExternalModule(ctx.sourceFile) ? seen : new Set());
+            walkWorker(
+                ctx,
+                (statement.body as ts.ModuleBlock).statements,
+                ts.isExternalModule(ctx.sourceFile) ? seen : new Set(),
+            );
         }
     }
 }

--- a/src/rules/noDuplicateSuperRule.ts
+++ b/src/rules/noDuplicateSuperRule.ts
@@ -34,7 +34,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_DUPLICATE = "Multiple calls to 'super()' found. It must be called only once.";
+    public static FAILURE_STRING_DUPLICATE =
+        "Multiple calls to 'super()' found. It must be called only once.";
     public static FAILURE_STRING_LOOP = "'super()' called in a loop. It must be called only once.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
@@ -44,10 +45,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-       if (isConstructorDeclaration(node) && node.body !== undefined) {
-           getSuperForNode(node.body);
-       }
-       return ts.forEachChild(node, cb);
+        if (isConstructorDeclaration(node) && node.body !== undefined) {
+            getSuperForNode(node.body);
+        }
+        return ts.forEachChild(node, cb);
     });
 
     function getSuperForNode(node: ts.Node): Super {
@@ -76,7 +77,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
                 return Kind.NoSuper;
 
             case ts.SyntaxKind.SuperKeyword:
-                return node.parent!.kind === ts.SyntaxKind.CallExpression && (node.parent as ts.CallExpression).expression === node
+                return node.parent!.kind === ts.SyntaxKind.CallExpression &&
+                    (node.parent as ts.CallExpression).expression === node
                     ? { node: node.parent! as ts.CallExpression, break: false }
                     : Kind.NoSuper;
 
@@ -92,7 +94,10 @@ function walk(ctx: Lint.WalkContext<void>): void {
 
             case ts.SyntaxKind.IfStatement: {
                 const { thenStatement, elseStatement } = node as ts.IfStatement;
-                return worse(getSuperForNode(thenStatement), elseStatement !== undefined ? getSuperForNode(elseStatement) : Kind.NoSuper);
+                return worse(
+                    getSuperForNode(thenStatement),
+                    elseStatement !== undefined ? getSuperForNode(elseStatement) : Kind.NoSuper,
+                );
             }
 
             case ts.SyntaxKind.SwitchStatement:
@@ -141,7 +146,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
      */
     function combineSequentialChildren(node: ts.Node): Super {
         let seenSingle: Single | undefined;
-        const res = ts.forEachChild<Super | undefined>(node, (child) => {
+        const res = ts.forEachChild<Super | undefined>(node, child => {
             const childSuper = getSuperForNode(child);
             switch (childSuper) {
                 case Kind.NoSuper:
@@ -193,6 +198,14 @@ interface Single {
 // If/else run separately, so return the branch more likely to result in eventual errors.
 function worse(a: Super, b: Super): Super {
     return typeof a === "number"
-        ? typeof b === "number" ? (a < b ? b : a) : b
-        : typeof b === "number" ? a : a.break ? b : a;
+        ? typeof b === "number"
+            ? a < b
+                ? b
+                : a
+            : b
+        : typeof b === "number"
+            ? a
+            : a.break
+                ? b
+                : a;
 }

--- a/src/rules/noDuplicateSwitchCaseRule.ts
+++ b/src/rules/noDuplicateSwitchCaseRule.ts
@@ -30,7 +30,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         typescriptOnly: false,
     };
 
-    public static readonly FAILURE_STRING_FACTORY = (text: string) => `Duplicate switch case: '${text}'.`;
+    public static readonly FAILURE_STRING_FACTORY = (text: string) =>
+        `Duplicate switch case: '${text}'.`;
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);

--- a/src/rules/noDuplicateVariableRule.ts
+++ b/src/rules/noDuplicateVariableRule.ts
@@ -42,10 +42,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "string",
             enum: [OPTION_CHECK_PARAMETERS],
         },
-        optionExamples: [
-            true,
-            [true, OPTION_CHECK_PARAMETERS],
-        ],
+        optionExamples: [true, [true, OPTION_CHECK_PARAMETERS]],
         type: "functionality",
         typescriptOnly: false,
     };
@@ -56,9 +53,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoDuplicateVariableWalker(sourceFile, this.ruleName, {
-            parameters: this.ruleArguments.indexOf(OPTION_CHECK_PARAMETERS) !== - 1,
-        }));
+        return this.applyWithWalker(
+            new NoDuplicateVariableWalker(sourceFile, this.ruleName, {
+                parameters: this.ruleArguments.indexOf(OPTION_CHECK_PARAMETERS) !== -1,
+            }),
+        );
     }
 }
 
@@ -76,7 +75,10 @@ class NoDuplicateVariableWalker extends Lint.AbstractWalker<Options> {
             }
             if (this.options.parameters && utils.isParameterDeclaration(node)) {
                 this.handleBindingName(node.name, false);
-            } else if (utils.isVariableDeclarationList(node) && !utils.isBlockScopedVariableDeclarationList(node)) {
+            } else if (
+                utils.isVariableDeclarationList(node) &&
+                !utils.isBlockScopedVariableDeclarationList(node)
+            ) {
                 for (const variable of node.declarations) {
                     this.handleBindingName(variable.name, true);
                 }

--- a/src/rules/noDynamicDeleteRule.ts
+++ b/src/rules/noDynamicDeleteRule.ts
@@ -67,7 +67,11 @@ function walk(context: Lint.WalkContext<void>) {
                 fix = Lint.Replacement.replaceFromTo(start, start + width, `[${convertedOperand}]`);
             }
         } else if (tsutils.isStringLiteral(argumentExpression)) {
-            fix = Lint.Replacement.replaceFromTo(start, start + width, `.${argumentExpression.text}`);
+            fix = Lint.Replacement.replaceFromTo(
+                start,
+                start + width,
+                `.${argumentExpression.text}`,
+            );
         }
 
         context.addFailureAt(start, width, Rule.FAILURE_STRING, fix);
@@ -83,9 +87,7 @@ function walk(context: Lint.WalkContext<void>) {
 }
 
 function convertUnaryOperand(node: ts.PrefixUnaryExpression) {
-    return tsutils.isNumericLiteral(node.operand)
-        ? node.operand.text
-        : undefined;
+    return tsutils.isNumericLiteral(node.operand) ? node.operand.text : undefined;
 }
 
 function isDeleteExpression(node: ts.Node): node is ts.DeleteExpression {
@@ -105,5 +107,8 @@ function isNecessaryDynamicAccess(argumentExpression: ts.Expression): boolean {
         return true;
     }
 
-    return tsutils.isStringLiteral(argumentExpression) && !tsutils.isValidPropertyAccess(argumentExpression.text);
+    return (
+        tsutils.isStringLiteral(argumentExpression) &&
+        !tsutils.isValidPropertyAccess(argumentExpression.text)
+    );
 }

--- a/src/rules/noEmptyInterfaceRule.ts
+++ b/src/rules/noEmptyInterfaceRule.ts
@@ -36,7 +36,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING = "An empty interface is equivalent to `{}`.";
-    public static FAILURE_STRING_FOR_EXTENDS = "An interface declaring no members is equivalent to its supertype.";
+    public static FAILURE_STRING_FOR_EXTENDS =
+        "An interface declaring no members is equivalent to its supertype.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -45,18 +46,24 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isInterfaceDeclaration(node) &&
+        if (
+            isInterfaceDeclaration(node) &&
             node.members.length === 0 &&
-            (node.heritageClauses === undefined || extendsOneTypeWithoutTypeArguments(node.heritageClauses[0]))) {
+            (node.heritageClauses === undefined ||
+                extendsOneTypeWithoutTypeArguments(node.heritageClauses[0]))
+        ) {
             return ctx.addFailureAtNode(
                 node.name,
-                node.heritageClauses !== undefined ? Rule.FAILURE_STRING_FOR_EXTENDS : Rule.FAILURE_STRING);
+                node.heritageClauses !== undefined
+                    ? Rule.FAILURE_STRING_FOR_EXTENDS
+                    : Rule.FAILURE_STRING,
+            );
         }
         return ts.forEachChild(node, cb);
     });
 }
 
-function extendsOneTypeWithoutTypeArguments({types}: ts.HeritageClause): boolean {
+function extendsOneTypeWithoutTypeArguments({ types }: ts.HeritageClause): boolean {
     switch (types.length) {
         case 0:
             return true; // don't crash on empty extends list

--- a/src/rules/noEmptyRule.ts
+++ b/src/rules/noEmptyRule.ts
@@ -76,16 +76,18 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<Options>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (node.kind === ts.SyntaxKind.Block &&
+        if (
+            node.kind === ts.SyntaxKind.Block &&
             (node as ts.Block).statements.length === 0 &&
-            !isExcluded(node.parent!, ctx.options)) {
+            !isExcluded(node.parent!, ctx.options)
+        ) {
             const start = node.getStart(ctx.sourceFile);
             // Block always starts with open brace. Adding 1 to its start gives us the end of the brace,
             // which can be used to conveniently check for comments between braces
             if (Lint.hasCommentAfterPosition(ctx.sourceFile.text, start + 1)) {
                 return;
             }
-            return ctx.addFailure(start , node.end, Rule.FAILURE_STRING);
+            return ctx.addFailure(start, node.end, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);
     });
@@ -96,21 +98,27 @@ function isExcluded(node: ts.Node, options: Options): boolean {
         return true;
     }
 
-    if (options.allowEmptyFunctions &&
+    if (
+        options.allowEmptyFunctions &&
         (node.kind === ts.SyntaxKind.MethodDeclaration ||
-         node.kind === ts.SyntaxKind.FunctionDeclaration ||
-         node.kind === ts.SyntaxKind.FunctionExpression ||
-         node.kind === ts.SyntaxKind.ArrowFunction)) {
+            node.kind === ts.SyntaxKind.FunctionDeclaration ||
+            node.kind === ts.SyntaxKind.FunctionExpression ||
+            node.kind === ts.SyntaxKind.ArrowFunction)
+    ) {
         return true;
     }
 
-    return isConstructorDeclaration(node) &&
-        (
-            /* If constructor is private or protected, the block is allowed to be empty.
+    return (
+        isConstructorDeclaration(node) &&
+        /* If constructor is private or protected, the block is allowed to be empty.
                The constructor is there on purpose to disallow instantiation from outside the class */
-            /* The public modifier does not serve a purpose here. It can only be used to allow instantiation of a base class where
+        /* The public modifier does not serve a purpose here. It can only be used to allow instantiation of a base class where
                the super constructor is protected. But then the block would not be empty, because of the call to super() */
-            hasModifier(node.modifiers, ts.SyntaxKind.PrivateKeyword, ts.SyntaxKind.ProtectedKeyword) ||
-            node.parameters.some(isParameterProperty)
-        );
+        (hasModifier(
+            node.modifiers,
+            ts.SyntaxKind.PrivateKeyword,
+            ts.SyntaxKind.ProtectedKeyword,
+        ) ||
+            node.parameters.some(isParameterProperty))
+    );
 }

--- a/src/rules/noEvalRule.ts
+++ b/src/rules/noEvalRule.ts
@@ -46,8 +46,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isCallExpression(node) &&
-            node.expression.kind === ts.SyntaxKind.Identifier && (node.expression as ts.Identifier).text === "eval") {
+        if (
+            isCallExpression(node) &&
+            node.expression.kind === ts.SyntaxKind.Identifier &&
+            (node.expression as ts.Identifier).text === "eval"
+        ) {
             ctx.addFailureAtNode(node.expression, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/noFloatingPromisesRule.ts
+++ b/src/rules/noFloatingPromisesRule.ts
@@ -25,7 +25,8 @@ export class Rule extends Lint.Rules.TypedRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-floating-promises",
         description: "Promises returned by functions must be handled appropriately.",
-        descriptionDetails: "Unhandled Promises can cause unexpected behavior, such as resolving at unexpected times.",
+        descriptionDetails:
+            "Unhandled Promises can cause unexpected behavior, such as resolving at unexpected times.",
         optionsDescription: Lint.Utils.dedent`
             A list of \'string\' names of any additional classes that should also be handled as Promises.
         `,
@@ -33,7 +34,7 @@ export class Rule extends Lint.Rules.TypedRule {
             type: "list",
             listType: {
                 type: "array",
-                items: {type: "string"},
+                items: { type: "string" },
             },
         },
         optionExamples: [true, [true, "JQueryPromise"]],
@@ -57,7 +58,7 @@ export class Rule extends Lint.Rules.TypedRule {
         return this.applyWithFunction(
             sourceFile,
             walk,
-            ["Promise", ...this.ruleArguments as string[]],
+            ["Promise", ...(this.ruleArguments as string[])],
             program.getTypeChecker(),
         );
     }
@@ -67,9 +68,11 @@ function walk(ctx: Lint.WalkContext<string[]>, tc: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
         if (isExpressionStatement(node)) {
             const { expression } = node;
-            if (isCallExpression(expression) &&
+            if (
+                isCallExpression(expression) &&
                 !isPromiseCatchCall(expression) &&
-                !isPromiseThenCallWithRejectionHandler(expression)) {
+                !isPromiseThenCallWithRejectionHandler(expression)
+            ) {
                 const { symbol } = tc.getTypeAtLocation(expression);
                 if (symbol !== undefined && ctx.options.indexOf(symbol.name) !== -1) {
                     ctx.addFailureAtNode(expression, Rule.FAILURE_STRING);
@@ -81,11 +84,16 @@ function walk(ctx: Lint.WalkContext<string[]>, tc: ts.TypeChecker) {
 }
 
 function isPromiseCatchCall(expression: ts.CallExpression): boolean {
-    return isPropertyAccessExpression(expression.expression) && expression.expression.name.text === "catch";
+    return (
+        isPropertyAccessExpression(expression.expression) &&
+        expression.expression.name.text === "catch"
+    );
 }
 
 function isPromiseThenCallWithRejectionHandler(expression: ts.CallExpression): boolean {
-    return isPropertyAccessExpression(expression.expression) &&
+    return (
+        isPropertyAccessExpression(expression.expression) &&
         expression.expression.name.text === "then" &&
-        expression.arguments.length >= 2;
+        expression.arguments.length >= 2
+    );
 }

--- a/src/rules/noForInArrayRule.ts
+++ b/src/rules/noForInArrayRule.ts
@@ -47,7 +47,8 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "for-in loops over arrays are forbidden. Use for-of or array.forEach instead.";
+    public static FAILURE_STRING =
+        "for-in loops over arrays are forbidden. Use for-of or array.forEach instead.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
@@ -58,9 +59,11 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (node.kind === ts.SyntaxKind.ForInStatement) {
             const type = checker.getTypeAtLocation((node as ts.ForInStatement).expression);
-            if (type.symbol !== undefined && type.symbol.name === "Array" ||
+            if (
+                (type.symbol !== undefined && type.symbol.name === "Array") ||
                 // tslint:disable-next-line:no-bitwise
-                (type.flags & ts.TypeFlags.StringLike) !== 0) {
+                (type.flags & ts.TypeFlags.StringLike) !== 0
+            ) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
         }

--- a/src/rules/noImplicitDependenciesRule.ts
+++ b/src/rules/noImplicitDependenciesRule.ts
@@ -36,7 +36,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-implicit-dependencies",
-        description: "Disallows importing modules that are not listed as dependency in the project's package.json",
+        description:
+            "Disallows importing modules that are not listed as dependency in the project's package.json",
         descriptionDetails: Lint.Utils.dedent`
             Disallows importing transient dependencies and modules installed above your package's root directory.
         `,
@@ -60,12 +61,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             minItems: 0,
             maxItems: 3,
         },
-        optionExamples: [
-          true,
-          [true, OPTION_DEV],
-          [true, OPTION_OPTIONAL],
-          [true, ["src", "app"]],
-        ],
+        optionExamples: [true, [true, OPTION_DEV], [true, OPTION_OPTIONAL], [true, ["src", "app"]]],
         type: "functionality",
         typescriptOnly: false,
     };
@@ -76,13 +72,13 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        let whitelist = this.ruleArguments.find((arg) => Array.isArray(arg)) as string[];
+        let whitelist = this.ruleArguments.find(arg => Array.isArray(arg)) as string[];
         if (whitelist === null || whitelist === undefined) {
-          whitelist = [];
+            whitelist = [];
         }
 
         return this.applyWithFunction(sourceFile, walk, {
-            dev: this.ruleArguments.indexOf(OPTION_DEV) !== - 1,
+            dev: this.ruleArguments.indexOf(OPTION_DEV) !== -1,
             optional: this.ruleArguments.indexOf(OPTION_OPTIONAL) !== -1,
             whitelist,
         });
@@ -90,13 +86,17 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function walk(ctx: Lint.WalkContext<Options>) {
-    const {options} = ctx;
+    const { options } = ctx;
     let dependencies: Set<string> | undefined;
     const whitelist = new Set(options.whitelist);
     for (const name of findImports(ctx.sourceFile, ImportKind.All)) {
         if (!ts.isExternalModuleNameRelative(name.text)) {
             const packageName = getPackageName(name.text);
-            if (!whitelist.has(packageName) && builtins.indexOf(packageName) === -1 && !hasDependency(packageName)) {
+            if (
+                !whitelist.has(packageName) &&
+                builtins.indexOf(packageName) === -1 &&
+                !hasDependency(packageName)
+            ) {
                 ctx.addFailureAtNode(name, Rule.FAILURE_STRING_FACTORY(packageName));
             }
         }
@@ -136,7 +136,9 @@ function getDependencies(fileName: string, options: Options): Set<string> {
         try {
             // don't use require here to avoid caching
             // remove BOM from file content before parsing
-            const content = JSON.parse(fs.readFileSync(packageJsonPath, "utf8").replace(/^\uFEFF/, "")) as PackageJson;
+            const content = JSON.parse(
+                fs.readFileSync(packageJsonPath, "utf8").replace(/^\uFEFF/, ""),
+            ) as PackageJson;
             if (content.dependencies !== undefined) {
                 addDependencies(result, content.dependencies);
             }

--- a/src/rules/noImportSideEffectRule.ts
+++ b/src/rules/noImportSideEffectRule.ts
@@ -43,7 +43,8 @@ export class Rule extends Lint.Rules.AbstractRule {
             One argument may be optionally provided:
 
             * \`${OPTION_IGNORE_MODULE}\` allows to specify a regex and ignore modules which it matches.`,
-        rationale: "Imports with side effects may have behavior which is hard for static verification.",
+        rationale:
+            "Imports with side effects may have behavior which is hard for static verification.",
         ruleName: "no-import-side-effect",
         type: "typescript",
         typescriptOnly: false,
@@ -51,8 +52,13 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "import with explicit side-effect";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const patternConfig = this.ruleArguments[this.ruleArguments.length - 1] as { "ignore-module": string } | undefined;
-        const ignorePattern = patternConfig === undefined ? undefined : new RegExp(patternConfig[OPTION_IGNORE_MODULE]);
+        const patternConfig = this.ruleArguments[this.ruleArguments.length - 1] as
+            | { "ignore-module": string }
+            | undefined;
+        const ignorePattern =
+            patternConfig === undefined
+                ? undefined
+                : new RegExp(patternConfig[OPTION_IGNORE_MODULE]);
         return this.applyWithFunction(sourceFile, walk, ignorePattern);
     }
 }

--- a/src/rules/noInferrableTypesRule.ts
+++ b/src/rules/noInferrableTypesRule.ts
@@ -32,8 +32,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-inferrable-types",
-        description: "Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.",
-        rationale: "Explicit types where they can be easily inferred by the compiler make code more verbose.",
+        description:
+            "Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.",
+        rationale:
+            "Explicit types where they can be easily inferred by the compiler make code more verbose.",
         optionsDescription: Lint.Utils.dedent`
             Two arguments may be optionally provided:
 
@@ -65,10 +67,12 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoInferrableTypesWalker(sourceFile, this.ruleName, {
-            ignoreParameters: this.ruleArguments.indexOf(OPTION_IGNORE_PARMS) !== -1,
-            ignoreProperties: this.ruleArguments.indexOf(OPTION_IGNORE_PROPERTIES) !== -1,
-        }));
+        return this.applyWithWalker(
+            new NoInferrableTypesWalker(sourceFile, this.ruleName, {
+                ignoreParameters: this.ruleArguments.indexOf(OPTION_IGNORE_PARMS) !== -1,
+                ignoreProperties: this.ruleArguments.indexOf(OPTION_IGNORE_PROPERTIES) !== -1,
+            }),
+        );
     }
 }
 
@@ -77,10 +81,17 @@ class NoInferrableTypesWalker extends Lint.AbstractWalker<Options> {
         const cb = (node: ts.Node): void => {
             if (shouldCheck(node, this.options)) {
                 const { name, type, initializer } = node;
-                if (type !== undefined && initializer !== undefined
-                    && typeIsInferrable(type.kind, initializer)) {
+                if (
+                    type !== undefined &&
+                    initializer !== undefined &&
+                    typeIsInferrable(type.kind, initializer)
+                ) {
                     const fix = Lint.Replacement.deleteFromTo(name.end, type.end);
-                    this.addFailureAtNode(type, Rule.FAILURE_STRING_FACTORY(ts.tokenToString(type.kind)!), fix);
+                    this.addFailureAtNode(
+                        type,
+                        Rule.FAILURE_STRING_FACTORY(ts.tokenToString(type.kind)!),
+                        fix,
+                    );
                 }
             }
             return ts.forEachChild(node, cb);
@@ -95,10 +106,12 @@ function shouldCheck(
 ): node is ts.ParameterDeclaration | ts.PropertyDeclaration | ts.VariableDeclaration {
     switch (node.kind) {
         case ts.SyntaxKind.Parameter:
-            return !ignoreParameters &&
+            return (
+                !ignoreParameters &&
                 !hasModifier(node.modifiers, ts.SyntaxKind.ReadonlyKeyword) &&
                 // "ignore-properties" also works for parameter properties
-                !(ignoreProperties && node.modifiers !== undefined);
+                !(ignoreProperties && node.modifiers !== undefined)
+            );
         case ts.SyntaxKind.PropertyDeclaration:
             return !ignoreProperties && !hasModifier(node.modifiers, ts.SyntaxKind.ReadonlyKeyword);
         case ts.SyntaxKind.VariableDeclaration:
@@ -111,7 +124,10 @@ function shouldCheck(
 function typeIsInferrable(type: ts.SyntaxKind, initializer: ts.Expression): boolean {
     switch (type) {
         case ts.SyntaxKind.BooleanKeyword:
-            return initializer.kind === ts.SyntaxKind.TrueKeyword || initializer.kind === ts.SyntaxKind.FalseKeyword;
+            return (
+                initializer.kind === ts.SyntaxKind.TrueKeyword ||
+                initializer.kind === ts.SyntaxKind.FalseKeyword
+            );
         case ts.SyntaxKind.NumberKeyword:
             return Lint.isNumeric(initializer);
         case ts.SyntaxKind.StringKeyword:

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -23,7 +23,8 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-inferred-empty-object-type",
-        description: "Disallow type inference of {} (empty object type) at function and constructor call sites",
+        description:
+            "Disallow type inference of {} (empty object type) at function and constructor call sites",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -38,16 +39,24 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static EMPTY_INTERFACE_INSTANCE = "Explicit type parameter needs to be provided to the constructor";
-    public static EMPTY_INTERFACE_FUNCTION = "Explicit type parameter needs to be provided to the function call";
+    public static EMPTY_INTERFACE_INSTANCE =
+        "Explicit type parameter needs to be provided to the constructor";
+    public static EMPTY_INTERFACE_FUNCTION =
+        "Explicit type parameter needs to be provided to the function call";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoInferredEmptyObjectTypeRule(sourceFile, this.ruleName, program.getTypeChecker()));
+        return this.applyWithWalker(
+            new NoInferredEmptyObjectTypeRule(sourceFile, this.ruleName, program.getTypeChecker()),
+        );
     }
 }
 
 class NoInferredEmptyObjectTypeRule extends Lint.AbstractWalker<void> {
-    constructor(sourceFile: ts.SourceFile, ruleName: string, private readonly checker: ts.TypeChecker) {
+    constructor(
+        sourceFile: ts.SourceFile,
+        ruleName: string,
+        private readonly checker: ts.TypeChecker,
+    ) {
         super(sourceFile, ruleName, undefined);
     }
 
@@ -66,8 +75,11 @@ class NoInferredEmptyObjectTypeRule extends Lint.AbstractWalker<void> {
     private checkNewExpression(node: ts.NewExpression): void {
         if (node.typeArguments === undefined) {
             const type = this.checker.getTypeAtLocation(node);
-            if (isTypeReference(type) && type.typeArguments !== undefined &&
-                type.typeArguments.some((a) => isObjectType(a) && this.isEmptyObjectInterface(a))) {
+            if (
+                isTypeReference(type) &&
+                type.typeArguments !== undefined &&
+                type.typeArguments.some(a => isObjectType(a) && this.isEmptyObjectInterface(a))
+            ) {
                 this.addFailureAtNode(node, Rule.EMPTY_INTERFACE_INSTANCE);
             }
         }
@@ -90,13 +102,15 @@ class NoInferredEmptyObjectTypeRule extends Lint.AbstractWalker<void> {
     }
 
     private isEmptyObjectInterface(objType: ts.ObjectType): boolean {
-        return isObjectFlagSet(objType, ts.ObjectFlags.Anonymous) &&
+        return (
+            isObjectFlagSet(objType, ts.ObjectFlags.Anonymous) &&
             objType.getProperties().length === 0 &&
             objType.getNumberIndexType() === undefined &&
             objType.getStringIndexType() === undefined &&
-            objType.getCallSignatures().every((signature) => {
+            objType.getCallSignatures().every(signature => {
                 const type = this.checker.getReturnTypeOfSignature(signature);
                 return isObjectType(type) && this.isEmptyObjectInterface(type);
-            });
+            })
+        );
     }
 }

--- a/src/rules/noInternalModuleRule.ts
+++ b/src/rules/noInternalModuleRule.ts
@@ -24,7 +24,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-internal-module",
         description: "Disallows internal `module`",
-        rationale: "Using `module` leads to a confusion of concepts with external modules. Use the newer `namespace` keyword instead.",
+        rationale:
+            "Using `module` leads to a confusion of concepts with external modules. Use the newer `namespace` keyword instead.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -34,10 +35,13 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "The internal 'module' syntax is deprecated, use the 'namespace' keyword instead.";
+    public static FAILURE_STRING =
+        "The internal 'module' syntax is deprecated, use the 'namespace' keyword instead.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoInternalModuleWalker(sourceFile, this.ruleName, undefined));
+        return this.applyWithWalker(
+            new NoInternalModuleWalker(sourceFile, this.ruleName, undefined),
+        );
     }
 }
 
@@ -55,15 +59,22 @@ class NoInternalModuleWalker extends Lint.AbstractWalker<void> {
     }
 
     private checkModuleDeclaration(node: ts.ModuleDeclaration, nested?: boolean): void {
-        if (!nested &&
+        if (
+            !nested &&
             node.name.kind === ts.SyntaxKind.Identifier &&
             !isNodeFlagSet(node, ts.NodeFlags.Namespace) &&
             // augmenting global uses a special syntax that is allowed
             // see https://github.com/Microsoft/TypeScript/pull/6213
-            !isNodeFlagSet(node, ts.NodeFlags.GlobalAugmentation)) {
+            !isNodeFlagSet(node, ts.NodeFlags.GlobalAugmentation)
+        ) {
             const end = node.name.pos;
             const start = end - "module".length;
-            this.addFailure(start, end, Rule.FAILURE_STRING, Lint.Replacement.replaceFromTo(start, end, "namespace"));
+            this.addFailure(
+                start,
+                end,
+                Rule.FAILURE_STRING,
+                Lint.Replacement.replaceFromTo(start, end, "namespace"),
+            );
         }
         if (node.body !== undefined) {
             switch (node.body.kind) {

--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-invalid-template-strings",
-        description: "Warns on use of `\${` in non-template strings.",
+        description: "Warns on use of `${` in non-template strings.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],

--- a/src/rules/noInvalidTemplateStringsRule.ts
+++ b/src/rules/noInvalidTemplateStringsRule.ts
@@ -24,6 +24,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-invalid-template-strings",
+        // tslint:disable-next-line no-invalid-template-strings
         description: "Warns on use of `${` in non-template strings.",
         optionsDescription: "Not configurable.",
         options: null,

--- a/src/rules/noInvalidThisRule.ts
+++ b/src/rules/noInvalidThisRule.ts
@@ -27,7 +27,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-invalid-this",
         description: "Disallows using the `this` keyword outside of classes.",
-        rationale: "See [the rule's author's rationale here.](https://github.com/palantir/tslint/pull/1105#issue-147549402)",
+        rationale:
+            "See [the rule's author's rationale here.](https://github.com/palantir/tslint/pull/1105#issue-147549402)",
         optionsDescription: Lint.Utils.dedent`
             One argument may be optionally provided:
 
@@ -47,12 +48,15 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_OUTSIDE = "the \"this\" keyword is disallowed outside of a class body";
-    public static FAILURE_STRING_INSIDE = "the \"this\" keyword is disallowed in function bodies inside class methods, " +
+    public static FAILURE_STRING_OUTSIDE =
+        'the "this" keyword is disallowed outside of a class body';
+    public static FAILURE_STRING_INSIDE =
+        'the "this" keyword is disallowed in function bodies inside class methods, ' +
         "use arrow functions instead";
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const hasOption = (name: string) => this.ruleArguments.indexOf(name) !== -1;
-        const checkFuncInMethod = hasOption(DEPRECATED_OPTION_FUNCTION_IN_METHOD) || hasOption(OPTION_FUNCTION_IN_METHOD);
+        const checkFuncInMethod =
+            hasOption(DEPRECATED_OPTION_FUNCTION_IN_METHOD) || hasOption(OPTION_FUNCTION_IN_METHOD);
         return this.applyWithFunction(sourceFile, walk, checkFuncInMethod);
     }
 }

--- a/src/rules/noIrregularWhitespaceRule.ts
+++ b/src/rules/noIrregularWhitespaceRule.ts
@@ -42,7 +42,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 /* Inspired by: https://github.com/eslint/eslint/blob/master/lib/rules/no-irregular-whitespace.js */
 /* tslint:disable:max-line-length */
-export const IRREGULAR_WHITESPACE_REGEX = /[\u000b\u000c\u0085\ufeff\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u202f\u205f\u3000\u2028\u2029]+/mg;
+export const IRREGULAR_WHITESPACE_REGEX = /[\u000b\u000c\u0085\ufeff\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u202f\u205f\u3000\u2028\u2029]+/gm;
 /* tslint:enable:max-line-length */
 
 function walk(ctx: Lint.WalkContext<void>): void {

--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -61,7 +61,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ts.SyntaxKind.Parameter,
     ]);
 
-    public static DEFAULT_ALLOWED = [ -1, 0, 1 ];
+    public static DEFAULT_ALLOWED = [-1, 0, 1];
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(
@@ -77,7 +77,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoMagicNumbersWalker extends Lint.AbstractWalker<number[]> {
     public walk(sourceFile: ts.SourceFile) {
         const cb = (node: ts.Node): void => {
-            if (isCallExpression(node) && isIdentifier(node.expression) && node.expression.text === "parseInt") {
+            if (
+                isCallExpression(node) &&
+                isIdentifier(node.expression) &&
+                node.expression.text === "parseInt"
+            ) {
                 return node.arguments.length === 0 ? undefined : cb(node.arguments[0]);
             }
 
@@ -85,7 +89,10 @@ class NoMagicNumbersWalker extends Lint.AbstractWalker<number[]> {
                 return this.checkNumericLiteral(node, (node as ts.NumericLiteral).text);
             }
             if (isNegativeNumberLiteral(node)) {
-                return this.checkNumericLiteral(node, `-${(node.operand as ts.NumericLiteral).text}`);
+                return this.checkNumericLiteral(
+                    node,
+                    `-${(node.operand as ts.NumericLiteral).text}`,
+                );
             }
             return ts.forEachChild(node, cb);
         };
@@ -96,7 +103,7 @@ class NoMagicNumbersWalker extends Lint.AbstractWalker<number[]> {
         /* Using Object.is() to differentiate between pos/neg zero */
         if (
             !Rule.ALLOWED_NODES.has(node.parent!.kind) &&
-            !this.options.some((allowedNum) => Object.is(allowedNum, parseFloat(num)))
+            !this.options.some(allowedNum => Object.is(allowedNum, parseFloat(num)))
         ) {
             this.addFailureAtNode(node, Rule.FAILURE_STRING);
         }

--- a/src/rules/noMergeableNamespaceRule.ts
+++ b/src/rules/noMergeableNamespaceRule.ts
@@ -59,7 +59,10 @@ class Walker extends Lint.AbstractWalker<void> {
                 const { text } = name;
                 const prev = seen.get(text);
                 if (prev !== undefined) {
-                    this.addFailureAtNode(name, Rule.failureStringFactory(text, this.getLineOfNode(prev.name)));
+                    this.addFailureAtNode(
+                        name,
+                        Rule.failureStringFactory(text, this.getLineOfNode(prev.name)),
+                    );
                 }
                 seen.set(text, statement as ts.NamespaceDeclaration);
             }

--- a/src/rules/noMisusedNewRule.ts
+++ b/src/rules/noMisusedNewRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { getPropertyName, isConstructSignatureDeclaration, isMethodDeclaration, isMethodSignature, isTypeReferenceNode } from "tsutils";
+import {
+    getPropertyName,
+    isConstructSignatureDeclaration,
+    isMethodDeclaration,
+    isMethodSignature,
+    isTypeReferenceNode,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -24,7 +30,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-misused-new",
-        description: "Warns on apparent attempts to define constructors for interfaces or `new` for classes.",
+        description:
+            "Warns on apparent attempts to define constructors for interfaces or `new` for classes.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -38,8 +45,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_INTERFACE = "Interfaces cannot be constructed, only classes. Did you mean `declare class`?";
-    public static FAILURE_STRING_CLASS = '`new` in a class is a method named "new". Did you mean `constructor`?';
+    public static FAILURE_STRING_INTERFACE =
+        "Interfaces cannot be constructed, only classes. Did you mean `declare class`?";
+    public static FAILURE_STRING_CLASS =
+        '`new` in a class is a method named "new". Did you mean `constructor`?';
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -53,9 +62,11 @@ function walk(ctx: Lint.WalkContext<void>) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING_INTERFACE);
             }
         } else if (isMethodDeclaration(node)) {
-            if (node.body === undefined &&
+            if (
+                node.body === undefined &&
                 getPropertyName(node.name) === "new" &&
-                returnTypeMatchesParent(node.parent as ts.ClassLikeDeclaration, node)) {
+                returnTypeMatchesParent(node.parent as ts.ClassLikeDeclaration, node)
+            ) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING_CLASS);
             }
         } else if (isConstructSignatureDeclaration(node)) {
@@ -67,9 +78,15 @@ function walk(ctx: Lint.WalkContext<void>) {
     });
 }
 
-function returnTypeMatchesParent(parent: { name?: ts.Identifier }, decl: ts.SignatureDeclaration): boolean {
+function returnTypeMatchesParent(
+    parent: { name?: ts.Identifier },
+    decl: ts.SignatureDeclaration,
+): boolean {
     if (parent.name === undefined || decl.type === undefined || !isTypeReferenceNode(decl.type)) {
         return false;
     }
-    return decl.type.typeName.kind === ts.SyntaxKind.Identifier && decl.type.typeName.text === parent.name.text;
+    return (
+        decl.type.typeName.kind === ts.SyntaxKind.Identifier &&
+        decl.type.typeName.text === parent.name.text
+    );
 }

--- a/src/rules/noNamespaceRule.ts
+++ b/src/rules/noNamespaceRule.ts
@@ -30,7 +30,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-namespace",
-        description: "Disallows use of internal \`module\`s and \`namespace\`s.",
+        description: "Disallows use of internal `module`s and `namespace`s.",
         descriptionDetails: "This rule still allows the use of `declare module ... {}`",
         rationale: Lint.Utils.dedent`
             ES6-style external modules are the standard way to modularize code.
@@ -71,9 +71,12 @@ function walk(ctx: Lint.WalkContext<Options>) {
     }
     for (const node of ctx.sourceFile.statements) {
         if (node.kind === ts.SyntaxKind.ModuleDeclaration) {
-            if ((node as ts.ModuleDeclaration).name.kind !== ts.SyntaxKind.StringLiteral &&
+            if (
+                (node as ts.ModuleDeclaration).name.kind !== ts.SyntaxKind.StringLiteral &&
                 !isNodeFlagSet(node, ts.NodeFlags.GlobalAugmentation) &&
-                (!ctx.options.allowDeclarations || !hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword))) {
+                (!ctx.options.allowDeclarations ||
+                    !hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword))
+            ) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
         }

--- a/src/rules/noNullKeywordRule.ts
+++ b/src/rules/noNullKeywordRule.ts
@@ -82,7 +82,11 @@ function walk(ctx: Lint.WalkContext<void>) {
         if (eq === undefined) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         } else if (!eq.isStrict) {
-            ctx.addFailureAtNode(node, Rule.FAILURE_STRING, Lint.Replacement.replaceNode(node, "undefined", ctx.sourceFile));
+            ctx.addFailureAtNode(
+                node,
+                Rule.FAILURE_STRING,
+                Lint.Replacement.replaceNode(node, "undefined", ctx.sourceFile),
+            );
         }
     }
 }

--- a/src/rules/noObjectLiteralTypeAssertionRule.ts
+++ b/src/rules/noObjectLiteralTypeAssertionRule.ts
@@ -15,7 +15,11 @@
  * limitations under the License.
  */
 
-import { isAssertionExpression, isObjectLiteralExpression, isParenthesizedExpression } from "tsutils";
+import {
+    isAssertionExpression,
+    isObjectLiteralExpression,
+    isParenthesizedExpression,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -41,7 +45,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Type assertion on object literals is forbidden, use a type annotation instead.";
+    public static FAILURE_STRING =
+        "Type assertion on object literals is forbidden, use a type annotation instead.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -50,8 +55,15 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isAssertionExpression(node) && node.type.kind !== ts.SyntaxKind.AnyKeyword &&
-            isObjectLiteralExpression(isParenthesizedExpression(node.expression) ? node.expression.expression : node.expression)) {
+        if (
+            isAssertionExpression(node) &&
+            node.type.kind !== ts.SyntaxKind.AnyKeyword &&
+            isObjectLiteralExpression(
+                isParenthesizedExpression(node.expression)
+                    ? node.expression.expression
+                    : node.expression,
+            )
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/noParameterPropertiesRule.ts
+++ b/src/rules/noParameterPropertiesRule.ts
@@ -54,9 +54,11 @@ function walk(ctx: Lint.WalkContext<void>) {
         if (node.kind === ts.SyntaxKind.Constructor) {
             for (const parameter of (node as ts.ConstructorDeclaration).parameters) {
                 if (isParameterProperty(parameter)) {
-                    ctx.addFailure(parameter.getStart(ctx.sourceFile),
-                                   parameter.name.pos,
-                                   Rule.FAILURE_STRING_FACTORY(parameter.name.getText(ctx.sourceFile)));
+                    ctx.addFailure(
+                        parameter.getStart(ctx.sourceFile),
+                        parameter.name.pos,
+                        Rule.FAILURE_STRING_FACTORY(parameter.name.getText(ctx.sourceFile)),
+                    );
                 }
             }
         }

--- a/src/rules/noParameterReassignmentRule.ts
+++ b/src/rules/noParameterReassignmentRule.ts
@@ -15,7 +15,11 @@
  * limitations under the License.
  */
 
-import { collectVariableUsage, getDeclarationOfBindingElement, isReassignmentTarget } from "tsutils";
+import {
+    collectVariableUsage,
+    getDeclarationOfBindingElement,
+    isReassignmentTarget,
+} from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -59,7 +63,10 @@ function isParameter(node: ts.Node): boolean {
         case ts.SyntaxKind.Parameter:
             return true;
         case ts.SyntaxKind.BindingElement:
-            return getDeclarationOfBindingElement(node as ts.BindingElement).kind === ts.SyntaxKind.Parameter;
+            return (
+                getDeclarationOfBindingElement(node as ts.BindingElement).kind ===
+                ts.SyntaxKind.Parameter
+            );
         default:
             return false;
     }

--- a/src/rules/noRedundantJsdocRule.ts
+++ b/src/rules/noRedundantJsdocRule.ts
@@ -67,7 +67,10 @@ function walk(ctx: Lint.WalkContext<void>): void {
         switch (tag.kind) {
             case ts.SyntaxKind.JSDocTag:
                 if (redundantTags.has(tag.tagName.text)) {
-                    ctx.addFailureAtNode(tag.tagName, Rule.FAILURE_STRING_REDUNDANT_TAG(tag.tagName.text));
+                    ctx.addFailureAtNode(
+                        tag.tagName,
+                        Rule.FAILURE_STRING_REDUNDANT_TAG(tag.tagName.text),
+                    );
                 }
                 break;
 
@@ -80,12 +83,21 @@ function walk(ctx: Lint.WalkContext<void>): void {
             case ts.SyntaxKind.JSDocTypedefTag:
             case ts.SyntaxKind.JSDocPropertyTag:
                 // Always redundant
-                ctx.addFailureAtNode(tag.tagName, Rule.FAILURE_STRING_REDUNDANT_TAG(tag.tagName.text));
+                ctx.addFailureAtNode(
+                    tag.tagName,
+                    Rule.FAILURE_STRING_REDUNDANT_TAG(tag.tagName.text),
+                );
                 break;
 
             case ts.SyntaxKind.JSDocTemplateTag:
-                if ((tag as ts.JSDocTemplateTag).comment === undefined || (tag as ts.JSDocTemplateTag).comment === "") {
-                    ctx.addFailureAtNode(tag.tagName, Rule.FAILURE_STRING_NO_COMMENT(tag.tagName.text));
+                if (
+                    (tag as ts.JSDocTemplateTag).comment === undefined ||
+                    (tag as ts.JSDocTemplateTag).comment === ""
+                ) {
+                    ctx.addFailureAtNode(
+                        tag.tagName,
+                        Rule.FAILURE_STRING_NO_COMMENT(tag.tagName.text),
+                    );
                 }
                 break;
 
@@ -97,7 +109,10 @@ function walk(ctx: Lint.WalkContext<void>): void {
                 }
                 if (comment === undefined || comment === "") {
                     // Redundant if no documentation
-                    ctx.addFailureAtNode(tag.tagName, Rule.FAILURE_STRING_NO_COMMENT(tag.tagName.text));
+                    ctx.addFailureAtNode(
+                        tag.tagName,
+                        Rule.FAILURE_STRING_NO_COMMENT(tag.tagName.text),
+                    );
                 }
                 break;
             }

--- a/src/rules/noReferenceImportRule.ts
+++ b/src/rules/noReferenceImportRule.ts
@@ -45,7 +45,9 @@ function walk(ctx: Lint.WalkContext<void>) {
     if (ctx.sourceFile.typeReferenceDirectives.length === 0) {
         return;
     }
-    const imports = new Set(findImports(ctx.sourceFile, ImportKind.AllStaticImports).map((name) => name.text));
+    const imports = new Set(
+        findImports(ctx.sourceFile, ImportKind.AllStaticImports).map(name => name.text),
+    );
     for (const ref of ctx.sourceFile.typeReferenceDirectives) {
         if (imports.has(ref.fileName)) {
             ctx.addFailure(ref.pos, ref.end, Rule.FAILURE_STRING(ref.fileName));

--- a/src/rules/noReturnAwaitRule.ts
+++ b/src/rules/noReturnAwaitRule.ts
@@ -48,7 +48,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
         if (node.kind === ts.SyntaxKind.AwaitExpression && isUnnecessaryAwait(node)) {
-            const {expression} = node as ts.AwaitExpression;
+            const { expression } = node as ts.AwaitExpression;
             const keywordStart = expression.pos - "await".length;
             ctx.addFailure(
                 keywordStart,
@@ -103,7 +103,7 @@ function isInsideTryBlock(node: ts.Node): boolean {
                 // statements inside the try block always have an error handler, either catch or finally
                 node.parent.tryBlock === node ||
                 // statement inside the catch block only have an error handler if there is a finally block
-                node.parent.finallyBlock !== undefined && node.parent.catchClause === node
+                (node.parent.finallyBlock !== undefined && node.parent.catchClause === node)
             ) {
                 return true;
             }

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -16,8 +16,15 @@
  */
 
 import {
-    hasModifier, isBlockScopedVariableDeclarationList, isClassExpression, isFunctionExpression, isFunctionWithBody, isNodeFlagSet,
-    isScopeBoundary, isThisParameter, ScopeBoundary,
+    hasModifier,
+    isBlockScopedVariableDeclarationList,
+    isClassExpression,
+    isFunctionExpression,
+    isFunctionWithBody,
+    isNodeFlagSet,
+    isScopeBoundary,
+    isThisParameter,
+    ScopeBoundary,
 } from "tsutils";
 import * as ts from "typescript";
 
@@ -69,20 +76,31 @@ export class Rule extends Lint.Rules.AbstractRule {
         options: {
             type: "object",
             properties: {
-                class: {type: "boolean"},
-                enum: {type: "boolean"},
-                function: {type: "boolean"},
-                import: {type: "boolean"},
-                interface: {type: "boolean"},
-                namespace: {type: "boolean"},
-                typeAlias: {type: "boolean"},
-                typeParameter: {type: "boolean"},
-                temporalDeadZone: {type: "boolean"},
+                class: { type: "boolean" },
+                enum: { type: "boolean" },
+                function: { type: "boolean" },
+                import: { type: "boolean" },
+                interface: { type: "boolean" },
+                namespace: { type: "boolean" },
+                typeAlias: { type: "boolean" },
+                typeParameter: { type: "boolean" },
+                temporalDeadZone: { type: "boolean" },
             },
         },
         optionExamples: [
             true,
-            [true, {class: true, enum: true, function: true, interface: false, namespace: true, typeAlias: false, typeParameter: false}],
+            [
+                true,
+                {
+                    class: true,
+                    enum: true,
+                    function: true,
+                    interface: false,
+                    namespace: true,
+                    typeAlias: false,
+                    typeParameter: false,
+                },
+            ],
         ],
         type: "functionality",
         typescriptOnly: false,
@@ -95,12 +113,25 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(
-            new NoShadowedVariableWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments[0] as Partial<Options> | undefined)),
+            new NoShadowedVariableWalker(
+                sourceFile,
+                this.ruleName,
+                parseOptions(this.ruleArguments[0] as Partial<Options> | undefined),
+            ),
         );
     }
 }
 
-type Kind = "class" | "import" | "interface" | "function" | "enum" | "namespace" | "typeParameter" | "typeAlias" | "temporalDeadZone";
+type Kind =
+    | "class"
+    | "import"
+    | "interface"
+    | "function"
+    | "enum"
+    | "namespace"
+    | "typeParameter"
+    | "typeAlias"
+    | "temporalDeadZone";
 type Options = Record<Kind, boolean>;
 
 function parseOptions(option: Partial<Options> | undefined): Options {
@@ -159,8 +190,11 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
 
         const cb = (node: ts.Node): void => {
             const parentScope = this.scope;
-            if ((this.options.function && isFunctionExpression(node) || this.options.class && isClassExpression(node)) &&
-                node.name !== undefined) {
+            if (
+                ((this.options.function && isFunctionExpression(node)) ||
+                    (this.options.class && isClassExpression(node))) &&
+                node.name !== undefined
+            ) {
                 /* special handling for named function and class expressions:
                    technically the name of the function is only visible inside of it,
                    but variables with the same name declared inside don't cause compiler errors.
@@ -209,7 +243,10 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
                     }
                     break;
                 case ts.SyntaxKind.FunctionDeclaration:
-                    if (this.options.function && (node as ts.FunctionDeclaration).name !== undefined) {
+                    if (
+                        this.options.function &&
+                        (node as ts.FunctionDeclaration).name !== undefined
+                    ) {
                         parentScope.addVariable((node as ts.FunctionDeclaration).name!, false);
                     }
                     break;
@@ -217,9 +254,13 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
                     if (this.options.class && (node as ts.ClassDeclaration).name !== undefined) {
                         parentScope.addVariable((node as ts.ClassDeclaration).name!, true, true);
                     }
-                    // falls through
+                // falls through
                 case ts.SyntaxKind.ClassExpression:
-                    this.visitClassLikeDeclaration(node as ts.ClassLikeDeclaration, parentScope, cb);
+                    this.visitClassLikeDeclaration(
+                        node as ts.ClassLikeDeclaration,
+                        parentScope,
+                        cb,
+                    );
                     this.onScopeEnd(parentScope);
                     this.scope = parentScope;
                     return;
@@ -239,14 +280,17 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
                     }
                     break;
                 case ts.SyntaxKind.Parameter:
-                    if (node.parent!.kind !== ts.SyntaxKind.IndexSignature &&
+                    if (
+                        node.parent!.kind !== ts.SyntaxKind.IndexSignature &&
                         !isThisParameter(node as ts.ParameterDeclaration) &&
-                        isFunctionWithBody(node.parent!)) {
+                        isFunctionWithBody(node.parent!)
+                    ) {
                         this.handleBindingName((node as ts.ParameterDeclaration).name, false, true);
                     }
                     break;
                 case ts.SyntaxKind.ModuleDeclaration:
-                    if (this.options.namespace &&
+                    if (
+                        this.options.namespace &&
                         node.parent!.kind !== ts.SyntaxKind.ModuleDeclaration &&
                         (node as ts.ModuleDeclaration).name.kind === ts.SyntaxKind.Identifier &&
                         !isNodeFlagSet(node, ts.NodeFlags.GlobalAugmentation)
@@ -268,7 +312,13 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
                 case ts.SyntaxKind.ImportSpecifier:
                 case ts.SyntaxKind.ImportEqualsDeclaration:
                     if (this.options.import) {
-                        this.scope.addVariable((node as ts.NamespaceImport | ts.ImportSpecifier | ts.ImportEqualsDeclaration).name, false);
+                        this.scope.addVariable(
+                            (node as
+                                | ts.NamespaceImport
+                                | ts.ImportSpecifier
+                                | ts.ImportEqualsDeclaration).name,
+                            false,
+                        );
                     }
             }
             if (boundary !== ScopeBoundary.None) {
@@ -284,9 +334,13 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
         this.onScopeEnd();
     }
 
-    private visitClassLikeDeclaration(declaration: ts.ClassLikeDeclaration, parentScope: Scope, cb: (node: ts.Node) => void) {
+    private visitClassLikeDeclaration(
+        declaration: ts.ClassLikeDeclaration,
+        parentScope: Scope,
+        cb: (node: ts.Node) => void,
+    ) {
         const currentScope = this.scope;
-        ts.forEachChild(declaration, (node) => {
+        ts.forEachChild(declaration, node => {
             if (!hasModifier(node.modifiers, ts.SyntaxKind.StaticKeyword)) {
                 return cb(node);
             }
@@ -321,14 +375,18 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
     }
 
     private onScopeEnd(parent?: Scope) {
-        const {variables, variablesSeen} = this.scope;
+        const { variables, variablesSeen } = this.scope;
         variablesSeen.forEach((identifiers, name) => {
             const declarationsInScope = variables.get(name);
             for (const identifier of identifiers) {
-                if (declarationsInScope !== undefined &&
+                if (
+                    declarationsInScope !== undefined &&
                     (this.options.temporalDeadZone ||
-                     // check if any of the declaration either has no temporal dead zone or is declared before the identifier
-                     declarationsInScope.some((declaration) => !declaration.tdz || declaration.identifier.pos < identifier.pos))
+                        // check if any of the declaration either has no temporal dead zone or is declared before the identifier
+                        declarationsInScope.some(
+                            declaration =>
+                                !declaration.tdz || declaration.identifier.pos < identifier.pos,
+                        ))
                 ) {
                     this.addFailureAtNode(identifier, Rule.FAILURE_STRING_FACTORY(name));
                 } else if (parent !== undefined) {

--- a/src/rules/noSparseArraysRule.ts
+++ b/src/rules/noSparseArraysRule.ts
@@ -46,7 +46,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<void>): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (!utils.isArrayLiteralExpression(node)) {
-            if (utils.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+            if (
+                utils.isBinaryExpression(node) &&
+                node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+            ) {
                 // Ignore LHS of assignments.
                 traverseExpressionsInLHS(node.left, cb);
                 return cb(node.right);

--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -55,18 +55,27 @@ function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (isElementAccessExpression(node)) {
             const argument = node.argumentExpression;
-            if (argument !== undefined && isStringLiteral(argument) && isValidPropertyAccess(argument.text)) {
+            if (
+                argument !== undefined &&
+                isStringLiteral(argument) &&
+                isValidPropertyAccess(argument.text)
+            ) {
                 // typescript@<2.5.0 has an extra underscore in escaped identifier text content,
                 // to avoid fixing issue `expr['__foo'] → expr.___foo`, unescapeIdentifier() is to be used
                 // As of typescript@3, unescapeIdentifier() removed, thus check in runtime, if the method exists
                 // tslint:disable-next-line no-unsafe-any strict-boolean-expressions
-                const unescapeIdentifier: typeof Rule["id"] = (ts as any).unescapeIdentifier || Rule.id;
+                const unescapeIdentifier: typeof Rule["id"] =
+                    (ts as any).unescapeIdentifier || Rule.id;
                 const propertyName = unescapeIdentifier(argument.text);
                 ctx.addFailureAtNode(
                     argument,
                     Rule.FAILURE_STRING,
                     // expr['foo'] -> expr.foo
-                    Lint.Replacement.replaceFromTo(node.expression.end, node.end, `.${propertyName}`),
+                    Lint.Replacement.replaceFromTo(
+                        node.expression.end,
+                        node.end,
+                        `.${propertyName}`,
+                    ),
                 );
             }
         }

--- a/src/rules/noStringLiteralRule.ts
+++ b/src/rules/noStringLiteralRule.ts
@@ -60,11 +60,11 @@ function walk(ctx: Lint.WalkContext<void>) {
                 isStringLiteral(argument) &&
                 isValidPropertyAccess(argument.text)
             ) {
-                // typescript@<2.5.0 has an extra underscore in escaped identifier text content,
-                // to avoid fixing issue `expr['__foo'] → expr.___foo`, unescapeIdentifier() is to be used
-                // As of typescript@3, unescapeIdentifier() removed, thus check in runtime, if the method exists
-                // tslint:disable-next-line no-unsafe-any strict-boolean-expressions
                 const unescapeIdentifier: typeof Rule["id"] =
+                    // typescript@<2.5.0 has an extra underscore in escaped identifier text content,
+                    // to avoid fixing issue `expr['__foo'] → expr.___foo`, unescapeIdentifier() is to be used
+                    // As of typescript@3, unescapeIdentifier() removed, thus check in runtime, if the method exists
+                    // tslint:disable-next-line no-unsafe-any strict-boolean-expressions
                     (ts as any).unescapeIdentifier || Rule.id;
                 const propertyName = unescapeIdentifier(argument.text);
                 ctx.addFailureAtNode(

--- a/src/rules/noStringThrowRule.ts
+++ b/src/rules/noStringThrowRule.ts
@@ -59,7 +59,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING =
-            "Throwing plain strings (not instances of Error) gives no stack traces";
+        "Throwing plain strings (not instances of Error) gives no stack traces";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -90,7 +90,10 @@ function isString(node: ts.Node): boolean {
             return true;
         case ts.SyntaxKind.BinaryExpression: {
             const { operatorToken, left, right } = node as ts.BinaryExpression;
-            return operatorToken.kind === ts.SyntaxKind.PlusToken && (isString(left) || isString(right));
+            return (
+                operatorToken.kind === ts.SyntaxKind.PlusToken &&
+                (isString(left) || isString(right))
+            );
         }
         case ts.SyntaxKind.ParenthesizedExpression:
             return isString((node as ts.ParenthesizedExpression).expression);

--- a/src/rules/noSubmoduleImportsRule.ts
+++ b/src/rules/noSubmoduleImportsRule.ts
@@ -36,12 +36,16 @@ export class Rule extends Lint.Rules.AbstractRule {
                 type: "string",
             },
         },
-        optionExamples: [true, [true, "rxjs", "@angular/platform-browser", "@angular/core/testing"]],
+        optionExamples: [
+            true,
+            [true, "rxjs", "@angular/platform-browser", "@angular/core/testing"],
+        ],
         type: "functionality",
         typescriptOnly: false,
     };
 
-    public static FAILURE_STRING = "Submodule import paths from this package are disallowed; import from the root instead";
+    public static FAILURE_STRING =
+        "Submodule import paths from this package are disallowed; import from the root instead";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, this.ruleArguments);
@@ -50,9 +54,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<string[]>) {
     for (const name of findImports(ctx.sourceFile, ImportKind.All)) {
-        if (!ts.isExternalModuleNameRelative(name.text) &&
+        if (
+            !ts.isExternalModuleNameRelative(name.text) &&
             isSubmodulePath(name.text) &&
-            !isWhitelisted(name.text, ctx.options)) {
+            !isWhitelisted(name.text, ctx.options)
+        ) {
             ctx.addFailureAtNode(name, Rule.FAILURE_STRING);
         }
     }

--- a/src/rules/noSwitchCaseFallThroughRule.ts
+++ b/src/rules/noSwitchCaseFallThroughRule.ts
@@ -64,7 +64,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoSwitchCaseFallThroughWalker(sourceFile, this.ruleName, undefined));
+        return this.applyWithWalker(
+            new NoSwitchCaseFallThroughWalker(sourceFile, this.ruleName, undefined),
+        );
     }
 }
 
@@ -81,10 +83,12 @@ export class NoSwitchCaseFallThroughWalker extends Lint.AbstractWalker<void> {
 
     private visitSwitchStatement({ caseBlock: { clauses } }: ts.SwitchStatement): void {
         clauses.forEach((clause, i) => {
-            if (i !== clauses.length - 1
-                    && clause.statements.length !== 0
-                    && !utils.endsControlFlow(clause)
-                    && !this.isFallThroughAllowed(clause)) {
+            if (
+                i !== clauses.length - 1 &&
+                clause.statements.length !== 0 &&
+                !utils.endsControlFlow(clause) &&
+                !this.isFallThroughAllowed(clause)
+            ) {
                 const keyword = clauses[i + 1].getChildAt(0);
                 this.addFailureAtNode(keyword, Rule.FAILURE_STRING(keyword.kind));
             }
@@ -93,7 +97,13 @@ export class NoSwitchCaseFallThroughWalker extends Lint.AbstractWalker<void> {
 
     private isFallThroughAllowed(clause: ts.CaseOrDefaultClause): boolean {
         const comments = ts.getLeadingCommentRanges(this.sourceFile.text, clause.end);
-        return comments !== undefined &&
-            comments.some((comment) => /^\s*falls through\b/i.test(this.sourceFile.text.slice(comment.pos + 2, comment.end)));
+        return (
+            comments !== undefined &&
+            comments.some(comment =>
+                /^\s*falls through\b/i.test(
+                    this.sourceFile.text.slice(comment.pos + 2, comment.end),
+                ),
+            )
+        );
     }
 }

--- a/src/rules/noThisAssignmentRule.ts
+++ b/src/rules/noThisAssignmentRule.ts
@@ -114,7 +114,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options = parseConfigOptions((this.ruleArguments as [ConfigOptions])[0]);
-        const noThisAssignmentWalker = new NoThisAssignmentWalker(sourceFile, this.ruleName, options);
+        const noThisAssignmentWalker = new NoThisAssignmentWalker(
+            sourceFile,
+            this.ruleName,
+            options,
+        );
 
         return this.applyWithWalker(noThisAssignmentWalker);
     }
@@ -122,7 +126,8 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 class NoThisAssignmentWalker extends Lint.AbstractWalker<Options> {
     private readonly allowedThisNameTesters = this.options.allowedNames.map(
-        (allowedThisName) => new RegExp(allowedThisName));
+        allowedThisName => new RegExp(allowedThisName),
+    );
 
     public walk(sourceFile: ts.SourceFile): void {
         ts.forEachChild(sourceFile, this.visitNode);
@@ -134,7 +139,7 @@ class NoThisAssignmentWalker extends Lint.AbstractWalker<Options> {
         }
 
         ts.forEachChild(node, this.visitNode);
-    }
+    };
 
     private visitVariableDeclaration(node: ts.VariableDeclaration): void {
         if (node.initializer === undefined || node.initializer.kind !== ts.SyntaxKind.ThisKeyword) {
@@ -144,7 +149,10 @@ class NoThisAssignmentWalker extends Lint.AbstractWalker<Options> {
         switch (node.name.kind) {
             case ts.SyntaxKind.Identifier:
                 if (this.variableNameIsBanned(node.name.text)) {
-                    this.addFailureAtNode(node, Rule.FAILURE_STRING_FACTORY_IDENTIFIERS(node.name.text));
+                    this.addFailureAtNode(
+                        node,
+                        Rule.FAILURE_STRING_FACTORY_IDENTIFIERS(node.name.text),
+                    );
                 }
                 break;
 

--- a/src/rules/noTrailingWhitespaceRule.ts
+++ b/src/rules/noTrailingWhitespaceRule.ts
@@ -38,7 +38,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-trailing-whitespace",
         description: "Disallows trailing whitespace at the end of a line.",
-        rationale: "Keeps version control diffs clean as it prevents accidental whitespace from being committed.",
+        rationale:
+            "Keeps version control diffs clean as it prevents accidental whitespace from being committed.",
         optionsDescription: Lint.Utils.dedent`
             Possible settings are:
 
@@ -51,14 +52,15 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "array",
             items: {
                 type: "string",
-                enum: [OPTION_IGNORE_COMMENTS, OPTION_IGNORE_JSDOC, OPTION_IGNORE_TEMPLATE_STRINGS, OPTION_IGNORE_BLANK_LINES],
+                enum: [
+                    OPTION_IGNORE_COMMENTS,
+                    OPTION_IGNORE_JSDOC,
+                    OPTION_IGNORE_TEMPLATE_STRINGS,
+                    OPTION_IGNORE_BLANK_LINES,
+                ],
             },
         },
-        optionExamples: [
-            true,
-            [true, OPTION_IGNORE_COMMENTS],
-            [true, OPTION_IGNORE_JSDOC],
-        ],
+        optionExamples: [true, [true, OPTION_IGNORE_COMMENTS], [true, OPTION_IGNORE_JSDOC]],
         type: "style",
         typescriptOnly: false,
     };
@@ -96,12 +98,22 @@ function walk(ctx: Lint.WalkContext<Options>) {
         return;
     }
     const excludedRanges = ctx.options.ignoreTemplates
-        ? ctx.options.ignoreJsDoc ? getExcludedRanges(sourceFile, ctx.options) : getTemplateRanges(sourceFile)
-        : ctx.options.ignoreJsDoc ? getExcludedComments(sourceFile, ctx.options) : [];
+        ? ctx.options.ignoreJsDoc
+            ? getExcludedRanges(sourceFile, ctx.options)
+            : getTemplateRanges(sourceFile)
+        : ctx.options.ignoreJsDoc
+            ? getExcludedComments(sourceFile, ctx.options)
+            : [];
     for (const possibleFailure of possibleFailures) {
-        if (!excludedRanges.some((range) => range.pos < possibleFailure.pos && possibleFailure.pos < range.end)) {
+        if (
+            !excludedRanges.some(
+                range => range.pos < possibleFailure.pos && possibleFailure.pos < range.end,
+            )
+        ) {
             ctx.addFailure(
-                possibleFailure.pos, possibleFailure.end, Rule.FAILURE_STRING,
+                possibleFailure.pos,
+                possibleFailure.end,
+                Rule.FAILURE_STRING,
                 Lint.Replacement.deleteFromTo(possibleFailure.pos, possibleFailure.end),
             );
         }
@@ -114,7 +126,10 @@ function getExcludedRanges(sourceFile: ts.SourceFile, options: Options): ts.Text
         if (kind >= ts.SyntaxKind.FirstTemplateToken && kind <= ts.SyntaxKind.LastTemplateToken) {
             intervals.push(range);
         } else if (options.ignoreComments) {
-            if (kind === ts.SyntaxKind.SingleLineCommentTrivia || kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+            if (
+                kind === ts.SyntaxKind.SingleLineCommentTrivia ||
+                kind === ts.SyntaxKind.MultiLineCommentTrivia
+            ) {
                 intervals.push(range);
             }
         } else if (options.ignoreJsDoc) {
@@ -129,8 +144,10 @@ function getExcludedRanges(sourceFile: ts.SourceFile, options: Options): ts.Text
 function getExcludedComments(sourceFile: ts.SourceFile, options: Options): ts.TextRange[] {
     const intervals: ts.TextRange[] = [];
     forEachComment(sourceFile, (text, comment) => {
-        if (options.ignoreComments ||
-            options.ignoreJsDoc && isJsDoc(text, comment.kind, comment)) {
+        if (
+            options.ignoreComments ||
+            (options.ignoreJsDoc && isJsDoc(text, comment.kind, comment))
+        ) {
             intervals.push(comment);
         }
     });
@@ -138,5 +155,9 @@ function getExcludedComments(sourceFile: ts.SourceFile, options: Options): ts.Te
 }
 
 function isJsDoc(sourceText: string, kind: ts.SyntaxKind, range: ts.TextRange) {
-    return kind === ts.SyntaxKind.MultiLineCommentTrivia && sourceText[range.pos + 2] === "*" && sourceText[range.pos + 3] !== "*";
+    return (
+        kind === ts.SyntaxKind.MultiLineCommentTrivia &&
+        sourceText[range.pos + 2] === "*" &&
+        sourceText[range.pos + 3] !== "*"
+    );
 }

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -80,7 +80,8 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Avoid referencing unbound methods which may cause unintentional scoping of 'this'.";
+    public static FAILURE_STRING =
+        "Avoid referencing unbound methods which may cause unintentional scoping of 'this'.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         return this.applyWithFunction(

--- a/src/rules/noUnnecessaryCallbackWrapperRule.ts
+++ b/src/rules/noUnnecessaryCallbackWrapperRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { hasModifier, isArrowFunction, isCallExpression, isIdentifier, isSpreadElement } from "tsutils";
+import {
+    hasModifier,
+    isArrowFunction,
+    isCallExpression,
+    isIdentifier,
+    isSpreadElement,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -53,9 +59,13 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, cb);
     function cb(node: ts.Node): void {
-        if (isArrowFunction(node) && !hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword) &&
-            isCallExpression(node.body) && isIdentifier(node.body.expression) &&
-            isRedundantCallback(node.parameters, node.body.arguments, node.body.expression)) {
+        if (
+            isArrowFunction(node) &&
+            !hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword) &&
+            isCallExpression(node.body) &&
+            isIdentifier(node.body.expression) &&
+            isRedundantCallback(node.parameters, node.body.arguments, node.body.expression)
+        ) {
             const start = node.getStart(ctx.sourceFile);
             ctx.addFailure(start, node.end, Rule.FAILURE_STRING(node.body.expression.text), [
                 Lint.Replacement.deleteFromTo(start, node.body.getStart(ctx.sourceFile)),
@@ -65,19 +75,18 @@ function walk(ctx: Lint.WalkContext<void>) {
             return ts.forEachChild(node, cb);
         }
     }
-
 }
 
 function isRedundantCallback(
-        parameters: ts.NodeArray<ts.ParameterDeclaration>,
-        args: ts.NodeArray<ts.Node>,
-        expression: ts.Identifier,
-        ): boolean {
+    parameters: ts.NodeArray<ts.ParameterDeclaration>,
+    args: ts.NodeArray<ts.Node>,
+    expression: ts.Identifier,
+): boolean {
     if (parameters.length !== args.length) {
         return false;
     }
     for (let i = 0; i < parameters.length; ++i) {
-        const {dotDotDotToken, name} = parameters[i];
+        const { dotDotDotToken, name } = parameters[i];
         let arg = args[i];
         if (dotDotDotToken !== undefined) {
             if (!isSpreadElement(arg)) {
@@ -85,9 +94,13 @@ function isRedundantCallback(
             }
             arg = arg.expression;
         }
-        if (!isIdentifier(name) || !isIdentifier(arg) || name.text !== arg.text
-                // If the invoked expression is one of the parameters, bail.
-                || expression.text === name.text) {
+        if (
+            !isIdentifier(name) ||
+            !isIdentifier(arg) ||
+            name.text !== arg.text ||
+            // If the invoked expression is one of the parameters, bail.
+            expression.text === name.text
+        ) {
             return false;
         }
     }

--- a/src/rules/noUnnecessaryClassRule.ts
+++ b/src/rules/noUnnecessaryClassRule.ts
@@ -74,13 +74,19 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_CONSTRUCTOR_ONLY = "Every member of this class is a constructor. Use functions instead.";
-    public static FAILURE_STATIC_ONLY = "Every member of this class is static. Use namespaces or plain objects instead.";
+    public static FAILURE_CONSTRUCTOR_ONLY =
+        "Every member of this class is a constructor. Use functions instead.";
+    public static FAILURE_STATIC_ONLY =
+        "Every member of this class is static. Use namespaces or plain objects instead.";
     public static FAILURE_EMPTY_CLASS = "This class has no members.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(
-            new NoUnnecessaryClassWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)),
+            new NoUnnecessaryClassWalker(
+                sourceFile,
+                this.ruleName,
+                parseOptions(this.ruleArguments),
+            ),
         );
     }
 }
@@ -99,7 +105,10 @@ class NoUnnecessaryClassWalker extends Lint.AbstractWalker<Options> {
     private checkMembers(node: ts.ClassDeclaration) {
         if (node.members.length === 0) {
             if (!this.options.allowEmptyClass) {
-                this.addFailureAtNode(getChildOfKind(node, ts.SyntaxKind.ClassKeyword)!, Rule.FAILURE_EMPTY_CLASS);
+                this.addFailureAtNode(
+                    getChildOfKind(node, ts.SyntaxKind.ClassKeyword)!,
+                    Rule.FAILURE_EMPTY_CLASS,
+                );
             }
             return;
         }
@@ -132,7 +141,8 @@ class NoUnnecessaryClassWalker extends Lint.AbstractWalker<Options> {
 function isNonStaticMember(member: ts.ClassElement): boolean {
     return (
         isConstructorWithShorthandProps(member) ||
-        (!isConstructorDeclaration(member) && !hasModifier(member.modifiers, ts.SyntaxKind.StaticKeyword))
+        (!isConstructorDeclaration(member) &&
+            !hasModifier(member.modifiers, ts.SyntaxKind.StaticKeyword))
     );
 }
 

--- a/src/rules/noUnnecessaryInitializerRule.ts
+++ b/src/rules/noUnnecessaryInitializerRule.ts
@@ -24,7 +24,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-unnecessary-initializer",
-        description: "Forbids a 'var'/'let' statement or destructuring initializer to be initialized to 'undefined'.",
+        description:
+            "Forbids a 'var'/'let' statement or destructuring initializer to be initialized to 'undefined'.",
         hasFix: true,
         optionsDescription: "Not configurable.",
         options: null,
@@ -56,7 +57,10 @@ function walk(ctx: Lint.WalkContext<void>): void {
                 break;
 
             case ts.SyntaxKind.VariableDeclaration:
-                if (!isBindingPattern((node as ts.VariableDeclaration).name) && !isNodeFlagSet(node.parent!, ts.NodeFlags.Const)) {
+                if (
+                    !isBindingPattern((node as ts.VariableDeclaration).name) &&
+                    !isNodeFlagSet(node.parent!, ts.NodeFlags.Const)
+                ) {
                     checkInitializer(node as ts.VariableDeclaration);
                 }
                 break;
@@ -86,15 +90,21 @@ function walk(ctx: Lint.WalkContext<void>): void {
         }
     }
 
-    function failWithFix(node: ts.VariableDeclaration | ts.BindingElement | ts.ParameterDeclaration) {
+    function failWithFix(
+        node: ts.VariableDeclaration | ts.BindingElement | ts.ParameterDeclaration,
+    ) {
         const fix = Lint.Replacement.deleteFromTo(
             getChildOfKind(node, ts.SyntaxKind.EqualsToken)!.pos,
-            node.end);
+            node.end,
+        );
         ctx.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
     }
 }
 
-function parametersAllOptionalAfter(parameters: ReadonlyArray<ts.ParameterDeclaration>, idx: number): boolean {
+function parametersAllOptionalAfter(
+    parameters: ReadonlyArray<ts.ParameterDeclaration>,
+    idx: number,
+): boolean {
     for (let i = idx + 1; i < parameters.length; i++) {
         if (parameters[i].questionToken !== undefined) {
             return true;
@@ -107,7 +117,9 @@ function parametersAllOptionalAfter(parameters: ReadonlyArray<ts.ParameterDeclar
 }
 
 function isUndefined(node: ts.Node | undefined): boolean {
-    return node !== undefined &&
+    return (
+        node !== undefined &&
         node.kind === ts.SyntaxKind.Identifier &&
-        (node as ts.Identifier).originalKeywordKind === ts.SyntaxKind.UndefinedKeyword;
+        (node as ts.Identifier).originalKeywordKind === ts.SyntaxKind.UndefinedKeyword
+    );
 }

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -68,14 +68,18 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
                     visitNamespaceAccess(node, expression, name);
                     break;
                 }
-                // falls through
+            // falls through
 
             default:
                 ts.forEachChild(node, cb);
         }
     }
 
-    function visitNamespaceAccess(node: ts.Node, qualifier: ts.EntityNameOrEntityNameExpression, name: ts.Identifier): void {
+    function visitNamespaceAccess(
+        node: ts.Node,
+        qualifier: ts.EntityNameOrEntityNameExpression,
+        name: ts.Identifier,
+    ): void {
         if (qualifierIsUnnecessary(qualifier, name)) {
             const fix = Lint.Replacement.deleteFromTo(qualifier.getStart(), name.getStart());
             ctx.addFailureAtNode(qualifier, Rule.FAILURE_STRING(qualifier.getText()), fix);
@@ -85,7 +89,10 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
         }
     }
 
-    function qualifierIsUnnecessary(qualifier: ts.EntityNameOrEntityNameExpression, name: ts.Identifier): boolean {
+    function qualifierIsUnnecessary(
+        qualifier: ts.EntityNameOrEntityNameExpression,
+        name: ts.Identifier,
+    ): boolean {
         const namespaceSymbol = checker.getSymbolAtLocation(qualifier);
         if (namespaceSymbol === undefined || !symbolIsNamespaceInScope(namespaceSymbol)) {
             return false;
@@ -101,17 +108,21 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
         return fromScope === undefined || symbolsAreEqual(accessedSymbol, fromScope);
     }
 
-    function getSymbolInScope(node: ts.Node, flags: ts.SymbolFlags, name: string): ts.Symbol | undefined {
+    function getSymbolInScope(
+        node: ts.Node,
+        flags: ts.SymbolFlags,
+        name: string,
+    ): ts.Symbol | undefined {
         // TODO:PERF `getSymbolsInScope` gets a long list. Is there a better way?
         const scope = checker.getSymbolsInScope(node, flags);
-        return scope.find((scopeSymbol) => scopeSymbol.name === name);
+        return scope.find(scopeSymbol => scopeSymbol.name === name);
     }
 
     function symbolIsNamespaceInScope(symbol: ts.Symbol): boolean {
         const symbolDeclarations = symbol.getDeclarations();
         if (symbolDeclarations === undefined) {
             return false;
-        } else if (symbolDeclarations.some((decl) => namespacesInScope.some((ns) => ns === decl))) {
+        } else if (symbolDeclarations.some(decl => namespacesInScope.some(ns => ns === decl))) {
             return true;
         }
 
@@ -124,12 +135,20 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
             inScope = checker.getExportSymbolOfSymbol(inScope);
             return accessed === inScope;
         }
-        return accessed === inScope ||
+        return (
+            accessed === inScope ||
             // For compatibility with typescript@2.5: compare declarations because the symbols don't have the same reference
-            Lint.Utils.arraysAreEqual(accessed.declarations, inScope.declarations, (a, b) => a === b);
+            Lint.Utils.arraysAreEqual(
+                accessed.declarations,
+                inScope.declarations,
+                (a, b) => a === b,
+            )
+        );
     }
 }
 
 function tryGetAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol | undefined {
-    return utils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias) ? checker.getAliasedSymbol(symbol) : undefined;
+    return utils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)
+        ? checker.getAliasedSymbol(symbol)
+        : undefined;
 }

--- a/src/rules/noUnnecessaryTypeAssertionRule.ts
+++ b/src/rules/noUnnecessaryTypeAssertionRule.ts
@@ -28,7 +28,7 @@ export class Rule extends Lint.Rules.TypedRule {
             type: "list",
             listType: {
                 type: "array",
-                items: {type: "string"},
+                items: { type: "string" },
             },
         },
         optionsDescription: "A list of whitelisted assertion types to ignore",
@@ -39,15 +39,23 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "This assertion is unnecessary since it does not change the type of the expression.";
+    public static FAILURE_STRING =
+        "This assertion is unnecessary since it does not change the type of the expression.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithWalker(new Walker(sourceFile, this.ruleName, this.ruleArguments, program.getTypeChecker()));
+        return this.applyWithWalker(
+            new Walker(sourceFile, this.ruleName, this.ruleArguments, program.getTypeChecker()),
+        );
     }
 }
 
 class Walker extends Lint.AbstractWalker<string[]> {
-    constructor(sourceFile: ts.SourceFile, ruleName: string, options: string[], private readonly checker: ts.TypeChecker) {
+    constructor(
+        sourceFile: ts.SourceFile,
+        ruleName: string,
+        options: string[],
+        private readonly checker: ts.TypeChecker,
+    ) {
         super(sourceFile, ruleName, options);
     }
 
@@ -71,7 +79,11 @@ class Walker extends Lint.AbstractWalker<string[]> {
     private checkNonNullAssertion(node: ts.NonNullExpression) {
         const type = this.checker.getTypeAtLocation(node.expression);
         if (type === this.checker.getNonNullableType(type)) {
-            this.addFailureAtNode(node, Rule.FAILURE_STRING, Lint.Replacement.deleteFromTo(node.expression.end, node.end));
+            this.addFailureAtNode(
+                node,
+                Rule.FAILURE_STRING,
+                Lint.Replacement.deleteFromTo(node.expression.end, node.end),
+            );
         }
     }
 
@@ -81,9 +93,11 @@ class Walker extends Lint.AbstractWalker<string[]> {
         }
         const castType = this.checker.getTypeAtLocation(node);
 
-        if (isTypeFlagSet(castType, ts.TypeFlags.Literal) ||
-            isObjectType(castType) && (isObjectFlagSet(castType, ts.ObjectFlags.Tuple) || couldBeTupleType(castType))) {
-
+        if (
+            isTypeFlagSet(castType, ts.TypeFlags.Literal) ||
+            (isObjectType(castType) &&
+                (isObjectFlagSet(castType, ts.ObjectFlags.Tuple) || couldBeTupleType(castType)))
+        ) {
             // It's not always safe to remove a cast to a literal type or tuple
             // type, as those types are sometimes widened without the cast.
             return;
@@ -91,9 +105,13 @@ class Walker extends Lint.AbstractWalker<string[]> {
 
         const uncastType = this.checker.getTypeAtLocation(node.expression);
         if (uncastType === castType) {
-            this.addFailureAtNode(node, Rule.FAILURE_STRING, node.kind === ts.SyntaxKind.TypeAssertionExpression
-                ? Lint.Replacement.deleteFromTo(node.getStart(), node.expression.getStart())
-                : Lint.Replacement.deleteFromTo(node.expression.end, node.end));
+            this.addFailureAtNode(
+                node,
+                Rule.FAILURE_STRING,
+                node.kind === ts.SyntaxKind.TypeAssertionExpression
+                    ? Lint.Replacement.deleteFromTo(node.getStart(), node.expression.getStart())
+                    : Lint.Replacement.deleteFromTo(node.expression.end, node.end),
+            );
         }
     }
 }

--- a/src/rules/noUnsafeAnyRule.ts
+++ b/src/rules/noUnsafeAnyRule.ts
@@ -15,7 +15,14 @@
  * limitations under the License.
  */
 
-import { isIdentifier, isReassignmentTarget, isSymbolFlagSet, isTokenKind, isTypeFlagSet, isTypeNodeKind } from "tsutils";
+import {
+    isIdentifier,
+    isReassignmentTarget,
+    isSymbolFlagSet,
+    isTokenKind,
+    isTypeFlagSet,
+    isTypeNodeKind,
+} from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 import { isLowerCase } from "../utils";
@@ -50,12 +57,18 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING = "Unsafe use of expression of type 'any'.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoUnsafeAnyWalker(sourceFile, this.ruleName, program.getTypeChecker()));
+        return this.applyWithWalker(
+            new NoUnsafeAnyWalker(sourceFile, this.ruleName, program.getTypeChecker()),
+        );
     }
 }
 
 class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
-    constructor(sourceFile: ts.SourceFile, ruleName: string, private readonly checker: ts.TypeChecker) {
+    constructor(
+        sourceFile: ts.SourceFile,
+        ruleName: string,
+        private readonly checker: ts.TypeChecker,
+    ) {
         super(sourceFile, ruleName, undefined);
     }
 
@@ -104,12 +117,17 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
             case ts.SyntaxKind.TypeOfExpression:
             case ts.SyntaxKind.VoidExpression:
                 return this.visitNode(
-                    (node as ts.ExpressionStatement | ts.AssertionExpression | ts.TemplateSpan | ts.ThrowStatement | ts.TypeOfExpression |
-                             ts.VoidExpression).expression,
+                    (node as
+                        | ts.ExpressionStatement
+                        | ts.AssertionExpression
+                        | ts.TemplateSpan
+                        | ts.ThrowStatement
+                        | ts.TypeOfExpression
+                        | ts.VoidExpression).expression,
                     true,
                 );
             case ts.SyntaxKind.PropertyAssignment: {
-                const {name, initializer} = (node as ts.PropertyAssignment);
+                const { name, initializer } = node as ts.PropertyAssignment;
                 this.visitNode(name, /*anyOk*/ true);
                 if (isReassignmentTarget(node.parent as ts.ObjectLiteralExpression)) {
                     return this.visitNode(initializer, true);
@@ -117,7 +135,10 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
                 return this.checkContextualType(initializer, true);
             }
             case ts.SyntaxKind.ShorthandPropertyAssignment: {
-                const { name, objectAssignmentInitializer} = node as ts.ShorthandPropertyAssignment;
+                const {
+                    name,
+                    objectAssignmentInitializer,
+                } = node as ts.ShorthandPropertyAssignment;
                 if (objectAssignmentInitializer !== undefined) {
                     return this.checkContextualType(objectAssignmentInitializer);
                 }
@@ -126,8 +147,13 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
             case ts.SyntaxKind.PropertyDeclaration: {
                 const { name, initializer } = node as ts.PropertyDeclaration;
                 this.visitNode(name, true);
-                return initializer !== undefined &&
-                    this.visitNode(initializer, isPropertyAny(node as ts.PropertyDeclaration, this.checker));
+                return (
+                    initializer !== undefined &&
+                    this.visitNode(
+                        initializer,
+                        isPropertyAny(node as ts.PropertyDeclaration, this.checker),
+                    )
+                );
             }
             case ts.SyntaxKind.SpreadAssignment:
                 return this.visitNode(
@@ -152,7 +178,9 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
             }
             case ts.SyntaxKind.CallExpression:
             case ts.SyntaxKind.NewExpression: {
-                const { expression, arguments: args } = node as ts.CallExpression | ts.NewExpression;
+                const { expression, arguments: args } = node as
+                    | ts.CallExpression
+                    | ts.NewExpression;
                 if (args !== undefined) {
                     for (const arg of args) {
                         this.checkContextualType(arg);
@@ -182,10 +210,13 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
             }
             case ts.SyntaxKind.ReturnStatement: {
                 const { expression } = node as ts.ReturnStatement;
-                return expression !== undefined  && this.checkContextualType(expression, true);
+                return expression !== undefined && this.checkContextualType(expression, true);
             }
             case ts.SyntaxKind.SwitchStatement: {
-                const { expression, caseBlock: { clauses } } = node as ts.SwitchStatement;
+                const {
+                    expression,
+                    caseBlock: { clauses },
+                } = node as ts.SwitchStatement;
                 // Allow `switch (x) {}` where `x` is any
                 this.visitNode(expression, /*anyOk*/ true);
                 for (const clause of clauses) {
@@ -211,15 +242,21 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
                 return elseStatement !== undefined && this.visitNode(elseStatement);
             }
             case ts.SyntaxKind.PrefixUnaryExpression: {
-                const {operator, operand} = node as ts.PrefixUnaryExpression;
+                const { operator, operand } = node as ts.PrefixUnaryExpression;
                 this.visitNode(operand, operator === ts.SyntaxKind.ExclamationToken); // allow falsyness check
                 return false;
             }
             case ts.SyntaxKind.ForStatement: {
                 const { initializer, condition, incrementor, statement } = node as ts.ForStatement;
-                if (initializer !== undefined) { this.visitNode(initializer, true); }
-                if (condition !== undefined) { this.visitNode(condition, true); } // allow truthyness check
-                if (incrementor !== undefined) { this.visitNode(incrementor, true); }
+                if (initializer !== undefined) {
+                    this.visitNode(initializer, true);
+                }
+                if (condition !== undefined) {
+                    this.visitNode(condition, true);
+                } // allow truthyness check
+                if (incrementor !== undefined) {
+                    this.visitNode(incrementor, true);
+                }
                 return this.visitNode(statement);
             }
             case ts.SyntaxKind.DoStatement:
@@ -234,7 +271,9 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
             }
             case ts.SyntaxKind.VariableDeclaration:
             case ts.SyntaxKind.Parameter:
-                return this.checkVariableOrParameterDeclaration(node as ts.VariableDeclaration | ts.ParameterDeclaration);
+                return this.checkVariableOrParameterDeclaration(node as
+                    | ts.VariableDeclaration
+                    | ts.ParameterDeclaration);
             case ts.SyntaxKind.BinaryExpression:
                 return this.checkBinaryExpression(node as ts.BinaryExpression, anyOk);
             case ts.SyntaxKind.AwaitExpression:
@@ -253,8 +292,10 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
                 return false;
             }
             case ts.SyntaxKind.JsxExpression:
-                return (node as ts.JsxExpression).expression !== undefined &&
-                    this.checkContextualType((node as ts.JsxExpression).expression!);
+                return (
+                    (node as ts.JsxExpression).expression !== undefined &&
+                    this.checkContextualType((node as ts.JsxExpression).expression!)
+                );
         }
         if (isTypeNodeKind(node.kind) || isTokenKind(node.kind)) {
             return false;
@@ -272,20 +313,27 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
 
     private checkContextualType(node: ts.Expression, allowIfNoContextualType?: boolean) {
         const type = this.checker.getContextualType(node);
-        return this.visitNode(node, type === undefined && allowIfNoContextualType || isAny(type));
+        return this.visitNode(node, (type === undefined && allowIfNoContextualType) || isAny(type));
     }
 
     // Allow `const x = foo;` and `const x: any = foo`, but not `const x: Foo = foo;`.
-    private checkVariableOrParameterDeclaration({ name, type, initializer }: ts.VariableDeclaration | ts.ParameterDeclaration) {
+    private checkVariableOrParameterDeclaration({
+        name,
+        type,
+        initializer,
+    }: ts.VariableDeclaration | ts.ParameterDeclaration) {
         this.checkBindingName(name);
         // Always allow the LHS to be `any`. Just don't allow RHS to be `any` when LHS isn't.
-        return initializer !== undefined &&
+        return (
+            initializer !== undefined &&
             this.visitNode(
                 initializer,
                 /*anyOk*/
-                name.kind === ts.SyntaxKind.Identifier && (type === undefined || type.kind === ts.SyntaxKind.AnyKeyword) ||
-                type !== undefined && type.kind === ts.SyntaxKind.AnyKeyword,
-            );
+                (name.kind === ts.SyntaxKind.Identifier &&
+                    (type === undefined || type.kind === ts.SyntaxKind.AnyKeyword)) ||
+                    (type !== undefined && type.kind === ts.SyntaxKind.AnyKeyword),
+            )
+        );
     }
 
     private checkBinaryExpression(node: ts.BinaryExpression, anyOk: boolean | undefined) {
@@ -311,8 +359,10 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
                 break;
             case ts.SyntaxKind.PlusToken: // Allow implicit stringification
             case ts.SyntaxKind.PlusEqualsToken:
-                allowAnyLeft = allowAnyRight = isStringLike(node.left, this.checker)
-                    || (isStringLike(node.right, this.checker) && node.operatorToken.kind === ts.SyntaxKind.PlusToken);
+                allowAnyLeft = allowAnyRight =
+                    isStringLike(node.left, this.checker) ||
+                    (isStringLike(node.right, this.checker) &&
+                        node.operatorToken.kind === ts.SyntaxKind.PlusToken);
         }
         this.visitNode(node.left, allowAnyLeft);
         this.visitNode(node.right, allowAnyRight);
@@ -347,7 +397,10 @@ class NoUnsafeAnyWalker extends Lint.AbstractWalker<void> {
             }
             for (const element of node.elements) {
                 if (element.kind !== ts.SyntaxKind.OmittedExpression) {
-                    if (element.propertyName !== undefined && element.propertyName.kind === ts.SyntaxKind.ComputedPropertyName) {
+                    if (
+                        element.propertyName !== undefined &&
+                        element.propertyName.kind === ts.SyntaxKind.ComputedPropertyName
+                    ) {
                         this.visitNode(element.propertyName.expression);
                     }
                     this.checkBindingName(element.name);
@@ -365,7 +418,9 @@ function isPropertyAny(node: ts.PropertyDeclaration, checker: ts.TypeChecker) {
     if (!isNodeAny(node.name, checker) || node.name.kind === ts.SyntaxKind.ComputedPropertyName) {
         return false;
     }
-    for (const base of checker.getBaseTypes(checker.getTypeAtLocation(node.parent) as ts.InterfaceType)) {
+    for (const base of checker.getBaseTypes(checker.getTypeAtLocation(
+        node.parent,
+    ) as ts.InterfaceType)) {
         const prop = base.getProperty(node.name.text);
         if (prop !== undefined && prop.declarations !== undefined) {
             return isAny(checker.getTypeOfSymbolAtLocation(prop, prop.declarations[0]));

--- a/src/rules/noUnsafeFinallyRule.ts
+++ b/src/rules/noUnsafeFinallyRule.ts
@@ -50,7 +50,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
-type JumpStatement = ts.BreakStatement | ts.ContinueStatement | ts.ThrowStatement | ts.ReturnStatement;
+type JumpStatement =
+    | ts.BreakStatement
+    | ts.ContinueStatement
+    | ts.ThrowStatement
+    | ts.ReturnStatement;
 
 function walk(ctx: Lint.WalkContext<void>): void {
     let inFinally = false;
@@ -75,9 +79,12 @@ function walk(ctx: Lint.WalkContext<void>): void {
             case ts.SyntaxKind.ThrowStatement:
             case ts.SyntaxKind.ReturnStatement:
                 if (inFinally && !jumpIsLocalToFinallyBlock(node as JumpStatement)) {
-                    ctx.addFailureAtNode(node, Rule.FAILURE_STRING(printJumpKind(node as JumpStatement)));
+                    ctx.addFailureAtNode(
+                        node,
+                        Rule.FAILURE_STRING(printJumpKind(node as JumpStatement)),
+                    );
                 }
-                // falls through
+            // falls through
 
             default:
                 return ts.forEachChild(node, cb);

--- a/src/rules/noUnusedExpressionRule.ts
+++ b/src/rules/noUnusedExpressionRule.ts
@@ -16,8 +16,14 @@
  */
 
 import {
-    isAssignmentKind, isBinaryExpression, isConditionalExpression, isExpressionStatement,
-    isIdentifier, isNumericLiteral, isParenthesizedExpression, isVoidExpression,
+    isAssignmentKind,
+    isBinaryExpression,
+    isConditionalExpression,
+    isExpressionStatement,
+    isIdentifier,
+    isNumericLiteral,
+    isParenthesizedExpression,
+    isVoidExpression,
 } from "tsutils";
 import * as ts from "typescript";
 
@@ -115,11 +121,21 @@ function walk(ctx: Lint.WalkContext<Options>) {
             return false;
         } else if (isVoidExpression(node)) {
             // allow `void 0` and `void(0)`
-            if (!isLiteralZero(isParenthesizedExpression(node.expression) ? node.expression.expression : node.expression)) {
+            if (
+                !isLiteralZero(
+                    isParenthesizedExpression(node.expression)
+                        ? node.expression.expression
+                        : node.expression,
+                )
+            ) {
                 check(node.expression);
             }
             return false;
-        } else if (isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.CommaToken && !isIndirectEval(node)) {
+        } else if (
+            isBinaryExpression(node) &&
+            node.operatorToken.kind === ts.SyntaxKind.CommaToken &&
+            !isIndirectEval(node)
+        ) {
             check(node.left);
             return cb(node.right);
         }
@@ -176,8 +192,10 @@ function isUnusedExpression(node: ts.Node, options: Options): boolean {
         case ts.SyntaxKind.BinaryExpression:
             return !isAssignmentKind((node as ts.BinaryExpression).operatorToken.kind);
         case ts.SyntaxKind.PrefixUnaryExpression:
-            return (node as ts.PrefixUnaryExpression).operator !== ts.SyntaxKind.PlusPlusToken &&
-                   (node as ts.PrefixUnaryExpression).operator !== ts.SyntaxKind.MinusMinusToken;
+            return (
+                (node as ts.PrefixUnaryExpression).operator !== ts.SyntaxKind.PlusPlusToken &&
+                (node as ts.PrefixUnaryExpression).operator !== ts.SyntaxKind.MinusMinusToken
+            );
         default:
             return true;
     }
@@ -188,14 +206,20 @@ function isLiteralZero(node: ts.Expression) {
 }
 
 function isIndirectEval(node: ts.BinaryExpression): boolean {
-    return isIdentifier(node.right) && node.right.text === "eval" &&
+    return (
+        isIdentifier(node.right) &&
+        node.right.text === "eval" &&
         isLiteralZero(node.left) &&
         node.parent!.kind === ts.SyntaxKind.ParenthesizedExpression &&
-        node.parent!.parent!.kind === ts.SyntaxKind.CallExpression;
+        node.parent!.parent!.kind === ts.SyntaxKind.CallExpression
+    );
 }
 
 function isDirective(node: ts.ExpressionStatement) {
-    if (node.expression.kind !== ts.SyntaxKind.StringLiteral || !canContainDirective(node.parent!)) {
+    if (
+        node.expression.kind !== ts.SyntaxKind.StringLiteral ||
+        !canContainDirective(node.parent!)
+    ) {
         return false;
     }
 
@@ -203,7 +227,10 @@ function isDirective(node: ts.ExpressionStatement) {
     // check if all previous statements in block are also directives
     for (let i = parent.statements.indexOf(node) - 1; i >= 0; --i) {
         const statement = parent.statements[i];
-        if (!isExpressionStatement(statement) || statement.expression.kind !== ts.SyntaxKind.StringLiteral) {
+        if (
+            !isExpressionStatement(statement) ||
+            statement.expression.kind !== ts.SyntaxKind.StringLiteral
+        ) {
             return false;
         }
     }

--- a/src/rules/noUnusedVariableRule.ts
+++ b/src/rules/noUnusedVariableRule.ts
@@ -56,7 +56,7 @@ export class Rule extends Lint.Rules.TypedRule {
                     {
                         type: "object",
                         properties: {
-                            "ignore-pattern": {type: "string"},
+                            "ignore-pattern": { type: "string" },
                         },
                         additionalProperties: false,
                     },
@@ -65,7 +65,7 @@ export class Rule extends Lint.Rules.TypedRule {
             minLength: 0,
             maxLength: 3,
         },
-        optionExamples: [true, [true, {"ignore-pattern": "^_"}]],
+        optionExamples: [true, [true, { "ignore-pattern": "^_" }]],
         rationale: Lint.Utils.dedent`
             Variables that are declared and not used anywhere in code are likely an error due to incomplete refactoring.
             Such variables take up space in the code, are mild performance pains, and can lead to confusion by readers.
@@ -107,7 +107,10 @@ function parseOptions(options: any[]): Options {
 }
 
 function walk(ctx: Lint.WalkContext<Options>, program: ts.Program): void {
-    const { sourceFile, options: { checkParameters, ignorePattern } } = ctx;
+    const {
+        sourceFile,
+        options: { checkParameters, ignorePattern },
+    } = ctx;
     const unusedCheckedProgram = getUnusedCheckedProgram(program, checkParameters);
     const diagnostics = ts.getPreEmitDiagnostics(unusedCheckedProgram, sourceFile);
     const checker = unusedCheckedProgram.getTypeChecker(); // Doesn't matter which program is used for this.
@@ -117,14 +120,22 @@ function walk(ctx: Lint.WalkContext<Options>, program: ts.Program): void {
     const importSpecifierFailures = new Map<ts.Identifier, string>();
 
     for (const diag of diagnostics) {
-        if (diag.start === undefined) { continue; }
+        if (diag.start === undefined) {
+            continue;
+        }
         const kind = getUnusedDiagnostic(diag);
-        if (kind === undefined) { continue; }
+        if (kind === undefined) {
+            continue;
+        }
 
         const failure = ts.flattenDiagnosticMessageText(diag.messageText, "\n");
 
         // BUG: this means imports / destructures with all (2+) unused variables don't respect ignore pattern
-        if (ignorePattern !== undefined && kind !== UnusedKind.DECLARATION && kind !== UnusedKind.ALL_DESTRUCTURES) {
+        if (
+            ignorePattern !== undefined &&
+            kind !== UnusedKind.DECLARATION &&
+            kind !== UnusedKind.ALL_DESTRUCTURES
+        ) {
             const varName = /'(.*)'/.exec(failure)![1];
             if (ignorePattern.test(varName)) {
                 continue;
@@ -161,8 +172,12 @@ function walk(ctx: Lint.WalkContext<Options>, program: ts.Program): void {
  * - If all of the import specifiers in an import are unused, add a combined failure for them all.
  * - Unused imports are fixable.
  */
-function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Map<ts.Identifier, string>, sourceFile: ts.SourceFile) {
-    forEachImport(sourceFile, (importNode) => {
+function addImportSpecifierFailures(
+    ctx: Lint.WalkContext<Options>,
+    failures: Map<ts.Identifier, string>,
+    sourceFile: ts.SourceFile,
+) {
+    forEachImport(sourceFile, importNode => {
         if (importNode.kind === ts.SyntaxKind.ImportEqualsDeclaration) {
             tryRemoveAll(importNode.name);
             return;
@@ -179,15 +194,21 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Ma
             return;
         }
 
-        const allNamedBindingsAreFailures = namedBindings === undefined || namedBindings.elements.every((e) => failures.has(e.name));
+        const allNamedBindingsAreFailures =
+            namedBindings === undefined || namedBindings.elements.every(e => failures.has(e.name));
         if (namedBindings !== undefined && allNamedBindingsAreFailures) {
             for (const e of namedBindings.elements) {
                 failures.delete(e.name);
             }
         }
 
-        if ((defaultName === undefined || failures.has(defaultName)) && allNamedBindingsAreFailures) {
-            if (defaultName !== undefined) { failures.delete(defaultName); }
+        if (
+            (defaultName === undefined || failures.has(defaultName)) &&
+            allNamedBindingsAreFailures
+        ) {
+            if (defaultName !== undefined) {
+                failures.delete(defaultName);
+            }
             removeAll(importNode, "All imports on this line are unused.");
             return;
         }
@@ -196,7 +217,10 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Ma
             const failure = tryDelete(defaultName);
             if (failure !== undefined) {
                 const start = defaultName.getStart();
-                const end = namedBindings !== undefined ? namedBindings.getStart() : importNode.moduleSpecifier.getStart();
+                const end =
+                    namedBindings !== undefined
+                        ? namedBindings.getStart()
+                        : importNode.moduleSpecifier.getStart();
                 const fix = Lint.Replacement.deleteFromTo(start, end);
                 ctx.addFailureAtNode(defaultName, failure, fix);
             }
@@ -204,7 +228,8 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Ma
 
         if (namedBindings !== undefined) {
             if (allNamedBindingsAreFailures) {
-                const start = defaultName !== undefined ? defaultName.getEnd() : namedBindings.getStart();
+                const start =
+                    defaultName !== undefined ? defaultName.getEnd() : namedBindings.getStart();
                 const fix = Lint.Replacement.deleteFromTo(start, namedBindings.getEnd());
                 const failure = "All named bindings are unused.";
                 ctx.addFailureAtNode(namedBindings, failure, fix);
@@ -219,8 +244,12 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Ma
 
                     const prevElement = elements[i - 1];
                     const nextElement = elements[i + 1];
-                    const start = prevElement !== undefined ? prevElement.getEnd() : element.getStart();
-                    const end = nextElement !== undefined && prevElement == undefined ? nextElement.getStart() : element.getEnd();
+                    const start =
+                        prevElement !== undefined ? prevElement.getEnd() : element.getStart();
+                    const end =
+                        nextElement !== undefined && prevElement == undefined
+                            ? nextElement.getStart()
+                            : element.getEnd();
                     const fix = Lint.Replacement.deleteFromTo(start, end);
                     ctx.addFailureAtNode(element.name, failure, fix);
                 }
@@ -239,13 +268,17 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Ma
             let end = importNode.getEnd();
             utils.forEachToken(
                 importNode,
-                (token) => {
+                token => {
                     ts.forEachTrailingCommentRange(
-                        ctx.sourceFile.text, token.end, (_, commentEnd, __) => {
+                        ctx.sourceFile.text,
+                        token.end,
+                        (_, commentEnd, __) => {
                             end = commentEnd;
-                        });
+                        },
+                    );
                 },
-                ctx.sourceFile);
+                ctx.sourceFile,
+            );
             if (isEntireLine(start, end)) {
                 end = getNextLineStart(end);
             }
@@ -255,8 +288,10 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Ma
         }
 
         function isEntireLine(start: number, end: number): boolean {
-            return ctx.sourceFile.getLineAndCharacterOfPosition(start).character === 0 &&
-                ctx.sourceFile.getLineEndOfPosition(end) === end;
+            return (
+                ctx.sourceFile.getLineAndCharacterOfPosition(start).character === 0 &&
+                ctx.sourceFile.getLineEndOfPosition(end) === end
+            );
         }
 
         function getNextLineStart(position: number): number {
@@ -288,7 +323,11 @@ function addImportSpecifierFailures(ctx: Lint.WalkContext<Options>, failures: Ma
  * Ignore this import if it's used as an implicit type somewhere.
  * Workround for https://github.com/Microsoft/TypeScript/issues/9944
  */
-function isImportUsed(importSpecifier: ts.Identifier, sourceFile: ts.SourceFile, checker: ts.TypeChecker): boolean {
+function isImportUsed(
+    importSpecifier: ts.Identifier,
+    sourceFile: ts.SourceFile,
+    checker: ts.TypeChecker,
+): boolean {
     const importedSymbol = checker.getSymbolAtLocation(importSpecifier);
     if (importedSymbol === undefined) {
         return false;
@@ -299,25 +338,33 @@ function isImportUsed(importSpecifier: ts.Identifier, sourceFile: ts.SourceFile,
         return false;
     }
 
-    return ts.forEachChild(sourceFile, function cb(child): boolean | undefined {
-        if (isImportLike(child)) {
-            return false;
-        }
+    return (
+        ts.forEachChild(sourceFile, function cb(child): boolean | undefined {
+            if (isImportLike(child)) {
+                return false;
+            }
 
-        const type = getImplicitType(child, checker);
-        // TODO: checker.typeEquals https://github.com/Microsoft/TypeScript/issues/13502
-        if (type !== undefined && checker.typeToString(type) === checker.symbolToString(symbol)) {
-            return true;
-        }
+            const type = getImplicitType(child, checker);
+            // TODO: checker.typeEquals https://github.com/Microsoft/TypeScript/issues/13502
+            if (
+                type !== undefined &&
+                checker.typeToString(type) === checker.symbolToString(symbol)
+            ) {
+                return true;
+            }
 
-        return ts.forEachChild(child, cb);
-    }) === true;
+            return ts.forEachChild(child, cb);
+        }) === true
+    );
 }
 
 function getImplicitType(node: ts.Node, checker: ts.TypeChecker): ts.Type | undefined {
-    if ((utils.isPropertyDeclaration(node) || utils.isVariableDeclaration(node)) &&
-        node.type === undefined && node.name.kind === ts.SyntaxKind.Identifier ||
-        utils.isBindingElement(node) && node.name.kind === ts.SyntaxKind.Identifier) {
+    if (
+        ((utils.isPropertyDeclaration(node) || utils.isVariableDeclaration(node)) &&
+            node.type === undefined &&
+            node.name.kind === ts.SyntaxKind.Identifier) ||
+        (utils.isBindingElement(node) && node.name.kind === ts.SyntaxKind.Identifier)
+    ) {
         return checker.getTypeAtLocation(node);
     } else if (utils.isSignatureDeclaration(node) && node.type === undefined) {
         const sig = checker.getSignatureFromDeclaration(node);
@@ -329,11 +376,17 @@ function getImplicitType(node: ts.Node, checker: ts.TypeChecker): ts.Type | unde
 
 type ImportLike = ts.ImportDeclaration | ts.ImportEqualsDeclaration;
 function isImportLike(node: ts.Node): node is ImportLike {
-    return node.kind === ts.SyntaxKind.ImportDeclaration || node.kind === ts.SyntaxKind.ImportEqualsDeclaration;
+    return (
+        node.kind === ts.SyntaxKind.ImportDeclaration ||
+        node.kind === ts.SyntaxKind.ImportEqualsDeclaration
+    );
 }
 
-function forEachImport<T>(sourceFile: ts.SourceFile, f: (i: ImportLike) => T | undefined): T | undefined {
-    return ts.forEachChild(sourceFile, (child) => {
+function forEachImport<T>(
+    sourceFile: ts.SourceFile,
+    f: (i: ImportLike) => T | undefined,
+): T | undefined {
+    return ts.forEachChild(sourceFile, child => {
         if (isImportLike(child)) {
             const res = f(child);
             if (res !== undefined) {
@@ -344,8 +397,12 @@ function forEachImport<T>(sourceFile: ts.SourceFile, f: (i: ImportLike) => T | u
     });
 }
 
-function findImports(pos: number, sourceFile: ts.SourceFile, kind: UnusedKind): ReadonlyArray<ts.Identifier> {
-    const imports = forEachImport(sourceFile, (i) => {
+function findImports(
+    pos: number,
+    sourceFile: ts.SourceFile,
+    kind: UnusedKind,
+): ReadonlyArray<ts.Identifier> {
+    const imports = forEachImport(sourceFile, i => {
         if (!isInRange(i, pos)) {
             return undefined;
         }
@@ -359,7 +416,10 @@ function findImports(pos: number, sourceFile: ts.SourceFile, kind: UnusedKind): 
             }
 
             const { name: defaultName, namedBindings } = i.importClause;
-            if (namedBindings !== undefined && namedBindings.kind === ts.SyntaxKind.NamespaceImport) {
+            if (
+                namedBindings !== undefined &&
+                namedBindings.kind === ts.SyntaxKind.NamespaceImport
+            ) {
                 return [namedBindings.name];
             }
 
@@ -384,12 +444,13 @@ function findImports(pos: number, sourceFile: ts.SourceFile, kind: UnusedKind): 
                     imp.push(defaultName);
                 }
                 if (namedBindings !== undefined) {
-                    imp.push(...namedBindings.elements.map((el) => el.name));
+                    imp.push(...namedBindings.elements.map(el => el.name));
                 }
                 return imp.length > 0 ? imp : undefined;
-            } else if (defaultName !== undefined && (
-                isInRange(defaultName, pos) || namedBindings === undefined // defaultName is the only option
-            )) {
+            } else if (
+                defaultName !== undefined &&
+                (isInRange(defaultName, pos) || namedBindings === undefined) // defaultName is the only option
+            ) {
                 return [defaultName];
             } else if (namedBindings !== undefined) {
                 if (namedBindings.elements.length === 1) {
@@ -418,11 +479,11 @@ const enum UnusedKind {
     DECLARATION, // Introduced in TS 2.8
     ALL_DESTRUCTURES, // introduced in TS 2.9
 }
-function getUnusedDiagnostic(diag: ts.Diagnostic): UnusedKind | undefined  {
+function getUnusedDiagnostic(diag: ts.Diagnostic): UnusedKind | undefined {
     // https://github.com/Microsoft/TypeScript/blob/master/src/compiler/diagnosticMessages.json
     switch (diag.code) {
         case 6133: // Pre TS 2.9 "'{0}' is declared but never used.
-                   // TS 2.9+ "'{0}' is declared but its value is never read."
+        // TS 2.9+ "'{0}' is declared but its value is never read."
         case 6196: // TS 2.9+ "'{0}' is declared but never used."
             return UnusedKind.VARIABLE_OR_PARAMETER;
         case 6138:
@@ -459,13 +520,16 @@ function makeUnusedCheckedProgram(program: ts.Program, checkParameters: boolean)
         noUnusedParameters: originalOptions.noUnusedParameters || checkParameters,
     };
     const sourceFilesByName = new Map<string, ts.SourceFile>(
-        program.getSourceFiles().map<[string, ts.SourceFile]>((s) => [getCanonicalFileName(s.fileName), s]));
+        program
+            .getSourceFiles()
+            .map<[string, ts.SourceFile]>(s => [getCanonicalFileName(s.fileName), s]),
+    );
 
     // tslint:disable object-literal-sort-keys
     return ts.createProgram(Array.from(sourceFilesByName.keys()), options, {
-        fileExists: (f) => sourceFilesByName.has(getCanonicalFileName(f)),
-        readFile: (f) => sourceFilesByName.get(getCanonicalFileName(f))!.text,
-        getSourceFile: (f) => sourceFilesByName.get(getCanonicalFileName(f))!,
+        fileExists: f => sourceFilesByName.has(getCanonicalFileName(f)),
+        readFile: f => sourceFilesByName.get(getCanonicalFileName(f))!.text,
+        getSourceFile: f => sourceFilesByName.get(getCanonicalFileName(f))!,
         getDefaultLibFileName: () => ts.getDefaultLibFileName(options),
         writeFile: () => undefined,
         getCurrentDirectory: () => "",

--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -70,7 +70,8 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
             case ts.SyntaxKind.ExportSpecifier:
                 return checkIdentifier(
                     (node as ts.ExportSpecifier).name,
-                    checker.getExportSpecifierLocalTargetSymbol(node as ts.ExportSpecifier));
+                    checker.getExportSpecifierLocalTargetSymbol(node as ts.ExportSpecifier),
+                );
             default:
                 return ts.forEachChild(node, recur);
         }
@@ -82,7 +83,7 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
             return;
         }
 
-        const declaredBefore = declarations.some((decl) => {
+        const declaredBefore = declarations.some(decl => {
             switch (decl.kind) {
                 case ts.SyntaxKind.FunctionDeclaration:
                     // Functions may be declared later.
@@ -104,6 +105,10 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
      * var { x: y } = { x: 43 };
      */
     function isPropNameInBinding(node: ts.Node): boolean {
-        return node.parent !== undefined && isBindingElement(node.parent) && node.parent.propertyName === node;
+        return (
+            node.parent !== undefined &&
+            isBindingElement(node.parent) &&
+            node.parent.propertyName === node
+        );
     }
 }

--- a/src/rules/noVarKeywordRule.ts
+++ b/src/rules/noVarKeywordRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { hasModifier, isBlockScopedVariableDeclarationList, isNodeFlagSet, isVariableDeclarationList, isVariableStatement } from "tsutils";
+import {
+    hasModifier,
+    isBlockScopedVariableDeclarationList,
+    isNodeFlagSet,
+    isVariableDeclarationList,
+    isVariableStatement,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -54,14 +60,18 @@ function walk(ctx: Lint.WalkContext<void>): void {
     const { sourceFile } = ctx;
     return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
         const parent = node.parent!;
-        if (isVariableDeclarationList(node)
-                && !isBlockScopedVariableDeclarationList(node)
-                // If !isVariableStatement, this is inside of a for loop.
-                && (!isVariableStatement(parent) || !isGlobalVarDeclaration(parent))) {
+        if (
+            isVariableDeclarationList(node) &&
+            !isBlockScopedVariableDeclarationList(node) &&
+            // If !isVariableStatement, this is inside of a for loop.
+            (!isVariableStatement(parent) || !isGlobalVarDeclaration(parent))
+        ) {
             const start = node.getStart(sourceFile);
             const width = "var".length;
             // Don't apply fix in a declaration file, because may have meant 'const'.
-            const fix = sourceFile.isDeclarationFile ? undefined : new Lint.Replacement(start, width, "let");
+            const fix = sourceFile.isDeclarationFile
+                ? undefined
+                : new Lint.Replacement(start, width, "let");
             ctx.addFailureAt(start, width, Rule.FAILURE_STRING, fix);
         }
 
@@ -72,6 +82,9 @@ function walk(ctx: Lint.WalkContext<void>): void {
 // Allow `declare var x: number;` or `declare global { var x: number; }`
 function isGlobalVarDeclaration(node: ts.VariableStatement): boolean {
     const parent = node.parent!;
-    return hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
-        || parent.kind === ts.SyntaxKind.ModuleBlock && isNodeFlagSet(parent.parent!, ts.NodeFlags.GlobalAugmentation);
+    return (
+        hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword) ||
+        (parent.kind === ts.SyntaxKind.ModuleBlock &&
+            isNodeFlagSet(parent.parent!, ts.NodeFlags.GlobalAugmentation))
+    );
 }

--- a/src/rules/noVoidExpressionRule.ts
+++ b/src/rules/noVoidExpressionRule.ts
@@ -58,11 +58,18 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Expression has type `void`. Put it on its own line as a statement.";
+    public static FAILURE_STRING =
+        "Expression has type `void`. Put it on its own line as a statement.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        const ignoreArrowFunctionShorthand = this.ruleArguments.indexOf(OPTION_IGNORE_ARROW_FUNCTION_SHORTHAND) !== -1;
-        return this.applyWithFunction(sourceFile, walk, { ignoreArrowFunctionShorthand }, program.getTypeChecker());
+        const ignoreArrowFunctionShorthand =
+            this.ruleArguments.indexOf(OPTION_IGNORE_ARROW_FUNCTION_SHORTHAND) !== -1;
+        return this.applyWithFunction(
+            sourceFile,
+            walk,
+            { ignoreArrowFunctionShorthand },
+            program.getTypeChecker(),
+        );
     }
 }
 
@@ -71,11 +78,16 @@ interface Options {
 }
 
 function walk(ctx: Lint.WalkContext<Options>, checker: ts.TypeChecker): void {
-    const { sourceFile, options: { ignoreArrowFunctionShorthand } } = ctx;
+    const {
+        sourceFile,
+        options: { ignoreArrowFunctionShorthand },
+    } = ctx;
     return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
-        if (isPossiblyVoidExpression(node)
-                && !isParentAllowedVoid(node)
-                && isTypeFlagSet(checker.getTypeAtLocation(node), ts.TypeFlags.Void)) {
+        if (
+            isPossiblyVoidExpression(node) &&
+            !isParentAllowedVoid(node) &&
+            isTypeFlagSet(checker.getTypeAtLocation(node), ts.TypeFlags.Void)
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/numberLiteralFormatRule.ts
+++ b/src/rules/numberLiteralFormatRule.ts
@@ -25,7 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "number-literal-format",
-        description: "Checks that decimal literals should begin with '0.' instead of just '.', and should not end with a trailing '0'.",
+        description:
+            "Checks that decimal literals should begin with '0.' instead of just '.', and should not end with a trailing '0'.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -41,7 +42,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_LEADING_0 = "Number literal should not have a leading '0'.";
     public static FAILURE_STRING_TRAILING_0 = "Number literal should not have a trailing '0'.";
     public static FAILURE_STRING_TRAILING_DECIMAL = "Number literal should not end in '.'.";
-    public static FAILURE_STRING_LEADING_DECIMAL = "Number literal should begin with '0.' and not just '.'.";
+    public static FAILURE_STRING_LEADING_DECIMAL =
+        "Number literal should begin with '0.' and not just '.'.";
     public static FAILURE_STRING_NOT_UPPERCASE = "Hexadecimal number literal should be uppercase.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {

--- a/src/rules/objectLiteralKeyQuotesRule.ts
+++ b/src/rules/objectLiteralKeyQuotesRule.ts
@@ -23,7 +23,11 @@ const OPTION_ALWAYS = "always";
 const OPTION_AS_NEEDED = "as-needed";
 const OPTION_CONSISTENT = "consistent";
 const OPTION_CONSISTENT_AS_NEEDED = "consistent-as-needed";
-type Option = typeof OPTION_ALWAYS | typeof OPTION_AS_NEEDED | typeof OPTION_CONSISTENT | typeof OPTION_CONSISTENT_AS_NEEDED;
+type Option =
+    | typeof OPTION_ALWAYS
+    | typeof OPTION_AS_NEEDED
+    | typeof OPTION_CONSISTENT
+    | typeof OPTION_CONSISTENT_AS_NEEDED;
 
 interface Options {
     option: Option;
@@ -74,7 +78,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static INCONSISTENT_PROPERTY = "All property names in this object literal must be consistently quoted or unquoted.";
+    public static INCONSISTENT_PROPERTY =
+        "All property names in this object literal must be consistently quoted or unquoted.";
     public static UNNEEDED_QUOTES(name: string) {
         return `Unnecessarily quoted property '${name}' found.`;
     }
@@ -83,9 +88,12 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new ObjectLiteralKeyQuotesWalker(sourceFile, this.ruleName, {
-            option: this.ruleArguments.length === 0 ? "always" : this.ruleArguments[0] as Option,
-        }));
+        return this.applyWithWalker(
+            new ObjectLiteralKeyQuotesWalker(sourceFile, this.ruleName, {
+                option:
+                    this.ruleArguments.length === 0 ? "always" : (this.ruleArguments[0] as Option),
+            }),
+        );
     }
 }
 
@@ -104,7 +112,10 @@ class ObjectLiteralKeyQuotesWalker extends Lint.AbstractWalker<Options> {
                         break;
                     case "as-needed":
                         for (const name of propertyNames) {
-                            if (name.kind === ts.SyntaxKind.StringLiteral && isValidPropertyName(name.text)) {
+                            if (
+                                name.kind === ts.SyntaxKind.StringLiteral &&
+                                isValidPropertyName(name.text)
+                            ) {
                                 this.reportUnnecessary(name);
                             }
                         }
@@ -112,12 +123,19 @@ class ObjectLiteralKeyQuotesWalker extends Lint.AbstractWalker<Options> {
                     case "consistent":
                         if (hasInconsistentQuotes(propertyNames)) {
                             // No fix -- don't know if they would want to add quotes or remove them.
-                            this.addFailureAt(node.getStart(this.sourceFile), 1, Rule.INCONSISTENT_PROPERTY);
+                            this.addFailureAt(
+                                node.getStart(this.sourceFile),
+                                1,
+                                Rule.INCONSISTENT_PROPERTY,
+                            );
                         }
                         break;
                     case "consistent-as-needed":
                         for (const name of propertyNames) {
-                            if (name.kind === ts.SyntaxKind.StringLiteral && !isValidPropertyName(name.text)) {
+                            if (
+                                name.kind === ts.SyntaxKind.StringLiteral &&
+                                !isValidPropertyName(name.text)
+                            ) {
                                 for (const propertyName of propertyNames) {
                                     if (propertyName.kind !== ts.SyntaxKind.StringLiteral) {
                                         this.reportMissing(propertyName);
@@ -149,14 +167,22 @@ class ObjectLiteralKeyQuotesWalker extends Lint.AbstractWalker<Options> {
     }
 
     private reportUnnecessary(node: ts.StringLiteral) {
-        this.addFailureAtNode(node, Rule.UNNEEDED_QUOTES(node.text), Lint.Replacement.replaceNode(node, node.text, this.sourceFile));
+        this.addFailureAtNode(
+            node,
+            Rule.UNNEEDED_QUOTES(node.text),
+            Lint.Replacement.replaceNode(node, node.text, this.sourceFile),
+        );
     }
 }
 
-function mapPropertyName(property: ts.ObjectLiteralElementLike): ts.StringLiteral | ts.NumericLiteral | ts.Identifier | undefined {
-    if (property.kind === ts.SyntaxKind.ShorthandPropertyAssignment ||
+function mapPropertyName(
+    property: ts.ObjectLiteralElementLike,
+): ts.StringLiteral | ts.NumericLiteral | ts.Identifier | undefined {
+    if (
+        property.kind === ts.SyntaxKind.ShorthandPropertyAssignment ||
         property.kind === ts.SyntaxKind.SpreadAssignment ||
-        property.name.kind === ts.SyntaxKind.ComputedPropertyName) {
+        property.name.kind === ts.SyntaxKind.ComputedPropertyName
+    ) {
         return undefined;
     }
     return property.name;

--- a/src/rules/objectLiteralShorthandRule.ts
+++ b/src/rules/objectLiteralShorthandRule.ts
@@ -69,7 +69,10 @@ function disallowShorthandWalker(ctx: Lint.WalkContext<void>) {
                 Rule.SHORTHAND_ASSIGNMENT,
                 Lint.Replacement.appendText(node.getStart(ctx.sourceFile), `${node.name.text}: `),
             );
-        } else if (isMethodDeclaration(node) && node.parent!.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+        } else if (
+            isMethodDeclaration(node) &&
+            node.parent!.kind === ts.SyntaxKind.ObjectLiteralExpression
+        ) {
             ctx.addFailureAtNode(
                 node.name,
                 Rule.SHORTHAND_ASSIGNMENT,
@@ -83,21 +86,30 @@ function disallowShorthandWalker(ctx: Lint.WalkContext<void>) {
 function enforceShorthandWalker(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
         if (isPropertyAssignment(node)) {
-            if (node.name.kind === ts.SyntaxKind.Identifier &&
+            if (
+                node.name.kind === ts.SyntaxKind.Identifier &&
                 isIdentifier(node.initializer) &&
-                node.name.text === node.initializer.text) {
+                node.name.text === node.initializer.text
+            ) {
                 ctx.addFailureAtNode(
                     node,
                     `${Rule.LONGHAND_PROPERTY}('{${node.name.text}}').`,
                     Lint.Replacement.deleteFromTo(node.name.end, node.end),
                 );
-            } else if (isFunctionExpression(node.initializer) &&
-                       // allow named function expressions
-                       node.initializer.name === undefined) {
-                const [name, fix] = handleLonghandMethod(node.name, node.initializer, ctx.sourceFile);
+            } else if (
+                isFunctionExpression(node.initializer) &&
+                // allow named function expressions
+                node.initializer.name === undefined
+            ) {
+                const [name, fix] = handleLonghandMethod(
+                    node.name,
+                    node.initializer,
+                    ctx.sourceFile,
+                );
                 ctx.addFailure(
                     node.getStart(ctx.sourceFile),
-                    getChildOfKind(node.initializer, ts.SyntaxKind.OpenParenToken, ctx.sourceFile)!.pos,
+                    getChildOfKind(node.initializer, ts.SyntaxKind.OpenParenToken, ctx.sourceFile)!
+                        .pos,
                     `${Rule.LONGHAND_METHOD}('{${name}() {...}}').`,
                     fix,
                 );
@@ -114,13 +126,22 @@ function fixShorthandMethodDeclaration(node: ts.MethodDeclaration, sourceFile: t
     return Lint.Replacement.replaceFromTo(
         node.getStart(sourceFile),
         node.name.end,
-        `${node.name.getText(sourceFile)}:${isAsync ? " async" : ""} function${isGenerator ? "*" : ""}`,
+        `${node.name.getText(sourceFile)}:${isAsync ? " async" : ""} function${
+            isGenerator ? "*" : ""
+        }`,
     );
 }
 
-function handleLonghandMethod(name: ts.PropertyName, initializer: ts.FunctionExpression, sourceFile: ts.SourceFile): [string, Lint.Fix] {
+function handleLonghandMethod(
+    name: ts.PropertyName,
+    initializer: ts.FunctionExpression,
+    sourceFile: ts.SourceFile,
+): [string, Lint.Fix] {
     const nameStart = name.getStart(sourceFile);
-    let fix: Lint.Fix = Lint.Replacement.deleteFromTo(name.end, getChildOfKind(initializer, ts.SyntaxKind.OpenParenToken)!.pos);
+    let fix: Lint.Fix = Lint.Replacement.deleteFromTo(
+        name.end,
+        getChildOfKind(initializer, ts.SyntaxKind.OpenParenToken)!.pos,
+    );
     let prefix = "";
     if (initializer.asteriskToken !== undefined) {
         prefix = "*";

--- a/src/rules/objectLiteralSortKeysRule.ts
+++ b/src/rules/objectLiteralSortKeysRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { isInterfaceDeclaration, isObjectLiteralExpression, isSameLine, isTypeAliasDeclaration, isTypeLiteralNode } from "tsutils";
+import {
+    isInterfaceDeclaration,
+    isObjectLiteralExpression,
+    isSameLine,
+    isTypeAliasDeclaration,
+    isTypeLiteralNode,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -75,7 +81,10 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
         return `The key '${name}' is not sorted alphabetically`;
     }
 
-    public static FAILURE_STRING_USE_DECLARATION_ORDER(propName: string, typeName: string | undefined): string {
+    public static FAILURE_STRING_USE_DECLARATION_ORDER(
+        propName: string,
+        typeName: string | undefined,
+    ): string {
         const type = typeName === undefined ? "its type declaration" : `'${typeName}'`;
         return `The key '${propName}' is not in the same order as it is in ${type}.`;
     }
@@ -87,7 +96,9 @@ export class Rule extends Lint.Rules.OptionallyTypedRule {
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options = parseOptions(this.ruleArguments);
         if (options.matchDeclarationOrder) {
-            throw new Error(`${this.ruleName} needs type info to use "${OPTION_MATCH_DECLARATION_ORDER}".`);
+            throw new Error(
+                `${this.ruleName} needs type info to use "${OPTION_MATCH_DECLARATION_ORDER}".`,
+            );
         }
         return this.applyWithFunction(sourceFile, walk, options);
     }
@@ -132,9 +143,17 @@ function walk(ctx: Lint.WalkContext<Options>, checker?: ts.TypeChecker): void {
             const type = getContextualType(node, checker!);
             // If type has an index signature, we can't check ordering.
             // If type has call/construct signatures, it can't be satisfied by an object literal anyway.
-            if (type !== undefined
-                && type.members.every((m) => m.kind === ts.SyntaxKind.PropertySignature || m.kind === ts.SyntaxKind.MethodSignature)) {
-                checkMatchesDeclarationOrder(node, type, type.members as ReadonlyArray<ts.PropertySignature | ts.MethodSignature>);
+            if (
+                type !== undefined &&
+                type.members.every(
+                    m =>
+                        m.kind === ts.SyntaxKind.PropertySignature ||
+                        m.kind === ts.SyntaxKind.MethodSignature,
+                )
+            ) {
+                checkMatchesDeclarationOrder(node, type, type.members as ReadonlyArray<
+                    ts.PropertySignature | ts.MethodSignature
+                >);
                 return;
             }
         }
@@ -159,7 +178,10 @@ function walk(ctx: Lint.WalkContext<Options>, checker?: ts.TypeChecker): void {
                     if (shorthandFirst) {
                         if (property.kind === ts.SyntaxKind.ShorthandPropertyAssignment) {
                             if (lastPropertyWasShorthand === false) {
-                                ctx.addFailureAtNode(property.name, Rule.FAILURE_STRING_SHORTHAND_FIRST(property.name.text));
+                                ctx.addFailureAtNode(
+                                    property.name,
+                                    Rule.FAILURE_STRING_SHORTHAND_FIRST(property.name.text),
+                                );
                                 return; // only show warning on first out-of-order property
                             }
 
@@ -173,12 +195,19 @@ function walk(ctx: Lint.WalkContext<Options>, checker?: ts.TypeChecker): void {
                         }
                     }
 
-                    if (property.name.kind === ts.SyntaxKind.Identifier ||
-                        property.name.kind === ts.SyntaxKind.StringLiteral) {
-                        const key = ignoreCase ? property.name.text.toLowerCase() : property.name.text;
+                    if (
+                        property.name.kind === ts.SyntaxKind.Identifier ||
+                        property.name.kind === ts.SyntaxKind.StringLiteral
+                    ) {
+                        const key = ignoreCase
+                            ? property.name.text.toLowerCase()
+                            : property.name.text;
                         // comparison with undefined is expected
                         if (lastKey! > key && !hasBlankLineBefore(ctx.sourceFile, property)) {
-                            ctx.addFailureAtNode(property.name, Rule.FAILURE_STRING_ALPHABETICAL(property.name.text));
+                            ctx.addFailureAtNode(
+                                property.name,
+                                Rule.FAILURE_STRING_ALPHABETICAL(property.name.text),
+                            );
                             return; // only show warning on first out-of-order property
                         }
                         lastKey = key;
@@ -192,7 +221,6 @@ function walk(ctx: Lint.WalkContext<Options>, checker?: ts.TypeChecker): void {
         type: TypeLike,
         members: ReadonlyArray<{ name: ts.PropertyName }>,
     ): void {
-
         let memberIndex = 0;
         outer: for (const prop of properties) {
             if (prop.kind === ts.SyntaxKind.SpreadAssignment) {
@@ -200,20 +228,28 @@ function walk(ctx: Lint.WalkContext<Options>, checker?: ts.TypeChecker): void {
                 continue;
             }
 
-            if (prop.name.kind === ts.SyntaxKind.ComputedPropertyName) { continue; }
+            if (prop.name.kind === ts.SyntaxKind.ComputedPropertyName) {
+                continue;
+            }
 
             const propName = prop.name.text;
 
             for (; memberIndex !== members.length; memberIndex++) {
                 const { name: memberName } = members[memberIndex];
-                if (memberName.kind !== ts.SyntaxKind.ComputedPropertyName && propName === memberName.text) {
+                if (
+                    memberName.kind !== ts.SyntaxKind.ComputedPropertyName &&
+                    propName === memberName.text
+                ) {
                     continue outer;
                 }
             }
 
             // This We didn't find the member we were looking for past the previous member,
             // so it must have come before it and is therefore out of order.
-            ctx.addFailureAtNode(prop.name, Rule.FAILURE_STRING_USE_DECLARATION_ORDER(propName, getTypeName(type)));
+            ctx.addFailureAtNode(
+                prop.name,
+                Rule.FAILURE_STRING_USE_DECLARATION_ORDER(propName, getTypeName(type)),
+            );
             // Don't bother with multiple errors.
             break;
         }
@@ -224,18 +260,26 @@ function hasBlankLineBefore(sourceFile: ts.SourceFile, element: ts.ObjectLiteral
     let comments = ts.getLeadingCommentRanges(sourceFile.text, element.pos);
 
     if (comments === undefined) {
-        comments = [];  // it will be easier to work with an empty array down below...
+        comments = []; // it will be easier to work with an empty array down below...
     }
 
-    const elementStart = comments.length > 0 ? comments[comments.length - 1].end : element.getFullStart();
+    const elementStart =
+        comments.length > 0 ? comments[comments.length - 1].end : element.getFullStart();
 
     // either the element itself, or one of its leading comments must have an extra new line before them
-    return hasDoubleNewLine(sourceFile, elementStart) || comments.some((comment) => {
-        const commentLine = ts.getLineAndCharacterOfPosition(sourceFile, comment.pos).line;
-        const commentLineStartPosition = ts.getPositionOfLineAndCharacter(sourceFile, commentLine, 0);
+    return (
+        hasDoubleNewLine(sourceFile, elementStart) ||
+        comments.some(comment => {
+            const commentLine = ts.getLineAndCharacterOfPosition(sourceFile, comment.pos).line;
+            const commentLineStartPosition = ts.getPositionOfLineAndCharacter(
+                sourceFile,
+                commentLine,
+                0,
+            );
 
-        return hasDoubleNewLine(sourceFile, commentLineStartPosition - 4);
-    });
+            return hasDoubleNewLine(sourceFile, commentLineStartPosition - 4);
+        })
+    );
 }
 
 function hasDoubleNewLine(sourceFile: ts.SourceFile, position: number) {

--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -100,8 +100,8 @@ class OneLineWalker extends Lint.AbstractWalker<Options> {
                     break;
                 case ts.SyntaxKind.EnumDeclaration:
                     this.check({
-                        pos: (node as ts.EnumDeclaration).name.end,
                         end: (node as ts.EnumDeclaration).members.pos,
+                        pos: (node as ts.EnumDeclaration).name.end,
                     });
                     break;
                 case ts.SyntaxKind.InterfaceDeclaration:

--- a/src/rules/oneLineRule.ts
+++ b/src/rules/oneLineRule.ts
@@ -38,7 +38,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "one-line",
-        description: "Requires the specified tokens to be on the same line as the expression preceding them.",
+        description:
+            "Requires the specified tokens to be on the same line as the expression preceding them.",
         optionsDescription: Lint.Utils.dedent`
             Five arguments may be optionally provided:
 
@@ -66,13 +67,15 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static WHITESPACE_FAILURE_STRING = "missing whitespace";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new OneLineWalker(sourceFile, this.ruleName, {
-            brace: this.ruleArguments.indexOf(OPTION_BRACE) !== -1,
-            catch: this.ruleArguments.indexOf(OPTION_CATCH) !== -1,
-            else: this.ruleArguments.indexOf(OPTION_ELSE) !== -1,
-            finally: this.ruleArguments.indexOf(OPTION_FINALLY) !== -1,
-            whitespace: this.ruleArguments.indexOf(OPTION_WHITESPACE) !== -1,
-        }));
+        return this.applyWithWalker(
+            new OneLineWalker(sourceFile, this.ruleName, {
+                brace: this.ruleArguments.indexOf(OPTION_BRACE) !== -1,
+                catch: this.ruleArguments.indexOf(OPTION_CATCH) !== -1,
+                else: this.ruleArguments.indexOf(OPTION_ELSE) !== -1,
+                finally: this.ruleArguments.indexOf(OPTION_FINALLY) !== -1,
+                whitespace: this.ruleArguments.indexOf(OPTION_WHITESPACE) !== -1,
+            }),
+        );
     }
 }
 
@@ -81,24 +84,34 @@ class OneLineWalker extends Lint.AbstractWalker<Options> {
         const cb = (node: ts.Node): void => {
             switch (node.kind) {
                 case ts.SyntaxKind.Block:
-                    if (!isBlockLike(node.parent!)
-                        || node.parent!.kind === ts.SyntaxKind.CaseClause && (node.parent as ts.CaseClause).statements.length === 1) {
-                        this.check({pos: node.pos, end: (node as ts.Block).statements.pos});
+                    if (
+                        !isBlockLike(node.parent!) ||
+                        (node.parent!.kind === ts.SyntaxKind.CaseClause &&
+                            (node.parent as ts.CaseClause).statements.length === 1)
+                    ) {
+                        this.check({ pos: node.pos, end: (node as ts.Block).statements.pos });
                     }
                     break;
                 case ts.SyntaxKind.CaseBlock:
-                    this.check({pos: node.pos, end: (node as ts.CaseBlock).clauses.pos});
+                    this.check({ pos: node.pos, end: (node as ts.CaseBlock).clauses.pos });
                     break;
                 case ts.SyntaxKind.ModuleBlock:
-                    this.check({pos: node.pos, end: (node as ts.ModuleBlock).statements.pos});
+                    this.check({ pos: node.pos, end: (node as ts.ModuleBlock).statements.pos });
                     break;
                 case ts.SyntaxKind.EnumDeclaration:
-                    this.check({pos: (node as ts.EnumDeclaration).name.end, end: (node as ts.EnumDeclaration).members.pos});
+                    this.check({
+                        pos: (node as ts.EnumDeclaration).name.end,
+                        end: (node as ts.EnumDeclaration).members.pos,
+                    });
                     break;
                 case ts.SyntaxKind.InterfaceDeclaration:
                 case ts.SyntaxKind.ClassDeclaration:
                 case ts.SyntaxKind.ClassExpression: {
-                    const openBrace = getChildOfKind(node, ts.SyntaxKind.OpenBraceToken, sourceFile);
+                    const openBrace = getChildOfKind(
+                        node,
+                        ts.SyntaxKind.OpenBraceToken,
+                        sourceFile,
+                    );
                     if (openBrace !== undefined) {
                         this.check(openBrace);
                     }
@@ -107,7 +120,7 @@ class OneLineWalker extends Lint.AbstractWalker<Options> {
                 case ts.SyntaxKind.IfStatement: {
                     const { thenStatement, elseStatement } = node as ts.IfStatement;
                     if (elseStatement !== undefined && thenStatement.kind === ts.SyntaxKind.Block) {
-                        this.check({pos: thenStatement.end, end: elseStatement.pos}, "else");
+                        this.check({ pos: thenStatement.end, end: elseStatement.pos }, "else");
                     }
                     break;
                 }
@@ -116,30 +129,36 @@ class OneLineWalker extends Lint.AbstractWalker<Options> {
                     if (catchClause !== undefined) {
                         this.check(catchClause.getChildAt(0, sourceFile), "catch");
                         if (finallyBlock !== undefined) {
-                            this.check({pos: catchClause.end, end: finallyBlock.pos}, "finally");
+                            this.check({ pos: catchClause.end, end: finallyBlock.pos }, "finally");
                         }
                     } else if (finallyBlock !== undefined) {
-                        this.check({pos: tryBlock.end, end: finallyBlock.pos}, "finally");
+                        this.check({ pos: tryBlock.end, end: finallyBlock.pos }, "finally");
                     }
                     break;
                 }
                 case ts.SyntaxKind.BinaryExpression: {
                     const { operatorToken, right } = node as ts.BinaryExpression;
-                    if (operatorToken.kind === ts.SyntaxKind.EqualsToken && isObjectLiteralExpression(right)) {
-                        this.check({pos: right.pos, end: right.properties.pos});
+                    if (
+                        operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+                        isObjectLiteralExpression(right)
+                    ) {
+                        this.check({ pos: right.pos, end: right.properties.pos });
                     }
                     break;
                 }
                 case ts.SyntaxKind.VariableDeclaration: {
                     const { initializer } = node as ts.VariableDeclaration;
                     if (initializer !== undefined && isObjectLiteralExpression(initializer)) {
-                        this.check({pos: initializer.pos, end: initializer.properties.pos});
+                        this.check({ pos: initializer.pos, end: initializer.properties.pos });
                     }
                     break;
                 }
                 case ts.SyntaxKind.TypeAliasDeclaration: {
                     const { type } = node as ts.TypeAliasDeclaration;
-                    if (type.kind === ts.SyntaxKind.MappedType || type.kind === ts.SyntaxKind.TypeLiteral) {
+                    if (
+                        type.kind === ts.SyntaxKind.MappedType ||
+                        type.kind === ts.SyntaxKind.TypeLiteral
+                    ) {
                         this.check(type.getChildAt(0, sourceFile));
                     }
                 }
@@ -151,15 +170,27 @@ class OneLineWalker extends Lint.AbstractWalker<Options> {
 
     private check(range: ts.TextRange, kind?: "catch" | "else" | "finally") {
         const tokenStart = range.end - (kind === undefined ? 1 : kind.length);
-        if (this.options[kind === undefined ? "brace" : kind] && !isSameLine(this.sourceFile, range.pos, tokenStart)) {
+        if (
+            this.options[kind === undefined ? "brace" : kind] &&
+            !isSameLine(this.sourceFile, range.pos, tokenStart)
+        ) {
             this.addFailure(
                 tokenStart,
                 range.end,
                 `misplaced ${kind === undefined ? "opening brace" : `'${kind}'`}`,
-                Lint.Replacement.replaceFromTo(range.pos, tokenStart, this.options.whitespace ? " " : ""),
+                Lint.Replacement.replaceFromTo(
+                    range.pos,
+                    tokenStart,
+                    this.options.whitespace ? " " : "",
+                ),
             );
         } else if (this.options.whitespace && range.pos === tokenStart) {
-            this.addFailure(tokenStart, range.end, Rule.WHITESPACE_FAILURE_STRING, Lint.Replacement.appendText(range.pos, " "));
+            this.addFailure(
+                tokenStart,
+                range.end,
+                Rule.WHITESPACE_FAILURE_STRING,
+                Lint.Replacement.appendText(range.pos, " "),
+            );
         }
     }
 }

--- a/src/rules/oneVariablePerDeclarationRule.ts
+++ b/src/rules/oneVariablePerDeclarationRule.ts
@@ -48,10 +48,13 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Multiple variable declarations in the same statement are forbidden";
+    public static FAILURE_STRING =
+        "Multiple variable declarations in the same statement are forbidden";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, walk, { ignoreForLoop: this.ruleArguments.indexOf(OPTION_IGNORE_FOR_LOOP) !== -1 });
+        return this.applyWithFunction(sourceFile, walk, {
+            ignoreForLoop: this.ruleArguments.indexOf(OPTION_IGNORE_FOR_LOOP) !== -1,
+        });
     }
 }
 
@@ -61,9 +64,11 @@ function walk(ctx: Lint.WalkContext<{ ignoreForLoop: boolean }>): void {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         } else if (isForStatement(node) && !ctx.options.ignoreForLoop) {
             const { initializer } = node;
-            if (initializer !== undefined
-                    && initializer.kind === ts.SyntaxKind.VariableDeclarationList
-                    && (initializer as ts.VariableDeclarationList).declarations.length > 1) {
+            if (
+                initializer !== undefined &&
+                initializer.kind === ts.SyntaxKind.VariableDeclarationList &&
+                (initializer as ts.VariableDeclarationList).declarations.length > 1
+            ) {
                 ctx.addFailureAtNode(initializer, Rule.FAILURE_STRING);
             }
         }

--- a/src/rules/onlyArrowFunctionsRule.ts
+++ b/src/rules/onlyArrowFunctionsRule.ts
@@ -29,7 +29,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "only-arrow-functions",
         description: "Disallows traditional (non-arrow) function expressions.",
-        rationale: "Traditional functions don't bind lexical scope, which can lead to unexpected behavior when accessing 'this'.",
+        rationale:
+            "Traditional functions don't bind lexical scope, which can lead to unexpected behavior when accessing 'this'.",
         optionsDescription: Lint.Utils.dedent`
             Two arguments may be optionally provided:
 
@@ -75,18 +76,24 @@ function parseOptions(ruleArguments: string[]): Options {
 }
 
 function walk(ctx: Lint.WalkContext<Options>): void {
-    const { sourceFile, options: { allowDeclarations, allowNamedFunctions } } = ctx;
+    const {
+        sourceFile,
+        options: { allowDeclarations, allowNamedFunctions },
+    } = ctx;
     return ts.forEachChild(sourceFile, function cb(node): void {
         switch (node.kind) {
             case ts.SyntaxKind.FunctionDeclaration:
                 if (allowDeclarations) {
                     break;
                 }
-                // falls through
+            // falls through
             case ts.SyntaxKind.FunctionExpression: {
                 const f = node as ts.FunctionLikeDeclaration;
                 if (!(allowNamedFunctions && f.name !== undefined) && !functionIsExempt(f)) {
-                    ctx.addFailureAtNode(utils.getChildOfKind(node, ts.SyntaxKind.FunctionKeyword, ctx.sourceFile)!, Rule.FAILURE_STRING);
+                    ctx.addFailureAtNode(
+                        utils.getChildOfKind(node, ts.SyntaxKind.FunctionKeyword, ctx.sourceFile)!,
+                        Rule.FAILURE_STRING,
+                    );
                 }
             }
         }
@@ -96,11 +103,16 @@ function walk(ctx: Lint.WalkContext<Options>): void {
 
 /** Generator functions and functions using `this` are allowed. */
 function functionIsExempt(node: ts.FunctionLikeDeclaration): boolean {
-    return node.asteriskToken !== undefined ||
-        node.parameters.length !== 0 && utils.isThisParameter(node.parameters[0]) ||
-        node.body !== undefined && ts.forEachChild(node, usesThis) === true;
+    return (
+        node.asteriskToken !== undefined ||
+        (node.parameters.length !== 0 && utils.isThisParameter(node.parameters[0])) ||
+        (node.body !== undefined && ts.forEachChild(node, usesThis) === true)
+    );
 }
 
 function usesThis(node: ts.Node): boolean | undefined {
-    return node.kind === ts.SyntaxKind.ThisKeyword || !utils.hasOwnThisReference(node) && ts.forEachChild(node, usesThis);
+    return (
+        node.kind === ts.SyntaxKind.ThisKeyword ||
+        (!utils.hasOwnThisReference(node) && ts.forEachChild(node, usesThis))
+    );
 }

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -105,7 +105,13 @@ export class Rule extends Lint.Rules.AbstractRule {
         },
         optionExamples: [
             true,
-            [true, {"import-sources-order": "lowercase-last", "named-imports-order": "lowercase-first"}],
+            [
+                true,
+                {
+                    "import-sources-order": "lowercase-last",
+                    "named-imports-order": "lowercase-first",
+                },
+            ],
         ],
         type: "style",
         typescriptOnly: false,
@@ -118,7 +124,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static NAMED_IMPORTS_UNORDERED = "Named imports must be alphabetized.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new Walker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)));
+        return this.applyWithWalker(
+            new Walker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)),
+        );
     }
 }
 
@@ -127,21 +135,24 @@ export class Rule extends Lint.Rules.AbstractRule {
 type Transform = (x: string) => string;
 const TRANSFORMS = new Map<string, Transform>([
     ["any", () => ""],
-    ["case-insensitive", (x) => x.toLowerCase()],
+    ["case-insensitive", x => x.toLowerCase()],
     ["lowercase-first", flipCase],
-    ["lowercase-last", (x) => x],
-    ["full", (x) => x],
-    ["basename", (x) => {
-        if (!ts.isExternalModuleNameRelative(x)) {
-            return x;
-        }
+    ["lowercase-last", x => x],
+    ["full", x => x],
+    [
+        "basename",
+        x => {
+            if (!ts.isExternalModuleNameRelative(x)) {
+                return x;
+            }
 
-        const splitIndex = x.lastIndexOf("/");
-        if (splitIndex === -1) {
-            return x;
-        }
-        return x.substr(splitIndex + 1);
-    }],
+            const splitIndex = x.lastIndexOf("/");
+            if (splitIndex === -1) {
+                return x;
+            }
+            return x.substr(splitIndex + 1);
+        },
+    ],
 ]);
 
 enum ImportType {
@@ -201,8 +212,15 @@ class Walker extends Lint.AbstractWalker<Options> {
     }
 
     private checkStatement(statement: ts.Statement): void {
-        if (!(isImportDeclaration(statement) || isImportEqualsDeclaration(statement)) ||
-            /\r?\n\r?\n/.test(this.sourceFile.text.slice(statement.getFullStart(), statement.getStart(this.sourceFile)))) {
+        if (
+            !(isImportDeclaration(statement) || isImportEqualsDeclaration(statement)) ||
+            /\r?\n\r?\n/.test(
+                this.sourceFile.text.slice(
+                    statement.getFullStart(),
+                    statement.getStart(this.sourceFile),
+                ),
+            )
+        ) {
             this.endBlock();
         }
 
@@ -227,11 +245,17 @@ class Walker extends Lint.AbstractWalker<Options> {
             return;
         }
 
-        const source = this.options.importSourcesOrderTransform(removeQuotes(node.moduleSpecifier.text));
+        const source = this.options.importSourcesOrderTransform(
+            removeQuotes(node.moduleSpecifier.text),
+        );
         this.checkSource(source, node);
 
         const { importClause } = node;
-        if (importClause !== undefined && importClause.namedBindings !== undefined && isNamedImports(importClause.namedBindings)) {
+        if (
+            importClause !== undefined &&
+            importClause.namedBindings !== undefined &&
+            isNamedImports(importClause.namedBindings)
+        ) {
             this.checkNamedImports(importClause.namedBindings);
         }
     }
@@ -283,8 +307,9 @@ class Walker extends Lint.AbstractWalker<Options> {
         const pair = findUnsortedPair(imports, this.options.namedImportsOrderTransform);
         if (pair !== undefined) {
             const [a, b] = pair;
-            const sortedDeclarations = sortByKey(imports, (x) =>
-                this.options.namedImportsOrderTransform(x.getText())).map((x) => x.getText());
+            const sortedDeclarations = sortByKey(imports, x =>
+                this.options.namedImportsOrderTransform(x.getText()),
+            ).map(x => x.getText());
             // replace in reverse order to preserve earlier offsets
             for (let i = imports.length - 1; i >= 0; i--) {
                 const start = imports[i].getStart();
@@ -306,7 +331,11 @@ class Walker extends Lint.AbstractWalker<Options> {
     private checkBlockGroups(importsBlock: ImportsBlock): boolean {
         const oddImportDeclaration = this.getOddImportDeclaration(importsBlock);
         if (oddImportDeclaration !== undefined) {
-            this.addFailureAtNode(oddImportDeclaration.node, Rule.IMPORT_SOURCES_NOT_GROUPED, this.getReplacements());
+            this.addFailureAtNode(
+                oddImportDeclaration.node,
+                Rule.IMPORT_SOURCES_NOT_GROUPED,
+                this.getReplacements(),
+            );
             return true;
         }
         return false;
@@ -322,22 +351,27 @@ class Walker extends Lint.AbstractWalker<Options> {
             return importDeclarations[0];
         } else {
             this.nextType = type;
-            return importDeclarations.find((importDeclaration) => importDeclaration.type !== type);
+            return importDeclarations.find(importDeclaration => importDeclaration.type !== type);
         }
     }
 
     private getReplacements(): Lint.Replacement[] {
         const importDeclarationsList = this.importsBlocks
-            .map((block) => block.getImportDeclarations())
-            .filter((imports) => imports.length > 0);
+            .map(block => block.getImportDeclarations())
+            .filter(imports => imports.length > 0);
         const allImportDeclarations = ([] as ImportDeclaration[]).concat(...importDeclarationsList);
         const replacements = this.getReplacementsForExistingImports(importDeclarationsList);
-        const startOffset = allImportDeclarations.length === 0 ? 0 : allImportDeclarations[0].nodeStartOffset;
-        replacements.push(Lint.Replacement.appendText(startOffset, this.getGroupedImports(allImportDeclarations)));
+        const startOffset =
+            allImportDeclarations.length === 0 ? 0 : allImportDeclarations[0].nodeStartOffset;
+        replacements.push(
+            Lint.Replacement.appendText(startOffset, this.getGroupedImports(allImportDeclarations)),
+        );
         return replacements;
     }
 
-    private getReplacementsForExistingImports(importDeclarationsList: ImportDeclaration[][]): Lint.Replacement[] {
+    private getReplacementsForExistingImports(
+        importDeclarationsList: ImportDeclaration[][],
+    ): Lint.Replacement[] {
         return importDeclarationsList.map((items, index) => {
             let start = items[0].nodeStartOffset;
             if (index > 0) {
@@ -353,12 +387,18 @@ class Walker extends Lint.AbstractWalker<Options> {
     }
 
     private getGroupedImports(importDeclarations: ImportDeclaration[]): string {
-        return [ImportType.LIBRARY_IMPORT, ImportType.PARENT_DIRECTORY_IMPORT, ImportType.CURRENT_DIRECTORY_IMPORT]
-            .map((type) => {
-                const imports = importDeclarations.filter((importDeclaration) => importDeclaration.type === type);
+        return [
+            ImportType.LIBRARY_IMPORT,
+            ImportType.PARENT_DIRECTORY_IMPORT,
+            ImportType.CURRENT_DIRECTORY_IMPORT,
+        ]
+            .map(type => {
+                const imports = importDeclarations.filter(
+                    importDeclaration => importDeclaration.type === type,
+                );
                 return getSortedImportDeclarationsAsText(imports);
             })
-            .filter((text) => text.length > 0)
+            .filter(text => text.length > 0)
             .join(this.getEolChar());
     }
 
@@ -378,9 +418,9 @@ class Walker extends Lint.AbstractWalker<Options> {
 
 interface ImportDeclaration {
     node: ts.ImportDeclaration | ts.ImportEqualsDeclaration;
-    nodeEndOffset: number;      // end position of node within source file
-    nodeStartOffset: number;    // start position of node within source file
-    text: string;               // initialized with original import text; modified if the named imports are reordered
+    nodeEndOffset: number; // end position of node within source file
+    nodeStartOffset: number; // start position of node within source file
+    text: string; // initialized with original import text; modified if the named imports are reordered
     sourcePath: string;
     type: ImportType;
 }
@@ -388,7 +428,11 @@ interface ImportDeclaration {
 class ImportsBlock {
     private importDeclarations: ImportDeclaration[] = [];
 
-    public addImportDeclaration(sourceFile: ts.SourceFile, node: ImportDeclaration["node"], sourcePath: string) {
+    public addImportDeclaration(
+        sourceFile: ts.SourceFile,
+        node: ImportDeclaration["node"],
+        sourcePath: string,
+    ) {
         const start = this.getStartOffset(node);
         const end = this.getEndOffset(sourceFile, node);
         const text = sourceFile.text.substring(start, end);
@@ -428,7 +472,8 @@ class ImportsBlock {
         }
 
         const initialText = importDeclaration.text;
-        importDeclaration.text = initialText.substring(0, start) + replacement + initialText.substring(start + length);
+        importDeclaration.text =
+            initialText.substring(0, start) + replacement + initialText.substring(start + length);
     }
 
     public getLastImportSource() {
@@ -481,19 +526,24 @@ class ImportsBlock {
 
 // Convert aBcD --> AbCd
 function flipCase(str: string): string {
-    return Array.from(str).map((char) => {
-        if (char >= "a" && char <= "z") {
-            return char.toUpperCase();
-        } else if (char >= "A" && char <= "Z") {
-            return char.toLowerCase();
-        }
-        return char;
-    }).join("");
+    return Array.from(str)
+        .map(char => {
+            if (char >= "a" && char <= "z") {
+                return char.toUpperCase();
+            } else if (char >= "A" && char <= "Z") {
+                return char.toLowerCase();
+            }
+            return char;
+        })
+        .join("");
 }
 
 // After applying a transformation, are the nodes sorted according to the text they contain?
 // If not, return the pair of nodes which are out of order.
-function findUnsortedPair(xs: ReadonlyArray<ts.Node>, transform: (x: string) => string): [ts.Node, ts.Node] | undefined {
+function findUnsortedPair(
+    xs: ReadonlyArray<ts.Node>,
+    transform: (x: string) => string,
+): [ts.Node, ts.Node] | undefined {
     for (let i = 1; i < xs.length; i++) {
         if (transform(xs[i].getText()) < transform(xs[i - 1].getText())) {
             return [xs[i - 1], xs[i]];
@@ -520,15 +570,15 @@ function compare(a: string, b: string): 0 | 1 | -1 {
 
 function removeQuotes(value: string): string {
     // strip out quotes
-    if (value.length > 1 && (value[0] === "'" || value[0] === "\"")) {
+    if (value.length > 1 && (value[0] === "'" || value[0] === '"')) {
         value = value.substr(1, value.length - 2);
     }
     return value;
 }
 
 function getSortedImportDeclarationsAsText(importDeclarations: ImportDeclaration[]): string {
-    const sortedDeclarations = sortByKey(importDeclarations.slice(), (x) => x.sourcePath);
-    return sortedDeclarations.map((x) => x.text).join("");
+    const sortedDeclarations = sortByKey(importDeclarations.slice(), x => x.sourcePath);
+    return sortedDeclarations.map(x => x.text).join("");
 }
 
 function sortByKey<T>(xs: ReadonlyArray<T>, getSortKey: (x: T) => string): T[] {

--- a/src/rules/preferConditionalExpressionRule.ts
+++ b/src/rules/preferConditionalExpressionRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { isBinaryExpression, isBlock, isExpressionStatement, isIfStatement, isSameLine } from "tsutils";
+import {
+    isBinaryExpression,
+    isBlock,
+    isExpressionStatement,
+    isIfStatement,
+    isSameLine,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -57,14 +63,18 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function walk(ctx: Lint.WalkContext<Options>): void {
-    const { sourceFile, options: { checkElseIf } } = ctx;
+    const {
+        sourceFile,
+        options: { checkElseIf },
+    } = ctx;
     return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
         if (isIfStatement(node)) {
             const assigned = detectAssignment(node, sourceFile, checkElseIf);
             if (assigned !== undefined) {
                 ctx.addFailureAtNode(
                     node.getChildAt(0, sourceFile),
-                    Rule.FAILURE_STRING(assigned.getText(sourceFile)));
+                    Rule.FAILURE_STRING(assigned.getText(sourceFile)),
+                );
             }
             if (assigned !== undefined || !checkElseIf) {
                 // Be careful not to fail again for the "else if"
@@ -95,7 +105,7 @@ function detectAssignment(
     inElse?: boolean,
 ): ts.Expression | undefined {
     if (isIfStatement(statement)) {
-        if (inElse === false || !checkElseIf && inElse || statement.elseStatement === undefined) {
+        if (inElse === false || (!checkElseIf && inElse) || statement.elseStatement === undefined) {
             return undefined;
         }
         const then = detectAssignment(statement.thenStatement, sourceFile, checkElseIf, false);
@@ -109,8 +119,15 @@ function detectAssignment(
             ? detectAssignment(statement.statements[0], sourceFile, checkElseIf, inElse)
             : undefined;
     } else if (isExpressionStatement(statement) && isBinaryExpression(statement.expression)) {
-        const { operatorToken: { kind }, left, right } = statement.expression;
-        return kind === ts.SyntaxKind.EqualsToken && isSameLine(sourceFile, right.getStart(sourceFile), right.end) ? left : undefined;
+        const {
+            operatorToken: { kind },
+            left,
+            right,
+        } = statement.expression;
+        return kind === ts.SyntaxKind.EqualsToken &&
+            isSameLine(sourceFile, right.getStart(sourceFile), right.end)
+            ? left
+            : undefined;
     } else {
         return undefined;
     }

--- a/src/rules/preferConstRule.ts
+++ b/src/rules/preferConstRule.ts
@@ -31,7 +31,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "prefer-const",
-        description: "Requires that variable declarations use `const` instead of `let` and `var` if possible.",
+        description:
+            "Requires that variable declarations use `const` instead of `let` and `var` if possible.",
         descriptionDetails: Lint.Utils.dedent`
             If a variable is only assigned to once when it is declared, it should be declared using 'const'`,
         hasFix: true,
@@ -49,23 +50,24 @@ export class Rule extends Lint.Rules.AbstractRule {
                 },
             },
         },
-        optionExamples: [
-            true,
-            [true, {destructuring: OPTION_DESTRUCTURING_ALL}],
-        ],
+        optionExamples: [true, [true, { destructuring: OPTION_DESTRUCTURING_ALL }]],
         type: "maintainability",
         typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING_FACTORY(identifier: string, blockScoped: boolean) {
-        return `Identifier '${identifier}' is never reassigned; use 'const' instead of '${blockScoped ? "let" : "var"}'.`;
+        return `Identifier '${identifier}' is never reassigned; use 'const' instead of '${
+            blockScoped ? "let" : "var"
+        }'.`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options: Options = {
-            destructuringAll: this.ruleArguments.length !== 0 &&
-                (this.ruleArguments[0] as {destructuring?: string}).destructuring === OPTION_DESTRUCTURING_ALL,
+            destructuringAll:
+                this.ruleArguments.length !== 0 &&
+                (this.ruleArguments[0] as { destructuring?: string }).destructuring ===
+                    OPTION_DESTRUCTURING_ALL,
         };
         const preferConstWalker = new PreferConstWalker(sourceFile, this.ruleName, options);
         return this.applyWithWalker(preferConstWalker);
@@ -81,7 +83,11 @@ class Scope {
         this.functionScope = functionScope === undefined ? this : functionScope;
     }
 
-    public addVariable(identifier: ts.Identifier, declarationInfo: DeclarationInfo, destructuringInfo?: DestructuringInfo) {
+    public addVariable(
+        identifier: ts.Identifier,
+        declarationInfo: DeclarationInfo,
+        destructuringInfo?: DestructuringInfo,
+    ) {
         // block scoped variables go to the block scope, function scoped variables to the containing function scope
         const scope = declarationInfo.isBlockScoped ? this : this.functionScope;
         scope.variables.set(identifier.text, {
@@ -134,16 +140,21 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
             const boundary = utils.isScopeBoundary(node);
             if (boundary !== utils.ScopeBoundary.None) {
                 if (boundary === utils.ScopeBoundary.Function) {
-                    if (node.kind === ts.SyntaxKind.ModuleDeclaration && utils.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)) {
+                    if (
+                        node.kind === ts.SyntaxKind.ModuleDeclaration &&
+                        utils.hasModifier(node.modifiers, ts.SyntaxKind.DeclareKeyword)
+                    ) {
                         // don't check ambient namespaces
                         return;
                     }
                     this.scope = new Scope();
-                    if (utils.isFunctionDeclaration(node) ||
+                    if (
+                        utils.isFunctionDeclaration(node) ||
                         utils.isMethodDeclaration(node) ||
                         utils.isFunctionExpression(node) ||
                         utils.isArrowFunction(node) ||
-                        utils.isConstructorDeclaration(node)) {
+                        utils.isConstructorDeclaration(node)
+                    ) {
                         // special handling for function parameters
                         // each parameter initializer can only reassign preceding parameters of variables of the containing scope
                         if (node.body !== undefined) {
@@ -159,8 +170,10 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
                     }
                 } else {
                     this.scope = new Scope(this.scope.functionScope);
-                    if ((utils.isForInStatement(node) || utils.isForOfStatement(node)) &&
-                        node.initializer.kind !== ts.SyntaxKind.VariableDeclarationList) {
+                    if (
+                        (utils.isForInStatement(node) || utils.isForOfStatement(node)) &&
+                        node.initializer.kind !== ts.SyntaxKind.VariableDeclarationList
+                    ) {
                         this.handleExpression(node.initializer);
                     }
                 }
@@ -181,13 +194,19 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
                         isBlockScoped: true,
                     });
                 }
-            } else if (utils.isPostfixUnaryExpression(node) ||
-                       utils.isPrefixUnaryExpression(node) &&
-                       (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)) {
+            } else if (
+                utils.isPostfixUnaryExpression(node) ||
+                (utils.isPrefixUnaryExpression(node) &&
+                    (node.operator === ts.SyntaxKind.PlusPlusToken ||
+                        node.operator === ts.SyntaxKind.MinusMinusToken))
+            ) {
                 if (utils.isIdentifier(node.operand)) {
                     this.scope.reassigned.add(node.operand.text);
                 }
-            } else if (utils.isBinaryExpression(node) && utils.isAssignmentKind(node.operatorToken.kind)) {
+            } else if (
+                utils.isBinaryExpression(node) &&
+                utils.isAssignmentKind(node.operatorToken.kind)
+            ) {
                 this.handleExpression(node.left);
             }
 
@@ -253,9 +272,8 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
             const destructuringInfo: DestructuringInfo = {
                 reassignedSiblings: false,
             };
-            utils.forEachDestructuringIdentifier(
-                name,
-                (declaration) => this.scope.addVariable(declaration.name, declarationInfo, destructuringInfo),
+            utils.forEachDestructuringIdentifier(name, declaration =>
+                this.scope.addVariable(declaration.name, declarationInfo, destructuringInfo),
             );
         }
     }
@@ -263,23 +281,32 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
     private handleVariableDeclaration(declarationList: ts.VariableDeclarationList) {
         let declarationInfo: DeclarationInfo;
         const kind = utils.getVariableDeclarationKind(declarationList);
-        if (kind === utils.VariableDeclarationKind.Const ||
-            utils.hasModifier(declarationList.parent!.modifiers, ts.SyntaxKind.ExportKeyword, ts.SyntaxKind.DeclareKeyword)) {
-
+        if (
+            kind === utils.VariableDeclarationKind.Const ||
+            utils.hasModifier(
+                declarationList.parent!.modifiers,
+                ts.SyntaxKind.ExportKeyword,
+                ts.SyntaxKind.DeclareKeyword,
+            )
+        ) {
             declarationInfo = {
                 canBeConst: false,
                 isBlockScoped: kind !== utils.VariableDeclarationKind.Var,
             };
         } else {
             declarationInfo = {
-                allInitialized: declarationList.parent!.kind === ts.SyntaxKind.ForOfStatement ||
-                                declarationList.parent!.kind === ts.SyntaxKind.ForInStatement ||
-                                declarationList.declarations.every((declaration) => declaration.initializer !== undefined),
+                allInitialized:
+                    declarationList.parent!.kind === ts.SyntaxKind.ForOfStatement ||
+                    declarationList.parent!.kind === ts.SyntaxKind.ForInStatement ||
+                    declarationList.declarations.every(
+                        declaration => declaration.initializer !== undefined,
+                    ),
                 canBeConst: true,
                 declarationList,
                 isBlockScoped: kind === utils.VariableDeclarationKind.Let,
-                isForLoop: declarationList.parent!.kind === ts.SyntaxKind.ForStatement ||
-                           declarationList.parent!.kind === ts.SyntaxKind.ForOfStatement,
+                isForLoop:
+                    declarationList.parent!.kind === ts.SyntaxKind.ForStatement ||
+                    declarationList.parent!.kind === ts.SyntaxKind.ForOfStatement,
                 reassignedSiblings: false,
             };
         }
@@ -290,8 +317,8 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
     }
 
     private settle(parent?: Scope) {
-        const {variables, reassigned} = this.scope;
-        reassigned.forEach((name) => {
+        const { variables, reassigned } = this.scope;
+        reassigned.forEach(name => {
             const variableInfo = variables.get(name);
             if (variableInfo !== undefined) {
                 if (variableInfo.declarationInfo.canBeConst) {
@@ -313,27 +340,38 @@ class PreferConstWalker extends Lint.AbstractWalker<Options> {
         this.settle(parent);
         const appliedFixes = new Set<ts.VariableDeclarationList>();
         this.scope.variables.forEach((info, name) => {
-            if (info.declarationInfo.canBeConst &&
+            if (
+                info.declarationInfo.canBeConst &&
                 !info.reassigned &&
                 // don't add failures for reassigned variables in for loop initializer
                 !(info.declarationInfo.reassignedSiblings && info.declarationInfo.isForLoop) &&
                 // if {destructuring: "all"} is set, only add a failure if all variables in a destructuring assignment can be const
                 (!this.options.destructuringAll ||
-                 info.destructuringInfo === undefined ||
-                 !info.destructuringInfo.reassignedSiblings)) {
-
+                    info.destructuringInfo === undefined ||
+                    !info.destructuringInfo.reassignedSiblings)
+            ) {
                 let fix: Lint.Fix | undefined;
                 // only apply fixes if the VariableDeclarationList has no reassigned variables
                 // and the variable is block scoped aka `let` and initialized
-                if (info.declarationInfo.allInitialized &&
+                if (
+                    info.declarationInfo.allInitialized &&
                     !info.declarationInfo.reassignedSiblings &&
                     info.declarationInfo.isBlockScoped &&
-                    !appliedFixes.has(info.declarationInfo.declarationList)) {
-                    fix = new Lint.Replacement(info.declarationInfo.declarationList.getStart(this.sourceFile), 3, "const");
+                    !appliedFixes.has(info.declarationInfo.declarationList)
+                ) {
+                    fix = new Lint.Replacement(
+                        info.declarationInfo.declarationList.getStart(this.sourceFile),
+                        3,
+                        "const",
+                    );
                     // add only one fixer per VariableDeclarationList
                     appliedFixes.add(info.declarationInfo.declarationList);
                 }
-                this.addFailureAtNode(info.identifier, Rule.FAILURE_STRING_FACTORY(name, info.declarationInfo.isBlockScoped), fix);
+                this.addFailureAtNode(
+                    info.identifier,
+                    Rule.FAILURE_STRING_FACTORY(name, info.declarationInfo.isBlockScoped),
+                    fix,
+                );
             }
         });
     }

--- a/src/rules/preferForOfRule.ts
+++ b/src/rules/preferForOfRule.ts
@@ -24,8 +24,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "prefer-for-of",
-        description: "Recommends a 'for-of' loop over a standard 'for' loop if the index is only used to access the array being iterated.",
-        rationale: "A for(... of ...) loop is easier to implement and read when the index is not needed.",
+        description:
+            "Recommends a 'for-of' loop over a standard 'for' loop if the index is only used to access the array being iterated.",
+        rationale:
+            "A for(... of ...) loop is easier to implement and read when the index is not needed.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -34,7 +36,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Expected a 'for-of' loop instead of a 'for' loop with this simple iteration";
+    public static FAILURE_STRING =
+        "Expected a 'for-of' loop instead of a 'for' loop with this simple iteration";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -63,10 +66,13 @@ function walk(ctx: Lint.WalkContext<void>): void {
         if (variables === undefined) {
             variables = utils.collectVariableUsage(sourceFile);
         }
-        for (const {location} of variables.get(indexVariable)!.uses) {
-            if (location.pos < node.initializer!.end || location.pos >= node.end || // bail out on use outside of for loop
-                location.pos >= node.statement.pos && // only check uses in loop body
-                isNonSimpleIncrementorUse(location, arrayExpr, sourceFile)) {
+        for (const { location } of variables.get(indexVariable)!.uses) {
+            if (
+                location.pos < node.initializer!.end ||
+                location.pos >= node.end || // bail out on use outside of for loop
+                (location.pos >= node.statement.pos && // only check uses in loop body
+                    isNonSimpleIncrementorUse(location, arrayExpr, sourceFile))
+            ) {
                 return;
             }
         }
@@ -74,14 +80,20 @@ function walk(ctx: Lint.WalkContext<void>): void {
     }
 }
 
-function isNonSimpleIncrementorUse(node: ts.Identifier, arrayExpr: ts.Expression, sourceFile: ts.SourceFile): boolean {
+function isNonSimpleIncrementorUse(
+    node: ts.Identifier,
+    arrayExpr: ts.Expression,
+    sourceFile: ts.SourceFile,
+): boolean {
     // check if iterator is used for something other than reading data from array
     const parent = node.parent!;
-    return !utils.isElementAccessExpression(parent)
+    return (
+        !utils.isElementAccessExpression(parent) ||
         // `a[i] = ...` or similar
-        || utils.isReassignmentTarget(parent)
+        utils.isReassignmentTarget(parent) ||
         // `b[i]`
-        || !nodeEquals(arrayExpr, unwrapParentheses(parent.expression), sourceFile);
+        !nodeEquals(arrayExpr, unwrapParentheses(parent.expression), sourceFile)
+    );
 }
 
 function nodeEquals(a: ts.Node, b: ts.Node, sourceFile: ts.SourceFile): boolean {
@@ -89,7 +101,9 @@ function nodeEquals(a: ts.Node, b: ts.Node, sourceFile: ts.SourceFile): boolean 
 }
 
 // returns the iterator and array of a `for` loop if the `for` loop is basic.
-function getForLoopHeaderInfo(forLoop: ts.ForStatement): { indexVariable: ts.Identifier; arrayExpr: ts.Expression } | undefined {
+function getForLoopHeaderInfo(
+    forLoop: ts.ForStatement,
+): { indexVariable: ts.Identifier; arrayExpr: ts.Expression } | undefined {
     const { initializer, condition, incrementor } = forLoop;
     if (initializer === undefined || condition === undefined || incrementor === undefined) {
         return undefined;
@@ -100,7 +114,11 @@ function getForLoopHeaderInfo(forLoop: ts.ForStatement): { indexVariable: ts.Ide
         return undefined;
     }
     const { name: indexVariable, initializer: indexInit } = initializer.declarations[0];
-    if (indexVariable.kind !== ts.SyntaxKind.Identifier || indexInit === undefined || !isNumber(indexInit, "0")) {
+    if (
+        indexVariable.kind !== ts.SyntaxKind.Identifier ||
+        indexInit === undefined ||
+        !isNumber(indexInit, "0")
+    ) {
         return undefined;
     }
 
@@ -115,9 +133,11 @@ function getForLoopHeaderInfo(forLoop: ts.ForStatement): { indexVariable: ts.Ide
     }
 
     const { left, operatorToken, right } = condition;
-    if (!isIdentifierNamed(left, indexVariable.text) ||
-            operatorToken.kind !== ts.SyntaxKind.LessThanToken ||
-            !utils.isPropertyAccessExpression(right)) {
+    if (
+        !isIdentifierNamed(left, indexVariable.text) ||
+        operatorToken.kind !== ts.SyntaxKind.LessThanToken ||
+        !utils.isPropertyAccessExpression(right)
+    ) {
         return undefined;
     }
 
@@ -133,7 +153,9 @@ function isIncremented(node: ts.Node, indexVariableName: string): boolean {
     switch (node.kind) {
         case ts.SyntaxKind.PrefixUnaryExpression:
         case ts.SyntaxKind.PostfixUnaryExpression: {
-            const { operator, operand } = node as ts.PrefixUnaryExpression | ts.PostfixUnaryExpression;
+            const { operator, operand } = node as
+                | ts.PrefixUnaryExpression
+                | ts.PostfixUnaryExpression;
             // `++x` or `x++`
             return operator === ts.SyntaxKind.PlusPlusToken && isVar(operand);
         }
@@ -154,7 +176,10 @@ function isIncremented(node: ts.Node, indexVariableName: string): boolean {
                     }
                     const { operatorToken: rhsOp, left, right } = rhs;
                     // `x = 1 + x` or `x = x + 1`
-                    return rhsOp.kind === ts.SyntaxKind.PlusToken && (isVar(left) && isOne(right) || isOne(left) && isVar(right));
+                    return (
+                        rhsOp.kind === ts.SyntaxKind.PlusToken &&
+                        ((isVar(left) && isOne(right)) || (isOne(left) && isVar(right)))
+                    );
                 }
                 default:
                     return false;

--- a/src/rules/preferFunctionOverMethodRule.ts
+++ b/src/rules/preferFunctionOverMethodRule.ts
@@ -40,10 +40,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             type: "string",
             enum: [OPTION_ALLOW_PUBLIC, OPTION_ALLOW_PROTECTED],
         },
-        optionExamples: [
-            true,
-            [true, OPTION_ALLOW_PUBLIC, OPTION_ALLOW_PROTECTED],
-        ],
+        optionExamples: [true, [true, OPTION_ALLOW_PUBLIC, OPTION_ALLOW_PROTECTED]],
         type: "style",
         typescriptOnly: false,
     };
@@ -52,10 +49,12 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING = "Class method does not use 'this'. Use a function instead.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new PreferFunctionOverMethodWalker(sourceFile, this.ruleName, {
-            allowProtected: this.ruleArguments.indexOf(OPTION_ALLOW_PROTECTED) !== -1,
-            allowPublic: this.ruleArguments.indexOf(OPTION_ALLOW_PUBLIC) !== -1,
-        }));
+        return this.applyWithWalker(
+            new PreferFunctionOverMethodWalker(sourceFile, this.ruleName, {
+                allowProtected: this.ruleArguments.indexOf(OPTION_ALLOW_PROTECTED) !== -1,
+                allowPublic: this.ruleArguments.indexOf(OPTION_ALLOW_PUBLIC) !== -1,
+            }),
+        );
     }
 }
 
@@ -80,27 +79,38 @@ class PreferFunctionOverMethodWalker extends Lint.AbstractWalker<Options> {
                 this.currentScope = undefined;
                 ts.forEachChild(node, cb);
                 this.currentScope = scope;
-            } else if (this.currentScope !== undefined &&
-                       (node.kind === ts.SyntaxKind.ThisKeyword && !isRecursiveCall(node, this.currentScope.name) ||
-                        node.kind === ts.SyntaxKind.SuperKeyword)) {
+            } else if (
+                this.currentScope !== undefined &&
+                ((node.kind === ts.SyntaxKind.ThisKeyword &&
+                    !isRecursiveCall(node, this.currentScope.name)) ||
+                    node.kind === ts.SyntaxKind.SuperKeyword)
+            ) {
                 this.currentScope.isThisUsed = true;
             } else {
                 return ts.forEachChild(node, cb);
             }
-
         };
         return ts.forEachChild(sourceFile, cb);
     }
 
     private isExempt(node: ts.MethodDeclaration): boolean {
         // TODO: handle the override keyword once it lands in the language
-        return node.body === undefined || // exclude abstract methods and overload signatures
+        return (
+            node.body === undefined || // exclude abstract methods and overload signatures
             // exclude object methods
-            node.parent!.kind !== ts.SyntaxKind.ClassDeclaration && node.parent!.kind !== ts.SyntaxKind.ClassExpression ||
+            (node.parent!.kind !== ts.SyntaxKind.ClassDeclaration &&
+                node.parent!.kind !== ts.SyntaxKind.ClassExpression) ||
             hasModifier(node.modifiers, ts.SyntaxKind.StaticKeyword) ||
-            this.options.allowProtected && hasModifier(node.modifiers, ts.SyntaxKind.ProtectedKeyword) ||
-            this.options.allowPublic && (hasModifier(node.modifiers, ts.SyntaxKind.PublicKeyword) ||
-                                         !hasModifier(node.modifiers, ts.SyntaxKind.ProtectedKeyword, ts.SyntaxKind.PrivateKeyword));
+            (this.options.allowProtected &&
+                hasModifier(node.modifiers, ts.SyntaxKind.ProtectedKeyword)) ||
+            (this.options.allowPublic &&
+                (hasModifier(node.modifiers, ts.SyntaxKind.PublicKeyword) ||
+                    !hasModifier(
+                        node.modifiers,
+                        ts.SyntaxKind.ProtectedKeyword,
+                        ts.SyntaxKind.PrivateKeyword,
+                    )))
+        );
     }
 }
 
@@ -110,7 +120,9 @@ interface ThisUsed {
 }
 
 function isRecursiveCall(node: ts.Node, name?: string) {
-    return name !== undefined &&
+    return (
+        name !== undefined &&
         node.parent!.kind === ts.SyntaxKind.PropertyAccessExpression &&
-        (node.parent as ts.PropertyAccessExpression).name.text === name;
+        (node.parent as ts.PropertyAccessExpression).name.text === name
+    );
 }

--- a/src/rules/preferMethodSignatureRule.ts
+++ b/src/rules/preferMethodSignatureRule.ts
@@ -30,7 +30,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         options: null,
         optionExamples: [true],
         type: "style",
-        typescriptOnly: false
+        typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
 
@@ -71,7 +71,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
                     Rule.FAILURE_STRING,
                     type.type === undefined
                         ? undefined
-                        : [Lint.Replacement.replaceNode(node, Rule.METH_SIGN_STRING(node))]
+                        : [Lint.Replacement.replaceNode(node, Rule.METH_SIGN_STRING(node))],
                 );
             }
         }

--- a/src/rules/preferObjectSpreadRule.ts
+++ b/src/rules/preferObjectSpreadRule.ts
@@ -32,7 +32,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "prefer-object-spread",
-        description: "Enforces the use of the ES2015 object spread operator over `Object.assign()` where appropriate.",
+        description:
+            "Enforces the use of the ES2015 object spread operator over `Object.assign()` where appropriate.",
         rationale: "Object spread allows for better type checking and inference.",
         optionsDescription: "Not configurable.",
         options: null,
@@ -44,7 +45,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public static FAILURE_STRING = "Use the object spread operator instead.";
-    public static ASSIGNMENT_FAILURE_STRING = "'Object.assign' returns the first argument. Prefer object spread if you want a new object.";
+    public static ASSIGNMENT_FAILURE_STRING =
+        "'Object.assign' returns the first argument. Prefer object spread if you want a new object.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -53,9 +55,13 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isCallExpression(node) && node.arguments.length !== 0 &&
-            isPropertyAccessExpression(node.expression) && node.expression.name.text === "assign" &&
-            isIdentifier(node.expression.expression) && node.expression.expression.text === "Object" &&
+        if (
+            isCallExpression(node) &&
+            node.arguments.length !== 0 &&
+            isPropertyAccessExpression(node.expression) &&
+            node.expression.name.text === "assign" &&
+            isIdentifier(node.expression.expression) &&
+            node.expression.expression.text === "Object" &&
             !ts.isFunctionLike(node.arguments[0]) &&
             // Object.assign(...someArray) cannot be written as object spread
             !node.arguments.some(isSpreadElement) &&
@@ -65,13 +71,20 @@ function walk(ctx: Lint.WalkContext<void>) {
              * support for spread types.
              * PR: https://github.com/Microsoft/TypeScript/issues/10727
              */
-            !node.arguments.some(isThisKeyword)) {
+            !node.arguments.some(isThisKeyword)
+        ) {
             if (node.arguments[0].kind === ts.SyntaxKind.ObjectLiteralExpression) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING, createFix(node, ctx.sourceFile));
-            } else if (isExpressionValueUsed(node) && !hasSideEffects(node.arguments[0], SideEffectOptions.Constructor)) {
-                ctx.addFailureAtNode(node, Rule.ASSIGNMENT_FAILURE_STRING, createFix(node, ctx.sourceFile));
+            } else if (
+                isExpressionValueUsed(node) &&
+                !hasSideEffects(node.arguments[0], SideEffectOptions.Constructor)
+            ) {
+                ctx.addFailureAtNode(
+                    node,
+                    Rule.ASSIGNMENT_FAILURE_STRING,
+                    createFix(node, ctx.sourceFile),
+                );
             }
-
         }
         return ts.forEachChild(node, cb);
     });
@@ -81,7 +94,11 @@ function createFix(node: ts.CallExpression, sourceFile: ts.SourceFile): Lint.Fix
     const args = node.arguments;
     const objectNeedsParens = node.parent!.kind === ts.SyntaxKind.ArrowFunction;
     const fix = [
-        Lint.Replacement.replaceFromTo(node.getStart(sourceFile), args[0].getStart(sourceFile), `${objectNeedsParens ? "(" : ""}{`),
+        Lint.Replacement.replaceFromTo(
+            node.getStart(sourceFile),
+            args[0].getStart(sourceFile),
+            `${objectNeedsParens ? "(" : ""}{`,
+        ),
         new Lint.Replacement(node.end - 1, 1, `}${objectNeedsParens ? ")" : ""}`),
     ];
     for (let i = 0; i < args.length; ++i) {
@@ -101,12 +118,17 @@ function createFix(node: ts.CallExpression, sourceFile: ts.SourceFile): Lint.Fix
                     // remove open brace
                     Lint.Replacement.deleteText(arg.getStart(sourceFile), 1),
                     // remove trailing comma if exists and close brace
-                    Lint.Replacement.deleteFromTo(arg.properties[arg.properties.length - 1].end, arg.end),
+                    Lint.Replacement.deleteFromTo(
+                        arg.properties[arg.properties.length - 1].end,
+                        arg.end,
+                    ),
                 );
             }
         } else {
             const parens = needsParens(arg);
-            fix.push(Lint.Replacement.appendText(arg.getStart(sourceFile), parens ? "...(" : "..."));
+            fix.push(
+                Lint.Replacement.appendText(arg.getStart(sourceFile), parens ? "...(" : "..."),
+            );
             if (parens) {
                 fix.push(Lint.Replacement.appendText(arg.end, ")"));
             }

--- a/src/rules/preferReadonlyRule.ts
+++ b/src/rules/preferReadonlyRule.ts
@@ -31,14 +31,12 @@ interface Options {
 
 export class Rule extends Lint.Rules.TypedRule {
     public static metadata: Lint.IRuleMetadata = {
-        description: "Requires that private variables are marked as `readonly` if they're never modified outside of the constructor.",
+        description:
+            "Requires that private variables are marked as `readonly` if they're never modified outside of the constructor.",
         descriptionDetails: Lint.Utils.dedent`
             If a private variable is only assigned to in the constructor, it should be declared as \`readonly\`.
         `,
-        optionExamples: [
-            true,
-            [true, OPTION_ONLY_INLINE_LAMBDAS],
-        ],
+        optionExamples: [true, [true, OPTION_ONLY_INLINE_LAMBDAS]],
         options: {
             enum: [OPTION_ONLY_INLINE_LAMBDAS],
             type: "string",
@@ -93,7 +91,10 @@ function walk(context: Lint.WalkContext<Options>, typeChecker: ts.TypeChecker) {
 
             case ts.SyntaxKind.PropertyAccessExpression:
                 if (scope !== undefined) {
-                    handlePropertyAccessExpression(node as ts.PropertyAccessExpression, node.parent!);
+                    handlePropertyAccessExpression(
+                        node as ts.PropertyAccessExpression,
+                        node.parent!,
+                    );
                 }
                 break;
 
@@ -119,7 +120,7 @@ function walk(context: Lint.WalkContext<Options>, typeChecker: ts.TypeChecker) {
 
     function handleClassDeclarationOrExpression(node: ts.ClassLikeDeclaration) {
         const parentScope = scope;
-        const childScope = scope = new ClassScope(node, typeChecker);
+        const childScope = (scope = new ClassScope(node, typeChecker));
 
         ts.forEachChild(node, visitNode);
 
@@ -161,20 +162,30 @@ function walk(context: Lint.WalkContext<Options>, typeChecker: ts.TypeChecker) {
 
             case ts.SyntaxKind.PostfixUnaryExpression:
             case ts.SyntaxKind.PrefixUnaryExpression:
-                handleParentPostfixOrPrefixUnaryExpression(parent as ts.PostfixUnaryExpression | ts.PrefixUnaryExpression);
+                handleParentPostfixOrPrefixUnaryExpression(parent as
+                    | ts.PostfixUnaryExpression
+                    | ts.PrefixUnaryExpression);
         }
 
         ts.forEachChild(node, visitNode);
     }
 
-    function handleParentBinaryExpression(node: ts.PropertyAccessExpression, parent: ts.BinaryExpression) {
+    function handleParentBinaryExpression(
+        node: ts.PropertyAccessExpression,
+        parent: ts.BinaryExpression,
+    ) {
         if (parent.left === node && utils.isAssignmentKind(parent.operatorToken.kind)) {
             scope.addVariableModification(node);
         }
     }
 
-    function handleParentPostfixOrPrefixUnaryExpression(node: ts.PostfixUnaryExpression | ts.PrefixUnaryExpression) {
-        if (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) {
+    function handleParentPostfixOrPrefixUnaryExpression(
+        node: ts.PostfixUnaryExpression | ts.PrefixUnaryExpression,
+    ) {
+        if (
+            node.operator === ts.SyntaxKind.PlusPlusToken ||
+            node.operator === ts.SyntaxKind.MinusMinusToken
+        ) {
             scope.addVariableModification(node.operand as ts.PropertyAccessExpression);
         }
     }
@@ -188,7 +199,9 @@ function walk(context: Lint.WalkContext<Options>, typeChecker: ts.TypeChecker) {
             return false;
         }
 
-        return node.initializer === undefined || node.initializer.kind !== ts.SyntaxKind.ArrowFunction;
+        return (
+            node.initializer === undefined || node.initializer.kind !== ts.SyntaxKind.ArrowFunction
+        );
     }
 
     function finalizeScope(childScope: ClassScope) {
@@ -234,9 +247,11 @@ class ClassScope {
     }
 
     public addDeclaredVariable(node: ParameterOrPropertyDeclaration) {
-        if (!utils.isModifierFlagSet(node, ts.ModifierFlags.Private)
-            || utils.isModifierFlagSet(node, ts.ModifierFlags.Readonly)
-            || node.name.kind === ts.SyntaxKind.ComputedPropertyName) {
+        if (
+            !utils.isModifierFlagSet(node, ts.ModifierFlags.Private) ||
+            utils.isModifierFlagSet(node, ts.ModifierFlags.Readonly) ||
+            node.name.kind === ts.SyntaxKind.ComputedPropertyName
+        ) {
             return;
         }
 
@@ -249,18 +264,25 @@ class ClassScope {
 
     public addVariableModification(node: ts.PropertyAccessExpression) {
         const modifierType = this.typeChecker.getTypeAtLocation(node.expression);
-        if (modifierType.symbol === undefined || !typeIsOrHasBaseType(modifierType, this.classType)) {
+        if (
+            modifierType.symbol === undefined ||
+            !typeIsOrHasBaseType(modifierType, this.classType)
+        ) {
             return;
         }
 
-        const toStatic = utils.isObjectType(modifierType) && utils.isObjectFlagSet(modifierType, ts.ObjectFlags.Anonymous);
+        const toStatic =
+            utils.isObjectType(modifierType) &&
+            utils.isObjectFlagSet(modifierType, ts.ObjectFlags.Anonymous);
         if (!toStatic && this.constructorScopeDepth === DIRECTLY_INSIDE_CONSTRUCTOR) {
             return;
         }
 
         const variable = node.name.text;
 
-        (toStatic ? this.staticVariableModifications : this.memberVariableModifications).add(variable);
+        (toStatic ? this.staticVariableModifications : this.memberVariableModifications).add(
+            variable,
+        );
     }
 
     public enterConstructor() {
@@ -284,11 +306,11 @@ class ClassScope {
     }
 
     public finalizeUnmodifiedPrivateNonReadonlys() {
-        this.memberVariableModifications.forEach((variableName) => {
+        this.memberVariableModifications.forEach(variableName => {
             this.privateModifiableMembers.delete(variableName);
         });
 
-        this.staticVariableModifications.forEach((variableName) => {
+        this.staticVariableModifications.forEach(variableName => {
             this.privateModifiableStatics.delete(variableName);
         });
 

--- a/src/rules/preferSwitchRule.ts
+++ b/src/rules/preferSwitchRule.ts
@@ -26,7 +26,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "prefer-switch",
-        description: "Prefer a `switch` statement to an `if` statement with simple `===` comparisons.",
+        description:
+            "Prefer a `switch` statement to an `if` statement with simple `===` comparisons.",
         optionsDescription: Lint.Utils.dedent`
             An optional object with the property '${OPTION_MIN_CASES}'.
             This is the number cases needed before a switch statement is recommended.
@@ -76,7 +77,7 @@ function walk(ctx: Lint.WalkContext<number>): void {
 function check(node: ts.IfStatement, sourceFile: ts.SourceFile, minCases: number): boolean {
     let switchVariable: ts.Expression | undefined;
     let casesSeen = 0;
-    const couldBeSwitch = everyCase(node, (expr) => {
+    const couldBeSwitch = everyCase(node, expr => {
         casesSeen++;
         if (switchVariable !== undefined) {
             return nodeEquals(expr, switchVariable, sourceFile);
@@ -88,11 +89,18 @@ function check(node: ts.IfStatement, sourceFile: ts.SourceFile, minCases: number
     return couldBeSwitch && casesSeen >= minCases;
 }
 
-function everyCase({ expression, elseStatement }: ts.IfStatement, test: (e: ts.Expression) => boolean): boolean {
+function everyCase(
+    { expression, elseStatement }: ts.IfStatement,
+    test: (e: ts.Expression) => boolean,
+): boolean {
     if (!everyCondition(expression, test)) {
         return false;
     }
-    return elseStatement === undefined || !utils.isIfStatement(elseStatement) || everyCase(elseStatement, test);
+    return (
+        elseStatement === undefined ||
+        !utils.isIfStatement(elseStatement) ||
+        everyCase(elseStatement, test)
+    );
 }
 
 function everyCondition(node: ts.Expression, test: (e: ts.Expression) => boolean): boolean {

--- a/src/rules/preferTemplateRule.ts
+++ b/src/rules/preferTemplateRule.ts
@@ -45,8 +45,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Use a template literal instead of concatenating with a string literal.";
-    public static FAILURE_STRING_MULTILINE = "Use a multiline template literal instead of concatenating string literals with newlines.";
+    public static FAILURE_STRING =
+        "Use a template literal instead of concatenating with a string literal.";
+    public static FAILURE_STRING_MULTILINE =
+        "Use a multiline template literal instead of concatenating string literals with newlines.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         if (sourceFile.isDeclarationFile) {
@@ -54,7 +56,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         }
 
         const allowSingleConcat = this.ruleArguments.indexOf(OPTION_SINGLE_CONCAT) !== -1;
-        return this.applyWithFunction(sourceFile, walk, {allowSingleConcat});
+        return this.applyWithFunction(sourceFile, walk, { allowSingleConcat });
     }
 }
 
@@ -83,7 +85,9 @@ function getError(node: ts.Node, allowSingleConcat: boolean): string | undefined
         // They're both strings.
         // If they're joined by a newline, recommend a template expression instead.
         // Otherwise ignore. ("a" + "b", probably writing a long newline-less string on many lines.)
-        return containsNewline(left as StringLike) || containsNewline(right as StringLike) ? Rule.FAILURE_STRING_MULTILINE : undefined;
+        return containsNewline(left as StringLike) || containsNewline(right as StringLike)
+            ? Rule.FAILURE_STRING_MULTILINE
+            : undefined;
     } else if (!l && !r) {
         // Watch out for `"a" + b + c`. Parsed as `("a" + b) + c`.
         return containsAnyStringLiterals(left) ? Rule.FAILURE_STRING : undefined;
@@ -93,7 +97,9 @@ function getError(node: ts.Node, allowSingleConcat: boolean): string | undefined
     } else {
         // `? + "b"`
         // If LHS consists of only string literals (as in `"a" + "b" + "c"`, allow it.)
-        return !containsOnlyStringLiterals(left) && (!allowSingleConcat || isPlusExpression(left))  ? Rule.FAILURE_STRING : undefined;
+        return !containsOnlyStringLiterals(left) && (!allowSingleConcat || isPlusExpression(left))
+            ? Rule.FAILURE_STRING
+            : undefined;
     }
 }
 
@@ -108,11 +114,20 @@ function containsNewline(node: StringLike): boolean {
 }
 
 function containsOnlyStringLiterals(node: ts.Expression): boolean {
-    return isPlusExpression(node) && isStringLike(node.right) && (isStringLike(node.left) || containsAnyStringLiterals(node.left));
+    return (
+        isPlusExpression(node) &&
+        isStringLike(node.right) &&
+        (isStringLike(node.left) || containsAnyStringLiterals(node.left))
+    );
 }
 
 function containsAnyStringLiterals(node: ts.Expression): boolean {
-    return isPlusExpression(node) && (isStringLike(node.right) || isStringLike(node.left) || containsAnyStringLiterals(node.left));
+    return (
+        isPlusExpression(node) &&
+        (isStringLike(node.right) ||
+            isStringLike(node.left) ||
+            containsAnyStringLiterals(node.left))
+    );
 }
 
 function isPlusExpression(node: ts.Node): node is ts.BinaryExpression {

--- a/src/rules/preferWhileRule.ts
+++ b/src/rules/preferWhileRule.ts
@@ -24,8 +24,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "prefer-while",
-        description: "Prefer `while` loops instead of `for` loops without an initializer and incrementor.",
-        rationale: "Simplifies the readability of the loop statement, while maintaining the same functionality.",
+        description:
+            "Prefer `while` loops instead of `for` loops without an initializer and incrementor.",
+        rationale:
+            "Simplifies the readability of the loop statement, while maintaining the same functionality.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -36,7 +38,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "Prefer `while` loops instead of `for` loops without an initializer and incrementor.";
+    public static FAILURE_STRING =
+        "Prefer `while` loops instead of `for` loops without an initializer and incrementor.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const failures: Lint.RuleFailure[] = [];
@@ -53,7 +56,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 
     private doesNodeViolateRule(node: ts.ForStatement) {
-        return (node.initializer === undefined && node.incrementor === undefined);
+        return node.initializer === undefined && node.incrementor === undefined;
     }
 
     private createFailure(sourceFile: ts.SourceFile, node: ts.ForStatement): Lint.RuleFailure {
@@ -65,10 +68,21 @@ export class Rule extends Lint.Rules.AbstractRule {
             fix = Lint.Replacement.replaceFromTo(start, end, "while (true)");
         } else {
             fix = [
-                Lint.Replacement.replaceFromTo(start, node.condition.getStart(sourceFile), "while ("),
+                Lint.Replacement.replaceFromTo(
+                    start,
+                    node.condition.getStart(sourceFile),
+                    "while (",
+                ),
                 Lint.Replacement.deleteFromTo(node.condition.end, end - 1),
             ];
         }
-        return new Lint.RuleFailure(sourceFile, start, end, Rule.FAILURE_STRING, this.ruleName, fix);
+        return new Lint.RuleFailure(
+            sourceFile,
+            start,
+            end,
+            Rule.FAILURE_STRING,
+            this.ruleName,
+            fix,
+        );
     }
 }

--- a/src/rules/promiseFunctionAsyncRule.ts
+++ b/src/rules/promiseFunctionAsyncRule.ts
@@ -79,8 +79,7 @@ export class Rule extends Lint.Rules.TypedRule {
             minLength: 0,
             maxLength: 4,
         },
-        optionExamples: [true,
-                         [true, OPTION_FUNCTION_DECLARATION, OPTION_METHOD_DECLARATION]],
+        optionExamples: [true, [true, OPTION_FUNCTION_DECLARATION, OPTION_METHOD_DECLARATION]],
         type: "typescript",
         typescriptOnly: false,
         requiresTypeInfo: true,
@@ -90,7 +89,12 @@ export class Rule extends Lint.Rules.TypedRule {
     public static FAILURE_STRING = "functions that return promises must be async";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, walk, parseOptions(this.ruleArguments), program.getTypeChecker());
+        return this.applyWithFunction(
+            sourceFile,
+            walk,
+            parseOptions(this.ruleArguments),
+            program.getTypeChecker(),
+        );
     }
 }
 
@@ -104,12 +108,18 @@ function walk(ctx: Lint.WalkContext<EnabledSyntaxKinds>, tc: ts.TypeChecker) {
                     if ((node as ts.FunctionLikeDeclaration).body === undefined) {
                         break;
                     }
-                    // falls through
+                // falls through
                 case ts.SyntaxKind.FunctionExpression:
                 case ts.SyntaxKind.ArrowFunction:
-                    if (!hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword)
-                        && returnsPromise(node as ts.FunctionLikeDeclaration, tc)) {
-                        ctx.addFailure(node.getStart(sourceFile), (node as ts.FunctionLikeDeclaration).body!.pos, Rule.FAILURE_STRING);
+                    if (
+                        !hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword) &&
+                        returnsPromise(node as ts.FunctionLikeDeclaration, tc)
+                    ) {
+                        ctx.addFailure(
+                            node.getStart(sourceFile),
+                            (node as ts.FunctionLikeDeclaration).body!.pos,
+                            Rule.FAILURE_STRING,
+                        );
                     }
             }
         }

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -88,7 +88,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const args = this.ruleArguments;
 
-        const quoteMark = getQuotemarkPreference(args) ;
+        const quoteMark = getQuotemarkPreference(args);
         const jsxQuoteMark = getJSXQuotemarkPreference(args);
 
         return this.applyWithFunction(sourceFile, walk, {
@@ -107,11 +107,17 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<Options>) {
     const { sourceFile, options } = ctx;
     ts.forEachChild(sourceFile, function cb(node) {
-        if (isStringLiteral(node)
-                || options.avoidTemplate && isNoSubstitutionTemplateLiteral(node)
-                && node.parent!.kind !== ts.SyntaxKind.TaggedTemplateExpression
-                && isSameLine(sourceFile, node.getStart(sourceFile), node.end)) {
-            const expectedQuoteMark = node.parent!.kind === ts.SyntaxKind.JsxAttribute ? options.jsxQuoteMark : options.quoteMark;
+        if (
+            isStringLiteral(node) ||
+            (options.avoidTemplate &&
+                isNoSubstitutionTemplateLiteral(node) &&
+                node.parent!.kind !== ts.SyntaxKind.TaggedTemplateExpression &&
+                isSameLine(sourceFile, node.getStart(sourceFile), node.end))
+        ) {
+            const expectedQuoteMark =
+                node.parent!.kind === ts.SyntaxKind.JsxAttribute
+                    ? options.jsxQuoteMark
+                    : options.quoteMark;
             const actualQuoteMark = sourceFile.text[node.end - 1];
 
             if (actualQuoteMark === expectedQuoteMark) {
@@ -130,9 +136,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
 
                 // If we are expecting double quotes, use single quotes to avoid
                 //   escaping. Otherwise, just use double quotes.
-                fixQuoteMark = expectedQuoteMark === '"' ?
-                    "'" :
-                    '"';
+                fixQuoteMark = expectedQuoteMark === '"' ? "'" : '"';
 
                 // It also includes the fixQuoteMark. Let's try to use single
                 //   quotes instead, unless we originally expected single
@@ -141,9 +145,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 //   in trying to avoid escaping. What is the desired priority
                 //   here?
                 if (node.text.includes(fixQuoteMark)) {
-                    fixQuoteMark = expectedQuoteMark === "'" ?
-                        "`" :
-                        "'";
+                    fixQuoteMark = expectedQuoteMark === "'" ? "`" : "'";
 
                     // It contains all of the other kinds of quotes. Escaping is
                     //   unavoidable, sadly.
@@ -162,8 +164,12 @@ function walk(ctx: Lint.WalkContext<Options>) {
 
             text = text.replace(new RegExp(`\\\\${actualQuoteMark}`, "g"), actualQuoteMark);
 
-            return ctx.addFailure(start, node.end, Rule.FAILURE_STRING(actualQuoteMark, fixQuoteMark),
-                                  new Lint.Replacement(start, node.end - start, fixQuoteMark + text + fixQuoteMark));
+            return ctx.addFailure(
+                start,
+                node.end,
+                Rule.FAILURE_STRING(actualQuoteMark, fixQuoteMark),
+                new Lint.Replacement(start, node.end - start, fixQuoteMark + text + fixQuoteMark),
+            );
         }
         ts.forEachChild(node, cb);
     });

--- a/src/rules/radixRule.ts
+++ b/src/rules/radixRule.ts
@@ -60,32 +60,46 @@ function isPropertyAccessOfIdentifier(
     expression: ts.LeftHandSideExpression,
     identifers: string[],
 ): expression is ts.PropertyAccessExpression {
-    return isPropertyAccessExpression(expression) && isIdentifier(expression.expression) &&
-        identifers.some((identifer) => (expression.expression as ts.Identifier).text === identifer);
+    return (
+        isPropertyAccessExpression(expression) &&
+        isIdentifier(expression.expression) &&
+        identifers.some(identifer => (expression.expression as ts.Identifier).text === identifer)
+    );
 }
 
 function isPropertyAccessOfProperty(
     expression: ts.LeftHandSideExpression,
     identifers: string[],
 ): expression is ts.PropertyAccessExpression {
-    return isPropertyAccessExpression(expression) && isPropertyAccessExpression(expression.expression) &&
-        identifers.some((identifer) => (expression.expression as ts.PropertyAccessExpression).name.text === identifer);
+    return (
+        isPropertyAccessExpression(expression) &&
+        isPropertyAccessExpression(expression.expression) &&
+        identifers.some(
+            identifer =>
+                (expression.expression as ts.PropertyAccessExpression).name.text === identifer,
+        )
+    );
 }
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (isCallExpression(node) && node.arguments.length === 1 &&
-            (
-                // parseInt("123")
-                isParseInt(node.expression) ||
+        if (
+            isCallExpression(node) &&
+            node.arguments.length === 1 &&
+            // parseInt("123")
+            (isParseInt(node.expression) ||
                 // window.parseInt("123") || global.parseInt("123") || Number.parseInt("123")
-                isPropertyAccessParseInt(node.expression) &&
-                isPropertyAccessOfIdentifier(node.expression, [ "global", "window", "Number" ])  ||
+                (isPropertyAccessParseInt(node.expression) &&
+                    isPropertyAccessOfIdentifier(node.expression, [
+                        "global",
+                        "window",
+                        "Number",
+                    ])) ||
                 // window.Number.parseInt("123") || global.Number.parseInt("123")
-                isPropertyAccessParseInt(node.expression) &&
-                isPropertyAccessOfProperty(node.expression, [ "Number" ]) &&
-                isPropertyAccessOfIdentifier(node.expression.expression, [ "global", "window" ])
-            )) {
+                (isPropertyAccessParseInt(node.expression) &&
+                    isPropertyAccessOfProperty(node.expression, ["Number"]) &&
+                    isPropertyAccessOfIdentifier(node.expression.expression, ["global", "window"])))
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/restrictPlusOperandsRule.ts
+++ b/src/rules/restrictPlusOperandsRule.ts
@@ -24,7 +24,8 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "restrict-plus-operands",
-        description: "When adding two variables, operands must both be of type number or of type string.",
+        description:
+            "When adding two variables, operands must both be of type number or of type string.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -34,7 +35,8 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static INVALID_TYPES_ERROR = "Operands of '+' operation must either be both strings or both numbers";
+    public static INVALID_TYPES_ERROR =
+        "Operands of '+' operation must either be both strings or both numbers";
     public static SUGGEST_TEMPLATE_LITERALS = ", consider using template literals";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
@@ -49,7 +51,10 @@ function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker) {
             const rightType = getBaseTypeOfLiteralType(tc.getTypeAtLocation(node.right));
             if (leftType === "invalid" || rightType === "invalid" || leftType !== rightType) {
                 if (leftType === "string" || rightType === "string") {
-                    return ctx.addFailureAtNode(node, Rule.INVALID_TYPES_ERROR + Rule.SUGGEST_TEMPLATE_LITERALS);
+                    return ctx.addFailureAtNode(
+                        node,
+                        Rule.INVALID_TYPES_ERROR + Rule.SUGGEST_TEMPLATE_LITERALS,
+                    );
                 } else {
                     return ctx.addFailureAtNode(node, Rule.INVALID_TYPES_ERROR);
                 }
@@ -60,20 +65,26 @@ function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker) {
 }
 
 function getBaseTypeOfLiteralType(type: ts.Type): "string" | "number" | "invalid" {
-    if (isTypeFlagSet(type, ts.TypeFlags.StringLiteral) || isTypeFlagSet(type, ts.TypeFlags.String)) {
+    if (
+        isTypeFlagSet(type, ts.TypeFlags.StringLiteral) ||
+        isTypeFlagSet(type, ts.TypeFlags.String)
+    ) {
         return "string";
-    } else if (isTypeFlagSet(type, ts.TypeFlags.NumberLiteral) || isTypeFlagSet(type, ts.TypeFlags.Number)) {
+    } else if (
+        isTypeFlagSet(type, ts.TypeFlags.NumberLiteral) ||
+        isTypeFlagSet(type, ts.TypeFlags.Number)
+    ) {
         return "number";
     } else if (isUnionType(type) && !isTypeFlagSet(type, ts.TypeFlags.Enum)) {
         const types = type.types.map(getBaseTypeOfLiteralType);
         return allSame(types) ? types[0] : "invalid";
     } else if (isTypeFlagSet(type, ts.TypeFlags.EnumLiteral)) {
         // Compatibility for TypeScript pre-2.4, which used EnumLiteralType instead of LiteralType
-        getBaseTypeOfLiteralType((type as any as { baseType: ts.LiteralType }).baseType);
+        getBaseTypeOfLiteralType(((type as any) as { baseType: ts.LiteralType }).baseType);
     }
     return "invalid";
 }
 
 function allSame(array: string[]) {
-    return array.every((value) => value === array[0]);
+    return array.every(value => value === array[0]);
 }

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -144,8 +144,8 @@ function isEffectivelyVoidPromise(type: ts.Type): boolean {
     // Would need access to `checker.getPromisedTypeOfPromise` to do this properly.
     // Assume that the return type is the global Promise (since this is an async function) and get its type argument.
 
-    // tslint:disable-next-line no-bitwise
     return (
+        // tslint:disable-next-line:no-bitwise
         isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
         (isUnionType(type) && type.types.every(isEffectivelyVoidPromise)) ||
         (isTypeReference(type) &&
@@ -157,8 +157,8 @@ function isEffectivelyVoidPromise(type: ts.Type): boolean {
 
 /** True for `void`, `undefined`, or `void | undefined`. */
 function isEffectivelyVoid(type: ts.Type): boolean {
-    // tslint:disable-next-line no-bitwise
     return (
+        // tslint:disable-next-line:no-bitwise
         isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
         (isUnionType(type) && type.types.every(isEffectivelyVoid))
     );

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -15,7 +15,14 @@
  * limitations under the License.
  */
 
-import { hasModifier, isIdentifier, isReturnStatement, isTypeFlagSet, isTypeReference, isUnionType } from "tsutils";
+import {
+    hasModifier,
+    isIdentifier,
+    isReturnStatement,
+    isTypeFlagSet,
+    isTypeReference,
+    isUnionType,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -24,7 +31,8 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "return-undefined",
-        description: "Prefer `return;` in void functions and `return undefined;` in value-returning functions.",
+        description:
+            "Prefer `return;` in void functions and `return undefined;` in value-returning functions.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -70,7 +78,8 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
                 node,
                 returnKindFromType === ReturnKind.Void
                     ? Rule.FAILURE_STRING_VOID_RETURN
-                    : Rule.FAILURE_STRING_VALUE_RETURN);
+                    : Rule.FAILURE_STRING_VALUE_RETURN,
+            );
         }
     }
 }
@@ -108,15 +117,23 @@ function getReturnKind(node: FunctionLike, checker: ts.TypeChecker): ReturnKind 
             return ReturnKind.Value;
     }
 
-    const contextual = isFunctionExpressionLike(node) && node.type === undefined
-        ? tryGetReturnType(checker.getContextualType(node), checker)
-        : undefined;
-    const returnType = contextual !== undefined ? contextual : tryGetReturnType(checker.getTypeAtLocation(node), checker);
+    const contextual =
+        isFunctionExpressionLike(node) && node.type === undefined
+            ? tryGetReturnType(checker.getContextualType(node), checker)
+            : undefined;
+    const returnType =
+        contextual !== undefined
+            ? contextual
+            : tryGetReturnType(checker.getTypeAtLocation(node), checker);
 
     if (returnType === undefined || isTypeFlagSet(returnType, ts.TypeFlags.Any)) {
         return undefined;
     }
-    if ((hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword) ? isEffectivelyVoidPromise : isEffectivelyVoid)(returnType)) {
+    if (
+        (hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword)
+            ? isEffectivelyVoidPromise
+            : isEffectivelyVoid)(returnType)
+    ) {
         return ReturnKind.Void;
     }
     return ReturnKind.Value;
@@ -128,20 +145,29 @@ function isEffectivelyVoidPromise(type: ts.Type): boolean {
     // Assume that the return type is the global Promise (since this is an async function) and get its type argument.
 
     // tslint:disable-next-line no-bitwise
-    return isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
-        isUnionType(type) && type.types.every(isEffectivelyVoidPromise) ||
-        isTypeReference(type) && type.typeArguments !== undefined && type.typeArguments.length === 1 &&
-            isEffectivelyVoidPromise(type.typeArguments[0]);
+    return (
+        isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
+        (isUnionType(type) && type.types.every(isEffectivelyVoidPromise)) ||
+        (isTypeReference(type) &&
+            type.typeArguments !== undefined &&
+            type.typeArguments.length === 1 &&
+            isEffectivelyVoidPromise(type.typeArguments[0]))
+    );
 }
 
 /** True for `void`, `undefined`, or `void | undefined`. */
 function isEffectivelyVoid(type: ts.Type): boolean {
     // tslint:disable-next-line no-bitwise
-    return isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
-        isUnionType(type) && type.types.every(isEffectivelyVoid);
+    return (
+        isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
+        (isUnionType(type) && type.types.every(isEffectivelyVoid))
+    );
 }
 
-function tryGetReturnType(fnType: ts.Type | undefined, checker: ts.TypeChecker): ts.Type | undefined {
+function tryGetReturnType(
+    fnType: ts.Type | undefined,
+    checker: ts.TypeChecker,
+): ts.Type | undefined {
     if (fnType === undefined) {
         return undefined;
     }
@@ -170,5 +196,7 @@ function isFunctionLike(node: ts.Node): node is FunctionLike {
 }
 
 function isFunctionExpressionLike(node: ts.Node): node is ts.FunctionExpression | ts.ArrowFunction {
-    return node.kind === ts.SyntaxKind.FunctionExpression || node.kind === ts.SyntaxKind.ArrowFunction;
+    return (
+        node.kind === ts.SyntaxKind.FunctionExpression || node.kind === ts.SyntaxKind.ArrowFunction
+    );
 }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -87,14 +87,18 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options: Options = {
-            boundClassMethods: this.ruleArguments.indexOf(OPTION_STRICT_BOUND_CLASS_METHODS) !== -1
-                ? BoundClassMethodOption.Strict
-                : this.ruleArguments.indexOf(OPTION_IGNORE_BOUND_CLASS_METHODS) !== -1
-                    ? BoundClassMethodOption.Ignore
-                    : BoundClassMethodOption.Default,
+            boundClassMethods:
+                this.ruleArguments.indexOf(OPTION_STRICT_BOUND_CLASS_METHODS) !== -1
+                    ? BoundClassMethodOption.Strict
+                    : this.ruleArguments.indexOf(OPTION_IGNORE_BOUND_CLASS_METHODS) !== -1
+                        ? BoundClassMethodOption.Ignore
+                        : BoundClassMethodOption.Default,
             interfaces: this.ruleArguments.indexOf(OPTION_IGNORE_INTERFACES) === -1,
         };
-        const Walker = this.ruleArguments.indexOf(OPTION_NEVER) === -1 ? SemicolonAlwaysWalker : SemicolonNeverWalker;
+        const Walker =
+            this.ruleArguments.indexOf(OPTION_NEVER) === -1
+                ? SemicolonAlwaysWalker
+                : SemicolonNeverWalker;
         return this.applyWithWalker(new Walker(sourceFile, this.ruleName, options));
     }
 }
@@ -120,7 +124,12 @@ abstract class SemicolonWalker extends Lint.AbstractWalker<Options> {
     }
 
     protected reportUnnecessary(pos: number, noFix?: boolean) {
-        this.addFailure(pos - 1, pos, Rule.FAILURE_STRING_UNNECESSARY, noFix ? undefined : Lint.Replacement.deleteText(pos - 1, 1));
+        this.addFailure(
+            pos - 1,
+            pos,
+            Rule.FAILURE_STRING_UNNECESSARY,
+            noFix ? undefined : Lint.Replacement.deleteText(pos - 1, 1),
+        );
     }
 
     protected checkSemicolonOrLineBreak(node: ts.Node) {
@@ -143,12 +152,19 @@ abstract class SemicolonWalker extends Lint.AbstractWalker<Options> {
         if (this.sourceFile.text[node.end - 1] !== ";") {
             return;
         }
-        const lastToken = utils.getPreviousToken(node.getLastToken(this.sourceFile), this.sourceFile)!;
+        const lastToken = utils.getPreviousToken(
+            node.getLastToken(this.sourceFile),
+            this.sourceFile,
+        )!;
         // yield does not continue on the next line if there is no yielded expression
-        if (lastToken.kind === ts.SyntaxKind.YieldKeyword && lastToken.parent!.kind === ts.SyntaxKind.YieldExpression ||
+        if (
+            (lastToken.kind === ts.SyntaxKind.YieldKeyword &&
+                lastToken.parent!.kind === ts.SyntaxKind.YieldExpression) ||
             // arrow functions with block as body don't continue on the next line
-            lastToken.kind === ts.SyntaxKind.CloseBraceToken && lastToken.parent!.kind === ts.SyntaxKind.Block &&
-                lastToken.parent!.parent!.kind === ts.SyntaxKind.ArrowFunction) {
+            (lastToken.kind === ts.SyntaxKind.CloseBraceToken &&
+                lastToken.parent!.kind === ts.SyntaxKind.Block &&
+                lastToken.parent!.parent!.kind === ts.SyntaxKind.ArrowFunction)
+        ) {
             return this.checkSemicolonOrLineBreak(node);
         }
         const nextToken = utils.getNextToken(node, this.sourceFile)!;
@@ -180,19 +196,22 @@ abstract class SemicolonWalker extends Lint.AbstractWalker<Options> {
             const parentKind = node.parent!.kind;
             // don't remove empty statement if it is a direct child of if, with or a LabeledStatement
             // otherwise this would unintentionally change control flow
-            const noFix = parentKind === ts.SyntaxKind.IfStatement ||
-                          parentKind === ts.SyntaxKind.LabeledStatement ||
-                          parentKind === ts.SyntaxKind.WithStatement;
+            const noFix =
+                parentKind === ts.SyntaxKind.IfStatement ||
+                parentKind === ts.SyntaxKind.LabeledStatement ||
+                parentKind === ts.SyntaxKind.WithStatement;
             this.reportUnnecessary(node.end, noFix);
         }
     }
 
     private visitPropertyDeclaration(node: ts.PropertyDeclaration) {
         // check if this is a multi-line arrow function
-        if (this.options.boundClassMethods !== BoundClassMethodOption.Strict &&
+        if (
+            this.options.boundClassMethods !== BoundClassMethodOption.Strict &&
             node.initializer !== undefined &&
             node.initializer.kind === ts.SyntaxKind.ArrowFunction &&
-            !utils.isSameLine(this.sourceFile, node.getStart(this.sourceFile), node.end)) {
+            !utils.isSameLine(this.sourceFile, node.getStart(this.sourceFile), node.end)
+        ) {
             if (this.options.boundClassMethods === BoundClassMethodOption.Default) {
                 this.checkUnnecessary(node);
             }
@@ -223,7 +242,9 @@ class SemicolonAlwaysWalker extends SemicolonWalker {
             case ts.SyntaxKind.MethodDeclaration:
             case ts.SyntaxKind.FunctionDeclaration:
                 // check shorthand module declarations and method / function signatures
-                if ((node as ts.FunctionLikeDeclaration | ts.ModuleDeclaration).body === undefined) {
+                if (
+                    (node as ts.FunctionLikeDeclaration | ts.ModuleDeclaration).body === undefined
+                ) {
                     this.checkMissing(node);
                 }
                 break;
@@ -248,15 +269,26 @@ class SemicolonAlwaysWalker extends SemicolonWalker {
     }
 
     private reportMissing(pos: number) {
-        this.addFailureAt(pos, 0, Rule.FAILURE_STRING_MISSING, Lint.Replacement.appendText(pos, ";"));
+        this.addFailureAt(
+            pos,
+            0,
+            Rule.FAILURE_STRING_MISSING,
+            Lint.Replacement.appendText(pos, ";"),
+        );
     }
 
     private checkInterface(node: ts.InterfaceDeclaration) {
         for (const member of node.members) {
             switch (this.sourceFile.text[member.end - 1]) {
-                case ";": break;
+                case ";":
+                    break;
                 case ",":
-                    this.addFailureAt(member.end - 1, 1, Rule.FAILURE_STRING_COMMA, new Lint.Replacement(member.end - 1, 1, ";"));
+                    this.addFailureAt(
+                        member.end - 1,
+                        1,
+                        Rule.FAILURE_STRING_COMMA,
+                        new Lint.Replacement(member.end - 1, 1, ";"),
+                    );
                     break;
                 default:
                     this.reportMissing(member.end);

--- a/src/rules/spaceWithinParensRule.ts
+++ b/src/rules/spaceWithinParensRule.ts
@@ -28,7 +28,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "space-within-parens",
-        description: "Enforces spaces within parentheses or disallow them.  Empty parentheses () are always allowed.",
+        description:
+            "Enforces spaces within parentheses or disallow them.  Empty parentheses () are always allowed.",
         hasFix: true,
         optionsDescription: Lint.Utils.dedent`
             You may enforce the amount of whitespace within parentheses.
@@ -41,14 +42,20 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     public static FAILURE_NO_SPACE = "Whitespace within parentheses is not allowed";
     public static FAILURE_NEEDS_SPACE(count: number): string {
-         return `Needs ${count} whitespace${count > 1 ? "s" : ""} within parentheses`;
+        return `Needs ${count} whitespace${count > 1 ? "s" : ""} within parentheses`;
     }
     public static FAILURE_NO_EXTRA_SPACE(count: number): string {
         return `No more than ${count} whitespace${count > 1 ? "s" : ""} within parentheses allowed`;
     }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new SpaceWithinParensWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments[0])));
+        return this.applyWithWalker(
+            new SpaceWithinParensWalker(
+                sourceFile,
+                this.ruleName,
+                parseOptions(this.ruleArguments[0]),
+            ),
+        );
     }
 }
 

--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -245,8 +245,8 @@ function isBooleanUndefined(type: ts.UnionType): boolean | undefined {
             isTruthy = true;
         } else if (isTypeFlagSet(ty, ts.TypeFlags.BooleanLiteral)) {
             isTruthy = isTruthy || (ty as ts.IntrinsicType).intrinsicName === "true";
+            // tslint:disable-next-line:no-bitwise
         } else if (!isTypeFlagSet(ty, ts.TypeFlags.Void | ts.TypeFlags.Undefined)) {
-            // tslint:disable-line:no-bitwise
             return undefined;
         }
     }
@@ -383,8 +383,9 @@ function getKind(type: ts.Type): TypeKind {
                 ? TypeKind.Boolean
                 : is(ts.TypeFlags.Null)
                     ? TypeKind.Null
-                    : is(ts.TypeFlags.Undefined | ts.TypeFlags.Void)
-                        ? TypeKind.Undefined // tslint:disable-line:no-bitwise
+                    : // tslint:disable-next-line:no-bitwise
+                      is(ts.TypeFlags.Undefined | ts.TypeFlags.Void)
+                        ? TypeKind.Undefined
                         : is(ts.TypeFlags.EnumLike)
                             ? TypeKind.Enum
                             : is(ts.TypeFlags.NumberLiteral)

--- a/src/rules/strictTypePredicatesRule.ts
+++ b/src/rules/strictTypePredicatesRule.ts
@@ -166,10 +166,10 @@ function getTypePredicateOneWay(
             return predicate === undefined
                 ? { kind: TypePredicateKind.TypeofTypo }
                 : {
-                      kind: TypePredicateKind.Plain,
                       expression,
-                      predicate,
                       isNullOrUndefined: left.text === "undefined",
+                      kind: TypePredicateKind.Plain,
+                      predicate,
                   };
 
         case ts.SyntaxKind.NullKeyword:
@@ -187,10 +187,10 @@ function getTypePredicateOneWay(
     function nullOrUndefined(flags: ts.TypeFlags): TypePredicate {
         return isStrictEquals
             ? {
-                  kind: TypePredicateKind.Plain,
                   expression: left,
-                  predicate: flagPredicate(flags),
                   isNullOrUndefined: true,
+                  kind: TypePredicateKind.Plain,
+                  predicate: flagPredicate(flags),
               }
             : { kind: TypePredicateKind.NonStructNullUndefined, expression: left };
     }

--- a/src/rules/strictTypePredicatesRule.ts
+++ b/src/rules/strictTypePredicatesRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { isBinaryExpression, isIdentifier, isLiteralExpression, isTypeFlagSet, isUnionType } from "tsutils";
+import {
+    isBinaryExpression,
+    isIdentifier,
+    isLiteralExpression,
+    isTypeFlagSet,
+    isUnionType,
+} from "tsutils";
 
 import * as ts from "typescript";
 import { showWarningOnce } from "../error";
@@ -50,7 +56,10 @@ export class Rule extends Lint.Rules.TypedRule {
         return `Expression is always ${value}.`;
     }
 
-    public static FAILURE_STRICT_PREFER_STRICT_EQUALS(value: "null" | "undefined", isPositive: boolean) {
+    public static FAILURE_STRICT_PREFER_STRICT_EQUALS(
+        value: "null" | "undefined",
+        isPositive: boolean,
+    ) {
         return `Use '${isPositive ? "===" : "!=="} ${value}' instead.`;
     }
 
@@ -74,7 +83,10 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
         return ts.forEachChild(node, cb);
     });
 
-    function checkEquals(node: ts.BinaryExpression, { isStrict, isPositive }: Lint.EqualsKind): void {
+    function checkEquals(
+        node: ts.BinaryExpression,
+        { isStrict, isPositive }: Lint.EqualsKind,
+    ): void {
         const exprPred = getTypePredicate(node, isStrict);
         if (exprPred === undefined) {
             return;
@@ -105,9 +117,11 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
             case TypePredicateKind.NonStructNullUndefined: {
                 const result = testNonStrictNullUndefined(exprType);
                 if (result !== undefined) {
-                    fail(typeof result === "boolean"
-                        ? Rule.FAILURE_STRING(result === isPositive)
-                        : Rule.FAILURE_STRICT_PREFER_STRICT_EQUALS(result, isPositive));
+                    fail(
+                        typeof result === "boolean"
+                            ? Rule.FAILURE_STRING(result === isPositive)
+                            : Rule.FAILURE_STRICT_PREFER_STRICT_EQUALS(result, isPositive),
+                    );
                 }
             }
         }
@@ -119,30 +133,44 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
 }
 
 /** Detects a type predicate given `left === right`. */
-function getTypePredicate(node: ts.BinaryExpression, isStrictEquals: boolean): TypePredicate | undefined {
+function getTypePredicate(
+    node: ts.BinaryExpression,
+    isStrictEquals: boolean,
+): TypePredicate | undefined {
     const { left, right } = node;
     const lr = getTypePredicateOneWay(left, right, isStrictEquals);
     return lr !== undefined ? lr : getTypePredicateOneWay(right, left, isStrictEquals);
 }
 
 /** Only gets the type predicate if the expression is on the left. */
-function getTypePredicateOneWay(left: ts.Expression, right: ts.Expression, isStrictEquals: boolean): TypePredicate | undefined {
+function getTypePredicateOneWay(
+    left: ts.Expression,
+    right: ts.Expression,
+    isStrictEquals: boolean,
+): TypePredicate | undefined {
     switch (right.kind) {
         case ts.SyntaxKind.TypeOfExpression:
             const expression = (right as ts.TypeOfExpression).expression;
             if (!isLiteralExpression(left)) {
-                if (isIdentifier(left) && left.text === "undefined" ||
+                if (
+                    (isIdentifier(left) && left.text === "undefined") ||
                     left.kind === ts.SyntaxKind.NullKeyword ||
                     left.kind === ts.SyntaxKind.TrueKeyword ||
-                    left.kind === ts.SyntaxKind.FalseKeyword) {
-                    return {kind: TypePredicateKind.TypeofTypo};
+                    left.kind === ts.SyntaxKind.FalseKeyword
+                ) {
+                    return { kind: TypePredicateKind.TypeofTypo };
                 }
                 return undefined;
             }
             const predicate = getTypePredicateForKind(left.text);
             return predicate === undefined
                 ? { kind: TypePredicateKind.TypeofTypo }
-                : { kind: TypePredicateKind.Plain, expression, predicate, isNullOrUndefined: left.text === "undefined" };
+                : {
+                      kind: TypePredicateKind.Plain,
+                      expression,
+                      predicate,
+                      isNullOrUndefined: left.text === "undefined",
+                  };
 
         case ts.SyntaxKind.NullKeyword:
             return nullOrUndefined(ts.TypeFlags.Null);
@@ -158,7 +186,12 @@ function getTypePredicateOneWay(left: ts.Expression, right: ts.Expression, isStr
 
     function nullOrUndefined(flags: ts.TypeFlags): TypePredicate {
         return isStrictEquals
-            ? { kind: TypePredicateKind.Plain, expression: left, predicate: flagPredicate(flags), isNullOrUndefined: true }
+            ? {
+                  kind: TypePredicateKind.Plain,
+                  expression: left,
+                  predicate: flagPredicate(flags),
+                  isNullOrUndefined: true,
+              }
             : { kind: TypePredicateKind.NonStructNullUndefined, expression: left };
     }
 }
@@ -169,7 +202,10 @@ function isEmptyType(checker: ts.TypeChecker, type: ts.Type) {
 
 const undefinedFlags = ts.TypeFlags.Undefined | ts.TypeFlags.Void;
 
-type TypePredicate = PlainTypePredicate | NonStrictNullUndefinedPredicate | { kind: TypePredicateKind.TypeofTypo };
+type TypePredicate =
+    | PlainTypePredicate
+    | NonStrictNullUndefinedPredicate
+    | { kind: TypePredicateKind.TypeofTypo };
 interface PlainTypePredicate {
     kind: TypePredicateKind.Plain;
     expression: ts.Expression;
@@ -205,16 +241,21 @@ function getTypePredicateForKind(kind: string): Predicate | undefined {
             return isFunction;
         case "object":
             // It's an object if it's not any of the above.
-            const allFlags = ts.TypeFlags.Undefined | ts.TypeFlags.Void | ts.TypeFlags.BooleanLike |
-                ts.TypeFlags.NumberLike | ts.TypeFlags.StringLike | ts.TypeFlags.ESSymbol;
-            return (type) => !isTypeFlagSet(type, allFlags) && !isFunction(type);
+            const allFlags =
+                ts.TypeFlags.Undefined |
+                ts.TypeFlags.Void |
+                ts.TypeFlags.BooleanLike |
+                ts.TypeFlags.NumberLike |
+                ts.TypeFlags.StringLike |
+                ts.TypeFlags.ESSymbol;
+            return type => !isTypeFlagSet(type, allFlags) && !isFunction(type);
         default:
             return undefined;
     }
 }
 
 function flagPredicate(testedFlag: ts.TypeFlags): Predicate {
-    return (type) => isTypeFlagSet(type, testedFlag);
+    return type => isTypeFlagSet(type, testedFlag);
 }
 
 function isFunction(t: ts.Type): boolean {
@@ -226,7 +267,10 @@ function isFunction(t: ts.Type): boolean {
 }
 
 /** Returns a boolean value if that should always be the result of a type predicate. */
-function getConstantBoolean(type: ts.Type, predicate: (t: ts.Type) => boolean): boolean | undefined {
+function getConstantBoolean(
+    type: ts.Type,
+    predicate: (t: ts.Type) => boolean,
+): boolean | undefined {
     let anyTrue = false;
     let anyFalse = false;
     for (const ty of unionParts(type)) {
@@ -259,11 +303,15 @@ function testNonStrictNullUndefined(type: ts.Type): boolean | "null" | "undefine
         }
     }
 
-    return !anyOther ? true
-        : anyNull && anyUndefined ? undefined
-        : anyNull ? "null"
-        : anyUndefined ? "undefined"
-        : false;
+    return !anyOther
+        ? true
+        : anyNull && anyUndefined
+            ? undefined
+            : anyNull
+                ? "null"
+                : anyUndefined
+                    ? "undefined"
+                    : false;
 }
 
 function unionParts(type: ts.Type) {

--- a/src/rules/switchDefaultRule.ts
+++ b/src/rules/switchDefaultRule.ts
@@ -44,8 +44,10 @@ export class Rule extends Lint.Rules.AbstractRule {
 
 function walk(ctx: Lint.WalkContext<void>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (node.kind === ts.SyntaxKind.SwitchStatement &&
-            !(node as ts.SwitchStatement).caseBlock.clauses.some(isDefaultClause)) {
+        if (
+            node.kind === ts.SyntaxKind.SwitchStatement &&
+            !(node as ts.SwitchStatement).caseBlock.clauses.some(isDefaultClause)
+        ) {
             ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
         }
         return ts.forEachChild(node, cb);

--- a/src/rules/switchFinalBreakRule.ts
+++ b/src/rules/switchFinalBreakRule.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { endsControlFlow, isBlock, isBreakStatement, isLabeledStatement, isSwitchStatement } from "tsutils";
+import {
+    endsControlFlow,
+    isBlock,
+    isBreakStatement,
+    isLabeledStatement,
+    isSwitchStatement,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -26,7 +32,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "switch-final-break",
-        description: "Checks whether the final clause of a switch statement ends in \`break;\`.",
+        description: "Checks whether the final clause of a switch statement ends in `break;`.",
         hasFix: true,
         optionsDescription: Lint.Utils.dedent`
             If no options are passed, a final 'break;' is forbidden.
@@ -34,9 +40,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             unless control flow is escaped in some other way.`,
         options: {
             type: "string",
-            enum: [
-                OPTION_ALWAYS,
-            ],
+            enum: [OPTION_ALWAYS],
         },
         optionExamples: [true, [true, OPTION_ALWAYS]],
         type: "style",
@@ -44,11 +48,15 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_ALWAYS = "Final clause in 'switch' statement should end with 'break;'.";
-    public static FAILURE_STRING_NEVER = "Final clause in 'switch' statement should not end with 'break;'.";
+    public static FAILURE_STRING_ALWAYS =
+        "Final clause in 'switch' statement should end with 'break;'.";
+    public static FAILURE_STRING_NEVER =
+        "Final clause in 'switch' statement should not end with 'break;'.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, walk, { always: this.ruleArguments.indexOf(OPTION_ALWAYS) !== -1 });
+        return this.applyWithFunction(sourceFile, walk, {
+            always: this.ruleArguments.indexOf(OPTION_ALWAYS) !== -1,
+        });
     }
 }
 
@@ -57,7 +65,10 @@ interface Options {
 }
 
 function walk(ctx: Lint.WalkContext<Options>): void {
-    const { sourceFile, options: { always } } = ctx;
+    const {
+        sourceFile,
+        options: { always },
+    } = ctx;
     ts.forEachChild(sourceFile, function cb(node) {
         if (isSwitchStatement(node)) {
             check(node);
@@ -67,11 +78,17 @@ function walk(ctx: Lint.WalkContext<Options>): void {
 
     function check(node: ts.SwitchStatement): void {
         const clause = last(node.caseBlock.clauses);
-        if (clause === undefined) { return; }
+        if (clause === undefined) {
+            return;
+        }
 
         if (always) {
             if (!endsControlFlow(clause)) {
-                ctx.addFailureAtNode(clause.getChildAt(0), Rule.FAILURE_STRING_ALWAYS, createAddFix(clause));
+                ctx.addFailureAtNode(
+                    clause.getChildAt(0),
+                    Rule.FAILURE_STRING_ALWAYS,
+                    createAddFix(clause),
+                );
             }
             return;
         }
@@ -89,7 +106,11 @@ function walk(ctx: Lint.WalkContext<Options>): void {
             }
         }
 
-        ctx.addFailureAtNode(lastStatement, Rule.FAILURE_STRING_NEVER, createRemoveFix(lastStatement));
+        ctx.addFailureAtNode(
+            lastStatement,
+            Rule.FAILURE_STRING_NEVER,
+            createRemoveFix(lastStatement),
+        );
     }
 
     function createAddFix(clause: ts.CaseClause | ts.DefaultClause) {
@@ -107,7 +128,6 @@ function walk(ctx: Lint.WalkContext<Options>): void {
     function createRemoveFix(lastStatement: ts.BreakStatement) {
         return Lint.Replacement.replaceFromTo(lastStatement.getFullStart(), lastStatement.end, "");
     }
-
 }
 
 function getLastStatement(clause: ts.CaseClause | ts.DefaultClause): ts.Statement | undefined {
@@ -116,7 +136,8 @@ function getLastStatement(clause: ts.CaseClause | ts.DefaultClause): ts.Statemen
     }
 
     const block = clause.statements[0];
-    const statements = clause.statements.length === 1 && isBlock(block) ? block.statements : clause.statements;
+    const statements =
+        clause.statements.length === 1 && isBlock(block) ? block.statements : clause.statements;
 
     return last(statements);
 }

--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -42,10 +42,17 @@ function fillOptions<T>(value: T): Record<OptionName, T> {
     };
 }
 
-type OptionsJson = Partial<Record<"multiline" | "singleline", Partial<CustomOptionValue> | OptionValue> & {esSpecCompliant: boolean}>;
+type OptionsJson = Partial<
+    Record<"multiline" | "singleline", Partial<CustomOptionValue> | OptionValue> & {
+        esSpecCompliant: boolean;
+    }
+>;
 function normalizeOptions(options: OptionsJson): Options {
-    return { multiline: normalize(options.multiline), singleline: normalize(options.singleline), specCompliant: !!options.esSpecCompliant};
-
+    return {
+        multiline: normalize(options.multiline),
+        singleline: normalize(options.singleline),
+        specCompliant: !!options.esSpecCompliant,
+    };
 }
 function normalize(value: OptionsJson["multiline"]): CustomOptionValue {
     return typeof value === "string" ? fillOptions(value) : { ...defaultOptions, ...value };
@@ -102,12 +109,12 @@ export class Rule extends Lint.Rules.AbstractRule {
             properties: {
                 multiline: metadataOptionShape,
                 singleline: metadataOptionShape,
-                esSpecCompliant: {type: "boolean"},
+                esSpecCompliant: { type: "boolean" },
             },
             additionalProperties: false,
         },
         optionExamples: [
-            [true, {multiline: "always", singleline: "never"}],
+            [true, { multiline: "always", singleline: "never" }],
             [
                 true,
                 {
@@ -145,13 +152,28 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         const cb = (node: ts.Node): void => {
             switch (node.kind) {
                 case ts.SyntaxKind.ArrayLiteralExpression:
-                    this.checkList((node as ts.ArrayLiteralExpression).elements, node.end, "arrays", isArrayRest);
+                    this.checkList(
+                        (node as ts.ArrayLiteralExpression).elements,
+                        node.end,
+                        "arrays",
+                        isArrayRest,
+                    );
                     break;
                 case ts.SyntaxKind.ArrayBindingPattern:
-                    this.checkList((node as ts.BindingPattern).elements, node.end, "arrays", isDestructuringRest);
+                    this.checkList(
+                        (node as ts.BindingPattern).elements,
+                        node.end,
+                        "arrays",
+                        isDestructuringRest,
+                    );
                     break;
                 case ts.SyntaxKind.ObjectBindingPattern:
-                    this.checkList((node as ts.BindingPattern).elements, node.end, "objects", isDestructuringRest);
+                    this.checkList(
+                        (node as ts.BindingPattern).elements,
+                        node.end,
+                        "objects",
+                        isDestructuringRest,
+                    );
                     break;
                 case ts.SyntaxKind.NamedImports:
                     this.checkList((node as ts.NamedImports).elements, node.end, "imports", noRest);
@@ -160,25 +182,43 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
                     this.checkList((node as ts.NamedExports).elements, node.end, "exports", noRest);
                     break;
                 case ts.SyntaxKind.ObjectLiteralExpression:
-                    this.checkList((node as ts.ObjectLiteralExpression).properties, node.end, "objects", isObjectRest);
+                    this.checkList(
+                        (node as ts.ObjectLiteralExpression).properties,
+                        node.end,
+                        "objects",
+                        isObjectRest,
+                    );
                     break;
                 case ts.SyntaxKind.EnumDeclaration:
-                    this.checkList((node as ts.EnumDeclaration).members, node.end, "objects", noRest);
+                    this.checkList(
+                        (node as ts.EnumDeclaration).members,
+                        node.end,
+                        "objects",
+                        noRest,
+                    );
                     break;
                 case ts.SyntaxKind.NewExpression:
                     if ((node as ts.NewExpression).arguments === undefined) {
                         break;
                     }
-                    // falls through
+                // falls through
                 case ts.SyntaxKind.CallExpression:
-                    this.checkList((node as ts.CallExpression | ts.NewExpression).arguments!, node.end, "functions", noRest);
+                    this.checkList(
+                        (node as ts.CallExpression | ts.NewExpression).arguments!,
+                        node.end,
+                        "functions",
+                        noRest,
+                    );
                     break;
                 case ts.SyntaxKind.ArrowFunction:
                     // don't check arrow functions without parens around the parameter
-                    if (getChildOfKind(node, ts.SyntaxKind.OpenParenToken, this.sourceFile) === undefined) {
+                    if (
+                        getChildOfKind(node, ts.SyntaxKind.OpenParenToken, this.sourceFile) ===
+                        undefined
+                    ) {
                         break;
                     }
-                    // falls through
+                // falls through
                 case ts.SyntaxKind.Constructor:
                 case ts.SyntaxKind.FunctionDeclaration:
                 case ts.SyntaxKind.FunctionExpression:
@@ -223,7 +263,12 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         return this.checkComma(hasTrailingComma, members, node.end, "typeLiterals", noRest);
     }
 
-    private checkList<T extends ts.Node>(list: ts.NodeArray<T>, closeElementPos: number, optionKey: OptionName, isRest: (n: T) => boolean) {
+    private checkList<T extends ts.Node>(
+        list: ts.NodeArray<T>,
+        closeElementPos: number,
+        optionKey: OptionName,
+        isRest: (n: T) => boolean,
+    ) {
         if (list.length === 0) {
             return;
         }
@@ -241,7 +286,12 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         const last = list[list.length - 1];
         if (this.options.specCompliant && isRest(last)) {
             if (hasTrailingComma) {
-                this.addFailureAt(list.end - 1, 1, Rule.FAILURE_STRING_FORBIDDEN, Lint.Replacement.deleteText(list.end - 1, 1));
+                this.addFailureAt(
+                    list.end - 1,
+                    1,
+                    Rule.FAILURE_STRING_FORBIDDEN,
+                    Lint.Replacement.deleteText(list.end - 1, 1),
+                );
             }
             return;
         }
@@ -252,9 +302,19 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
         const option = options[optionKey];
 
         if (option === "always" && !hasTrailingComma) {
-            this.addFailureAt(list.end, 0, Rule.FAILURE_STRING_ALWAYS, Lint.Replacement.appendText(list.end, ","));
+            this.addFailureAt(
+                list.end,
+                0,
+                Rule.FAILURE_STRING_ALWAYS,
+                Lint.Replacement.appendText(list.end, ","),
+            );
         } else if (option === "never" && hasTrailingComma) {
-            this.addFailureAt(list.end - 1, 1, Rule.FAILURE_STRING_NEVER, Lint.Replacement.deleteText(list.end - 1, 1));
+            this.addFailureAt(
+                list.end - 1,
+                1,
+                Rule.FAILURE_STRING_NEVER,
+                Lint.Replacement.deleteText(list.end - 1, 1),
+            );
         }
     }
 }

--- a/src/rules/tripleEqualsRule.ts
+++ b/src/rules/tripleEqualsRule.ts
@@ -33,7 +33,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "triple-equals",
         description: "Requires `===` and `!==` in place of `==` and `!=`.",
-        optionsDescription: Lint.Utils.dedent `
+        optionsDescription: Lint.Utils.dedent`
             Two arguments may be optionally provided:
 
             * \`"allow-null-check"\` allows \`==\` and \`!=\` when comparing to \`null\`.
@@ -47,11 +47,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             minLength: 0,
             maxLength: 2,
         },
-        optionExamples: [
-            true,
-            [true, "allow-null-check"],
-            [true, "allow-undefined-check"],
-        ],
+        optionExamples: [true, [true, "allow-null-check"], [true, "allow-undefined-check"]],
         type: "functionality",
         typescriptOnly: false,
     };
@@ -71,12 +67,20 @@ export class Rule extends Lint.Rules.AbstractRule {
 function walk(ctx: Lint.WalkContext<Options>) {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (isBinaryExpression(node)) {
-            if ((node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
-                 node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken) &&
-                !(isExpressionAllowed(node.right, ctx.options) || isExpressionAllowed(node.left, ctx.options))) {
-                ctx.addFailureAtNode(node.operatorToken, node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken
-                                                         ? Rule.EQ_FAILURE_STRING
-                                                         : Rule.NEQ_FAILURE_STRING);
+            if (
+                (node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+                    node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken) &&
+                !(
+                    isExpressionAllowed(node.right, ctx.options) ||
+                    isExpressionAllowed(node.left, ctx.options)
+                )
+            ) {
+                ctx.addFailureAtNode(
+                    node.operatorToken,
+                    node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken
+                        ? Rule.EQ_FAILURE_STRING
+                        : Rule.NEQ_FAILURE_STRING,
+                );
             }
         }
         return ts.forEachChild(node, cb);
@@ -87,7 +91,9 @@ function isExpressionAllowed(node: ts.Expression, options: Options) {
     if (node.kind === ts.SyntaxKind.NullKeyword) {
         return options.allowNull;
     }
-    return options.allowUndefined &&
+    return (
+        options.allowUndefined &&
         node.kind === ts.SyntaxKind.Identifier &&
-        (node as ts.Identifier).originalKeywordKind === ts.SyntaxKind.UndefinedKeyword;
+        (node as ts.Identifier).originalKeywordKind === ts.SyntaxKind.UndefinedKeyword
+    );
 }

--- a/src/rules/typeLiteralDelimiterRule.ts
+++ b/src/rules/typeLiteralDelimiterRule.ts
@@ -49,18 +49,13 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING_MISSING =
-        "Expected type literal to use ';' to separate members.";
-    public static FAILURE_STRING_COMMA =
-        "Expected type literal to use ';' instead of ','.";
+    public static FAILURE_STRING_MISSING = "Expected type literal to use ';' to separate members.";
+    public static FAILURE_STRING_COMMA = "Expected type literal to use ';' instead of ','.";
     public static FAILURE_STRING_TRAILING =
         "Did not expect single-line type literal to have a trailing ';'.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithFunction(
-            sourceFile,
-            walk,
-            this.getRuleOptions());
+        return this.applyWithFunction(sourceFile, walk, this.getRuleOptions());
     }
 
     private getRuleOptions(): Options {
@@ -84,22 +79,39 @@ function walk(ctx: Lint.WalkContext<Options>): void {
         node.members.forEach((member, idx) => {
             const end = member.end - 1;
             // Check if delimiter should be ommitted for a single-line type literal.
-            const shouldOmit = options.singleLine === "always"
-                ? false
-                : idx === node.members.length - 1 && isSameLine(sourceFile, node.getStart(sourceFile), node.getEnd());
+            const shouldOmit =
+                options.singleLine === "always"
+                    ? false
+                    : idx === node.members.length - 1 &&
+                      isSameLine(sourceFile, node.getStart(sourceFile), node.getEnd());
             const delimiter = sourceFile.text[end];
             switch (delimiter) {
                 case ";":
                     if (shouldOmit) {
-                        ctx.addFailureAt(end, 1, Rule.FAILURE_STRING_TRAILING, Lint.Replacement.replaceFromTo(end, end + 1, ""));
+                        ctx.addFailureAt(
+                            end,
+                            1,
+                            Rule.FAILURE_STRING_TRAILING,
+                            Lint.Replacement.replaceFromTo(end, end + 1, ""),
+                        );
                     }
                     break;
                 case ",":
-                    ctx.addFailureAt(end, 1, Rule.FAILURE_STRING_COMMA, Lint.Replacement.replaceFromTo(end, end + 1, ";"));
+                    ctx.addFailureAt(
+                        end,
+                        1,
+                        Rule.FAILURE_STRING_COMMA,
+                        Lint.Replacement.replaceFromTo(end, end + 1, ";"),
+                    );
                     break;
                 default:
                     if (!shouldOmit) {
-                        ctx.addFailureAt(end, 1, Rule.FAILURE_STRING_MISSING, Lint.Replacement.replaceFromTo(end + 1, end + 1, ";"));
+                        ctx.addFailureAt(
+                            end,
+                            1,
+                            Rule.FAILURE_STRING_MISSING,
+                            Lint.Replacement.replaceFromTo(end + 1, end + 1, ";"),
+                        );
                     }
             }
         });

--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -88,7 +88,9 @@ export class Rule extends Lint.Rules.AbstractRule {
             minLength: 0,
             maxLength: 7,
         },
-        optionExamples: [[true, OPTION_CALL_SIGNATURE, OPTION_PARAMETER, OPTION_MEMBER_VARIABLE_DECLARATION]],
+        optionExamples: [
+            [true, OPTION_CALL_SIGNATURE, OPTION_PARAMETER, OPTION_MEMBER_VARIABLE_DECLARATION],
+        ],
         type: "typescript",
         typescriptOnly: true,
         codeExamples,
@@ -96,7 +98,9 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:enable:object-literal-sort-keys */
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new TypedefWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)));
+        return this.applyWithWalker(
+            new TypedefWalker(sourceFile, this.ruleName, parseOptions(this.ruleArguments)),
+        );
     }
 }
 
@@ -110,7 +114,12 @@ class TypedefWalker extends Lint.AbstractWalker<Options> {
                 case ts.SyntaxKind.MethodDeclaration:
                 case ts.SyntaxKind.MethodSignature: {
                     const { name, parameters, type } = node as ts.CallSignatureDeclaration;
-                    this.checkTypeAnnotation("call-signature", name !== undefined ? name : parameters, type, name);
+                    this.checkTypeAnnotation(
+                        "call-signature",
+                        name !== undefined ? name : parameters,
+                        type,
+                        name,
+                    );
                     break;
                 }
                 case ts.SyntaxKind.ArrowFunction:
@@ -175,9 +184,11 @@ class TypedefWalker extends Lint.AbstractWalker<Options> {
         // variable declarations should always have a grandparent, but check that to be on the safe side.
         // catch statements will be the parent of the variable declaration
         // for-in/for-of loops will be the gradparent of the variable declaration
-        if (parent!.kind === ts.SyntaxKind.CatchClause
-                || parent!.parent!.kind === ts.SyntaxKind.ForInStatement
-                || parent!.parent!.kind === ts.SyntaxKind.ForOfStatement) {
+        if (
+            parent!.kind === ts.SyntaxKind.CatchClause ||
+            parent!.parent!.kind === ts.SyntaxKind.ForInStatement ||
+            parent!.parent!.kind === ts.SyntaxKind.ForOfStatement
+        ) {
             return;
         }
 
@@ -196,12 +207,15 @@ class TypedefWalker extends Lint.AbstractWalker<Options> {
     }
 
     private checkTypeAnnotation(
-            option: Option,
-            location: ts.Node | ts.NodeArray<ts.Node>,
-            typeAnnotation: ts.TypeNode | undefined,
-            name?: ts.Node): void {
+        option: Option,
+        location: ts.Node | ts.NodeArray<ts.Node>,
+        typeAnnotation: ts.TypeNode | undefined,
+        name?: ts.Node,
+    ): void {
         if (this.options[option] === true && typeAnnotation === undefined) {
-            const failure = `expected ${option}${name === undefined ? "" : `: '${name.getText()}'`} to have a typedef`;
+            const failure = `expected ${option}${
+                name === undefined ? "" : `: '${name.getText()}'`
+            } to have a typedef`;
             if (isNodeArray(location)) {
                 this.addFailure(location.pos - 1, location.end + 1, failure);
             } else {
@@ -215,6 +229,8 @@ function isTypedPropertyDeclaration(node: ts.Node): boolean {
     return utils.isPropertyDeclaration(node) && node.type !== undefined;
 }
 
-export function isNodeArray(nodeOrArray: ts.Node | ts.NodeArray<ts.Node>): nodeOrArray is ts.NodeArray<ts.Node> {
+export function isNodeArray(
+    nodeOrArray: ts.Node | ts.NodeArray<ts.Node>,
+): nodeOrArray is ts.NodeArray<ts.Node> {
     return Array.isArray(nodeOrArray);
 }

--- a/src/rules/typedefWhitespaceRule.ts
+++ b/src/rules/typedefWhitespaceRule.ts
@@ -21,7 +21,12 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 
 type Option = "nospace" | "onespace" | "space";
-type OptionType = "call-signature" | "index-signature" | "parameter" | "property-declaration" | "variable-declaration";
+type OptionType =
+    | "call-signature"
+    | "index-signature"
+    | "parameter"
+    | "property-declaration"
+    | "variable-declaration";
 type OptionInput = Partial<Record<OptionType, Option>>;
 type Options = Partial<Record<"left" | "right", OptionInput>>;
 
@@ -36,7 +41,7 @@ const SPACE_OBJECT = {
     properties: {
         "call-signature": SPACE_OPTIONS,
         "index-signature": SPACE_OPTIONS,
-        "parameter": SPACE_OPTIONS,
+        parameter: SPACE_OPTIONS,
         "property-declaration": SPACE_OPTIONS,
         "variable-declaration": SPACE_OPTIONS,
     },
@@ -47,7 +52,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "typedef-whitespace",
         description: "Requires or disallows whitespace for type definitions.",
-        descriptionDetails: "Determines if a space is required or not before the colon in a type specifier.",
+        descriptionDetails:
+            "Determines if a space is required or not before the colon in a type specifier.",
         optionsDescription: Lint.Utils.dedent`
             Two arguments which are both objects.
             The first argument specifies how much space should be to the _left_ of a typedef colon.
@@ -71,14 +77,14 @@ export class Rule extends Lint.Rules.AbstractRule {
                 {
                     "call-signature": "nospace",
                     "index-signature": "nospace",
-                    "parameter": "nospace",
+                    parameter: "nospace",
                     "property-declaration": "nospace",
                     "variable-declaration": "nospace",
                 },
                 {
                     "call-signature": "onespace",
                     "index-signature": "onespace",
-                    "parameter": "onespace",
+                    parameter: "onespace",
                     "property-declaration": "onespace",
                     "variable-declaration": "onespace",
                 },
@@ -100,7 +106,9 @@ export class Rule extends Lint.Rules.AbstractRule {
             left: args[0],
             right: args[1],
         };
-        return this.applyWithWalker(new TypedefWhitespaceWalker(sourceFile, this.ruleName, options));
+        return this.applyWithWalker(
+            new TypedefWhitespaceWalker(sourceFile, this.ruleName, options),
+        );
     }
 }
 
@@ -109,18 +117,24 @@ class TypedefWhitespaceWalker extends Lint.AbstractWalker<Options> {
         const cb = (node: ts.Node): void => {
             const optionType = getOptionType(node);
             if (optionType !== undefined) {
-                this.checkSpace(node as ts.SignatureDeclaration | ts.VariableLikeDeclaration, optionType);
+                this.checkSpace(
+                    node as ts.SignatureDeclaration | ts.VariableLikeDeclaration,
+                    optionType,
+                );
             }
             return ts.forEachChild(node, cb);
         };
         return ts.forEachChild(sourceFile, cb);
     }
 
-    private checkSpace(node: ts.SignatureDeclaration | ts.VariableLikeDeclaration, key: OptionType) {
+    private checkSpace(
+        node: ts.SignatureDeclaration | ts.VariableLikeDeclaration,
+        key: OptionType,
+    ) {
         if (!("type" in node) || node.type === undefined) {
             return;
         }
-        const {left, right} = this.options;
+        const { left, right } = this.options;
         const colon = getChildOfKind(node, ts.SyntaxKind.ColonToken, this.sourceFile)!;
         if (right !== undefined && right[key] !== undefined) {
             this.checkRight(colon.end, right[key]!, key);
@@ -132,7 +146,7 @@ class TypedefWhitespaceWalker extends Lint.AbstractWalker<Options> {
 
     private checkRight(colonEnd: number, option: Option, key: OptionType) {
         let pos = colonEnd;
-        const {text} = this.sourceFile;
+        const { text } = this.sourceFile;
         let current = text.charCodeAt(pos);
         if (ts.isLineBreak(current)) {
             return;
@@ -146,7 +160,7 @@ class TypedefWhitespaceWalker extends Lint.AbstractWalker<Options> {
 
     private checkLeft(colonStart: number, option: Option, key: OptionType) {
         let pos = colonStart;
-        const {text} = this.sourceFile;
+        const { text } = this.sourceFile;
         let current = text.charCodeAt(pos - 1);
         while (ts.isWhiteSpaceSingleLine(current)) {
             --pos;
@@ -158,28 +172,53 @@ class TypedefWhitespaceWalker extends Lint.AbstractWalker<Options> {
         return this.validateWhitespace(pos, colonStart, option, "before", key);
     }
 
-    private validateWhitespace(start: number, end: number, option: Option, location: "before" | "after", key: OptionType) {
+    private validateWhitespace(
+        start: number,
+        end: number,
+        option: Option,
+        location: "before" | "after",
+        key: OptionType,
+    ) {
         switch (option) {
             case "nospace":
                 if (start !== end) {
-                    this.addFailure(start, end, Rule.FAILURE_STRING(option, location, key), Lint.Replacement.deleteFromTo(start, end));
+                    this.addFailure(
+                        start,
+                        end,
+                        Rule.FAILURE_STRING(option, location, key),
+                        Lint.Replacement.deleteFromTo(start, end),
+                    );
                 }
                 break;
             case "space":
                 if (start === end) {
-                    this.addFailure(end, end, Rule.FAILURE_STRING(option, location, key), Lint.Replacement.appendText(end, " "));
+                    this.addFailure(
+                        end,
+                        end,
+                        Rule.FAILURE_STRING(option, location, key),
+                        Lint.Replacement.appendText(end, " "),
+                    );
                 }
                 break;
             case "onespace":
                 switch (end - start) {
                     case 0:
-                        this.addFailure(end, end, Rule.FAILURE_STRING(option, location, key), Lint.Replacement.appendText(end, " "));
+                        this.addFailure(
+                            end,
+                            end,
+                            Rule.FAILURE_STRING(option, location, key),
+                            Lint.Replacement.appendText(end, " "),
+                        );
                         break;
                     case 1:
                         break;
                     default:
-                        this.addFailure(start + 1, end, Rule.FAILURE_STRING(option, location, key),
-                                        Lint.Replacement.deleteFromTo(start + 1, end));
+                        this.addFailure(
+                            start + 1,
+                            end,
+                            Rule.FAILURE_STRING(option, location, key),
+                            Lint.Replacement.deleteFromTo(start + 1, end),
+                        );
                 }
         }
     }

--- a/src/rules/typeofCompareRule.ts
+++ b/src/rules/typeofCompareRule.ts
@@ -20,7 +20,15 @@ import * as ts from "typescript";
 
 import * as Lint from "../index";
 
-const LEGAL_TYPEOF_RESULTS = new Set(["undefined", "string", "boolean", "number", "function", "object", "symbol"]);
+const LEGAL_TYPEOF_RESULTS = new Set([
+    "undefined",
+    "string",
+    "boolean",
+    "number",
+    "function",
+    "object",
+    "symbol",
+]);
 
 export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -38,8 +46,11 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING =
-        `'typeof' expression must be compared to one of: ${Array.from(LEGAL_TYPEOF_RESULTS).map((x) => `"${x}"`).join(", ")}`;
+    public static FAILURE_STRING = `'typeof' expression must be compared to one of: ${Array.from(
+        LEGAL_TYPEOF_RESULTS,
+    )
+        .map(x => `"${x}"`)
+        .join(", ")}`;
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);
@@ -50,7 +61,10 @@ function walk(ctx: Lint.WalkContext<void>): void {
     ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (tsutils.isBinaryExpression(node)) {
             const { operatorToken, left, right } = node;
-            if (Lint.getEqualsKind(operatorToken) !== undefined && (isFaultyTypeof(left, right) || isFaultyTypeof(right, left))) {
+            if (
+                Lint.getEqualsKind(operatorToken) !== undefined &&
+                (isFaultyTypeof(left, right) || isFaultyTypeof(right, left))
+            ) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
         }

--- a/src/rules/unifiedSignaturesRule.ts
+++ b/src/rules/unifiedSignaturesRule.ts
@@ -301,8 +301,8 @@ function signaturesDifferByOptionalOrRestParameter(
     }
 
     return {
-        kind: "extra-parameter",
         extraParameter: longer[longer.length - 1],
+        kind: "extra-parameter",
         otherSignature: shorter,
     };
 }

--- a/src/rules/unifiedSignaturesRule.ts
+++ b/src/rules/unifiedSignaturesRule.ts
@@ -27,7 +27,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "unified-signatures",
-        description: "Warns for any two overloads that could be unified into one by using a union or an optional/rest parameter.",
+        description:
+            "Warns for any two overloads that could be unified into one by using a union or an optional/rest parameter.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: [true],
@@ -42,12 +43,19 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static FAILURE_STRING_OMITTING_REST_PARAMETER(otherLine?: number) {
         return `${this.FAILURE_STRING_START(otherLine)} with a rest parameter.`;
     }
-    public static FAILURE_STRING_SINGLE_PARAMETER_DIFFERENCE(otherLine: number | undefined, type1: string, type2: string) {
+    public static FAILURE_STRING_SINGLE_PARAMETER_DIFFERENCE(
+        otherLine: number | undefined,
+        type1: string,
+        type2: string,
+    ) {
         return `${this.FAILURE_STRING_START(otherLine)} taking \`${type1} | ${type2}\`.`;
     }
     private static FAILURE_STRING_START(otherLine?: number): string {
         // For only 2 overloads we don't need to specify which is the other one.
-        const overloads = otherLine === undefined ? "These overloads" : `This overload and the one on line ${otherLine}`;
+        const overloads =
+            otherLine === undefined
+                ? "These overloads"
+                : `This overload and the one on line ${otherLine}`;
         return `${overloads} can be combined into one signature`;
     }
 
@@ -66,7 +74,9 @@ function walk(ctx: Lint.WalkContext<void>): void {
                 break;
             case ts.SyntaxKind.InterfaceDeclaration:
             case ts.SyntaxKind.ClassDeclaration: {
-                const { members, typeParameters } = node as ts.ClassDeclaration | ts.InterfaceDeclaration;
+                const { members, typeParameters } = node as
+                    | ts.ClassDeclaration
+                    | ts.InterfaceDeclaration;
                 checkMembers(members, typeParameters);
                 break;
             }
@@ -78,40 +88,54 @@ function walk(ctx: Lint.WalkContext<void>): void {
     });
 
     function checkStatements(statements: ReadonlyArray<ts.Statement>): void {
-        addFailures(checkOverloads(statements, undefined, (statement) => {
-            if (utils.isFunctionDeclaration(statement)) {
-                const { body, name } = statement;
-                return body === undefined && name !== undefined ? { signature: statement, key: name.text } : undefined;
-            } else {
-                return undefined;
-            }
-        }));
+        addFailures(
+            checkOverloads(statements, undefined, statement => {
+                if (utils.isFunctionDeclaration(statement)) {
+                    const { body, name } = statement;
+                    return body === undefined && name !== undefined
+                        ? { signature: statement, key: name.text }
+                        : undefined;
+                } else {
+                    return undefined;
+                }
+            }),
+        );
     }
 
     function checkMembers(
         members: ReadonlyArray<ts.TypeElement | ts.ClassElement>,
-        typeParameters?: ReadonlyArray<ts.TypeParameterDeclaration>): void {
-        addFailures(checkOverloads(members, typeParameters, (member) => {
-            switch (member.kind) {
-                case ts.SyntaxKind.CallSignature:
-                case ts.SyntaxKind.ConstructSignature:
-                case ts.SyntaxKind.MethodSignature:
-                    break;
-                case ts.SyntaxKind.MethodDeclaration:
-                case ts.SyntaxKind.Constructor:
-                    if ((member as ts.MethodDeclaration | ts.ConstructorDeclaration).body !== undefined) {
+        typeParameters?: ReadonlyArray<ts.TypeParameterDeclaration>,
+    ): void {
+        addFailures(
+            checkOverloads(members, typeParameters, member => {
+                switch (member.kind) {
+                    case ts.SyntaxKind.CallSignature:
+                    case ts.SyntaxKind.ConstructSignature:
+                    case ts.SyntaxKind.MethodSignature:
+                        break;
+                    case ts.SyntaxKind.MethodDeclaration:
+                    case ts.SyntaxKind.Constructor:
+                        if (
+                            (member as ts.MethodDeclaration | ts.ConstructorDeclaration).body !==
+                            undefined
+                        ) {
+                            return undefined;
+                        }
+                        break;
+                    default:
                         return undefined;
-                    }
-                    break;
-                default:
-                    return undefined;
-            }
+                }
 
-            const signature = member as ts.CallSignatureDeclaration | ts.ConstructSignatureDeclaration | ts.MethodSignature |
-                ts.MethodDeclaration | ts.ConstructorDeclaration;
-            const key = getOverloadKey(signature);
-            return key === undefined ? undefined : { signature, key };
-        }));
+                const signature = member as
+                    | ts.CallSignatureDeclaration
+                    | ts.ConstructSignatureDeclaration
+                    | ts.MethodSignature
+                    | ts.MethodDeclaration
+                    | ts.ConstructorDeclaration;
+                const key = getOverloadKey(signature);
+                return key === undefined ? undefined : { signature, key };
+            }),
+        );
     }
 
     function addFailures(failures: Failure[]): void {
@@ -123,19 +147,26 @@ function walk(ctx: Lint.WalkContext<void>): void {
                     const lineOfOtherOverload = only2 ? undefined : getLine(p0.getStart());
                     ctx.addFailureAtNode(
                         p1,
-                        Rule.FAILURE_STRING_SINGLE_PARAMETER_DIFFERENCE(lineOfOtherOverload, typeText(p0), typeText(p1)));
+                        Rule.FAILURE_STRING_SINGLE_PARAMETER_DIFFERENCE(
+                            lineOfOtherOverload,
+                            typeText(p0),
+                            typeText(p1),
+                        ),
+                    );
                     break;
                 }
                 case "extra-parameter": {
                     const { extraParameter, otherSignature } = unify;
                     const lineOfOtherOverload = only2 ? undefined : getLine(otherSignature.pos);
-                    ctx.addFailureAtNode(extraParameter, extraParameter.dotDotDotToken !== undefined
-                        ? Rule.FAILURE_STRING_OMITTING_REST_PARAMETER(lineOfOtherOverload)
-                        : Rule.FAILURE_STRING_OMITTING_SINGLE_PARAMETER(lineOfOtherOverload));
+                    ctx.addFailureAtNode(
+                        extraParameter,
+                        extraParameter.dotDotDotToken !== undefined
+                            ? Rule.FAILURE_STRING_OMITTING_REST_PARAMETER(lineOfOtherOverload)
+                            : Rule.FAILURE_STRING_OMITTING_SINGLE_PARAMETER(lineOfOtherOverload),
+                    );
                 }
             }
         }
-
     }
 
     function getLine(pos: number): number {
@@ -148,13 +179,22 @@ interface Failure {
     only2: boolean;
 }
 type Unify =
-    | { kind: "single-parameter-difference"; p0: ts.ParameterDeclaration; p1: ts.ParameterDeclaration }
-    | { kind: "extra-parameter"; extraParameter: ts.ParameterDeclaration; otherSignature: ts.NodeArray<ts.ParameterDeclaration> };
+    | {
+          kind: "single-parameter-difference";
+          p0: ts.ParameterDeclaration;
+          p1: ts.ParameterDeclaration;
+      }
+    | {
+          kind: "extra-parameter";
+          extraParameter: ts.ParameterDeclaration;
+          otherSignature: ts.NodeArray<ts.ParameterDeclaration>;
+      };
 
 function checkOverloads<T>(
-        signatures: ReadonlyArray<T>,
-        typeParameters: ReadonlyArray<ts.TypeParameterDeclaration> | undefined,
-        getOverload: GetOverload<T>): Failure[] {
+    signatures: ReadonlyArray<T>,
+    typeParameters: ReadonlyArray<ts.TypeParameterDeclaration> | undefined,
+    getOverload: GetOverload<T>,
+): Failure[] {
     const result: Failure[] = [];
     const isTypeParameter = getIsTypeParameter(typeParameters);
     for (const overloads of collectOverloads(signatures, getOverload)) {
@@ -175,7 +215,11 @@ function checkOverloads<T>(
     return result;
 }
 
-function compareSignatures(a: ts.SignatureDeclaration, b: ts.SignatureDeclaration, isTypeParameter: IsTypeParameter): Unify | undefined {
+function compareSignatures(
+    a: ts.SignatureDeclaration,
+    b: ts.SignatureDeclaration,
+    isTypeParameter: IsTypeParameter,
+): Unify | undefined {
     if (!signaturesCanBeUnified(a, b, isTypeParameter)) {
         return undefined;
     }
@@ -185,18 +229,27 @@ function compareSignatures(a: ts.SignatureDeclaration, b: ts.SignatureDeclaratio
         : signaturesDifferByOptionalOrRestParameter(a.parameters, b.parameters);
 }
 
-function signaturesCanBeUnified(a: ts.SignatureDeclaration, b: ts.SignatureDeclaration, isTypeParameter: IsTypeParameter): boolean {
+function signaturesCanBeUnified(
+    a: ts.SignatureDeclaration,
+    b: ts.SignatureDeclaration,
+    isTypeParameter: IsTypeParameter,
+): boolean {
     // Must return the same type.
-    return typesAreEqual(a.type, b.type) &&
+    return (
+        typesAreEqual(a.type, b.type) &&
         // Must take the same type parameters.
         arraysAreEqual(a.typeParameters, b.typeParameters, typeParametersAreEqual) &&
         // If one uses a type parameter (from outside) and the other doesn't, they shouldn't be joined.
-        signatureUsesTypeParameter(a, isTypeParameter) === signatureUsesTypeParameter(b, isTypeParameter);
+        signatureUsesTypeParameter(a, isTypeParameter) ===
+            signatureUsesTypeParameter(b, isTypeParameter)
+    );
 }
 
 /** Detect `a(x: number, y: number, z: number)` and `a(x: number, y: string, z: number)`. */
-function signaturesDifferBySingleParameter(types1: ReadonlyArray<ts.ParameterDeclaration>, types2: ReadonlyArray<ts.ParameterDeclaration>,
-    ): Unify | undefined {
+function signaturesDifferBySingleParameter(
+    types1: ReadonlyArray<ts.ParameterDeclaration>,
+    types2: ReadonlyArray<ts.ParameterDeclaration>,
+): Unify | undefined {
     const index = getIndexOfFirstDifference(types1, types2, parametersAreEqual);
     if (index === undefined) {
         return undefined;
@@ -220,8 +273,10 @@ function signaturesDifferBySingleParameter(types1: ReadonlyArray<ts.ParameterDec
  * Detect `a(): void` and `a(x: number): void`.
  * Returns the parameter declaration (`x: number` in this example) that should be optional/rest, and overload it's a part of.
  */
-function signaturesDifferByOptionalOrRestParameter(sig1: ts.NodeArray<ts.ParameterDeclaration>, sig2: ts.NodeArray<ts.ParameterDeclaration>,
-    ): Unify | undefined {
+function signaturesDifferByOptionalOrRestParameter(
+    sig1: ts.NodeArray<ts.ParameterDeclaration>,
+    sig2: ts.NodeArray<ts.ParameterDeclaration>,
+): Unify | undefined {
     const minLength = Math.min(sig1.length, sig2.length);
     const longer = sig1.length < sig2.length ? sig2 : sig1;
     const shorter = sig1.length < sig2.length ? sig1 : sig2;
@@ -245,7 +300,11 @@ function signaturesDifferByOptionalOrRestParameter(sig1: ts.NodeArray<ts.Paramet
         return undefined;
     }
 
-    return { kind: "extra-parameter", extraParameter: longer[longer.length - 1], otherSignature: shorter };
+    return {
+        kind: "extra-parameter",
+        extraParameter: longer[longer.length - 1],
+        otherSignature: shorter,
+    };
 }
 
 /**
@@ -261,7 +320,9 @@ type GetOverload<T> = (node: T) => { signature: ts.SignatureDeclaration; key: st
 type IsTypeParameter = (typeName: string) => boolean;
 
 /** Given type parameters, returns a function to test whether a type is one of those parameters. */
-function getIsTypeParameter(typeParameters?: ReadonlyArray<ts.TypeParameterDeclaration>): IsTypeParameter {
+function getIsTypeParameter(
+    typeParameters?: ReadonlyArray<ts.TypeParameterDeclaration>,
+): IsTypeParameter {
     if (typeParameters === undefined) {
         return () => false;
     }
@@ -274,8 +335,13 @@ function getIsTypeParameter(typeParameters?: ReadonlyArray<ts.TypeParameterDecla
 }
 
 /** True if any of the outer type parameters are used in a signature. */
-function signatureUsesTypeParameter(sig: ts.SignatureDeclaration, isTypeParameter: IsTypeParameter): boolean {
-    return sig.parameters.some((p) => p.type !== undefined && typeContainsTypeParameter(p.type) === true);
+function signatureUsesTypeParameter(
+    sig: ts.SignatureDeclaration,
+    isTypeParameter: IsTypeParameter,
+): boolean {
+    return sig.parameters.some(
+        p => p.type !== undefined && typeContainsTypeParameter(p.type) === true,
+    );
 
     function typeContainsTypeParameter(type: ts.Node): boolean | undefined {
         if (utils.isTypeReferenceNode(type)) {
@@ -292,7 +358,10 @@ function signatureUsesTypeParameter(sig: ts.SignatureDeclaration, isTypeParamete
  * Given all signatures, collects an array of arrays of signatures which are all overloads.
  * Does not rely on overloads being adjacent. This is similar to code in adjacentOverloadSignaturesRule.ts, but not the same.
  */
-function collectOverloads<T>(nodes: ReadonlyArray<T>, getOverload: GetOverload<T>): ts.SignatureDeclaration[][] {
+function collectOverloads<T>(
+    nodes: ReadonlyArray<T>,
+    getOverload: GetOverload<T>,
+): ts.SignatureDeclaration[][] {
     const map = new Map<string, ts.SignatureDeclaration[]>();
     for (const sig of nodes) {
         const overload = getOverload(sig);
@@ -321,22 +390,34 @@ function parameterMayBeMissing(p: ts.ParameterDeclaration): boolean {
 }
 
 /** False if one is optional and the other isn't, or one is a rest parameter and the other isn't. */
-function parametersHaveEqualSigils(a: ts.ParameterDeclaration, b: ts.ParameterDeclaration): boolean {
-    return (a.dotDotDotToken !== undefined) === (b.dotDotDotToken !== undefined) &&
-        (a.questionToken !== undefined) === (b.questionToken !== undefined);
+function parametersHaveEqualSigils(
+    a: ts.ParameterDeclaration,
+    b: ts.ParameterDeclaration,
+): boolean {
+    return (
+        (a.dotDotDotToken !== undefined) === (b.dotDotDotToken !== undefined) &&
+        (a.questionToken !== undefined) === (b.questionToken !== undefined)
+    );
 }
 
-function typeParametersAreEqual(a: ts.TypeParameterDeclaration, b: ts.TypeParameterDeclaration): boolean {
+function typeParametersAreEqual(
+    a: ts.TypeParameterDeclaration,
+    b: ts.TypeParameterDeclaration,
+): boolean {
     return a.name.text === b.name.text && typesAreEqual(a.constraint, b.constraint);
 }
 
 function typesAreEqual(a: ts.TypeNode | undefined, b: ts.TypeNode | undefined): boolean {
     // TODO: Could traverse AST so that formatting differences don't affect this.
-    return a === b || a !== undefined && b !== undefined && a.getText() === b.getText();
+    return a === b || (a !== undefined && b !== undefined && a.getText() === b.getText());
 }
 
 /** Returns the first index where `a` and `b` differ. */
-function getIndexOfFirstDifference<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>, equal: Equal<T>): number | undefined {
+function getIndexOfFirstDifference<T>(
+    a: ReadonlyArray<T>,
+    b: ReadonlyArray<T>,
+    equal: Equal<T>,
+): number | undefined {
     for (let i = 0; i < a.length && i < b.length; i++) {
         if (!equal(a[i], b[i])) {
             return i;
@@ -346,7 +427,10 @@ function getIndexOfFirstDifference<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>, 
 }
 
 /** Calls `action` for every pair of values in `values`. */
-function forEachPair<T, Out>(values: ReadonlyArray<T>, action: (a: T, b: T) => Out | undefined): Out | undefined {
+function forEachPair<T, Out>(
+    values: ReadonlyArray<T>,
+    action: (a: T, b: T) => Out | undefined,
+): Out | undefined {
     for (let i = 0; i < values.length; i++) {
         for (let j = i + 1; j < values.length; j++) {
             const result = action(values[i], values[j]);

--- a/src/rules/useDefaultTypeParameterRule.ts
+++ b/src/rules/useDefaultTypeParameterRule.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { isClassLikeDeclaration, isInterfaceDeclaration, isSymbolFlagSet, isTypeAliasDeclaration } from "tsutils";
+import {
+    isClassLikeDeclaration,
+    isInterfaceDeclaration,
+    isSymbolFlagSet,
+    isTypeAliasDeclaration,
+} from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 import { find } from "../utils";
@@ -24,7 +29,8 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "use-default-type-parameter",
-        description: "Warns if an explicitly specified type argument is the default for that type parameter.",
+        description:
+            "Warns if an explicitly specified type argument is the default for that type parameter.",
         optionsDescription: "Not configurable.",
         options: null,
         optionExamples: ["true"],
@@ -34,7 +40,8 @@ export class Rule extends Lint.Rules.TypedRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "This is the default value for this type parameter, so it can be omitted.";
+    public static FAILURE_STRING =
+        "This is the default value for this type parameter, so it can be omitted.";
 
     public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
@@ -81,27 +88,37 @@ function getArgsAndParameters(node: ts.Node, checker: ts.TypeChecker): ArgsAndPa
         case ts.SyntaxKind.NewExpression:
         case ts.SyntaxKind.TypeReference:
         case ts.SyntaxKind.ExpressionWithTypeArguments:
-            const decl = node as ts.CallExpression | ts.NewExpression | ts.TypeReferenceNode | ts.ExpressionWithTypeArguments;
+            const decl = node as
+                | ts.CallExpression
+                | ts.NewExpression
+                | ts.TypeReferenceNode
+                | ts.ExpressionWithTypeArguments;
             const { typeArguments } = decl;
             if (typeArguments === undefined) {
                 return undefined;
             }
-            const typeParameters = decl.kind === ts.SyntaxKind.TypeReference
-                ? typeParamsFromType(decl.typeName, checker)
-                : decl.kind === ts.SyntaxKind.ExpressionWithTypeArguments
-                ? typeParamsFromType(decl.expression, checker)
-                : typeParamsFromCall(node as ts.CallExpression | ts.NewExpression, checker);
+            const typeParameters =
+                decl.kind === ts.SyntaxKind.TypeReference
+                    ? typeParamsFromType(decl.typeName, checker)
+                    : decl.kind === ts.SyntaxKind.ExpressionWithTypeArguments
+                        ? typeParamsFromType(decl.expression, checker)
+                        : typeParamsFromCall(node as ts.CallExpression | ts.NewExpression, checker);
             return typeParameters === undefined ? undefined : { typeArguments, typeParameters };
         default:
             return undefined;
     }
 }
 
-function typeParamsFromCall(node: ts.CallLikeExpression, checker: ts.TypeChecker): ReadonlyArray<ts.TypeParameterDeclaration> | undefined {
+function typeParamsFromCall(
+    node: ts.CallLikeExpression,
+    checker: ts.TypeChecker,
+): ReadonlyArray<ts.TypeParameterDeclaration> | undefined {
     const sig = checker.getResolvedSignature(node);
     const sigDecl = sig === undefined ? undefined : sig.getDeclaration();
     if (sigDecl === undefined) {
-        return node.kind === ts.SyntaxKind.NewExpression ? typeParamsFromType(node.expression, checker) : undefined;
+        return node.kind === ts.SyntaxKind.NewExpression
+            ? typeParamsFromType(node.expression, checker)
+            : undefined;
     }
 
     return sigDecl.typeParameters === undefined ? undefined : sigDecl.typeParameters;
@@ -109,19 +126,32 @@ function typeParamsFromCall(node: ts.CallLikeExpression, checker: ts.TypeChecker
 
 function typeParamsFromType(
     type: ts.EntityName | ts.Expression,
-    checker: ts.TypeChecker): ReadonlyArray<ts.TypeParameterDeclaration> | undefined {
+    checker: ts.TypeChecker,
+): ReadonlyArray<ts.TypeParameterDeclaration> | undefined {
     const sym = getAliasedSymbol(checker.getSymbolAtLocation(type), checker);
     if (sym === undefined || sym.declarations === undefined) {
         return undefined;
     }
 
-    return find(sym.declarations, (decl) =>
-        isClassLikeDeclaration(decl) || isTypeAliasDeclaration(decl) || isInterfaceDeclaration(decl) ? decl.typeParameters : undefined);
+    return find(
+        sym.declarations,
+        decl =>
+            isClassLikeDeclaration(decl) ||
+            isTypeAliasDeclaration(decl) ||
+            isInterfaceDeclaration(decl)
+                ? decl.typeParameters
+                : undefined,
+    );
 }
 
-function getAliasedSymbol(symbol: ts.Symbol | undefined, checker: ts.TypeChecker): ts.Symbol | undefined {
+function getAliasedSymbol(
+    symbol: ts.Symbol | undefined,
+    checker: ts.TypeChecker,
+): ts.Symbol | undefined {
     if (symbol === undefined) {
         return undefined;
     }
-    return isSymbolFlagSet(symbol, ts.SymbolFlags.Alias) ? checker.getAliasedSymbol(symbol) : symbol;
+    return isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)
+        ? checker.getAliasedSymbol(symbol)
+        : symbol;
 }

--- a/src/rules/useIsnanRule.ts
+++ b/src/rules/useIsnanRule.ts
@@ -25,7 +25,8 @@ export class Rule extends Lint.Rules.AbstractRule {
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "use-isnan",
-        description: "Enforces use of the `isNaN()` function to check for NaN references instead of a comparison to the `NaN` constant.",
+        description:
+            "Enforces use of the `isNaN()` function to check for NaN references instead of a comparison to the `NaN` constant.",
         rationale: Lint.Utils.dedent`
             Since \`NaN !== NaN\`, comparisons with regular operators will produce unexpected results.
             So, instead of \`if (myVar === NaN)\`, do \`if (isNaN(myVar))\`.`,
@@ -58,7 +59,10 @@ function walk(ctx: Lint.WalkContext<void>) {
                 case ts.SyntaxKind.EqualsEqualsEqualsToken:
                 case ts.SyntaxKind.ExclamationEqualsEqualsToken:
                     if (isExpressionNaN(node.right) || isExpressionNaN(node.left)) {
-                        ctx.addFailureAtNode(node, Rule.FAILURE_STRING + node.getText(ctx.sourceFile));
+                        ctx.addFailureAtNode(
+                            node,
+                            Rule.FAILURE_STRING + node.getText(ctx.sourceFile),
+                        );
                     }
             }
         }

--- a/src/rules/variableNameRule.ts
+++ b/src/rules/variableNameRule.ts
@@ -23,9 +23,19 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 import { isLowerCase, isUpperCase } from "../utils";
 
-const BANNED_KEYWORDS = ["any", "Number", "number", "String", "string", "Boolean", "boolean", "Undefined", "undefined"];
+const BANNED_KEYWORDS = [
+    "any",
+    "Number",
+    "number",
+    "String",
+    "string",
+    "Boolean",
+    "boolean",
+    "Undefined",
+    "undefined",
+];
 const bannedKeywordsSet = new Set(BANNED_KEYWORDS);
-const bannedKeywordsStr = BANNED_KEYWORDS.map((kw) => `\`${kw}\``).join(", ");
+const bannedKeywordsStr = BANNED_KEYWORDS.map(kw => `\`${kw}\``).join(", ");
 
 const OPTION_LEADING_UNDERSCORE = "allow-leading-underscore";
 const OPTION_TRAILING_UNDERSCORE = "allow-trailing-underscore";
@@ -111,7 +121,10 @@ function walk(ctx: Lint.WalkContext<Options>): void {
                     handleVariableNameKeyword(name);
                     // A destructuring pattern that does not rebind an expression is always an alias, e.g. `var {Foo} = ...;`.
                     // Only check if the name is rebound (`var {Foo: bar} = ...;`).
-                    if (node.parent!.kind !== ts.SyntaxKind.ObjectBindingPattern || propertyName !== undefined) {
+                    if (
+                        node.parent!.kind !== ts.SyntaxKind.ObjectBindingPattern ||
+                        propertyName !== undefined
+                    ) {
                         handleVariableNameFormat(name, initializer);
                     }
                 }
@@ -128,7 +141,10 @@ function walk(ctx: Lint.WalkContext<Options>): void {
             case ts.SyntaxKind.Parameter:
             case ts.SyntaxKind.PropertyDeclaration:
             case ts.SyntaxKind.VariableDeclaration: {
-                const { name, initializer } = node as ts.ParameterDeclaration | ts.PropertyDeclaration | ts.VariableDeclaration;
+                const { name, initializer } = node as
+                    | ts.ParameterDeclaration
+                    | ts.PropertyDeclaration
+                    | ts.VariableDeclaration;
                 if (name.kind === ts.SyntaxKind.Identifier) {
                     handleVariableNameFormat(name, initializer);
                     // do not check property declarations for keywords, they are allowed to be keywords

--- a/src/verify/lines.ts
+++ b/src/verify/lines.ts
@@ -16,14 +16,32 @@
  */
 
 // Use classes here instead of interfaces because we want runtime type data
-export class Line { }
-export class CodeLine extends Line { constructor(public contents: string) { super(); } }
-export class MessageSubstitutionLine extends Line { constructor(public key: string, public message: string) { super(); } }
+export class Line {}
+export class CodeLine extends Line {
+    constructor(public contents: string) {
+        super();
+    }
+}
+export class MessageSubstitutionLine extends Line {
+    constructor(public key: string, public message: string) {
+        super();
+    }
+}
 
-export class ErrorLine extends Line { constructor(public startCol: number) { super(); } }
-export class MultilineErrorLine extends ErrorLine { constructor(startCol: number) { super(startCol); } }
+export class ErrorLine extends Line {
+    constructor(public startCol: number) {
+        super();
+    }
+}
+export class MultilineErrorLine extends ErrorLine {
+    constructor(startCol: number) {
+        super(startCol);
+    }
+}
 export class EndErrorLine extends ErrorLine {
-    constructor(startCol: number, public endCol: number, public message: string) { super(startCol); }
+    constructor(startCol: number, public endCol: number, public message: string) {
+        super(startCol);
+    }
 }
 
 // example matches (between the quotes):
@@ -50,7 +68,7 @@ export function parseLine(text: string): Line {
     if (endErrorMatch !== null) {
         const [, squiggles, message] = endErrorMatch;
         const startErrorCol = text.indexOf("~");
-        const zeroLengthError = (squiggles === ZERO_LENGTH_ERROR);
+        const zeroLengthError = squiggles === ZERO_LENGTH_ERROR;
         const endErrorCol = zeroLengthError ? startErrorCol : text.lastIndexOf("~") + 1;
         return new EndErrorLine(startErrorCol, endErrorCol, message);
     }
@@ -76,7 +94,7 @@ export function parseLine(text: string): Line {
 export function printLine(line: Line, code?: string): string | undefined {
     if (line instanceof ErrorLine) {
         if (code === undefined) {
-           throw new Error("Must supply argument for code parameter when line is an ErrorLine");
+            throw new Error("Must supply argument for code parameter when line is an ErrorLine");
         }
 
         const leadingSpaces = " ".repeat(line.startCol);

--- a/src/verify/lintError.ts
+++ b/src/verify/lintError.ts
@@ -16,14 +16,14 @@
  */
 
 export interface PositionInFile {
-   line: number;
-   col: number;
+    line: number;
+    col: number;
 }
 
 export interface LintError {
-   startPos: PositionInFile;
-   endPos: PositionInFile;
-   message: string;
+    startPos: PositionInFile;
+    endPos: PositionInFile;
+    message: string;
 }
 
 export function errorComparator(err1: LintError, err2: LintError) {

--- a/src/verify/parse.ts
+++ b/src/verify/parse.ts
@@ -101,7 +101,9 @@ export function preprocessDirectives(text: string): string {
 export function removeErrorMarkup(text: string): string {
     const textWithMarkup = text.split("\n");
     const lines = textWithMarkup.map(parseLine);
-    const codeText = lines.filter((line) => (line instanceof CodeLine)).map((line) => (line as CodeLine).contents);
+    const codeText = lines
+        .filter(line => line instanceof CodeLine)
+        .map(line => (line as CodeLine).contents);
     return codeText.join("\n");
 }
 
@@ -118,9 +120,11 @@ export function parseErrorsFromMarkup(text: string): LintError[] {
         throw lintSyntaxError("text cannot start with an error mark line.");
     }
 
-    const messageSubstitutionLines = lines.filter((l) => l instanceof MessageSubstitutionLine) as MessageSubstitutionLine[];
+    const messageSubstitutionLines = lines.filter(
+        l => l instanceof MessageSubstitutionLine,
+    ) as MessageSubstitutionLine[];
     const messageSubstitutions = new Map<string, string>();
-    for (const {key, message} of messageSubstitutionLines) {
+    for (const { key, message } of messageSubstitutionLines) {
         messageSubstitutions.set(key, formatMessage(messageSubstitutions, message));
     }
 
@@ -128,7 +132,11 @@ export function parseErrorsFromMarkup(text: string): LintError[] {
     const errorLinesForCodeLines = createCodeLineNoToErrorsMap(lines);
 
     const lintErrors: LintError[] = [];
-    function addError(errorLine: EndErrorLine, errorStartPos: { line: number; col: number }, lineNo: number) {
+    function addError(
+        errorLine: EndErrorLine,
+        errorStartPos: { line: number; col: number },
+        lineNo: number,
+    ) {
         lintErrors.push({
             startPos: errorStartPos,
             endPos: { line: lineNo, col: errorLine.endCol },
@@ -137,7 +145,6 @@ export function parseErrorsFromMarkup(text: string): LintError[] {
     }
     // for each line of code...
     errorLinesForCodeLines.forEach((errorLinesForLineOfCode, lineNo) => {
-
         // for each error marking on that line...
         while (errorLinesForLineOfCode.length > 0) {
             const errorLine = errorLinesForLineOfCode.shift();
@@ -147,14 +154,15 @@ export function parseErrorsFromMarkup(text: string): LintError[] {
             if (errorLine instanceof EndErrorLine) {
                 addError(errorLine, errorStartPos, lineNo);
 
-            // if the error is the start of a multiline error
+                // if the error is the start of a multiline error
             } else if (errorLine instanceof MultilineErrorLine) {
-
                 // iterate through the MultilineErrorLines until we get to an EndErrorLine
                 for (let nextLineNo = lineNo + 1; ; ++nextLineNo) {
                     if (!isValidErrorMarkupContinuation(errorLinesForCodeLines, nextLineNo)) {
                         throw lintSyntaxError(
-                            `Error mark starting at ${errorStartPos.line}:${errorStartPos.col} does not end correctly.`,
+                            `Error mark starting at ${errorStartPos.line}:${
+                                errorStartPos.col
+                            } does not end correctly.`,
                         );
                     } else {
                         const nextErrorLine = errorLinesForCodeLines[nextLineNo].shift();
@@ -222,7 +230,11 @@ function parseFormatArguments(text: string): string[] | undefined {
     scanner.setText(text);
     const result: string[] = [];
     let expectValue = true;
-    for (let token = scanner.scan(); token !== ts.SyntaxKind.EndOfFileToken; token = scanner.scan()) {
+    for (
+        let token = scanner.scan();
+        token !== ts.SyntaxKind.EndOfFileToken;
+        token = scanner.scan()
+    ) {
         if (token === ts.SyntaxKind.StringLiteral) {
             if (!expectValue) {
                 return undefined;
@@ -250,11 +262,13 @@ export function createMarkupFromErrors(code: string, lintErrors: LintError[]) {
     const errorLinesForCodeText: ErrorLine[][] = codeText.map(() => []);
 
     for (const error of lintErrors) {
-        const {startPos, endPos, message} = error;
+        const { startPos, endPos, message } = error;
 
         if (startPos.line === endPos.line) {
             // single line error
-            errorLinesForCodeText[startPos.line].push(new EndErrorLine(startPos.col, endPos.col, message));
+            errorLinesForCodeText[startPos.line].push(
+                new EndErrorLine(startPos.col, endPos.col, message),
+            );
         } else {
             // multiline error
             errorLinesForCodeText[startPos.line].push(new MultilineErrorLine(startPos.col));
@@ -265,7 +279,10 @@ export function createMarkupFromErrors(code: string, lintErrors: LintError[]) {
         }
     }
 
-    return flatMap(codeText, (line, i) => [line, ...mapDefined(errorLinesForCodeText[i], (err) => printLine(err, line))]).join("\n");
+    return flatMap(codeText, (line, i) => [
+        line,
+        ...mapDefined(errorLinesForCodeText[i], err => printLine(err, line)),
+    ]).join("\n");
 }
 /* tslint:enable:object-literal-sort-keys */
 
@@ -282,7 +299,9 @@ function createCodeLineNoToErrorsMap(lines: Line[]) {
 }
 
 function isValidErrorMarkupContinuation(errorLinesForCodeLines: ErrorLine[][], lineNo: number) {
-    return lineNo < errorLinesForCodeLines.length
-        && errorLinesForCodeLines[lineNo].length !== 0
-        && errorLinesForCodeLines[lineNo][0].startCol === 0;
+    return (
+        lineNo < errorLinesForCodeLines.length &&
+        errorLinesForCodeLines[lineNo].length !== 0 &&
+        errorLinesForCodeLines[lineNo][0].startCol === 0
+    );
 }

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -29,16 +29,20 @@ const EXECUTABLE_PATH = path.resolve(EXECUTABLE_DIR, "npm-like-executable");
 const TEMP_JSON_PATH = path.resolve(EXECUTABLE_DIR, "tslint.json");
 
 const dummyLogger: Logger = {
-    log() { /* do nothing */ },
-    error() { /* do nothing */ },
+    log() {
+        /* do nothing */
+    },
+    error() {
+        /* do nothing */
+    },
 };
 
 describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
-    this.slow(3000);    // the executable is JIT-ed each time it runs; avoid showing slowness warnings
+    this.slow(3000); // the executable is JIT-ed each time it runs; avoid showing slowness warnings
     this.timeout(4000);
 
     describe("Files", () => {
-        it("exits with code 1 if no arguments passed", (done) => {
+        it("exits with code 1 if no arguments passed", done => {
             execCli([], (err, stdout, stderr) => {
                 assert.isNotNull(err, "process should exit with error");
                 assert.strictEqual(err.code, 1, "error code should be 1");
@@ -46,51 +50,58 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
                 assert.include(
                     stderr,
                     "No files specified. Use --project to lint a project folder.",
-                    "stderr should contain notification about missing files");
+                    "stderr should contain notification about missing files",
+                );
                 assert.strictEqual(stdout, "", "shouldn't contain any output in stdout");
                 done();
             });
         });
 
-        it("exits with code 0 if correct file is passed", (done) => {
-            execCli(["src/configuration.ts"], (err) => {
+        it("exits with code 0 if correct file is passed", done => {
+            execCli(["src/configuration.ts"], err => {
                 assert.isNull(err, "process should exit without an error");
                 done();
             });
         });
 
-        it("exits with code 0 if several files passed without `-f` flag", (done) => {
-            execCli(["src/configuration.ts", "src/formatterLoader.ts"], (err) => {
+        it("exits with code 0 if several files passed without `-f` flag", done => {
+            execCli(["src/configuration.ts", "src/formatterLoader.ts"], err => {
                 assert.isNull(err, "process should exit without an error");
                 done();
             });
         });
 
-        it("exits with code 1 if removed `-f` flag is passed", (done) => {
-            execCli(["src/configuration.ts", "-f", "src/formatterLoader.ts"], (err, stdout, stderr) => {
-                assert.isNotNull(err, "process should exit with error");
-                assert.strictEqual(err.code, 1, "error code should be 1");
+        it("exits with code 1 if removed `-f` flag is passed", done => {
+            execCli(
+                ["src/configuration.ts", "-f", "src/formatterLoader.ts"],
+                (err, stdout, stderr) => {
+                    assert.isNotNull(err, "process should exit with error");
+                    assert.strictEqual(err.code, 1, "error code should be 1");
 
-                assert.include(stderr, "error: unknown option `-f'");
-                assert.strictEqual(stdout, "", "shouldn't contain any output in stdout");
-                done();
-            });
+                    assert.include(stderr, "error: unknown option `-f'");
+                    assert.strictEqual(stdout, "", "shouldn't contain any output in stdout");
+                    done();
+                },
+            );
         });
 
         it("warns if file does not exist", async () => {
-            const result = await execRunnerWithOutput({files: ["foo/bar.ts"]});
+            const result = await execRunnerWithOutput({ files: ["foo/bar.ts"] });
             assert.strictEqual(result.status, Status.Ok, "process should exit without error");
             assert.include(result.stderr, "'foo/bar.ts' does not exist");
         });
 
         it("doesn't warn if non-existent file is excluded by --exclude", async () => {
-            const result = await execRunnerWithOutput({files: ["foo/bar.js"], exclude: ["**/*.js"]});
+            const result = await execRunnerWithOutput({
+                files: ["foo/bar.js"],
+                exclude: ["**/*.js"],
+            });
             assert.strictEqual(result.status, Status.Ok, "process should exit without error");
             assert.notInclude(result.stderr, "does not exist");
         });
 
         it("doesn't warn if glob pattern doesn't match any file", async () => {
-            const result = await execRunnerWithOutput({files: ["foobar/*.js"]});
+            const result = await execRunnerWithOutput({ files: ["foobar/*.js"] });
             assert.strictEqual(result.status, Status.Ok, "process should exit without error");
             assert.notInclude(result.stderr, "does not exist");
         });
@@ -98,37 +109,68 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
     describe("Configuration file", () => {
         it("exits with code 0 if relative path is passed without `./`", async () => {
-            const status = await execRunner({config: "test/config/tslint-almost-empty.json", files: ["src/test.ts"]});
+            const status = await execRunner({
+                config: "test/config/tslint-almost-empty.json",
+                files: ["src/test.ts"],
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 0 if config file that extends relative config file", async () => {
-            const status = await execRunner({config: "test/config/tslint-extends-package-no-mod.json", files: ["src/test.ts"]});
+            const status = await execRunner({
+                config: "test/config/tslint-extends-package-no-mod.json",
+                files: ["src/test.ts"],
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 1 if config file is invalid", async () => {
-            const result = await execRunnerWithOutput({config: "test/config/tslint-invalid.json", files: ["src/test.ts"]});
+            const result = await execRunnerWithOutput({
+                config: "test/config/tslint-invalid.json",
+                files: ["src/test.ts"],
+            });
 
             assert.equal(result.status, Status.FatalError, "process should exit with error");
-            assert.include(result.stderr, "Failed to load", "stderr should contain notification about failing to load json config");
+            assert.include(
+                result.stderr,
+                "Failed to load",
+                "stderr should contain notification about failing to load json config",
+            );
             assert.strictEqual(result.stdout, "", "shouldn't contain any output in stdout");
         });
 
         it("exits with code 1 if yaml config file is invalid", async () => {
-            const result = await execRunnerWithOutput({config: "test/config/tslint-invalid.yaml", files: ["src/test.ts"]});
+            const result = await execRunnerWithOutput({
+                config: "test/config/tslint-invalid.yaml",
+                files: ["src/test.ts"],
+            });
             assert.strictEqual(result.status, Status.FatalError, "error code should be 1");
 
-            assert.include(result.stderr, "Failed to load", "stderr should contain notification about failing to load yaml config");
+            assert.include(
+                result.stderr,
+                "Failed to load",
+                "stderr should contain notification about failing to load yaml config",
+            );
             assert.strictEqual(result.stdout, "", "shouldn't contain any output in stdout");
         });
 
         it("mentions the root cause if a config file extends from an invalid file", async () => {
-            const result = await execRunnerWithOutput({config: "test/config/tslint-extends-invalid.json", files: ["src/test.ts"]});
+            const result = await execRunnerWithOutput({
+                config: "test/config/tslint-extends-invalid.json",
+                files: ["src/test.ts"],
+            });
 
             assert.equal(result.status, Status.FatalError, "process should exit with error");
-            assert.include(result.stderr, "Failed to load", "stderr should contain notification about failing to load json config");
-            assert.include(result.stderr, "tslint-invalid.json", "stderr should mention the problem file");
+            assert.include(
+                result.stderr,
+                "Failed to load",
+                "stderr should contain notification about failing to load json config",
+            );
+            assert.include(
+                result.stderr,
+                "tslint-invalid.json",
+                "stderr should mention the problem file",
+            );
             assert.strictEqual(result.stdout, "", "shouldn't contain any output in stdout");
         });
     });
@@ -140,7 +182,7 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             assert.include(
                 stdout,
                 "hello from custom formatter",
-                "stdout should contain output of custom formatter"
+                "stdout should contain output of custom formatter",
             );
             done();
         };
@@ -152,12 +194,12 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
                     "tslint-custom-rules-with-dir.json",
                     "../../src/test.ts",
                     "-t",
-                    "tslint-test-custom-formatter"
+                    "tslint-test-custom-formatter",
                 ],
                 {
-                    cwd: "./test/config"
+                    cwd: "./test/config",
                 },
-                createFormatVerifier(done)
+                createFormatVerifier(done),
             );
         });
 
@@ -165,45 +207,50 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             execCli(
                 ["-c", "tslint-custom-rules-with-dir-and-format.json", "../../src/test.ts"],
                 {
-                    cwd: "./test/config"
+                    cwd: "./test/config",
                 },
-                createFormatVerifier(done)
+                createFormatVerifier(done),
             );
         });
     });
 
     describe("Custom rules", () => {
         it("exits with code 1 if nonexisting custom rules directory is passed", async () => {
-            const status = await execRunner(
-                {config: "./test/config/tslint-custom-rules.json", rulesDirectory: "./someRandomDir", files: ["src/test.ts"]},
-            );
+            const status = await execRunner({
+                config: "./test/config/tslint-custom-rules.json",
+                rulesDirectory: "./someRandomDir",
+                files: ["src/test.ts"],
+            });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
 
         it("exits with code 2 if custom rules directory is passed and file contains lint errors", async () => {
-            const status = await execRunner(
-                {config: "./test/config/tslint-custom-rules.json", rulesDirectory: "./test/files/custom-rules", files: ["src/test.ts"]},
-            );
+            const status = await execRunner({
+                config: "./test/config/tslint-custom-rules.json",
+                rulesDirectory: "./test/files/custom-rules",
+                files: ["src/test.ts"],
+            });
             assert.equal(status, Status.LintError, "error code should be 2");
         });
 
         it("exits with code 0 if custom rules directory is passed and file contains lint warnings", async () => {
-            const status = await execRunner(
-                {
-                    config: "./test/config/tslint-extends-package-warning.json",
-                    files: ["src/test.ts"],
-                    rulesDirectory: "./test/files/custom-rules",
-                },
-            );
+            const status = await execRunner({
+                config: "./test/config/tslint-extends-package-warning.json",
+                files: ["src/test.ts"],
+                rulesDirectory: "./test/files/custom-rules",
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 2 if custom rules directory is specified in config file and file contains lint errors", async () => {
-            const status = await execRunner({config: "./test/config/tslint-custom-rules-with-dir.json", files: ["src/test.ts"]});
+            const status = await execRunner({
+                config: "./test/config/tslint-custom-rules-with-dir.json",
+                files: ["src/test.ts"],
+            });
             assert.equal(status, Status.LintError, "error code should be 2");
         });
 
-        it("are compiled just in time when using ts-node", (done) => {
+        it("are compiled just in time when using ts-node", done => {
             execCli(
                 ["-c", "./test/config/tslint-custom-rules-uncompiled.json", "src/test.ts"],
                 {
@@ -214,7 +261,7 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
                         TS_NODE_FAST: "1",
                     },
                 },
-                (err) => {
+                err => {
                     assert.isNull(err, "process should exit without an error");
                     done();
                 },
@@ -224,54 +271,56 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
     describe("Config with excluded files", () => {
         it("exits with code 2 if linter options doesn't exclude file with lint errors", async () => {
-            const status = await execRunner(
-                {config: "./test/files/config-exclude/tslint-exclude-one.json", files: ["./test/files/config-exclude/included.ts"]},
-            );
+            const status = await execRunner({
+                config: "./test/files/config-exclude/tslint-exclude-one.json",
+                files: ["./test/files/config-exclude/included.ts"],
+            });
             assert.equal(status, Status.LintError, "error code should be 2");
         });
 
         it("exits with code 0 if linter options exclude one file with lint errors", async () => {
-            const status = await execRunner(
-                {config: "./test/files/config-exclude/tslint-exclude-one.json", files: ["./test/files/config-exclude/excluded.ts"]},
-            );
+            const status = await execRunner({
+                config: "./test/files/config-exclude/tslint-exclude-one.json",
+                files: ["./test/files/config-exclude/excluded.ts"],
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 0 if linter options excludes many files with lint errors", async () => {
-            const status = await execRunner(
-                {
-                    config: "./test/files/config-exclude/tslint-exclude-many.json",
-                    files: ["./test/rules/config-exclude/excluded1.ts", "./test/rules/config-exclude/subdir/excluded2.ts"],
-                },
-            );
+            const status = await execRunner({
+                config: "./test/files/config-exclude/tslint-exclude-many.json",
+                files: [
+                    "./test/rules/config-exclude/excluded1.ts",
+                    "./test/rules/config-exclude/subdir/excluded2.ts",
+                ],
+            });
             assert.strictEqual(status, Status.Ok, "process should exit without an error");
         });
 
         it("excludes files relative to tslint.json", async () => {
-            const status = await execRunner(
-                {config: "./test/files/config-exclude/tslint-exclude-one.json", files: ["./test/files/config-exclude/subdir/excluded.ts"]},
-            );
+            const status = await execRunner({
+                config: "./test/files/config-exclude/tslint-exclude-one.json",
+                files: ["./test/files/config-exclude/subdir/excluded.ts"],
+            });
             assert.equal(status, Status.LintError, "exit code should be 2");
         });
 
         it("excludes files relative to tslint.json they were declared in", async () => {
-            const status = await execRunner(
-                {
-                    config: "./test/files/config-exclude/subdir/tslint-extending.json",
-                    files: ["./test/files/config-exclude/subdir/excluded.ts"],
-                },
-            );
+            const status = await execRunner({
+                config: "./test/files/config-exclude/subdir/tslint-extending.json",
+                files: ["./test/files/config-exclude/subdir/excluded.ts"],
+            });
             assert.equal(status, Status.LintError, "exit code should be 2");
         });
     });
 
-    it("finds configuration above current directory", (done) => {
+    it("finds configuration above current directory", done => {
         execCli(
             ["index.test.ts"],
             {
                 cwd: "./test/files/config-findup/no-config",
             },
-            (err) => {
+            err => {
                 assert.isNotNull(err, "process should exit with an error");
                 assert.equal(err.code, 2, "exit code should be 2");
                 done();
@@ -282,30 +331,36 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
     describe("--fix flag", () => {
         it("fixes multiple rules without overwriting each other", async () => {
             const tempFile = path.relative(process.cwd(), createTempFile("ts"));
-            fs.writeFileSync(tempFile, 'import * as x from "b"\nimport * as y from "a_long_module";\n');
-            const result = await execRunnerWithOutput(
-                {config: "test/files/multiple-fixes-test/tslint.json", files: [tempFile], fix: true},
+            fs.writeFileSync(
+                tempFile,
+                'import * as x from "b"\nimport * as y from "a_long_module";\n',
             );
+            const result = await execRunnerWithOutput({
+                config: "test/files/multiple-fixes-test/tslint.json",
+                files: [tempFile],
+                fix: true,
+            });
             const content = fs.readFileSync(tempFile, "utf8");
             // compare against file name which will be returned by formatter (used in TypeScript)
             const denormalizedFileName = denormalizeWinPath(tempFile);
             fs.unlinkSync(tempFile);
             assert.equal(result.status, Status.Ok, "process should exit without an error");
-            assert.strictEqual(content, "import * as y from \"a_long_module\";\nimport * as x from \"b\";\n");
+            assert.strictEqual(
+                content,
+                'import * as y from "a_long_module";\nimport * as x from "b";\n',
+            );
             assert.strictEqual(result.stdout.trim(), `Fixed 2 error(s) in ${denormalizedFileName}`);
         }).timeout(8000);
     });
 
     describe("--force flag", () => {
         it("exits with code 0 if `--force` flag is passed", async () => {
-            const result = await execRunnerWithOutput(
-                {
-                    config: "./test/config/tslint-custom-rules.json",
-                    files: ["src/test.ts"],
-                    force: true,
-                    rulesDirectory: "./test/files/custom-rules",
-                },
-            );
+            const result = await execRunnerWithOutput({
+                config: "./test/config/tslint-custom-rules.json",
+                files: ["src/test.ts"],
+                force: true,
+                rulesDirectory: "./test/files/custom-rules",
+            });
             assert.equal(result.status, Status.Ok, "process should exit without an error");
             assert.include(result.stdout, "failure", "errors should be reported");
         });
@@ -313,124 +368,143 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
     describe("--test flag", () => {
         it("exits with code 0 if `--test` flag is used", async () => {
-            const status = await execRunner({test: true, files: ["test/rules/no-eval"]});
+            const status = await execRunner({ test: true, files: ["test/rules/no-eval"] });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 0 if `--test` flag is used with a wildcard", async () => {
-            const status = await execRunner({test: true, files: ["test/rules/no-e*"]});
+            const status = await execRunner({ test: true, files: ["test/rules/no-e*"] });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 1 if `--test` flag is used with incorrect rule", async () => {
-            const status = await execRunner({test: true, files: ["test/files/incorrect-rule-test"]});
+            const status = await execRunner({
+                test: true,
+                files: ["test/files/incorrect-rule-test"],
+            });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
 
         it("exits with code 1 if `--test` flag is used with incorrect rule in a wildcard", async () => {
-            const status = await execRunner({test: true, files: ["test/files/incorrect-rule-*"]});
+            const status = await execRunner({ test: true, files: ["test/files/incorrect-rule-*"] });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
 
         it("exits with code 0 if `--test` flag is used with custom rule", async () => {
-            const status = await execRunner({test: true, files: ["test/files/custom-rule-rule-test"]});
+            const status = await execRunner({
+                test: true,
+                files: ["test/files/custom-rule-rule-test"],
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 0 if `--test` and `-r` flags are used with custom rule", async () => {
-            const status = await execRunner(
-                {test: true, files: ["test/files/custom-rule-cli-rule-test"], rulesDirectory: "test/files/custom-rules-2"},
-            );
+            const status = await execRunner({
+                test: true,
+                files: ["test/files/custom-rule-cli-rule-test"],
+                rulesDirectory: "test/files/custom-rules-2",
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 0 if `--test` flag is used with fixes", async () => {
-            const status = await execRunner({test: true, files: ["test/files/fixes-test"]});
+            const status = await execRunner({ test: true, files: ["test/files/fixes-test"] });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 1 if `--test` flag is used with incorrect fixes", async () => {
-            const status = await execRunner({test: true, files: ["test/files/incorrect-fixes-test"]});
+            const status = await execRunner({
+                test: true,
+                files: ["test/files/incorrect-fixes-test"],
+            });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
 
         it("can be used with multiple paths", async () => {
             // pass a failing test as second path to make sure it gets executed
-            const status = await execRunner({test: true, files: ["test/files/custom-rule-rule-test", "test/files/incorrect-fixes-test"]});
+            const status = await execRunner({
+                test: true,
+                files: ["test/files/custom-rule-rule-test", "test/files/incorrect-fixes-test"],
+            });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
     });
 
     describe("--project flag", () => {
         it("exits with code 0 if `tsconfig.json` is passed and it specifies files without errors", async () => {
-            const status = await execRunner(
-                {config: "test/files/tsconfig-test/tslint.json", project: "test/files/tsconfig-test/tsconfig.json"},
-            );
+            const status = await execRunner({
+                config: "test/files/tsconfig-test/tslint.json",
+                project: "test/files/tsconfig-test/tsconfig.json",
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("can be passed a directory and defaults to tsconfig.json", async () => {
-            const status = await execRunner(
-                {config: "test/files/tsconfig-test/tslint.json", project: "test/files/tsconfig-test"},
-            );
+            const status = await execRunner({
+                config: "test/files/tsconfig-test/tslint.json",
+                project: "test/files/tsconfig-test",
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with error if passed a directory and there is not tsconfig.json", async () => {
-            const status = await execRunner(
-                {config: "test/files/tsconfig-test/tslint.json", project: "test/files"},
-            );
+            const status = await execRunner({
+                config: "test/files/tsconfig-test/tslint.json",
+                project: "test/files",
+            });
             assert.equal(status, Status.FatalError, "exit code should be 1");
         });
 
         it("exits with error if passed directory does not exist", async () => {
-            const status = await execRunner(
-                {config: "test/files/tsconfig-test/tslint.json", project: "test/files/non-existent"},
-            );
+            const status = await execRunner({
+                config: "test/files/tsconfig-test/tslint.json",
+                project: "test/files/non-existent",
+            });
             assert.equal(status, Status.FatalError, "exit code should be 1");
         });
 
         it("exits with code 1 if file is not included in project", async () => {
-            const status = await execRunner(
-                {
-                    config: "test/files/tsconfig-test/tslint.json",
-                    files: ["test/files/tsconfig-test/other.test.ts"],
-                    project: "test/files/tsconfig-test/tsconfig.json",
-                },
-            );
+            const status = await execRunner({
+                config: "test/files/tsconfig-test/tslint.json",
+                files: ["test/files/tsconfig-test/other.test.ts"],
+                project: "test/files/tsconfig-test/tsconfig.json",
+            });
             assert.equal(status, Status.FatalError, "exit code should be 1");
         });
 
         it("exits with code 0 if `tsconfig.json` is passed but it includes no ts files", async () => {
-            const status = await execRunner(
-                {config: "test/files/tsconfig-no-ts-files/tslint.json", project: "test/files/tsconfig-no-ts-files/tsconfig.json"},
-            );
+            const status = await execRunner({
+                config: "test/files/tsconfig-no-ts-files/tslint.json",
+                project: "test/files/tsconfig-no-ts-files/tsconfig.json",
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("can extend `tsconfig.json` with relative path", async () => {
-            const status1 = await execRunner(
-                {
-                    config: "test/files/tsconfig-extends-relative/tslint-ok.json",
-                    project: "test/files/tsconfig-extends-relative/test/tsconfig.json",
-                },
-            );
+            const status1 = await execRunner({
+                config: "test/files/tsconfig-extends-relative/tslint-ok.json",
+                project: "test/files/tsconfig-extends-relative/test/tsconfig.json",
+            });
             assert.equal(status1, Status.Ok, "process should exit without an error");
-            const status2 = await execRunner(
-                {
-                    config: "test/files/tsconfig-extends-relative/tslint-fail.json",
-                    project: "test/files/tsconfig-extends-relative/test/tsconfig.json",
-                },
-            );
+            const status2 = await execRunner({
+                config: "test/files/tsconfig-extends-relative/tslint-fail.json",
+                project: "test/files/tsconfig-extends-relative/test/tsconfig.json",
+            });
             assert.equal(status2, Status.LintError, "exit code should be 2");
         });
 
         it("warns if file-to-lint does not exist", async () => {
-            const result = await execRunnerWithOutput(
-                {project: "test/files/tsconfig-test/tsconfig.json", files: ["test/files/tsconfig-test/non-existent.test.ts"]},
-            );
+            const result = await execRunnerWithOutput({
+                project: "test/files/tsconfig-test/tsconfig.json",
+                files: ["test/files/tsconfig-test/non-existent.test.ts"],
+            });
             assert.strictEqual(result.status, Status.Ok, "process should exit without error");
-            assert.include(result.stderr, `${path.normalize("test/files/tsconfig-test/non-existent.test.ts")}' does not exist`);
+            assert.include(
+                result.stderr,
+                `${path.normalize(
+                    "test/files/tsconfig-test/non-existent.test.ts",
+                )}' does not exist`,
+            );
         });
 
         it("doesn't warn for non-existent file-to-lint if excluded by --exclude", async () => {
@@ -444,55 +518,77 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
         });
 
         it("doesn't warn if glob pattern doesn't match any file", async () => {
-            const result = await execRunnerWithOutput({project: "test/files/tsconfig-test/tsconfig.json", files: ["*.js"]});
+            const result = await execRunnerWithOutput({
+                project: "test/files/tsconfig-test/tsconfig.json",
+                files: ["*.js"],
+            });
             assert.strictEqual(result.status, Status.Ok, "process should exit without error");
             assert.notInclude(result.stderr, "does not exist");
         });
 
         it("reports errors from parsing tsconfig.json", async () => {
-            const result = await execRunnerWithOutput({project: "test/files/tsconfig-invalid/syntax-error.json"});
+            const result = await execRunnerWithOutput({
+                project: "test/files/tsconfig-invalid/syntax-error.json",
+            });
             assert.strictEqual(result.status, Status.FatalError, "exit code should be 1");
             assert.include(result.stderr, "error TS");
         });
 
         it("reports errors from validating tsconfig.json", async () => {
-            const result = await execRunnerWithOutput({project: "test/files/tsconfig-invalid/empty-files.json"});
+            const result = await execRunnerWithOutput({
+                project: "test/files/tsconfig-invalid/empty-files.json",
+            });
             assert.strictEqual(result.status, Status.FatalError, "exit code should be 1");
             assert.include(result.stderr, "error TS");
         });
 
         it("does not report an error if tsconfig.json matches no files", async () => {
-            const status = await execRunner({project: "test/files/tsconfig-invalid/no-match.json"});
+            const status = await execRunner({
+                project: "test/files/tsconfig-invalid/no-match.json",
+            });
             assert.strictEqual(status, Status.Ok, "process should exit without an error");
         });
 
         it("can execute typed rules without --type-check", async () => {
-            const status = await execRunner({project: "test/files/typed-rule/tsconfig.json"});
+            const status = await execRunner({ project: "test/files/typed-rule/tsconfig.json" });
             assert.equal(status, Status.LintError, "exit code should be 2");
         });
 
         it("handles 'allowJs' correctly", async () => {
-            const status = await execRunner({project: "test/files/tsconfig-allow-js/tsconfig.json"});
+            const status = await execRunner({
+                project: "test/files/tsconfig-allow-js/tsconfig.json",
+            });
             assert.equal(status, Status.LintError, "exit code should be 2");
         });
 
         it("doesn't lint external dependencies with 'allowJs'", async () => {
-            const status = await execRunner({project: "test/files/allow-js-exclude-node-modules/tsconfig.json"});
+            const status = await execRunner({
+                project: "test/files/allow-js-exclude-node-modules/tsconfig.json",
+            });
             assert.equal(status, Status.Ok, "process should exit without error");
         });
 
         it("works with '--exclude'", async () => {
-            const status = await execRunner(
-                {project: "test/files/tsconfig-allow-js/tsconfig.json", exclude: ["test/files/tsconfig-allow-js/testfile.test.js"]},
-            );
+            const status = await execRunner({
+                project: "test/files/tsconfig-allow-js/tsconfig.json",
+                exclude: ["test/files/tsconfig-allow-js/testfile.test.js"],
+            });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("can apply fixes from multiple rules", async () => {
-            fs.writeFileSync("test/files/project-multiple-fixes/testfile.test.ts",
-                             fs.readFileSync("test/files/project-multiple-fixes/before.test.ts", "utf-8"));
-            const status = await execRunner({project: "test/files/project-multiple-fixes/", fix: true});
-            const actual = fs.readFileSync("test/files/project-multiple-fixes/testfile.test.ts", "utf-8");
+            fs.writeFileSync(
+                "test/files/project-multiple-fixes/testfile.test.ts",
+                fs.readFileSync("test/files/project-multiple-fixes/before.test.ts", "utf-8"),
+            );
+            const status = await execRunner({
+                project: "test/files/project-multiple-fixes/",
+                fix: true,
+            });
+            const actual = fs.readFileSync(
+                "test/files/project-multiple-fixes/testfile.test.ts",
+                "utf-8",
+            );
             fs.unlinkSync("test/files/project-multiple-fixes/testfile.test.ts");
             assert.equal(status, Status.Ok, "process should exit without an error");
             assert.strictEqual(
@@ -503,8 +599,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
     });
 
     describe("--type-check", () => {
-        it("exits with code 1 if --project is not passed", (done) => {
-            execCli(["--type-check"], (err) => {
+        it("exits with code 1 if --project is not passed", done => {
+            execCli(["--type-check"], err => {
                 assert.isNotNull(err, "process should exit with error");
                 assert.strictEqual(err.code, 1, "error code should be 1");
                 done();
@@ -518,24 +614,23 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
         // clean up temp file after tests
         afterEach(cleanTempInitFile);
 
-        it("exits with code 0 if `--init` flag is used in folder without tslint.json", (done) => {
-            execCli(["--init"], { cwd: EXECUTABLE_DIR }, (err) => {
+        it("exits with code 0 if `--init` flag is used in folder without tslint.json", done => {
+            execCli(["--init"], { cwd: EXECUTABLE_DIR }, err => {
                 assert.isNull(err, "process should exit without an error");
                 assert.strictEqual(fs.existsSync(TEMP_JSON_PATH), true, "file should be created");
                 done();
             });
         });
 
-        it("exits with code 1 if `--init` flag is used in folder with tslint.json", (done) => {
+        it("exits with code 1 if `--init` flag is used in folder with tslint.json", done => {
             // make sure that file exists before test
             fs.writeFileSync(TEMP_JSON_PATH, "{}");
 
-            execCli(["--init"], { cwd: EXECUTABLE_DIR }, (err) => {
+            execCli(["--init"], { cwd: EXECUTABLE_DIR }, err => {
                 assert.isNotNull(err, "process should exit with error");
                 assert.strictEqual(err.code, 1, "error code should be 1");
                 done();
             });
-
         });
     });
 
@@ -548,9 +643,11 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             // when glob pattern is passed in double quotes in npm script `process.env` will contain:
             // on Windows - pattern string without any quotes
             // on Linux - pattern string without any quotes (glob is not expanded)
-            const status = await execRunner(
-                {config: "./test/config/tslint-custom-rules.json", rulesDirectory: "./test/files/custom-rules", files: ["src/**/test.ts"]},
-            );
+            const status = await execRunner({
+                config: "./test/config/tslint-custom-rules.json",
+                rulesDirectory: "./test/files/custom-rules",
+                files: ["src/**/test.ts"],
+            });
             assert.equal(status, Status.LintError, "error code should be 2");
         });
 
@@ -558,28 +655,30 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             // when glob pattern is passed in single quotes in npm script `process.env` will contain:
             // on Windows - pattern string wrapped in single quotes
             // on Linux - pattern string without any quotes (glob is not expanded)
-            const status = await execRunner(
-                {
-                    config: "./test/config/tslint-custom-rules.json",
-                    files: ["'src/**/test.ts'"],
-                    rulesDirectory: "./test/files/custom-rules",
-                },
-            );
+            const status = await execRunner({
+                config: "./test/config/tslint-custom-rules.json",
+                files: ["'src/**/test.ts'"],
+                rulesDirectory: "./test/files/custom-rules",
+            });
             assert.equal(status, Status.LintError, "error code should be 2");
         });
 
-        it("can handle multiple '--exclude' globs", (done) => {
+        it("can handle multiple '--exclude' globs", done => {
             execCli(
                 [
-                    "-c", "test/files/multiple-excludes/tslint.json",
-                    "--exclude", "'test/files/multiple-excludes/invalid.test.ts'",
-                    "--exclude", "'test/files/multiple-excludes/invalid2*'",
+                    "-c",
+                    "test/files/multiple-excludes/tslint.json",
+                    "--exclude",
+                    "'test/files/multiple-excludes/invalid.test.ts'",
+                    "--exclude",
+                    "'test/files/multiple-excludes/invalid2*'",
                     "'test/files/multiple-excludes/**.ts'",
                 ],
-                (err) => {
+                err => {
                     assert.isNull(err, "process should exit without an error");
                     done();
-                });
+                },
+            );
         });
     });
 });
@@ -587,8 +686,16 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 type ExecFileCallback = (error: Error & { code: number }, stdout: string, stderr: string) => void;
 
 function execCli(args: string[], cb: ExecFileCallback): cp.ChildProcess;
-function execCli(args: string[], options: cp.ExecFileOptions, cb: ExecFileCallback): cp.ChildProcess;
-function execCli(args: string[], options: cp.ExecFileOptions | ExecFileCallback, cb?: ExecFileCallback): cp.ChildProcess {
+function execCli(
+    args: string[],
+    options: cp.ExecFileOptions,
+    cb: ExecFileCallback,
+): cp.ChildProcess;
+function execCli(
+    args: string[],
+    options: cp.ExecFileOptions | ExecFileCallback,
+    cb?: ExecFileCallback,
+): cp.ChildProcess {
     let filePath = EXECUTABLE_PATH;
 
     // Specify extension for Windows executable to avoid ENOENT errors
@@ -609,24 +716,28 @@ function execCli(args: string[], options: cp.ExecFileOptions | ExecFileCallback,
     });
 }
 
-function execRunnerWithOutput(options: Partial<Options>) { // tslint:disable-line:promise-function-async
+function execRunnerWithOutput(options: Partial<Options>) {
+    // tslint:disable-line:promise-function-async
     let stdout = "";
     let stderr = "";
-    return execRunner(
-        options,
-        {
-            log(text) { stdout += text; },
-            error(text) { stderr += text; },
+    return execRunner(options, {
+        log(text) {
+            stdout += text;
         },
-    ).then((status) => ({status, stderr, stdout}));
+        error(text) {
+            stderr += text;
+        },
+    }).then(status => ({ status, stderr, stdout }));
 }
 
-function execRunner(options: Partial<Options>, logger: Logger = dummyLogger) { // tslint:disable-line:promise-function-async
-    return run({exclude: [], files: [], ...options}, logger);
+function execRunner(options: Partial<Options>, logger: Logger = dummyLogger) {
+    // tslint:disable-line:promise-function-async
+    return run({ exclude: [], files: [], ...options }, logger);
 }
 
-function isFunction(fn: any): fn is Function { // tslint:disable-line:ban-types
-    return ({}).toString.call(fn) === "[object Function]";
+function isFunction(fn: any): fn is Function {
+    // tslint:disable-line:ban-types
+    return {}.toString.call(fn) === "[object Function]";
 }
 
 function cleanTempInitFile(): void {

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -93,8 +93,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
         it("doesn't warn if non-existent file is excluded by --exclude", async () => {
             const result = await execRunnerWithOutput({
-                files: ["foo/bar.js"],
                 exclude: ["**/*.js"],
+                files: ["foo/bar.js"],
             });
             assert.strictEqual(result.status, Status.Ok, "process should exit without error");
             assert.notInclude(result.stderr, "does not exist");
@@ -218,8 +218,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
         it("exits with code 1 if nonexisting custom rules directory is passed", async () => {
             const status = await execRunner({
                 config: "./test/config/tslint-custom-rules.json",
-                rulesDirectory: "./someRandomDir",
                 files: ["src/test.ts"],
+                rulesDirectory: "./someRandomDir",
             });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
@@ -227,8 +227,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
         it("exits with code 2 if custom rules directory is passed and file contains lint errors", async () => {
             const status = await execRunner({
                 config: "./test/config/tslint-custom-rules.json",
-                rulesDirectory: "./test/files/custom-rules",
                 files: ["src/test.ts"],
+                rulesDirectory: "./test/files/custom-rules",
             });
             assert.equal(status, Status.LintError, "error code should be 2");
         });
@@ -379,8 +379,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
         it("exits with code 1 if `--test` flag is used with incorrect rule", async () => {
             const status = await execRunner({
-                test: true,
                 files: ["test/files/incorrect-rule-test"],
+                test: true,
             });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
@@ -392,17 +392,17 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
         it("exits with code 0 if `--test` flag is used with custom rule", async () => {
             const status = await execRunner({
-                test: true,
                 files: ["test/files/custom-rule-rule-test"],
+                test: true,
             });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
 
         it("exits with code 0 if `--test` and `-r` flags are used with custom rule", async () => {
             const status = await execRunner({
-                test: true,
                 files: ["test/files/custom-rule-cli-rule-test"],
                 rulesDirectory: "test/files/custom-rules-2",
+                test: true,
             });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
@@ -414,8 +414,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
         it("exits with code 1 if `--test` flag is used with incorrect fixes", async () => {
             const status = await execRunner({
-                test: true,
                 files: ["test/files/incorrect-fixes-test"],
+                test: true,
             });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
@@ -423,8 +423,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
         it("can be used with multiple paths", async () => {
             // pass a failing test as second path to make sure it gets executed
             const status = await execRunner({
-                test: true,
                 files: ["test/files/custom-rule-rule-test", "test/files/incorrect-fixes-test"],
+                test: true,
             });
             assert.equal(status, Status.FatalError, "error code should be 1");
         });
@@ -495,8 +495,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
         it("warns if file-to-lint does not exist", async () => {
             const result = await execRunnerWithOutput({
-                project: "test/files/tsconfig-test/tsconfig.json",
                 files: ["test/files/tsconfig-test/non-existent.test.ts"],
+                project: "test/files/tsconfig-test/tsconfig.json",
             });
             assert.strictEqual(result.status, Status.Ok, "process should exit without error");
             assert.include(
@@ -519,8 +519,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
         it("doesn't warn if glob pattern doesn't match any file", async () => {
             const result = await execRunnerWithOutput({
-                project: "test/files/tsconfig-test/tsconfig.json",
                 files: ["*.js"],
+                project: "test/files/tsconfig-test/tsconfig.json",
             });
             assert.strictEqual(result.status, Status.Ok, "process should exit without error");
             assert.notInclude(result.stderr, "does not exist");
@@ -570,8 +570,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
 
         it("works with '--exclude'", async () => {
             const status = await execRunner({
-                project: "test/files/tsconfig-allow-js/tsconfig.json",
                 exclude: ["test/files/tsconfig-allow-js/testfile.test.js"],
+                project: "test/files/tsconfig-allow-js/tsconfig.json",
             });
             assert.equal(status, Status.Ok, "process should exit without an error");
         });
@@ -582,8 +582,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
                 fs.readFileSync("test/files/project-multiple-fixes/before.test.ts", "utf-8"),
             );
             const status = await execRunner({
-                project: "test/files/project-multiple-fixes/",
                 fix: true,
+                project: "test/files/project-multiple-fixes/",
             });
             const actual = fs.readFileSync(
                 "test/files/project-multiple-fixes/testfile.test.ts",
@@ -645,8 +645,8 @@ describe("Executable", function(this: Mocha.ISuiteCallbackContext) {
             // on Linux - pattern string without any quotes (glob is not expanded)
             const status = await execRunner({
                 config: "./test/config/tslint-custom-rules.json",
-                rulesDirectory: "./test/files/custom-rules",
                 files: ["src/**/test.ts"],
+                rulesDirectory: "./test/files/custom-rules",
             });
             assert.equal(status, Status.LintError, "error code should be 2");
         });
@@ -716,8 +716,8 @@ function execCli(
     });
 }
 
+// tslint:disable-next-line:promise-function-async
 function execRunnerWithOutput(options: Partial<Options>) {
-    // tslint:disable-line:promise-function-async
     let stdout = "";
     let stderr = "";
     return execRunner(options, {
@@ -730,13 +730,13 @@ function execRunnerWithOutput(options: Partial<Options>) {
     }).then(status => ({ status, stderr, stdout }));
 }
 
+// tslint:disable-next-line:promise-function-async
 function execRunner(options: Partial<Options>, logger: Logger = dummyLogger) {
-    // tslint:disable-line:promise-function-async
     return run({ exclude: [], files: [], ...options }, logger);
 }
 
+// tslint:disable-next-line:ban-types
 function isFunction(fn: any): fn is Function {
-    // tslint:disable-line:ban-types
     return {}.toString.call(fn) === "[object Function]";
 }
 

--- a/test/formatters/checkstyleFormatterTests.ts
+++ b/test/formatters/checkstyleFormatterTests.ts
@@ -41,15 +41,46 @@ describe("Checkstyle Formatter", () => {
 
         const failures = [
             createFailure(sourceFile1, 0, 1, "first failure", "first-name", undefined, "error"),
-            createFailure(sourceFile1, 2, 3, "&<>'\" should be escaped", "escape", undefined, "error"),
-            createFailure(sourceFile1, maxPosition1 - 1, maxPosition1, "last failure", "last-name", undefined, "error"),
+            createFailure(
+                sourceFile1,
+                2,
+                3,
+                "&<>'\" should be escaped",
+                "escape",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile1,
+                maxPosition1 - 1,
+                maxPosition1,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
             createFailure(sourceFile2, 0, 1, "first failure", "first-name", undefined, "error"),
-            createFailure(sourceFile2, 2, 3, "&<>'\" should be escaped", "escape", undefined, "warning"),
-            createFailure(sourceFile2, maxPosition2 - 1, maxPosition2, "last failure", "last-name", undefined, "warning"),
+            createFailure(
+                sourceFile2,
+                2,
+                3,
+                "&<>'\" should be escaped",
+                "escape",
+                undefined,
+                "warning",
+            ),
+            createFailure(
+                sourceFile2,
+                maxPosition2 - 1,
+                maxPosition2,
+                "last failure",
+                "last-name",
+                undefined,
+                "warning",
+            ),
         ];
         // tslint:disable max-line-length
-        const expectedResult =
-            `<?xml version="1.0" encoding="utf-8"?>
+        const expectedResult = `<?xml version="1.0" encoding="utf-8"?>
             <checkstyle version="4.3">
             <file name="${TEST_FILE_1}">
                 <error line="1" column="1" severity="error" message="first failure" source="failure.tslint.first-name" />
@@ -68,6 +99,9 @@ describe("Checkstyle Formatter", () => {
 
     it("handles no failures", () => {
         const result = formatter.format([]);
-        assert.deepEqual(result, '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"></checkstyle>');
+        assert.deepEqual(
+            result,
+            '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"></checkstyle>',
+        );
     });
 });

--- a/test/formatters/codeFrameFormatterTests.ts
+++ b/test/formatters/codeFrameFormatterTests.ts
@@ -44,14 +44,45 @@ describe("CodeFrame Formatter", () => {
 
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
-            createFailure(sourceFile, 2, 3, "&<>'\" should be escaped", "escape", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
-            createFailure(sourceFile, 0, maxPosition, "full failure", "full-name", undefined, "error"),
-            createFailure(sourceFile, 0, maxPosition, "warning failure", "warning-name", undefined, "warning"),
+            createFailure(
+                sourceFile,
+                2,
+                3,
+                "&<>'\" should be escaped",
+                "escape",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile,
+                0,
+                maxPosition,
+                "full failure",
+                "full-name",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile,
+                0,
+                maxPosition,
+                "warning failure",
+                "warning-name",
+                undefined,
+                "warning",
+            ),
         ];
 
-        const expectedResultColored =
-            `formatters/codeFrameFormatter.test.ts
+        const expectedResultColored = `formatters/codeFrameFormatter.test.ts
             \u001b[31mfirst failure\u001b[39m \u001b[90m(first-name)\u001b[39m
             \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {
             \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {
@@ -88,7 +119,7 @@ describe("CodeFrame Formatter", () => {
 
         /** Convert output lines to an array of trimmed lines for easier comparing */
         function toTrimmedLines(lines: string): string[] {
-            return lines.split("\n").map((line) => line.trim());
+            return lines.split("\n").map(line => line.trim());
         }
 
         const expectedResult = toTrimmedLines(expectedResultColored);

--- a/test/formatters/externalFormatterTests.ts
+++ b/test/formatters/externalFormatterTests.ts
@@ -38,7 +38,15 @@ describe("External Formatter", () => {
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
             createFailure(sourceFile, 32, 36, "mid failure", "mid-name", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
         ];
 
         const expectedResult = dedent`

--- a/test/formatters/jsonFormatterTests.ts
+++ b/test/formatters/jsonFormatterTests.ts
@@ -36,11 +36,24 @@ describe("JSON Formatter", () => {
 
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
             createFailure(
-                sourceFile, 0, maxPosition, "full failure", "full-name",
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile,
+                0,
+                maxPosition,
+                "full failure",
+                "full-name",
                 new Replacement(0, 0, ""),
-                "error"),
+                "error",
+            ),
         ];
 
         /* tslint:disable:object-literal-sort-keys */

--- a/test/formatters/junitFormatterTests.ts
+++ b/test/formatters/junitFormatterTests.ts
@@ -41,15 +41,46 @@ describe("JUnit Formatter", () => {
 
         const failures = [
             createFailure(sourceFile1, 0, 1, "first failure", "first-name", undefined, "error"),
-            createFailure(sourceFile1, 2, 3, "&<>'\" should be escaped", "escape", undefined, "error"),
-            createFailure(sourceFile1, maxPosition1 - 1, maxPosition1, "last failure", "last-name", undefined, "error"),
+            createFailure(
+                sourceFile1,
+                2,
+                3,
+                "&<>'\" should be escaped",
+                "escape",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile1,
+                maxPosition1 - 1,
+                maxPosition1,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
             createFailure(sourceFile2, 0, 1, "first failure", "first-name", undefined, "error"),
-            createFailure(sourceFile2, 2, 3, "&<>'\" should be escaped", "escape", undefined, "warning"),
-            createFailure(sourceFile2, maxPosition2 - 1, maxPosition2, "last failure", "last-name", undefined, "warning"),
+            createFailure(
+                sourceFile2,
+                2,
+                3,
+                "&<>'\" should be escaped",
+                "escape",
+                undefined,
+                "warning",
+            ),
+            createFailure(
+                sourceFile2,
+                maxPosition2 - 1,
+                maxPosition2,
+                "last failure",
+                "last-name",
+                undefined,
+                "warning",
+            ),
         ];
 
-        const expectedResult =
-            `<?xml version="1.0" encoding="utf-8"?>
+        const expectedResult = `<?xml version="1.0" encoding="utf-8"?>
             <testsuites package="tslint">
                 <testsuite name="${TEST_FILE_1}">
                     <testcase name="Line 1, Column 1: first-name">
@@ -80,6 +111,9 @@ describe("JUnit Formatter", () => {
 
     it("handles no failures", () => {
         const result = formatter.format([]);
-        assert.deepEqual(result, '<?xml version="1.0" encoding="utf-8"?><testsuites package="tslint"></testsuites>');
+        assert.deepEqual(
+            result,
+            '<?xml version="1.0" encoding="utf-8"?><testsuites package="tslint"></testsuites>',
+        );
     });
 });

--- a/test/formatters/msbuildFormatterTests.ts
+++ b/test/formatters/msbuildFormatterTests.ts
@@ -38,13 +38,21 @@ describe("MSBuild Formatter", () => {
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
             createFailure(sourceFile, 32, 36, "mid failure", "mid-name", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "warning"),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "warning",
+            ),
         ];
 
         const expectedResult =
-            getFailureString(TEST_FILE, 1,  1, "first failure", "firstName", "error") +
+            getFailureString(TEST_FILE, 1, 1, "first failure", "firstName", "error") +
             getFailureString(TEST_FILE, 2, 12, "mid failure", "midName", "error") +
-            getFailureString(TEST_FILE, 9,  2,  "last failure", "lastName", "warning");
+            getFailureString(TEST_FILE, 9, 2, "last failure", "lastName", "warning");
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);
@@ -55,7 +63,16 @@ describe("MSBuild Formatter", () => {
         assert.equal(result, "\n");
     });
 
-    function getFailureString(file: string, line: number, character: number, reason: string, ruleCamelCase: string, severity: string) {
-        return `${path.normalize(file)}(${line},${character}): ${severity} ${ruleCamelCase}: ${reason}\n`;
+    function getFailureString(
+        file: string,
+        line: number,
+        character: number,
+        reason: string,
+        ruleCamelCase: string,
+        severity: string,
+    ) {
+        return `${path.normalize(
+            file,
+        )}(${line},${character}): ${severity} ${ruleCamelCase}: ${reason}\n`;
     }
 });

--- a/test/formatters/pmdFormatterTests.ts
+++ b/test/formatters/pmdFormatterTests.ts
@@ -36,12 +36,35 @@ describe("PMD Formatter", () => {
 
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
-            createFailure(sourceFile, 2, 3, "&<>'\" should be escaped", "escape", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "warning"),
-            createFailure(sourceFile, 0, maxPosition, "full failure", "full-name", undefined, "warning"),
+            createFailure(
+                sourceFile,
+                2,
+                3,
+                "&<>'\" should be escaped",
+                "escape",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "warning",
+            ),
+            createFailure(
+                sourceFile,
+                0,
+                maxPosition,
+                "full failure",
+                "full-name",
+                undefined,
+                "warning",
+            ),
         ];
-        const expectedResult =
-            `<pmd version="tslint">
+        const expectedResult = `<pmd version="tslint">
                 <file name="formatters/pmdFormatter.test.ts">
                     <violation begincolumn="1" beginline="1" priority="3" rule="first failure">
                     </violation>

--- a/test/formatters/stylishFormatterTests.ts
+++ b/test/formatters/stylishFormatterTests.ts
@@ -37,9 +37,33 @@ describe("Stylish Formatter", () => {
 
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
-            createFailure(sourceFile, 2, 3, "&<>'\" should be escaped", "escape", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
-            createFailure(sourceFile, 0, maxPosition, "full failure", "full-name", undefined, "error"),
+            createFailure(
+                sourceFile,
+                2,
+                3,
+                "&<>'\" should be escaped",
+                "escape",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile,
+                0,
+                maxPosition,
+                "full failure",
+                "full-name",
+                undefined,
+                "error",
+            ),
         ];
 
         const maxPositionObj = sourceFile.getLineAndCharacterOfPosition(maxPosition - 1);
@@ -51,8 +75,9 @@ describe("Stylish Formatter", () => {
             \u001b[31mERROR: 1:1\u001b[39m  \u001b[90mfirst-name\u001b[39m  \u001b[33mfirst failure\u001b[39m
             \u001b[31mERROR: 1:1\u001b[39m  \u001b[90mfull-name \u001b[39m  \u001b[33mfull failure\u001b[39m
             \u001b[31mERROR: 1:3\u001b[39m  \u001b[90mescape    \u001b[39m  \u001b[33m&<>'\" should be escaped\u001b[39m
-            \u001b[31mERROR: ${maxPositionTuple}\u001b[39m  \u001b[90mlast-name \u001b[39m  \u001b[33mlast failure\u001b[39m\n`
-            .slice(1); // remove leading newline
+            \u001b[31mERROR: ${maxPositionTuple}\u001b[39m  \u001b[90mlast-name \u001b[39m  \u001b[33mlast failure\u001b[39m\n`.slice(
+            1,
+        ); // remove leading newline
 
         assert.equal(formatter.format(failures), expectedResult);
     });

--- a/test/formatters/tapFormatterTests.ts
+++ b/test/formatters/tapFormatterTests.ts
@@ -38,7 +38,15 @@ describe("TAP Formatter", () => {
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
             createFailure(sourceFile, 32, 36, "mid failure", "mid-name", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
         ];
 
         const failureStrings = [
@@ -48,7 +56,10 @@ describe("TAP Formatter", () => {
         ];
 
         const actualResult = formatter.format(failures);
-        assert.equal(actualResult, `TAP version 13\n1..${failures.length}\n${failureStrings.join("\n")}\n`);
+        assert.equal(
+            actualResult,
+            `TAP version 13\n1..${failures.length}\n${failureStrings.join("\n")}\n`,
+        );
     });
 
     it("handles no failures", () => {
@@ -56,13 +67,15 @@ describe("TAP Formatter", () => {
         assert.equal(result, "TAP version 13\n1..0 # SKIP No failures\n");
     });
 
-    function getFailureString(num: number,
-                              ruleName: string,
-                              severity: string,
-                              file: string,
-                              line: number,
-                              character: number,
-                              reason: string) {
+    function getFailureString(
+        num: number,
+        ruleName: string,
+        severity: string,
+        file: string,
+        line: number,
+        character: number,
+        reason: string,
+    ) {
         return dedent`
             not ok ${num} - ${reason}
               ---

--- a/test/formatters/utils.ts
+++ b/test/formatters/utils.ts
@@ -17,14 +17,15 @@
 import * as ts from "typescript";
 import { Fix, RuleFailure, RuleSeverity } from "../../src/language/rule/rule";
 
-export function createFailure(sourceFile: ts.SourceFile,
-                              start: number,
-                              end: number,
-                              failure: string,
-                              ruleName: string,
-                              fix?: Fix,
-                              ruleSeverity: RuleSeverity = "warning") {
-
+export function createFailure(
+    sourceFile: ts.SourceFile,
+    start: number,
+    end: number,
+    failure: string,
+    ruleName: string,
+    fix?: Fix,
+    ruleSeverity: RuleSeverity = "warning",
+) {
     const rule = new RuleFailure(sourceFile, start, end, failure, ruleName, fix);
     rule.setRuleSeverity(ruleSeverity);
     return rule;

--- a/test/formatters/verboseFormatterTests.ts
+++ b/test/formatters/verboseFormatterTests.ts
@@ -38,7 +38,15 @@ describe("Verbose Formatter", () => {
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
             createFailure(sourceFile, 32, 36, "mid failure", "mid-name", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
         ];
 
         const expectedResult = dedent`

--- a/test/formatters/vsoFormatterTests.ts
+++ b/test/formatters/vsoFormatterTests.ts
@@ -37,13 +37,21 @@ describe("VSO Formatter", () => {
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
             createFailure(sourceFile, 32, 36, "mid failure", "mid-name", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
         ];
 
         const expectedResult =
-            getFailureString(TEST_FILE, 1,  1, "first failure", "first-name") +
+            getFailureString(TEST_FILE, 1, 1, "first failure", "first-name") +
             getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
-            getFailureString(TEST_FILE, 9,  2,  "last failure", "last-name");
+            getFailureString(TEST_FILE, 9, 2, "last failure", "last-name");
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);
@@ -55,13 +63,21 @@ describe("VSO Formatter", () => {
         const failures = [
             createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
             createFailure(sourceFile, 32, 36, "mid failure", "mid-name", undefined, "error"),
-            createFailure(sourceFile, maxPosition - 1, maxPosition, "last failure", "last-name", undefined, "error"),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
         ];
 
         const expectedResult =
-            getFailureString(TEST_FILE, 1,  1, "first failure", "first-name") +
+            getFailureString(TEST_FILE, 1, 1, "first failure", "first-name") +
             getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
-            getFailureString(TEST_FILE, 9,  2,  "last failure", "last-name");
+            getFailureString(TEST_FILE, 9, 2, "last failure", "last-name");
 
         const fixed = failures.slice();
 
@@ -74,7 +90,13 @@ describe("VSO Formatter", () => {
         assert.equal(result, "\n");
     });
 
-    function getFailureString(file: string, line: number, character: number, reason: string, code: string) {
+    function getFailureString(
+        file: string,
+        line: number,
+        character: number,
+        reason: string,
+        code: string,
+    ) {
         return `##vso[task.logissue type=warning;sourcepath=${file};linenumber=${line};columnnumber=${character};code=${code};]${reason}\n`;
     }
 });

--- a/test/rule-tester/parseTests.ts
+++ b/test/rule-tester/parseTests.ts
@@ -66,11 +66,17 @@ describe("Rule Test Parse", () => {
 
     describe("createMarkupFromErrors", () => {
         it("should generate correct markup", () => {
-            assert.strictEqual(parse.createMarkupFromErrors(testData.codeStr5, testData.resultErrs5), testData.lintStr5);
+            assert.strictEqual(
+                parse.createMarkupFromErrors(testData.codeStr5, testData.resultErrs5),
+                testData.lintStr5,
+            );
         });
 
         it("should generate correct markup with nil-length errors", () => {
-            assert.strictEqual(parse.createMarkupFromErrors(testData.codeStr7, testData.resultErrs7), testData.lintStr7);
+            assert.strictEqual(
+                parse.createMarkupFromErrors(testData.codeStr7, testData.resultErrs7),
+                testData.lintStr7,
+            );
         });
     });
 });

--- a/test/rule-tester/testData.ts
+++ b/test/rule-tester/testData.ts
@@ -27,7 +27,6 @@ And some brackets too   [brackets are here]
 export const codeStr1 = lintStr1;
 export const resultErrs1: LintError[] = [];
 
-
 export const lintStr2 = `
 A file with an error
 ~~~~~                  [error]
@@ -36,9 +35,8 @@ export const codeStr2 = `
 A file with an error
 `;
 export const resultErrs2: LintError[] = [
-  { startPos: { line: 1, col: 0 }, endPos: { line: 1, col: 5 }, message: "error" },
+    { startPos: { line: 1, col: 0 }, endPos: { line: 1, col: 5 }, message: "error" },
 ];
-
 
 export const lintStr3 = `
 A file with lots of errors
@@ -63,18 +61,16 @@ A file with lots of errors
    Final code here
 `;
 export const resultErrs3: LintError[] = [
-  { startPos: { line: 1, col: 0 }, endPos: { line: 1, col: 5 }, message: "error" },
-  { startPos: { line: 1, col: 3 }, endPos: { line: 3, col: 12 }, message: "multiline error1" },
-  { startPos: { line: 1, col: 4 }, endPos: { line: 1, col: 17 }, message: "error2" },
-  { startPos: { line: 2, col: 0 }, endPos: { line: 4, col: 2 }, message: "multiline error2" },
-  { startPos: { line: 3, col: 6 }, endPos: { line: 3, col: 7 }, message: "error3: fun" },
+    { startPos: { line: 1, col: 0 }, endPos: { line: 1, col: 5 }, message: "error" },
+    { startPos: { line: 1, col: 3 }, endPos: { line: 3, col: 12 }, message: "multiline error1" },
+    { startPos: { line: 1, col: 4 }, endPos: { line: 1, col: 17 }, message: "error2" },
+    { startPos: { line: 2, col: 0 }, endPos: { line: 4, col: 2 }, message: "multiline error2" },
+    { startPos: { line: 3, col: 6 }, endPos: { line: 3, col: 7 }, message: "error3: fun" },
 ];
-
 
 export const lintStr4 = "";
 export const codeStr4 = "";
 export const resultErrs4: LintError[] = [];
-
 
 // this is a ideally formatted lint string, errors ordered by start position,
 // error messages one space after end of line of code above
@@ -90,10 +86,9 @@ someObject.someProperty.doSomething();
 someVar <- someObject.crazyMethod(arg1, arg2, arg3);
 `;
 export const resultErrs5: LintError[] = [
-  { startPos: { line: 1, col: 10 }, endPos: { line: 1, col: 23}, message: "unsafe access" },
-  { startPos: { line: 1, col: 12 }, endPos: { line: 2, col: 7 }, message: "another error" },
+    { startPos: { line: 1, col: 10 }, endPos: { line: 1, col: 23 }, message: "unsafe access" },
+    { startPos: { line: 1, col: 12 }, endPos: { line: 2, col: 7 }, message: "another error" },
 ];
-
 
 export const lintStr6 = `
 if (code === lint-error-free) {
@@ -108,9 +103,12 @@ if (code === lint-error-free) {
 
 `;
 export const resultErrs6: LintError[] = [
-    { startPos: { line: 1, col: 13 }, endPos: { line: 1, col: 28 }, message: "A longer error message I didn't want to type every time!" },
+    {
+        startPos: { line: 1, col: 13 },
+        endPos: { line: 1, col: 28 },
+        message: "A longer error message I didn't want to type every time!",
+    },
 ];
-
 
 export const lintStr7 = `
 someCode.something();
@@ -130,8 +128,8 @@ more code {
 }
 `;
 export const resultErrs7: LintError[] = [
-  { startPos: { line: 1, col: 1 }, endPos: { line: 1, col: 1 }, message: "some error" },
-  { startPos: { line: 3, col: 0 }, endPos: { line: 4, col: 0 }, message: "another error" },
+    { startPos: { line: 1, col: 1 }, endPos: { line: 1, col: 1 }, message: "some error" },
+    { startPos: { line: 3, col: 0 }, endPos: { line: 4, col: 0 }, message: "another error" },
 ];
 
 /* tslint:enable:object-literal-sort-keys */

--- a/test/runner/runnerTests.ts
+++ b/test/runner/runnerTests.ts
@@ -26,7 +26,10 @@ const customRulesOptions: Options = {
 
 describe("Runner Tests", () => {
     it("outputs absolute path with --outputAbsolutePaths", async () => {
-        const { status, stdout, stderr } = await runLint({ ...customRulesOptions, outputAbsolutePaths: true });
+        const { status, stdout, stderr } = await runLint({
+            ...customRulesOptions,
+            outputAbsolutePaths: true,
+        });
         assert.equal(status, 2);
         // match either a path starting with `/` or something like `C:`
         assert.isTrue(/ERROR: (\/|\w:)/.test(stdout));
@@ -41,9 +44,18 @@ describe("Runner Tests", () => {
     });
 });
 
-async function runLint(options: Options): Promise<{ status: Status; stdout: string; stderr: string }> {
+async function runLint(
+    options: Options,
+): Promise<{ status: Status; stdout: string; stderr: string }> {
     let stdout = "";
     let stderr = "";
-    const status = await run(options, { log(m) { stdout += m; }, error(m) { stderr += m; } });
+    const status = await run(options, {
+        log(m) {
+            stdout += m;
+        },
+        error(m) {
+            stderr += m;
+        },
+    });
     return { status, stdout, stderr };
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4229 

#### Overview of change:

Continues on https://github.com/palantir/tslint/pull/4214 - I either merged incorrectly or missed some file exclusions that were needed.

#### Is there anything you'd like reviewers to focus on?
 
Two reasons why I'd like to merge this in very quickly:
* Other PRs are blocked on having many unrelated changes from Prettier
* This is a continuation of the already-approved #4214.

Of special note is `.prettierignore`, which has several folders added for data files that shouldn't be formatted.