### PR TITLE
prefer-object-spread: this is new to ES2018, not ES2015

### DIFF
--- a/src/rules/preferObjectSpreadRule.ts
+++ b/src/rules/preferObjectSpreadRule.ts
@@ -33,7 +33,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "prefer-object-spread",
         description:
-            "Enforces the use of the ES2015 object spread operator over `Object.assign()` where appropriate.",
+            "Enforces the use of the ES2018 object spread operator over `Object.assign()` where appropriate.",
         rationale: "Object spread allows for better type checking and inference.",
         optionsDescription: "Not configurable.",
         options: null,


### PR DESCRIPTION
Support for spread properties in object literals wasn't added until
ES2018, not ES2015.  The proposal is here:
  https://github.com/tc39/proposal-object-rest-spread

And MDN documents it as such too:
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals
