### PR TITLE
Allow unknown in 'no-object-literal-type-assertion' rule.

### DIFF
--- a/src/rules/noObjectLiteralTypeAssertionRule.ts
+++ b/src/rules/noObjectLiteralTypeAssertionRule.ts
@@ -61,7 +61,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
             // Compare with UnknownKeyword if using TS 3.0 or above
             (!!(ts.SyntaxKind as any).UnknownKeyword ?
              (node.type.kind !== (ts.SyntaxKind as any).UnknownKeyword) :
-             true) &&
+             node.type.getText(ctx.sourceFile) !== "unknown") &&
             isObjectLiteralExpression(
                 isParenthesizedExpression(node.expression)
                     ? node.expression.expression

--- a/src/rules/noObjectLiteralTypeAssertionRule.ts
+++ b/src/rules/noObjectLiteralTypeAssertionRule.ts
@@ -30,7 +30,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         ruleName: "no-object-literal-type-assertion",
         description: Lint.Utils.dedent`
             Forbids an object literal to appear in a type assertion expression.
-            Casting to \`any\` is still allowed.`,
+            Casting to \`any\` or to \`unknown\` is still allowed.`,
         rationale: Lint.Utils.dedent`
             Always prefer \`const x: T = { ... };\` to \`const x = { ... } as T;\`.
             The type assertion in the latter case is either unnecessary or hides an error.
@@ -58,6 +58,10 @@ function walk(ctx: Lint.WalkContext<void>): void {
         if (
             isAssertionExpression(node) &&
             node.type.kind !== ts.SyntaxKind.AnyKeyword &&
+            // Compare with UnknownKeyword if using TS 3.0 or above
+            (!!(ts.SyntaxKind as any).UnknownKeyword ?
+             (node.type.kind !== (ts.SyntaxKind as any).UnknownKeyword) :
+             true) &&
             isObjectLiteralExpression(
                 isParenthesizedExpression(node.expression)
                     ? node.expression.expression

--- a/test/rules/no-object-literal-type-assertion/test.ts.lint
+++ b/test/rules/no-object-literal-type-assertion/test.ts.lint
@@ -14,8 +14,6 @@ x as T;
 
 // Allow cast to 'unknown'
 {} as unknown;
-
 <unknown> {};
-~~~~~~~~~~~~ [0]
 
 [0]: Type assertion on object literals is forbidden, use a type annotation instead.

--- a/test/rules/no-object-literal-type-assertion/test.ts.lint
+++ b/test/rules/no-object-literal-type-assertion/test.ts.lint
@@ -17,6 +17,5 @@ x as T;
 
 <unknown> {};
 ~~~~~~~~~~~~ [0]
-// Remove previous line once TSLint requires TS 3.0 or above
 
 [0]: Type assertion on object literals is forbidden, use a type annotation instead.

--- a/test/rules/no-object-literal-type-assertion/test.ts.lint
+++ b/test/rules/no-object-literal-type-assertion/test.ts.lint
@@ -12,4 +12,11 @@ x as T;
 {} as any;
 <any> {};
 
+// Allow cast to 'unknown'
+{} as unknown;
+
+<unknown> {};
+~~~~~~~~~~~~ [0]
+// Remove previous line once TSLint requires TS 3.0 or above
+
 [0]: Type assertion on object literals is forbidden, use a type annotation instead.


### PR DESCRIPTION
Fix #4355