### PR TITLE
Add severity support for vso formatter

### DIFF
--- a/src/formatters/vsoFormatter.ts
+++ b/src/formatters/vsoFormatter.ts
@@ -39,13 +39,14 @@ export class Formatter extends AbstractFormatter {
         const outputLines = failures.map((failure: RuleFailure) => {
             const fileName = failure.getFileName();
             const failureString = failure.getFailure();
+            const failureSeverity = failure.getRuleSeverity();
             const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
             const line = lineAndCharacter.line + 1;
             const character = lineAndCharacter.character + 1;
             const code = failure.getRuleName();
             const properties = `sourcepath=${fileName};linenumber=${line};columnnumber=${character};code=${code};`;
 
-            return `##vso[task.logissue type=warning;${properties}]${failureString}`;
+            return `##vso[task.logissue type=${failureSeverity};${properties}]${failureString}`;
         });
 
         return `${outputLines.join("\n")}\n`;

--- a/test/formatters/vsoFormatterTests.ts
+++ b/test/formatters/vsoFormatterTests.ts
@@ -49,9 +49,9 @@ describe("VSO Formatter", () => {
         ];
 
         const expectedResult =
-            getFailureString(TEST_FILE, 1, 1, "first failure", "first-name") +
-            getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
-            getFailureString(TEST_FILE, 9, 2, "last failure", "last-name");
+            getFailureString(TEST_FILE, 1, 1, "first failure", "first-name", "error") +
+            getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name", "error") +
+            getFailureString(TEST_FILE, 9, 2, "last failure", "last-name", "error");
 
         const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);
@@ -75,13 +75,39 @@ describe("VSO Formatter", () => {
         ];
 
         const expectedResult =
-            getFailureString(TEST_FILE, 1, 1, "first failure", "first-name") +
-            getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name") +
-            getFailureString(TEST_FILE, 9, 2, "last failure", "last-name");
+            getFailureString(TEST_FILE, 1, 1, "first failure", "first-name", "error") +
+            getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name", "error") +
+            getFailureString(TEST_FILE, 9, 2, "last failure", "last-name", "error");
 
         const fixed = failures.slice();
 
         const actualResult = formatter.format(failures, fixed);
+        assert.equal(actualResult, expectedResult);
+    });
+
+    it("outputs correct severity", () => {
+        const maxPosition = sourceFile.getFullWidth();
+
+        const failures = [
+            createFailure(sourceFile, 0, 1, "first failure", "first-name", undefined, "error"),
+            createFailure(sourceFile, 32, 36, "mid failure", "mid-name", undefined, "warning"),
+            createFailure(
+                sourceFile,
+                maxPosition - 1,
+                maxPosition,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
+        ];
+
+        const expectedResult =
+            getFailureString(TEST_FILE, 1, 1, "first failure", "first-name", "error") +
+            getFailureString(TEST_FILE, 2, 12, "mid failure", "mid-name", "warning") +
+            getFailureString(TEST_FILE, 9, 2, "last failure", "last-name", "error");
+
+        const actualResult = formatter.format(failures);
         assert.equal(actualResult, expectedResult);
     });
 
@@ -96,7 +122,9 @@ describe("VSO Formatter", () => {
         character: number,
         reason: string,
         code: string,
+        severity: string,
     ) {
-        return `##vso[task.logissue type=warning;sourcepath=${file};linenumber=${line};columnnumber=${character};code=${code};]${reason}\n`;
+        const properties = `sourcepath=${file};linenumber=${line};columnnumber=${character};code=${code};`;
+        return `##vso[task.logissue type=${severity};${properties}]${reason}\n`;
     }
 });

--- a/test/formatters/vsoFormatterTests.ts
+++ b/test/formatters/vsoFormatterTests.ts
@@ -125,7 +125,6 @@ describe("VSO Formatter", () => {
         severity: string,
     ) {
         const properties = `sourcepath=${file};linenumber=${line};columnnumber=${character};code=${code};`;
-
         return `##vso[task.logissue type=${severity};${properties}]${reason}\n`;
     }
 });

--- a/test/formatters/vsoFormatterTests.ts
+++ b/test/formatters/vsoFormatterTests.ts
@@ -125,6 +125,7 @@ describe("VSO Formatter", () => {
         severity: string,
     ) {
         const properties = `sourcepath=${file};linenumber=${line};columnnumber=${character};code=${code};`;
+
         return `##vso[task.logissue type=${severity};${properties}]${reason}\n`;
     }
 });


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4248
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Updated the vso formatter to include the severity of the failure.
(Severity `warning` was hard-coded)

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

[enhancement] vso formatter now reports severity of rule failures

