### PR TITLE
Includes new name Azure DevOps for VSO

### DIFF
--- a/src/formatters/vsoFormatter.ts
+++ b/src/formatters/vsoFormatter.ts
@@ -27,7 +27,7 @@ export class Formatter extends AbstractFormatter {
         formatterName: "vso",
         description: "Formats output as VSO/TFS logging commands.",
         descriptionDetails: Utils.dedent`
-            Integrates with Azure DevOps(previously known as Visual Studio Online and Team Foundation Server) by outputting errors
+            Integrates with Azure DevOps (previously known as Visual Studio Online, Team Foundation Server, or Visual Studio Team Services) by outputting errors
             as 'warning' logging commands.`,
         sample:
             "##vso[task.logissue type=warning;sourcepath=myFile.ts;linenumber=1;columnnumber=14;code=semicolon;]Missing semicolon",

--- a/src/formatters/vsoFormatter.ts
+++ b/src/formatters/vsoFormatter.ts
@@ -27,8 +27,8 @@ export class Formatter extends AbstractFormatter {
         formatterName: "vso",
         description: "Formats output as VSO/TFS logging commands.",
         descriptionDetails: Utils.dedent`
-            Integrates with Azure DevOps (previously known as Visual Studio Online, Team Foundation Server, or Visual Studio Team Services) by outputting errors
-            as 'warning' logging commands.`,
+            Integrates with Azure DevOps (previously known as Visual Studio Online, Team Foundation Server,
+            or Visual Studio Team Services) by outputting errors as 'warning' logging commands.`,
         sample:
             "##vso[task.logissue type=warning;sourcepath=myFile.ts;linenumber=1;columnnumber=14;code=semicolon;]Missing semicolon",
         consumer: "machine",

--- a/src/formatters/vsoFormatter.ts
+++ b/src/formatters/vsoFormatter.ts
@@ -27,7 +27,7 @@ export class Formatter extends AbstractFormatter {
         formatterName: "vso",
         description: "Formats output as VSO/TFS logging commands.",
         descriptionDetails: Utils.dedent`
-            Integrates with Visual Studio Online and Team Foundation Server by outputting errors
+            Integrates with Azure DevOps(previously known as Visual Studio Online and Team Foundation Server) by outputting errors
             as 'warning' logging commands.`,
         sample:
             "##vso[task.logissue type=warning;sourcepath=myFile.ts;linenumber=1;columnnumber=14;code=semicolon;]Missing semicolon",


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4269 
- [ ] New feature, bugfix, or enhancement
- [ ] Includes tests
- [x] Documentation update

#### Overview of change:
 
Documentation is updated as VSO, VSTS is now known as AzureDevOps. 
