### PR TITLE
Add unknown as simple type to `array-type`

### DIFF
--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -162,6 +162,7 @@ function isSimpleType(nodeType: ts.TypeNode): boolean {
         case ts.SyntaxKind.VoidKeyword:
         case ts.SyntaxKind.NeverKeyword:
         case ts.SyntaxKind.ThisType:
+        case ts.SyntaxKind.UnknownKeyword:
             return true;
         case ts.SyntaxKind.TypeReference:
             // TypeReferences must be non-generic or be another Array with a simple type

--- a/test/rules/array-type/array-simple/test.ts.fix
+++ b/test/rules/array-type/array-simple/test.ts.fix
@@ -54,3 +54,7 @@ interface FooInterface {
     '.bar': {baz: string[];};
 }
 
+// Test an unknown Array
+let t: unknown[] = [];
+let u: unknown[] = [];
+

--- a/test/rules/array-type/array-simple/test.ts.lint
+++ b/test/rules/array-type/array-simple/test.ts.lint
@@ -70,4 +70,9 @@ interface FooInterface {
     '.bar': {baz: string[];};
 }
 
+// Test an unknown Array
+let t: unknown[] = [];
+let u: Array<unknown> = [];
+       ~~~~~~~~~~~~~~       [0]
+
 [0]: Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.

--- a/test/rules/array-type/array/test.ts.fix
+++ b/test/rules/array-type/array/test.ts.fix
@@ -43,3 +43,7 @@ interface FooInterface {
     '.bar': {baz: string[];};
 }
 
+// Test an unknown Array
+let t: unknown[] = [];
+let u: unknown[] = [];
+

--- a/test/rules/array-type/array/test.ts.lint
+++ b/test/rules/array-type/array/test.ts.lint
@@ -55,4 +55,9 @@ interface FooInterface {
     '.bar': {baz: string[];};
 }
 
+// Test an unknown Array
+let t: unknown[] = [];
+let u: Array<unknown> = [];
+       ~~~~~~~~~~~~~~       [0]
+
 [0]: Array type using 'Array<T>' is forbidden. Use 'T[]' instead.

--- a/test/rules/array-type/generic/test.ts.fix
+++ b/test/rules/array-type/generic/test.ts.fix
@@ -43,3 +43,7 @@ interface FooInterface {
     '.bar': {baz: Array<string>;};
 }
 
+// Test an unknown Array
+let t: Array<unknown> = [];
+let u: Array<unknown> = [];
+

--- a/test/rules/array-type/generic/test.ts.lint
+++ b/test/rules/array-type/generic/test.ts.lint
@@ -55,4 +55,9 @@ interface FooInterface {
                   ~~~~~~~~    [0]
 }
 
+// Test an unknown Array
+let t: unknown[] = [];
+       ~~~~~~~~~       [0]
+let u: Array<unknown> = [];
+
 [0]: Array type using 'T[]' is forbidden. Use 'Array<T>' instead.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4085
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update: N/a

#### Overview of change:
Add unknown to the simple types. Updated tests to test this functionality.

#### CHANGELOG.md entry:
[bugfix] `unknown` is recognized as simple type in `array-type`
