### PR TITLE
Fix strict-type-predicate for unknown

### DIFF
--- a/src/rules/strictTypePredicatesRule.ts
+++ b/src/rules/strictTypePredicatesRule.ts
@@ -244,8 +244,6 @@ function getTypePredicateForKind(kind: string): Predicate | undefined {
             return flagPredicate(ts.TypeFlags.ESSymbol);
         case "function":
             return isFunction;
-        case "unknown":
-            return flagPredicate(ts.TypeFlags.Unknown);
         case "object":
             // It's an object if it's not any of the above.
             const allFlags =
@@ -254,7 +252,6 @@ function getTypePredicateForKind(kind: string): Predicate | undefined {
                 ts.TypeFlags.BooleanLike |
                 ts.TypeFlags.NumberLike |
                 ts.TypeFlags.StringLike |
-                ts.TypeFlags.Unknown |
                 ts.TypeFlags.ESSymbol;
             return type => !isTypeFlagSet(type, allFlags) && !isFunction(type);
         default:

--- a/src/rules/strictTypePredicatesRule.ts
+++ b/src/rules/strictTypePredicatesRule.ts
@@ -99,7 +99,12 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker): void {
 
         const exprType = checker.getTypeAtLocation(exprPred.expression);
         // TODO: could use checker.getBaseConstraintOfType to help with type parameters, but it's not publicly exposed.
-        if (isTypeFlagSet(exprType, ts.TypeFlags.Any | ts.TypeFlags.TypeParameter)) {
+        if (
+            isTypeFlagSet(
+                exprType,
+                ts.TypeFlags.Any | ts.TypeFlags.TypeParameter | ts.TypeFlags.Unknown,
+            )
+        ) {
             return;
         }
 
@@ -239,6 +244,8 @@ function getTypePredicateForKind(kind: string): Predicate | undefined {
             return flagPredicate(ts.TypeFlags.ESSymbol);
         case "function":
             return isFunction;
+        case "unknown":
+            return flagPredicate(ts.TypeFlags.Unknown);
         case "object":
             // It's an object if it's not any of the above.
             const allFlags =
@@ -247,6 +254,7 @@ function getTypePredicateForKind(kind: string): Predicate | undefined {
                 ts.TypeFlags.BooleanLike |
                 ts.TypeFlags.NumberLike |
                 ts.TypeFlags.StringLike |
+                ts.TypeFlags.Unknown |
                 ts.TypeFlags.ESSymbol;
             return type => !isTypeFlagSet(type, allFlags) && !isFunction(type);
         default:

--- a/test/rules/strict-type-predicates/strict-null-checks/test.ts.lint
+++ b/test/rules/strict-type-predicates/strict-null-checks/test.ts.lint
@@ -194,6 +194,9 @@ declare function get<T>(): T;
     typeof get<string | number>() === `stirng`;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [typeof]
 
+    typeof get<any>() === "unknown";
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [typeof]
+
     let a: string, b: string;
     typeof a === typeof b;
     typeof a === b;

--- a/test/rules/strict-type-predicates/unknown/test.ts.lint
+++ b/test/rules/strict-type-predicates/unknown/test.ts.lint
@@ -1,0 +1,34 @@
+[typescript]: >= 3.0.0
+
+declare function get<T>(): T;
+
+// typeof
+{
+    typeof get<unknown>() === "undefined";
+    typeof get<unknown>() === "boolean";
+    typeof get<unknown>() === "number";
+    typeof get<unknown>() === "string";
+    typeof get<unknown>() === "symbol";
+    typeof get<unknown>() === "function";
+    typeof get<unknown>() === "object";
+}
+
+// negation
+{
+    get<unknown>() !== null;
+    get<unknown>() !== undefined;
+}
+
+// reverse left/right
+{
+    "string" === typeof get<unknown>();
+
+    undefined === get<unknown>();
+}
+
+// type parameters
+{
+    function f<T>(t: T) {
+        typeof t === "boolean";
+    }
+}

--- a/test/rules/strict-type-predicates/unknown/test.ts.lint
+++ b/test/rules/strict-type-predicates/unknown/test.ts.lint
@@ -32,3 +32,11 @@ declare function get<T>(): T;
         typeof t === "boolean";
     }
 }
+
+const body: unknown = 'test';
+if (typeof body === 'object')
+    console.log('a');
+
+let test: unknown = undefined;
+if (test !== undefined)
+    console.log('b');

--- a/test/rules/strict-type-predicates/unknown/tsconfig.json
+++ b/test/rules/strict-type-predicates/unknown/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    }
+}

--- a/test/rules/strict-type-predicates/unknown/tslint.json
+++ b/test/rules/strict-type-predicates/unknown/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "strict-type-predicates": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: Closes #4107
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update: N/a

#### Overview of change:
Fixes the issue where a comparison with unknown would falsly give an error. Instead, comparison with unknown should always be allowed.

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[bugfix] fix `strict-type-predicate` with `unknown`
