### PR TITLE
Use default js-yaml schema

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -267,13 +267,7 @@ export function readConfigurationFile(filepath: string): RawConfigFile {
             if (resolvedConfigFileExt === ".json") {
                 return JSON.parse(stripComments(fileContent)) as RawConfigFile;
             } else {
-                return yaml.safeLoad(fileContent, {
-                    // Note: yaml.LoadOptions expects a schema value of type "any",
-                    // but this trips up the no-unsafe-any rule.
-                    // tslint:disable-next-line:no-unsafe-any
-                    schema: yaml.JSON_SCHEMA,
-                    strict: true,
-                }) as RawConfigFile;
+                return yaml.safeLoad(fileContent) as RawConfigFile;
             }
         } catch (e) {
             const error = e as Error;

--- a/test/config/tslint-with-merge.yaml
+++ b/test/config/tslint-with-merge.yaml
@@ -1,0 +1,18 @@
+commonRules: &common
+    rule-one:
+        severity: error
+    rule-two:
+        - true
+        - "common rule"
+jsRules:
+    <<: *common
+    rule-three:
+        - true
+        - "js rule"
+rules:
+    <<: *common
+    rule-one:
+        severity: warning
+    rule-three:
+        - true
+        - "ts rule"

--- a/test/configurationTests.ts
+++ b/test/configurationTests.ts
@@ -624,6 +624,41 @@ describe("Configuration", () => {
             assertRulesEqual(config.jsRules, expectedRules);
         });
 
+        it("can load .yaml files with merge key", () => {
+            const config = loadConfigurationFromPath("./test/config/tslint-with-merge.yaml");
+
+            const expectedRules = getEmptyRules();
+            expectedRules.set("rule-one", {
+                ruleArguments: undefined,
+                ruleSeverity: "warning",
+            });
+            expectedRules.set("rule-two", {
+                ruleArguments: ["common rule"],
+                ruleSeverity: "error",
+            });
+            expectedRules.set("rule-three", {
+                ruleArguments: ["ts rule"],
+                ruleSeverity: "error",
+            });
+
+            const expectedJsRules = getEmptyRules();
+            expectedJsRules.set("rule-one", {
+                ruleArguments: undefined,
+                ruleSeverity: "error",
+            });
+            expectedJsRules.set("rule-two", {
+                ruleArguments: ["common rule"],
+                ruleSeverity: "error",
+            });
+            expectedJsRules.set("rule-three", {
+                ruleArguments: ["js rule"],
+                ruleSeverity: "error",
+            });
+
+            assertRulesEqual(config.rules, expectedRules);
+            assertRulesEqual(config.jsRules, expectedJsRules);
+        });
+
         it("can load a built-in configuration", () => {
             const config = loadConfigurationFromPath("tslint:recommended");
             assert.strictEqual<RuleSeverity | undefined>(


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3821
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update (Not necessary? Nothing's really changed, just better Yaml support)

#### Overview of change:

This will change the yaml parser to use the default schema, which allows some additional Yaml types, see http://yaml.org/type/

Namely, this will allow the merge syntax, allowing users to define common rules and then merge them into the typescript and javascript rules.

For a full list of the additional Yaml types added, see the [js-yaml schema definition](https://github.com/nodeca/js-yaml/blob/master/lib/js-yaml/schema/default_safe.js).

Note: This change removes the options passed to `yaml.safeLoad` since they are no longer required. The default safe schema is what we want, and the `strict: true` is not a valid option, since js-yaml removed it a while back, see here: https://github.com/nodeca/js-yaml/commit/e6bac15

#### CHANGELOG.md entry:

[enhancement] Yaml parser now uses default schema, allowing for `<<:` to be used to merge anchors
<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
