### PR TITLE
Show offending value in 'no-magic-numbers' error message

### DIFF
--- a/src/rules/noMagicNumbersRule.ts
+++ b/src/rules/noMagicNumbersRule.ts
@@ -46,8 +46,6 @@ export class Rule extends Lint.Rules.AbstractRule {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public static FAILURE_STRING = "'magic numbers' are not allowed";
-
     public static ALLOWED_NODES = new Set<ts.SyntaxKind>([
         ts.SyntaxKind.ExportAssignment,
         ts.SyntaxKind.FirstAssignment,
@@ -62,6 +60,10 @@ export class Rule extends Lint.Rules.AbstractRule {
     ]);
 
     public static DEFAULT_ALLOWED = [-1, 0, 1];
+
+    public static FAILURE_STRING(num: string): string {
+        return `'magic numbers' are not allowed: ${num}`;
+    }
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(
@@ -105,7 +107,7 @@ class NoMagicNumbersWalker extends Lint.AbstractWalker<number[]> {
             !Rule.ALLOWED_NODES.has(node.parent!.kind) &&
             !this.options.some(allowedNum => Object.is(allowedNum, parseFloat(num)))
         ) {
-            this.addFailureAtNode(node, Rule.FAILURE_STRING);
+            this.addFailureAtNode(node, Rule.FAILURE_STRING(num));
         }
     }
 }

--- a/test/rules/no-magic-numbers/custom/test.ts.lint
+++ b/test/rules/no-magic-numbers/custom/test.ts.lint
@@ -9,11 +9,11 @@ console.log(-1337);
 console.log(- 1337);
 console.log(1337.7);
 console.log(1338);
-            ~~~~                      ['magic numbers' are not allowed]
+            ~~~~                      ['magic numbers' are not allowed: 1338]
 console.log(-1338)
-            ~~~~~                     ['magic numbers' are not allowed]
+            ~~~~~                     ['magic numbers' are not allowed: -1338]
 parseInt(foo === 4711 ? bar : baz, 10);
-                 ~~~~                 ['magic numbers' are not allowed]
+                 ~~~~                 ['magic numbers' are not allowed: 4711]
 parseInt(foo === -0 ? bar : baz, 10);
 export let x = 1337;
 export let x = -1337;

--- a/test/rules/no-magic-numbers/default/test.ts.lint
+++ b/test/rules/no-magic-numbers/default/test.ts.lint
@@ -1,24 +1,24 @@
 console.log(-1, 0, 1);
 console.log(42.42);
-            ~~~~~                     ['magic numbers' are not allowed]
+            ~~~~~                     ['magic numbers' are not allowed: 42.42]
 console.log(-0);
-            ~~                            ['magic numbers' are not allowed]
+            ~~                            ['magic numbers' are not allowed: -0]
 const a = 1337;
 const b = {
     a: 1338,
     b: 0,
 }
 b.b = 1339;
-      ~~~~                          ['magic numbers' are not allowed]
+      ~~~~                          ['magic numbers' are not allowed: 1339]
 
 console.log(1340);
-            ~~~~                    ['magic numbers' are not allowed]
+            ~~~~                    ['magic numbers' are not allowed: 1340]
 for(let i = 0;i>1341;++i) {
-                ~~~~                ['magic numbers' are not allowed]
+                ~~~~                ['magic numbers' are not allowed: 1341]
 }
 
 throw 1342;
-      ~~~~                          ['magic numbers' are not allowed]
+      ~~~~                          ['magic numbers' are not allowed: 1342]
 
 class A {
     static test = 1337;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #2067
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

I just fixed an issue about showing the offending value for no-magic-numbers rule.

Before:

`'magic numbers' are not allowed`

Now:

`'magic numbers' are not allowed: 3`

#### CHANGELOG.md entry:
 I didn't create one for such a small thing. Should I?