### PR TITLE
Bump docs ruby minor version to 2.3.7

### DIFF
--- a/docs/circle.yml
+++ b/docs/circle.yml
@@ -1,7 +1,7 @@
 machine:
     ruby:
         # see available versions here: https://circleci.com/docs/build-image-precise/#ruby
-        version: 2.2.5
+        version: 2.3.7
 test:
     override:
         - bundle exec jekyll build

--- a/docs/circle.yml
+++ b/docs/circle.yml
@@ -1,7 +1,7 @@
 machine:
     ruby:
         # see available versions here: https://circleci.com/docs/build-image-precise/#ruby
-        version: 2.2.3
+        version: 2.2.5
 test:
     override:
         - bundle exec jekyll build


### PR DESCRIPTION
Updated the old gems on the gh-pages branch to find out we need to bump the minor version of ruby too.