### PR TITLE
Fix prettier command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "lint:from-bin": "node bin/tslint --project test/tsconfig.json --format stylish",
         "precommit": "npm-run-all precommit:prettier",
         "precommit:prettier": "pretty-quick --staged",
-        "prettier": "prettier --write ./**/*.{js,ts,css,scss,md,yml} --ignore-path ./.prettierignore",
+        "prettier": "prettier --write './**/*.{js,ts,css,scss,md,yml}' --ignore-path ./.prettierignore",
         "publish:local": "./scripts/npmPublish.sh",
         "test": "npm-run-all test:pre -p test:mocha test:rules",
         "test:pre": "cd ./test/config && npm install --no-save",


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
It turns out this isn't expanding the `**` properly. Tested by touching `src/rules/orderedImportsRule.ts` and checking that it does not fix it (it didn't before).

#### Is there anything you'd like reviewers to focus on?

Not really.

#### CHANGELOG.md entry:

Fix the prettier command in package.json
