### PR TITLE
Update 'json-stringify-pretty-compact' to 1.2.0 and remove unnecessary type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "chai": "^3.5.0",
         "github": "^8.2.1",
         "husky": "^0.14.3",
-        "json-stringify-pretty-compact": "^1.0.3",
+        "json-stringify-pretty-compact": "^1.2.0",
         "mocha": "^3.2.0",
         "npm-run-all": "^4.0.2",
         "nyc": "^10.2.0",

--- a/scripts/custom-typings.d.ts
+++ b/scripts/custom-typings.d.ts
@@ -1,4 +1,0 @@
-declare module "json-stringify-pretty-compact" {
-    function stringify(x: any): string;
-    export = stringify;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,10 +1075,10 @@ jsesc@^1.3.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
   integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
-json-stringify-pretty-compact@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.0.4.tgz#d5161131be27fd9748391360597fcca250c6c5ce"
-  integrity sha1-1RYRMb4n/ZdIORNgWX/MolDGxc4=
+json-stringify-pretty-compact@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.2.0.tgz#0bc316b5e6831c07041fc35612487fb4e9ab98b8"
+  integrity sha512-/11Pj1OyX814QMKO7K8l85SHPTr/KsFxHp8GE2zVa0BtJgGimDjXHfM3FhC7keQdWDea7+nXf+f1de7ATZcZkQ==
 
 json3@3.3.2:
   version "3.3.2"


### PR DESCRIPTION
#### PR checklist

- [x] Just a refactoring

#### Overview of change:

* The typings are now included in the package (see https://github.com/lydell/json-stringify-pretty-compact/pull/16).
* This fixes "node_modules/json-stringify-pretty-compact/index.d.ts:7:12 - error TS2300: Duplicate identifier 'stringify'" compile errors.

#### CHANGELOG.md entry:

n/a