### PR TITLE
Changes the node version from 4 to 6 for TS 2.1 tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             - run: yarn test
     test2.1:
         docker:
-            - image: circleci/node:4
+            - image: circleci/node:6
         steps:
             - checkout
             - attach_workspace:


### PR DESCRIPTION
Node 4 is no longer supported.

#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?
This unblocks https://github.com/palantir/tslint/pull/4274

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
