### PR TITLE
Revert breaking change to tslint:recommended, update tslint:latest

### DIFF
--- a/src/configs/latest.ts
+++ b/src/configs/latest.ts
@@ -65,6 +65,9 @@ export const rules = {
     "no-duplicate-switch-case": true,
     "no-implicit-dependencies": true,
     "no-return-await": true,
+
+    // added in v5.12
+    "function-constructor": true,
 };
 // tslint:enable object-literal-sort-keys
 

--- a/src/configs/latest.ts
+++ b/src/configs/latest.ts
@@ -68,6 +68,7 @@ export const rules = {
 
     // added in v5.12
     "function-constructor": true,
+    "unnecessary-bind": true,
 };
 // tslint:enable object-literal-sort-keys
 

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -47,7 +47,6 @@ export const rules = {
     "cyclomatic-complexity": false,
     eofline: true,
     forin: true,
-    "function-constructor": true,
     "import-spacing": true,
     indent: {
         options: ["spaces"],


### PR DESCRIPTION
Addresses the issue I brought up in https://github.com/palantir/tslint/pull/4198#issuecomment-449134147

Also enables some v5.12 rules in `tslint:latest`