### PR TITLE
Add exception for generators in "return-undefined" rule

### DIFF
--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -117,6 +117,11 @@ function getReturnKind(node: FunctionLike, checker: ts.TypeChecker): ReturnKind 
             return ReturnKind.Value;
     }
 
+    // Handle generator functions/methods:
+    if (node.asteriskToken) {
+        return ReturnKind.Void;
+    }
+
     const contextual =
         isFunctionExpressionLike(node) && node.type === undefined
             ? tryGetReturnType(checker.getContextualType(node), checker)

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -118,7 +118,7 @@ function getReturnKind(node: FunctionLike, checker: ts.TypeChecker): ReturnKind 
     }
 
     // Handle generator functions/methods:
-    if (node.asteriskToken) {
+    if (node.asteriskToken !== undefined) {
         return ReturnKind.Void;
     }
 

--- a/test/rules/return-undefined/test.ts.lint
+++ b/test/rules/return-undefined/test.ts.lint
@@ -78,5 +78,19 @@ test(async () => {
          ~~~~~~~~~~~~~~~~~ [VOID]
 });
 
+
+function * generator(returnNothing: boolean) {
+    if (returnNothing) return;
+    yield 1;
+    return yield * [2, 3];
+}
+
+class ClassWithGeneratorMethod {
+    * generatorMethod(returnNothing: boolean) {
+        if (returnNothing) return;
+        yield 1;
+    }
+}
+
 [VOID]: `void` function should use `return;`, not `return undefined;`.
 [UNDEFINED]: Value-returning function should use `return undefined;`, not just `return;`.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4368
- [x] Bugfix
  - [x] Includes tests (added cases)
- [ ] Documentation update

#### Overview of change:

Added check for generators => handle them as `ReturnKind.Void` in the corresponding rule.

#### Is there anything you'd like reviewers to focus on?

* I check for `FunctionLikeDeclarationBase.asteriskToken` to detect generators. Is this the best way?

#### CHANGELOG.md entry:

[bugfix] Added exception for generators in `return-undefined` rule
