### PR TITLE
Corrects typo (no-unused-expression)

### DIFF
--- a/src/rules/noUnusedExpressionRule.ts
+++ b/src/rules/noUnusedExpressionRule.ts
@@ -50,7 +50,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         rationale: Lint.Utils.dedent`
             Detects potential errors where an assignment or function call was intended.`,
         optionsDescription: Lint.Utils.dedent`
-            Two arguments may be optionally provided:
+            Three arguments may be optionally provided:
 
             * \`${ALLOW_FAST_NULL_CHECKS}\` allows to use logical operators to perform fast null checks and perform
             method or function calls for side effects (e.g. \`e && e.preventDefault()\`).


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

Typo correction on "no-unused-expression" rule : 
Three arguments are available but the description says that only  **two** may be provided.
