### PR TITLE
Fix [ban]: wrong logic matching deeply nested methods

### DIFF
--- a/src/rules/banRule.ts
+++ b/src/rules/banRule.ts
@@ -94,6 +94,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 { name: ["it", "only"], message: "don't focus tests" },
                 { name: ["chai", "assert", "equal"], message: "Use 'strictEqual' instead." },
                 { name: ["*", "forEach"], message: "Use a regular for loop instead." },
+                { name: ["*", "_id", "toString"], message: "Use 'toHexString' instead." },
             ],
         ],
         type: "functionality",
@@ -167,14 +168,14 @@ class BanFunctionWalker extends Lint.AbstractWalker<Options> {
     }
 
     private checkForObjectMethodBan(expression: ts.PropertyAccessExpression) {
-        for (const ban of this.options.methods) {
+        outer: for (const ban of this.options.methods) {
             if (expression.name.text !== ban.name) {
                 continue;
             }
             let current = expression.expression;
             for (let i = ban.object.length - 1; i > 0; --i) {
                 if (!isPropertyAccessExpression(current) || current.name.text !== ban.object[i]) {
-                    continue;
+                    continue outer;
                 }
                 current = current.expression;
             }

--- a/test/rules/ban/test.ts.lint
+++ b/test/rules/ban/test.ts.lint
@@ -24,6 +24,7 @@ fit("some text", () => {});
 someObject.fit()
 chai.assert.equal(1, "1");
 ~~~~~~~~~~~~~~~~~ [err % ('chai.assert.equal', "Use 'strictEqual' instead.")]
+chai.equal(1, "1");
 assert.equal(1, "1");
 foo.assert.equal(1, "1");
 someObject.chai.assert.equal(1, "1");
@@ -33,5 +34,8 @@ arr.forEach(() => {});
 ~~~~~~~~~~~ [err % ('*.forEach', 'Use a regular for loop instead.')]
 someObject.someProperty.forEach(() => {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [err % ('*.forEach', 'Use a regular for loop instead.')]
+someObject._id.toString();
+~~~~~~~~~~~~~~~~~~~~~~~ [err % ('*._id.toString', "Use 'toHexString' instead.")]
+someObject.toString();
 
 [err]: Calls to '%s' are not allowed.

--- a/test/rules/ban/tslint.json
+++ b/test/rules/ban/tslint.json
@@ -10,7 +10,8 @@
       {"name": ["_", "map"]},
       ["_", "filter", "Use the native JavaScript 'myArray.filter' instead."],
       {"name": ["*", "forEach"], "message": "Use a regular for loop instead."},
-      {"name": ["chai", "assert", "equal"], "message": "Use 'strictEqual' instead."}
+      {"name": ["chai", "assert", "equal"], "message": "Use 'strictEqual' instead."},
+      {"name": ["*", "_id", "toString"], "message": "Use 'toHexString' instead."}
     ]
   }
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Fix a bug where `a.b.c()` may also match with `a.c()`.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[bugfix] `ban`: Fix a false positive which would occur when banning method calls nested inside objects. Previously, banning `["a", "b", "c"]` would trigger lint failures on the syntax `b.c()`, which was not the intent of this rule. 