### PR TITLE
trailing-comma: check for a closing parenthesis

### DIFF
--- a/src/rules/trailingCommaRule.ts
+++ b/src/rules/trailingCommaRule.ts
@@ -229,12 +229,19 @@ class TrailingCommaWalker extends Lint.AbstractWalker<Options> {
                 case ts.SyntaxKind.ConstructorType:
                 case ts.SyntaxKind.FunctionType:
                 case ts.SyntaxKind.CallSignature:
-                    this.checkList(
-                        (node as ts.SignatureDeclaration).parameters,
-                        getChildOfKind(node, ts.SyntaxKind.CloseParenToken, this.sourceFile)!.end,
-                        "functions",
-                        isRestParameter,
+                    const closingParen = getChildOfKind(
+                        node,
+                        ts.SyntaxKind.CloseParenToken,
+                        this.sourceFile,
                     );
+                    if (closingParen !== undefined) {
+                        this.checkList(
+                            (node as ts.SignatureDeclaration).parameters,
+                            closingParen.end,
+                            "functions",
+                            isRestParameter,
+                        );
+                    }
                     break;
                 case ts.SyntaxKind.TypeLiteral:
                     this.checkTypeLiteral(node as ts.TypeLiteralNode);


### PR DESCRIPTION
#### PR checklist

- [x] Issue: #4456
- [x] Bugfix
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:

FIxes an uncaught exception thrown by `trailing-comma`.

#### CHANGELOG.md entry:

[bugfix] `trailing-comma`
<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
