### PR TITLE
[no-void-expression] Allow void expressions in binary expressions

### DIFF
--- a/src/rules/noVoidExpressionRule.ts
+++ b/src/rules/noVoidExpressionRule.ts
@@ -99,6 +99,10 @@ function walk(ctx: Lint.WalkContext<Options>, checker: ts.TypeChecker): void {
                 return true;
             case ts.SyntaxKind.ArrowFunction:
                 return ignoreArrowFunctionShorthand;
+
+            // Something like "x && console.log(x)".
+            case ts.SyntaxKind.BinaryExpression:
+                return isParentAllowedVoid(node.parent!);
             default:
                 return false;
         }

--- a/test/rules/no-void-expression/default/test.ts.lint
+++ b/test/rules/no-void-expression/default/test.ts.lint
@@ -5,6 +5,9 @@ function print(strs) {}
 [].forEach(x => console.log(x));
                 ~~~~~~~~~~~~~~ [0]
 
+[].forEach(x => x && console.log(x));
+                     ~~~~~~~~~~~~~~ [0]
+
 async function f(): Promise<void> {
     const x = doIt();
               ~~~~~~  [0]
@@ -13,6 +16,9 @@ async function f(): Promise<void> {
     return print``;
            ~~~~~~~  [0]
 }
+
+true && console.log(0);
+false || console.log(0);
 
 declare function doIt(): void;
 declare function doAsync(): Promise<void>;

--- a/test/rules/no-void-expression/ignore-arrow-function-shorthand/test.ts.lint
+++ b/test/rules/no-void-expression/ignore-arrow-function-shorthand/test.ts.lint
@@ -1,4 +1,6 @@
 [].forEach(x => console.log(x));
+[].forEach(x => x && console.log(x));
+[].forEach(x => !x || console.log(x));
 
 [].forEach(x => {
     return console.log(x);


### PR DESCRIPTION
The no-void-expression rule currently warns in this case:

    x && console.log(x);

I think this can be accepted, since it's a common way to make a compact
"if".

Same with the ignore-arrow-function-shorthand option, tslint currently
warns for:

    [].forEach(x => x && console.log(x))

This patch changes the rule to accept these.

Fixes #4297
Fixes #2919

#### PR checklist

- [x] Addresses an existing issue: #4297, #2919
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update: no, do you think it needs to?

#### Overview of change:

See commit message above.

#### Is there anything you'd like reviewers to focus on?

No.

#### CHANGELOG.md entry:

    [bugfix] The no-void-expression rule now accepts void expressions as arguments of boolean binary operators (e.g.: x && console.log(x)).
