### PR TITLE
added the noWorkspacePollutionRule

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -275,6 +275,7 @@ export const RULES_EXCLUDED_FROM_ALL_CONFIG = [
     "noSwitchCaseFallThrough",
     "typeofCompare",
     "noUnusedVariable",
+    "noWorkspacePollution",
 ];
 
 // Exclude typescript-only rules from jsRules, otherwise it's identical.

--- a/src/rules/noWorkspacePollutionRule.ts
+++ b/src/rules/noWorkspacePollutionRule.ts
@@ -70,7 +70,19 @@ function throwIfPathRelationshipsAreIncorrect(workspaceNumOneDefinition: IWorksp
 }
 
 export class Rule extends Lint.Rules.AbstractRule {
-    /* tslint:disable:object-literal-sort-keys */
+    private static readonly optionExamples: Array<true | IWorkspaceOption> = [
+        true,
+        {
+            workspaceEntryPoint: "entrypoint.ts",
+            workspaceName: "workspaceNumOne",
+        },
+        {
+            workspaceEntryPoint: "entrypoint.ts",
+            workspaceName: "workspaceNumTwo",
+        },
+    ];
+
+    /* tslint:disable:object-literal-sort-keys member-ordering */
     public static metadata: Lint.IRuleMetadata = {
         ruleName,
         description: Lint.Utils.dedent`
@@ -102,21 +114,10 @@ export class Rule extends Lint.Rules.AbstractRule {
         typescriptOnly: false,
     };
 
+    /* tslint:disable:member-ordering */
     public static FAILURE_STRING =
         "Only the entrypoint defined as workspaceEntryPoint is public. Importing nested files would break separation of concerns. " +
         "Do not include this, or expose it via it's public entrypoint:";
-
-    private static readonly optionExamples: Array<true | IWorkspaceOption> = [
-        true,
-        {
-            workspaceEntryPoint: "entrypoint.ts",
-            workspaceName: "workspaceNumOne",
-        },
-        {
-            workspaceEntryPoint: "entrypoint.ts",
-            workspaceName: "workspaceNumTwo",
-        },
-    ];
 
     public isEnabled(): boolean {
         return super.isEnabled() && this.ruleArguments.length > 0;

--- a/src/rules/noWorkspacePollutionRule.ts
+++ b/src/rules/noWorkspacePollutionRule.ts
@@ -1,0 +1,223 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findImports, ImportKind } from "tsutils";
+import * as ts from "typescript";
+import * as Lint from "../index";
+
+const ruleName = "no-workspace-pollution";
+
+interface IWorkspaceOption {
+    workspaceName: string;
+    workspaceEntryPoint: string;
+}
+
+function throwIfNotIWorkspaceOption(input: any): input is IWorkspaceOption {
+    if (!input || typeof input != "object") {
+        throw new Error(`An option must be an object in the ${ruleName} rule.`);
+    }
+    const assumeItToBeTrue: Partial<IWorkspaceOption> = input;
+    if (!assumeItToBeTrue.workspaceName || typeof assumeItToBeTrue.workspaceName !== "string") {
+        throw new Error(`Missing the workspaceName string property in the ${ruleName} rule.`);
+    }
+    if (
+        !assumeItToBeTrue.workspaceEntryPoint ||
+        typeof assumeItToBeTrue.workspaceEntryPoint !== "string"
+    ) {
+        throw new Error(`Missing the workspaceEntryPoint string property in the ${ruleName} rule.`);
+    }
+    return true;
+}
+function throwIfPathRelationshipsAreIncorrect(workspaceNumOneDefinition: IWorkspaceOption): void {
+    if (
+        workspaceNumOneDefinition.workspaceName.includes("/") ||
+        workspaceNumOneDefinition.workspaceName.includes("\\")
+    ) {
+        throw new Error(
+            `workspaceName must be the name of a folder without a path (i.e. no relative paths) in the ${ruleName} rule. Please correct this: ${
+                workspaceNumOneDefinition.workspaceName
+            }`,
+        );
+    }
+    if (
+        workspaceNumOneDefinition.workspaceEntryPoint.includes("/") ||
+        workspaceNumOneDefinition.workspaceEntryPoint.includes("\\")
+    ) {
+        throw new Error(
+            `workspaceEntryPoint must be the name of a file without a path (i.e. no relative paths) in the ${ruleName} rule. Please correct this: ${
+                workspaceNumOneDefinition.workspaceEntryPoint
+            }`,
+        );
+    }
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+    private static optionExamples: Array<true | IWorkspaceOption> = [
+        true,
+        {
+            workspaceName: "workspaceNumOne",
+            workspaceEntryPoint: "entrypoint.ts",
+        },
+        {
+            workspaceName: "workspaceNumTwo",
+            workspaceEntryPoint: "entrypoint.ts",
+        },
+    ];
+
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: ruleName,
+        description: Lint.Utils.dedent`
+            Disallows importing sub modules of workspaces via \`import\` and \`require\`.
+            Instead only the entrypoint (as defined in the options/configuration) can be included.`,
+        rationale: Lint.Utils.dedent`
+            When utilizing a monorepo, you want the convenience of having access to the various workspaces in the repo.
+            However, it is not good practice to let workspaces import nested modules of the sibling workspaces as this would create a monolith that would be difficult to separate later.`,
+        optionsDescription: "A list of workspace definitions.",
+        options: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    workspaceName: {
+                        type: "string",
+                    },
+                    workspaceEntryPoint: {
+                        type: "string",
+                    },
+                },
+                required: ["workspaceName", "workspaceEntryPoint"],
+            },
+            minLength: 1,
+        },
+        optionExamples: [true, Rule.optionExamples],
+        type: "functionality",
+        typescriptOnly: false,
+    };
+
+    public static FAILURE_STRING =
+        "Only the entrypoint defined as workspaceEntryPoint is public. Importing nested files would break separation of concerns. Do not include this, or expose it via it's public entrypoint:";
+
+    public isEnabled(): boolean {
+        return super.isEnabled() && this.ruleArguments.length > 0;
+    }
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk, this.ruleArguments);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<IWorkspaceOption[]>) {
+    // const errorStrArray : string[] = [];  // TODO: remove this
+    const workspaceDefinitions = ctx.options;
+    for (const workspaceNumOneDefinition of workspaceDefinitions) {
+        throwIfNotIWorkspaceOption(workspaceNumOneDefinition);
+        throwIfPathRelationshipsAreIncorrect(workspaceNumOneDefinition);
+    }
+    for (const anImport of findImports(ctx.sourceFile, ImportKind.All)) {
+        // errorStrArray.push(`${name.text} fom within... ${ctx.sourceFile.fileName}`); // TODO: remove this
+
+        if (isAnInternalImport(anImport.text)) {
+            // If this is a sub import
+            // If this is a sub import for a different workspace
+            // Then ctx.addFailure
+            // else (i.e. this this import is within the same workspace)
+            // Then allow it becauses a workspace should have access to it's own private functions
+            // Else, allow any non-nested imports of workspaces in any workspace
+
+            const aPollutedWorkspace = getOffendingCrossWorkspaceUsage(
+                anImport,
+                ctx.sourceFile,
+                workspaceDefinitions,
+            );
+            if (aPollutedWorkspace) {
+                ctx.addFailure(
+                    anImport.getStart(ctx.sourceFile) + 1,
+                    anImport.end - 1,
+                    `${Rule.FAILURE_STRING} ${aPollutedWorkspace.workspaceName}/${
+                        aPollutedWorkspace.workspaceEntryPoint
+                    }`,
+                );
+            }
+        }
+        if (isLernaStyledInternalWorkspace(anImport.text, workspaceDefinitions)) {
+            // Do not allow sub includes from workspaces since that would be an inclusion of "private" capabilities.
+            if (anImport.text.includes("/")) {
+                ctx.addFailure(
+                    anImport.getStart(ctx.sourceFile) + 1,
+                    anImport.end - 1,
+                    Rule.FAILURE_STRING,
+                );
+            }
+        }
+    }
+    // throw new Error(errorStrArray.join(".\n")); // TODO: remove this
+}
+
+function isAnInternalImport(importStr: string): boolean {
+    return importStr.startsWith(".") && !importStr.includes("node_modules");
+}
+
+function isLernaStyledInternalWorkspace(
+    importStr: string,
+    knownWorkspaces: IWorkspaceOption[],
+): boolean {
+    return (
+        !isAnInternalImport(importStr) &&
+        knownWorkspaces.some(w => importStr.includes(w.workspaceName))
+    );
+}
+
+function getOffendingCrossWorkspaceUsage(
+    importStr: ts.LiteralExpression,
+    fileWhereTheImportOccurred: ts.SourceFile,
+    knownWorkspaces: IWorkspaceOption[],
+): IWorkspaceOption | null {
+    // We don't know what workspace this file is in, but we can make a guess by analyzing the path of the file
+    const potentialWorkspaceOfThisFile = fileWhereTheImportOccurred.fileName
+        .split("/")
+        .filter(aStr => !aStr.startsWith("."));
+    // remove any workspaces that have been defined that might be the workspace that this file is already in.
+    //      this is to allow a file to include any file within it's own workspace
+    const knownWorkspacesOutsideOfThisFile = knownWorkspaces.filter(
+        knownW =>
+            !potentialWorkspaceOfThisFile.some(
+                oneFromImport => oneFromImport === knownW.workspaceName,
+            ),
+    );
+
+    const potentialMatches = knownWorkspacesOutsideOfThisFile.filter(
+        (w: Readonly<IWorkspaceOption>) => {
+            const entrypointMinusExtension = w.workspaceEntryPoint.substring(
+                0,
+                w.workspaceEntryPoint.indexOf(".ts"),
+            );
+            const isUsingNonPublicOfAWorkspace =
+                importStr.text.includes(w.workspaceName) &&
+                // but you have to still let them include the public entrypoint
+                !importStr.text.endsWith(`${w.workspaceName}/${entrypointMinusExtension}`);
+
+            return isUsingNonPublicOfAWorkspace;
+        },
+    );
+    if (potentialMatches.length > 0) {
+        // then return the first
+        return potentialMatches[0];
+    } else {
+        return null;
+    }
+}

--- a/test/rules/no-workspace-pollution/tslint.json
+++ b/test/rules/no-workspace-pollution/tslint.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "no-workspace-pollution": [true, {
+      "workspaceName": "workspaceNumOne",
+      "workspaceEntryPoint": "index.ts.lint"
+    }, {
+      "workspaceName": "workspaceNumTwo",
+      "workspaceEntryPoint": "index.ts.lint"
+    }]
+  }
+}

--- a/test/rules/no-workspace-pollution/workspaceNumOne/index.ts.lint
+++ b/test/rules/no-workspace-pollution/workspaceNumOne/index.ts.lint
@@ -1,0 +1,7 @@
+import * as shouldBeAbleToBringInMyIndex from './../workspaceNumOne/index';
+import * as shouldBeAbleToBringInAnotherIndex from './../workspaceNumTwo/index';
+import * as thisShouldWorkBecauseItIsMyOwnPrivates from './../workspaceNumOne/privateMethods/utilities';
+import * as thisShouldFailBecauseItIsAPrivateModuleOfworkspaceNumTwo from './../workspaceNumTwo/privateMethods/utilities';
+                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+[0]: Only the entrypoint defined as workspaceEntryPoint is public. Importing nested files would break separation of concerns. Do not include this, or expose it via it's public entrypoint: workspaceNumTwo/index.ts.lint

--- a/test/rules/no-workspace-pollution/workspaceNumTwo/index.ts.lint
+++ b/test/rules/no-workspace-pollution/workspaceNumTwo/index.ts.lint
@@ -1,0 +1,7 @@
+import * as shouldBeAbleToBringInMyIndex from './../workspaceNumTwo/index';
+import * as shouldBeAbleToBringInAnotherIndex from './../workspaceNumOne/index';
+import * as thisShouldWorkBecauseItIsMyOwnPrivates from './../workspaceNumTwo/privateMethods/utilities';
+import * as thisShouldFailBecauseItIsAPrivateModuleOfworkspaceNumOne from './../workspaceNumOne/privateMethods/utilities';
+                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+[0]: Only the entrypoint defined as workspaceEntryPoint is public. Importing nested files would break separation of concerns. Do not include this, or expose it via it's public entrypoint: workspaceNumOne/index.ts.lint


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3754
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
This introduces a new rule that allows developers to define their workspaces inside of tslint.json so that tslint can enforce that each workspace only uses the publicly exported functions of each workspace. This linting will encourage separation of concerns. This is very important for monorepos where each repo is designed to be decoupled from the others. In other words, you wouldn't want arepo to have have includes like `"./../../../otherWorkspace/privateUtilityFunctions/dataHelper"`. But with the hopefully helpful error messages I've provided, the developer will be encouraged to import `"./../../../otherWorkspace/index"` instead.

#### Is there anything you'd like reviewers to focus on?

* I guess I'd appreciate some extra review of the JSON Schema stuff I did since most of the other rules use arrays, but I thought it was more self-documenting if the configuration used objects.

#### CHANGELOG.md entry:

[new-rule] `no-workspace-pollution`
