### PR TITLE
Improve JUnit formatter

### DIFF
--- a/src/formatters/junitFormatter.ts
+++ b/src/formatters/junitFormatter.ts
@@ -32,8 +32,8 @@ export class Formatter extends AbstractFormatter {
         <?xml version="1.0" encoding="utf-8"?>
         <testsuites package="tslint">
           <testsuite name="myFile.ts">
-            <testcase name="Line 1, Column 14: semicolon">
-              <failure type="warning">Missing semicolon</failure>
+            <testcase name="semicolon" classname="myFile.ts">
+              <failure type="warning">Missing semicolon Line 1, Column 14</failure>
             </testcase>
           </testsuite>
         </testsuites>
@@ -64,9 +64,12 @@ export class Formatter extends AbstractFormatter {
                     output += `<testsuite name="${this.escapeXml(failure.getFileName())}">`;
                 }
 
-                output += `<testcase name="Line ${lineAndCharacter.line + 1}, `;
-                output += `Column ${lineAndCharacter.character + 1}: ${rule}">`;
-                output += `<failure type="${severity}">${message}</failure>`;
+                output += `<testcase name="${rule}" `;
+                output += `classname="${this.escapeXml(failure.getFileName())}">`;
+                output += `<failure type="${severity}">${message} `;
+                output += `Line ${lineAndCharacter.line + 1}, `;
+                output += `Column ${lineAndCharacter.character + 1}`;
+                output += `</failure>`;
                 output += "</testcase>";
             }
             if (previousFilename !== null) {

--- a/test/formatters/junitFormatterTests.ts
+++ b/test/formatters/junitFormatterTests.ts
@@ -79,29 +79,28 @@ describe("JUnit Formatter", () => {
                 "warning",
             ),
         ];
-
         const expectedResult = `<?xml version="1.0" encoding="utf-8"?>
             <testsuites package="tslint">
                 <testsuite name="${TEST_FILE_1}">
-                    <testcase name="Line 1, Column 1: first-name">
-                        <failure type="error">first failure</failure>
+                    <testcase name="first-name" classname="${TEST_FILE_1}">
+                        <failure type="error">first failure Line 1, Column 1</failure>
                     </testcase>
-                    <testcase name="Line 1, Column 3: escape">
-                        <failure type="error">&amp;&lt;&gt;&#39;&quot; should be escaped</failure>
+                    <testcase name="escape" classname="${TEST_FILE_1}">
+                        <failure type="error">&amp;&lt;&gt;&#39;&quot; should be escaped Line 1, Column 3</failure>
                     </testcase>
-                    <testcase name="Line 6, Column 3: last-name">
-                        <failure type="error">last failure</failure>
+                    <testcase name="last-name" classname="${TEST_FILE_1}">
+                        <failure type="error">last failure Line 6, Column 3</failure>
                     </testcase>
                 </testsuite>
                 <testsuite name="${TEST_FILE_2}">
-                    <testcase name="Line 1, Column 1: first-name">
-                        <failure type="error">first failure</failure>
+                    <testcase name="first-name" classname="${TEST_FILE_2}">
+                        <failure type="error">first failure Line 1, Column 1</failure>
                     </testcase>
-                    <testcase name="Line 1, Column 3: escape">
-                        <failure type="warning">&amp;&lt;&gt;&#39;&quot; should be escaped</failure>
+                    <testcase name="escape" classname="${TEST_FILE_2}">
+                        <failure type="warning">&amp;&lt;&gt;&#39;&quot; should be escaped Line 1, Column 3</failure>
                     </testcase>
-                    <testcase name="Line 6, Column 3: last-name">
-                        <failure type="warning">last failure</failure>
+                    <testcase name="last-name" classname="${TEST_FILE_2}">
+                        <failure type="warning">last failure Line 6, Column 3</failure>
                     </testcase>
                 </testsuite>
             </testsuites>`.replace(/>\s+/g, ">"); // Remove whitespace between tags;


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

This updates the JUnit formatter to use the required property `classname`.
This change is related to an issue for [Gitlab-CE](https://gitlab.com/gitlab-org/gitlab-ce/issues/50964) which has problems with displaying JUnit results if they are missing the `classname` property.

#### Is there anything you'd like reviewers to focus on?

Not sure if we should add other properties which are required, but cannot be filled with a proper value like `time` or `tests` and `errors`. These could be filled with a dummy value, but I would rather leave them out.

#### CHANGELOG.md entry:
[enhancement] `Improve JUnit formatter`