### PR TITLE
Fix semicolon: Cannot read property 'initializer' of undefined

### DIFF
--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -357,8 +357,8 @@ class SemicolonNeverWalker extends SemicolonWalker {
     }
 
     private checkVariableStatement(node: ts.VariableStatement) {
-        const declarations = node.declarationList.declarations;
-        if (declarations[declarations.length - 1].initializer === undefined) {
+        const declaration = last(node.declarationList.declarations);
+        if (declaration === undefined || declaration.initializer === undefined) {
             // variable declaration does not continue on the next line if it has no initializer
             return this.checkSemicolonOrLineBreak(node);
         }
@@ -377,4 +377,11 @@ class SemicolonNeverWalker extends SemicolonWalker {
             this.checkSemicolonOrLineBreak(member);
         }
     }
+}
+
+/**
+ * Returns the last element of an array (or undefined if the array is empty).
+ */
+function last<T>(array: ArrayLike<T>): T | undefined {
+    return array[array.length - 1];
 }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -382,6 +382,6 @@ class SemicolonNeverWalker extends SemicolonWalker {
 /**
  * Returns the last element of an array (or undefined if the array is empty).
  */
-function last<T>(array: ArrayLike<T>): T | undefined {
+function last<T>(array: ReadonlyArray<T>): T | undefined {
     return array[array.length - 1];
 }

--- a/src/rules/semicolonRule.ts
+++ b/src/rules/semicolonRule.ts
@@ -357,8 +357,11 @@ class SemicolonNeverWalker extends SemicolonWalker {
     }
 
     private checkVariableStatement(node: ts.VariableStatement) {
-        const declaration = last(node.declarationList.declarations);
-        if (declaration === undefined || declaration.initializer === undefined) {
+        const declarations = node.declarationList.declarations;
+        if (
+            declarations.length !== 0 &&
+            declarations[declarations.length - 1].initializer === undefined
+        ) {
             // variable declaration does not continue on the next line if it has no initializer
             return this.checkSemicolonOrLineBreak(node);
         }
@@ -377,11 +380,4 @@ class SemicolonNeverWalker extends SemicolonWalker {
             this.checkSemicolonOrLineBreak(member);
         }
     }
-}
-
-/**
- * Returns the last element of an array (or undefined if the array is empty).
- */
-function last<T>(array: ReadonlyArray<T>): T | undefined {
-    return array[array.length - 1];
 }

--- a/test/rules/semicolon/never/test.ts.fix
+++ b/test/rules/semicolon/never/test.ts.fix
@@ -217,5 +217,11 @@ var foo = () => {}
 var bar; var foo = function() {};
 []
 
+var
+[]
+
 const
+[]
+
+let
 []

--- a/test/rules/semicolon/never/test.ts.fix
+++ b/test/rules/semicolon/never/test.ts.fix
@@ -60,7 +60,7 @@ class MyClass {
     }
 
     public initializedMethodPropertyWithoutSemicolon = () => {
-        return "hi again" 
+        return "hi again"
     }
 
     public initializedMethodProperty1Line = () => { return "hi" }
@@ -215,4 +215,7 @@ function *gen() {
 var foo = () => {}
 []
 var bar; var foo = function() {};
+[]
+
+const
 []

--- a/test/rules/semicolon/never/test.ts.lint
+++ b/test/rules/semicolon/never/test.ts.lint
@@ -83,7 +83,7 @@ class MyClass {
      ~ [0]
 
     public initializedMethodPropertyWithoutSemicolon = () => {
-        return "hi again"; 
+        return "hi again";
                          ~ [0]
     }
 
@@ -267,6 +267,9 @@ var foo = () => {};
                   ~ [0]
 []
 var bar; var foo = function() {};
+[]
+
+const
 []
 
 [0]: Unnecessary semicolon

--- a/test/rules/semicolon/never/test.ts.lint
+++ b/test/rules/semicolon/never/test.ts.lint
@@ -269,7 +269,13 @@ var foo = () => {};
 var bar; var foo = function() {};
 []
 
+var
+[]
+
 const
+[]
+
+let
 []
 
 [0]: Unnecessary semicolon


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4309 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

`SemicolonNeverWalker.checkVariableStatement` handles the case where `declarations` is an empty array.

#### Is there anything you'd like reviewers to focus on?

1. Is there any documentation that needs to be updated as a result of this change?
2. Unsure if better to export one of the existing utility functions:
  - `last` (`memberOrderingRule.ts`)
  - `arrayLast` (`switchFinalBreakRule.ts`).

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
