### PR TITLE
Fix an issue where module resolution didn't follow symlinks.

### DIFF
--- a/src/formatterLoader.ts
+++ b/src/formatterLoader.ts
@@ -17,9 +17,8 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import * as resolve from "resolve";
 import { FormatterConstructor } from "./index";
-import { camelize } from "./utils";
+import { camelize, tryResolvePackage } from "./utils";
 
 const CORE_FORMATTERS_DIRECTORY = path.resolve(__dirname, "formatters");
 
@@ -81,15 +80,14 @@ function loadFormatter(
 function loadFormatterModule(name: string): FormatterConstructor | undefined {
     let src: string;
     try {
-        // first try to find a module in the dependencies of the currently linted project
-        src = resolve.sync(name, { basedir: process.cwd() });
-    } catch {
-        try {
+        src =
+            // first try to find a module in the dependencies of the currently linted project
+            tryResolvePackage(name, process.cwd()) ||
             // if there is no local module, try relative to the installation of TSLint (might be global)
-            src = require.resolve(name);
-        } catch {
-            return undefined;
-        }
+            require.resolve(name);
+    } catch {
+        return undefined;
     }
+
     return (require(src) as { Formatter: FormatterConstructor }).Formatter;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+import * as fs from "fs";
+import * as resolve from "resolve";
+
 /**
  * Enforces the invariant that the input is an array.
  */
@@ -260,4 +263,30 @@ export function isKebabCased(name: string): boolean {
 
 export function isSnakeCased(name: string): boolean {
     return isSeparatorCased(name, "-");
+}
+
+/**
+ * This function tries to resolve a package by name, optionally relative to a file path. If the
+ * file path is under a symlink, it tries to resolve the package under both the real path and under
+ * the symlink path.
+ */
+export function tryResolvePackage(packageName: string, relativeTo?: string): string | undefined {
+    const realRelativeToPath: string | undefined = relativeTo
+        ? fs.realpathSync(relativeTo)
+        : undefined;
+    return (
+        _tryResolvePackage(packageName, realRelativeToPath) ||
+        _tryResolvePackage(packageName, relativeTo)
+    );
+}
+
+/**
+ * This function calls `resolve.sync` and if it fails, it returns `undefined`
+ */
+function _tryResolvePackage(packageName: string, relativeTo?: string): string | undefined {
+    try {
+        return resolve.sync(packageName, { basedir: relativeTo });
+    } catch (e) {
+        return undefined;
+    }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: https://github.com/palantir/tslint/issues/4294
- [x] bugfix
  - [ ] Includes tests - **The tests for this issue ended up being too complicated to be practical**
- [ ] Documentation update

#### Overview of change:

There is an issue where TSLint doesn't correctly resolve packages in a `node_modules` folder that are symlinked to another location where their dependencies are satisfied. This is how the pnpm arranges its `node_modules` folder, so this issue is easily reproducible with a `tslint.json` file that extends a file from another package, which also extends a file from another package.

#### CHANGELOG.md entry:

[bugfix] Files an issue where TSLint doesn't correctly resolve packages in a `node_modules` folder that are symlinked to another location where their dependencies are satisfied.
