### PR TITLE
Fixed no-unbound-method on built-in Array methods

### DIFF
--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -82,6 +82,22 @@ export class Rule extends Lint.Rules.TypedRule {
             logArrowBound();
             logManualBind();
             \`\`\`
+            
+            You may pass a context as argument in Array built-in methods
+            
+            \`\`\`
+            class MyClass {
+                private _definitions: number[] = [];
+            
+                public updateDefinition(def: number): number {
+                    return def * 2;
+                }
+            
+                public updateDefinitions(): void {
+                    this._definitions = this._definitions.map(this.updateDefinition, this);
+                }
+            }
+            \`\`\`
         `,
         type: "functionality",
         typescriptOnly: true,

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -169,9 +169,9 @@ function isSafeUse(node: ts.Node, tc: ts.TypeChecker): boolean {
                 arrayMethodsWithSecondArgAsContext.indexOf(name.getText()) > -1
             ) {
                 const type = tc.getTypeAtLocation(expression);
-                const typeNode = type === undefined ? undefined : tc.typeToTypeNode(type);
+                const symbol = type === undefined ? undefined : type.symbol;
 
-                return typeNode === undefined ? false : typeNode.kind === ts.SyntaxKind.ArrayType;
+                return symbol === undefined ? false : symbol.name === "Array";
             }
 
             return parentExpression === node;

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -163,15 +163,15 @@ function isSafeUse(node: ts.Node, tc: ts.TypeChecker): boolean {
              *  {...}.find(this.method, contextOrSmthElse) - custom method `find` on non-array object
              */
             if (
-                name &&
-                parentArgs &&
-                parentArgs[1] &&
+                name !== undefined &&
+                parentArgs !== undefined &&
+                parentArgs[1] !== undefined &&
                 arrayMethodsWithSecondArgAsContext.indexOf(name.getText()) > -1
             ) {
                 const type = tc.getTypeAtLocation(expression);
-                const typeNode = type && tc.typeToTypeNode(type);
+                const typeNode = type === undefined ? undefined : tc.typeToTypeNode(type);
 
-                return Boolean(typeNode && typeNode.kind === ts.SyntaxKind.ArrayType);
+                return typeNode === undefined ? false : typeNode.kind === ts.SyntaxKind.ArrayType;
             }
 
             return parentExpression === node;

--- a/test/rules/no-unbound-method/default/test.ts.lint
+++ b/test/rules/no-unbound-method/default/test.ts.lint
@@ -12,3 +12,23 @@ function f(i: I) {
 }
 
 [0]: Avoid referencing unbound methods which may cause unintentional scoping of 'this'.
+
+class Some {
+	private _definitions: number[] = [];
+
+	public updateDefinition(def: number): number {
+		return def * 2;
+	}
+
+	public testMethod () {}
+
+	public updateDefinitions(): void {
+		this._definitions = this._definitions.map(this.updateDefinition, this);
+		this._definitions.forEach(this.testMethod, this);
+		this._definitions.some(this.testMethod, this);
+		this._definitions.every(this.testMethod, this);
+		this._definitions.find(this.testMethod, this);
+		this._definitions.findIndex(this.testMethod, this);
+		this._definitions.flatMap(this.testMethod, this);
+	}
+}

--- a/test/rules/no-unbound-method/default/test.tsx.lint
+++ b/test/rules/no-unbound-method/default/test.tsx.lint
@@ -43,6 +43,14 @@ for (c.method; c.method; c.method) {}
                         ~~~~~ [0]
 [0].forEach(c.method.bind(c));
 
+[0].every(c.method, c);
+[0].find(c.method, c);
+[0].findIndex(c.method, c);
+[0].flatMap(c.method, c);
+[0].forEach(c.method, c);
+[0].map(c.method, c);
+[0].some(c.method, c);
+
 <button onClick={c.method}>Click me!</button>;
                  ~~~~~~~~ [0]
 


### PR DESCRIPTION
#### PR checklist

- [x] issue: #4439
- [x] bugfix
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
Fixed `no-unbound-method` rule to correctly handle the cases like

```js
[1, 2, 3].find(this.method, this)
```

#### CHANGELOG.md entry:

* [bugfix] `arrow-return-shorthand`
