### PR TITLE
Clarify no-shadowed-variable doc (#4306)

### DIFF
--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -36,14 +36,30 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "no-shadowed-variable",
         description: "Disallows shadowing variable declarations.",
         rationale: Lint.Utils.dedent`
-            Shadowing a variable masks access to it and obscures to what value an identifier actually refers.
-            For example, in the following code, it can be confusing why the filter is likely never true:
+            When a variable in a local scope and a variable in the containing scope have the same name, shadowing occurs.
+            Shadowing makes it impossible to access the variable in the containing scope and 
+            obscures to what value an identifier actually refers. Compare the following snippets:
 
             \`\`\`
-            const findNeighborsWithin = (instance: MyClass, instances: MyClass[]): MyClass[] => {
-                return instances.filter((instance) => instance.neighbors.includes(instance));
-            };
+            const a = 'no shadow';
+            function print() {
+                console.log(a);
+            }
+            print(); // logs 'no shadow'.
             \`\`\`
+
+            \`\`\`
+            const a = 'no shadow';
+            function print() {
+                const a = 'shadow'; // TSLint will complain here.
+                console.log(a);
+            }
+            print(); // logs 'shadow'.
+            \`\`\`
+
+            ESLint has [an equivalent rule](https://eslint.org/docs/rules/no-shadow).
+            For more background information, refer to 
+            [this MDN closure doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures#Lexical_scoping).
         `,
         optionsDescription: Lint.Utils.dedent`
             You can optionally pass an object to disable checking for certain kinds of declarations.


### PR DESCRIPTION
#### PR checklist

- [v] Addresses an existing issue: #4306 
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [v] Documentation update

#### Overview of change:

Clarify the rationale behind `no-shadowed-variable` and add some references.

#### Is there anything you'd like reviewers to focus on?

I couldn't find a way to run documentation locally, so I am not too sure how it would look like on Jekyll. It would be great to have a documentation on running docs locally.

#### CHANGELOG.md entry:

N/A
