### PR TITLE
Fix callable-types should handle `new(): T` just like `(): T`

### DIFF
--- a/src/language/formatter/formatter.ts
+++ b/src/language/formatter/formatter.ts
@@ -46,7 +46,13 @@ export interface IFormatterMetadata {
 
 export type ConsumerType = "human" | "machine";
 
-export type FormatterConstructor = new () => IFormatter;
+// TODO: Enabling the `callable-types` rule below produces a lint error
+// in several locations complaining about the `no-inferred-empty-object-type`
+// rule. As far as I can tell, this is a bug and requires further investigation.
+export interface FormatterConstructor {
+    // tslint:disable-next-line:callable-types
+    new (): IFormatter;
+}
 
 export interface IFormatter {
     /**

--- a/src/language/formatter/formatter.ts
+++ b/src/language/formatter/formatter.ts
@@ -46,9 +46,9 @@ export interface IFormatterMetadata {
 
 export type ConsumerType = "human" | "machine";
 
-// TODO: Enabling the `callable-types` rule below produces a lint error
-// in several locations complaining about the `no-inferred-empty-object-type`
-// rule. As far as I can tell, this is a bug and requires further investigation.
+// TODO: Enable the `callable-types` rule below. Currently, it
+// produces a lint error in several locations complaining about the
+// `no-inferred-empty-object-type` rule.
 export interface FormatterConstructor {
     // tslint:disable-next-line:callable-types
     new (): IFormatter;

--- a/src/language/formatter/formatter.ts
+++ b/src/language/formatter/formatter.ts
@@ -46,9 +46,7 @@ export interface IFormatterMetadata {
 
 export type ConsumerType = "human" | "machine";
 
-export interface FormatterConstructor {
-    new (): IFormatter;
-}
+export type FormatterConstructor = new () => IFormatter;
 
 export interface IFormatter {
     /**

--- a/src/language/formatter/formatter.ts
+++ b/src/language/formatter/formatter.ts
@@ -46,6 +46,7 @@ export interface IFormatterMetadata {
 
 export type ConsumerType = "human" | "machine";
 
+// See https://github.com/palantir/tslint/issues/4364
 // TODO: Enable the `callable-types` rule below. Currently, it
 // produces a lint error in several locations complaining about the
 // `no-inferred-empty-object-type` rule.

--- a/src/rules/callableTypesRule.ts
+++ b/src/rules/callableTypesRule.ts
@@ -18,6 +18,7 @@
 import {
     getChildOfKind,
     isCallSignatureDeclaration,
+    isConstructSignatureDeclaration,
     isIdentifier,
     isInterfaceDeclaration,
     isTypeLiteralNode,
@@ -58,7 +59,7 @@ function walk(ctx: Lint.WalkContext<void>) {
         ) {
             const member = node.members[0];
             if (
-                isCallSignatureDeclaration(member) &&
+                (isConstructSignatureDeclaration(member) || isCallSignatureDeclaration(member)) &&
                 // avoid bad parse
                 member.type !== undefined
             ) {
@@ -96,7 +97,7 @@ function noSupertype(node: ts.InterfaceDeclaration): boolean {
 }
 
 function renderSuggestion(
-    call: ts.CallSignatureDeclaration,
+    call: ts.CallSignatureDeclaration | ts.ConstructSignatureDeclaration,
     parent: ts.InterfaceDeclaration | ts.TypeLiteralNode,
     sourceFile: ts.SourceFile,
 ): string {

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -107,14 +107,13 @@ class NoInferredEmptyObjectTypeRule extends Lint.AbstractWalker<void> {
             objType.getProperties().length === 0 &&
             objType.getNumberIndexType() === undefined &&
             objType.getStringIndexType() === undefined &&
-            objType.getCallSignatures().every(signature => {
-                const type = this.checker.getReturnTypeOfSignature(signature);
-                return isObjectType(type) && this.isEmptyObjectInterface(type);
-            }) &&
-            objType.getConstructSignatures().every(signature => {
-                const type = this.checker.getReturnTypeOfSignature(signature);
-                return isObjectType(type) && this.isEmptyObjectInterface(type);
-            })
+            objType.getCallSignatures().every(this.isSignatureEmptyObjectInterface) &&
+            objType.getConstructSignatures().every(this.isSignatureEmptyObjectInterface)
         );
+    }
+
+    private isSignatureEmptyObjectInterface(signature: ts.Signature): boolean {
+        const type = this.checker.getReturnTypeOfSignature(signature);
+        return isObjectType(type) && this.isEmptyObjectInterface(type);
     }
 }

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -96,11 +96,7 @@ class NoInferredEmptyObjectTypeRule extends Lint.AbstractWalker<void> {
         }
 
         const retType = this.checker.getReturnTypeOfSignature(callSig);
-        if (
-            isObjectType(retType) &&
-            this.isEmptyObjectInterface(retType) &&
-            this.hasTypeParameters(retType)
-        ) {
+        if (isObjectType(retType) && this.isEmptyObjectInterface(retType)) {
             this.addFailureAtNode(node, Rule.EMPTY_INTERFACE_FUNCTION);
         }
     }
@@ -116,12 +112,5 @@ class NoInferredEmptyObjectTypeRule extends Lint.AbstractWalker<void> {
                 return isObjectType(type) && this.isEmptyObjectInterface(type);
             })
         );
-    }
-
-    private hasTypeParameters(objType: ts.ObjectType): boolean {
-        return objType.getConstructSignatures().every(signature => {
-            const parameters = signature.getTypeParameters();
-            return parameters !== undefined;
-        });
     }
 }

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -110,6 +110,10 @@ class NoInferredEmptyObjectTypeRule extends Lint.AbstractWalker<void> {
             objType.getCallSignatures().every(signature => {
                 const type = this.checker.getReturnTypeOfSignature(signature);
                 return isObjectType(type) && this.isEmptyObjectInterface(type);
+            }) &&
+            objType.getConstructSignatures().every(signature => {
+                const type = this.checker.getReturnTypeOfSignature(signature);
+                return isObjectType(type) && this.isEmptyObjectInterface(type);
             })
         );
     }

--- a/test/rules/callable-types/test.ts.fix
+++ b/test/rules/callable-types/test.ts.fix
@@ -26,7 +26,9 @@ interface K {
 }
 
 // handle modifiers
-export type I = () => void;
+export type I0 = () => void;
+
+export type I1 = new () => void;
 
 export type T = () => void
 

--- a/test/rules/callable-types/test.ts.lint
+++ b/test/rules/callable-types/test.ts.lint
@@ -54,9 +54,14 @@ interface K {
 }
 
 // handle modifiers
-export interface I {
+export interface I0 {
     (): void;
-    ~~~~~~~~~ [interface % ('type I = () => void;')]
+    ~~~~~~~~~ [interface % ('type I0 = () => void;')]
+}
+
+export interface I1 {
+    new (): void;
+    ~~~~~~~~~~~~~ [interface % ('type I1 = new () => void;')]
 }
 
 export type T = {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4291 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Walker for `callable-types` rule handles the case where an interface contains a single construct signature declaration.

#### CHANGELOG.md entry:

[bugfix][`callable-types`](https://palantir.github.io/tslint/rules/callable-types/) support interfaces containing a single construct signature (#4291)