### PR TITLE
Whitelist option for `no-unbound-method`

### DIFF
--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { hasModifier, isPropertyAccessExpression } from "tsutils";
+import {
+    hasModifier,
+    isCallExpression,
+    isPropertyAccessExpression,
+    isTypeOfExpression,
+} from "tsutils";
 import * as ts from "typescript";
 import * as Lint from "../index";
 
@@ -210,13 +215,12 @@ function isSafeUse(node: ts.Node): boolean {
     }
 }
 
-function isWhitelisted(node: ts.Node, whitelist: string[]): boolean {
-    if (node.parent.kind === ts.SyntaxKind.TypeOfExpression) {
+function isWhitelisted(node: ts.Node, whitelist: Set<string>): boolean {
+    if (isTypeOfExpression(node.parent)) {
         return whitelist.indexOf("typeof") !== -1;
     }
-    if (node.parent.kind === ts.SyntaxKind.CallExpression) {
-        const parent = node.parent as ts.CallExpression;
-        const expression = parent.expression as ts.Identifier;
+    if (isCallExpression(node.parent)) {
+        const expression = node.parent.expression as ts.Identifier;
         const callingMethodName = expression.escapedText as string;
         return whitelist.indexOf(callingMethodName) !== -1;
     }

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -149,7 +149,7 @@ function parseArguments(args: Array<string | OptionsInput>): Options {
             }
         } else {
             options.ignoreStatic = arg[OPTION_IGNORE_STATIC] || false;
-            (arg[OPTION_WHITELIST] || []).forEach(options.whitelist.add);
+            options.whitelist = new Set(arg[OPTION_WHITELIST] || []);
         }
     }
 

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -22,6 +22,13 @@ import * as Lint from "../index";
 const OPTION_IGNORE_STATIC = "ignore-static";
 const OPTION_WHITELIST = "whitelist";
 
+const OPTION_WHITELIST_EXAMPLE = [
+    true,
+    {
+        [OPTION_WHITELIST]: ["expect", "typeof"],
+    },
+];
+
 interface Options {
     ignoreStatic: boolean;
     whitelist: string[];
@@ -32,7 +39,16 @@ export class Rule extends Lint.Rules.TypedRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-unbound-method",
         description: "Warns when a method is used outside of a method call.",
-        optionsDescription: `You may optionally pass "${OPTION_IGNORE_STATIC}" to ignore static methods.`,
+        optionsDescription: Lint.Utils.dedent`
+            You may additionally pass "${OPTION_IGNORE_STATIC}" to ignore static methods, or an options object.
+            
+            The object might have two properties:
+            
+            * "${OPTION_IGNORE_STATIC}" - to ignore static methods.
+            * "${OPTION_WHITELIST}" - list of method names and keywords where method reference should be ignored, e.g.
+              * when method is referenced as a parameter to whitelisted method.
+              * when method is referenced in a typeof expression.
+            `,
         options: {
             anyOf: [
                 {
@@ -52,7 +68,7 @@ export class Rule extends Lint.Rules.TypedRule {
                 },
             ],
         },
-        optionExamples: [true, [true, OPTION_IGNORE_STATIC]],
+        optionExamples: [true, [true, OPTION_IGNORE_STATIC], OPTION_WHITELIST_EXAMPLE],
         rationale: Lint.Utils.dedent`
             Class functions don't preserve the class scope when passed as standalone variables.
             For example, this code will log the global scope (\`window\`/\`global\`), not the class instance:

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -232,7 +232,7 @@ function isWhitelisted(node: ts.Node, whitelist: Set<string>, allowTypeof: boole
     }
     if (isCallExpression(node.parent)) {
         const expression = node.parent.expression as ts.Identifier;
-        const callingMethodName = expression.escapedText as string;
+        const callingMethodName = expression.text as string;
         return whitelist.has(callingMethodName);
     }
     return false;

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -233,7 +233,7 @@ function isWhitelisted(node: ts.Node, whitelist: Set<string>, allowTypeof: boole
     }
     if (isCallExpression(node.parent) && isIdentifier(node.parent.expression)) {
         const expression = node.parent.expression;
-        const callingMethodName = expression.text as string;
+        const callingMethodName = expression.text;
         return whitelist.has(callingMethodName);
     }
     return false;

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -198,6 +198,11 @@ function isWhitelisted(node: ts.Node, whitelist: string[]): boolean {
     if (node.parent.kind === ts.SyntaxKind.TypeOfExpression) {
         return whitelist.indexOf("typeof") !== -1;
     }
+    if (node.parent.kind === ts.SyntaxKind.CallExpression) {
+        const parent = node.parent as ts.CallExpression;
+        const expression = parent.expression as ts.Identifier;
+        const callingMethodName = expression.escapedText as string;
+        return whitelist.indexOf(callingMethodName) !== -1;
+    }
     return false;
 }
-

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -157,7 +157,7 @@ function parseArguments(args: Array<string | OptionsInput>): Options {
         } else {
             options.allowTypeof = arg[OPTION_ALLOW_TYPEOF] || false;
             options.ignoreStatic = arg[OPTION_IGNORE_STATIC] || false;
-            options.whitelist = new Set(arg[OPTION_WHITELIST] || []);
+            options.whitelist = new Set(arg[OPTION_WHITELIST]);
         }
     }
 

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -20,13 +20,11 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 
 const OPTION_IGNORE_STATIC = "ignore-static";
-const OPTION_WHITELIST_METHOD = "whitelist-method";
-const OPTION_WHITELIST_OPERATOR = "whitelist-operator";
+const OPTION_WHITELIST = "whitelist";
 
 interface Options {
     ignoreStatic: boolean;
-    whitelistMethod: string[];
-    whitelistOperator: string[];
+    whitelist: string[];
 }
 
 export class Rule extends Lint.Rules.TypedRule {
@@ -45,12 +43,7 @@ export class Rule extends Lint.Rules.TypedRule {
                     type: "object",
                     properties: {
                         [OPTION_IGNORE_STATIC]: { type: "boolean" },
-                        [OPTION_WHITELIST_METHOD]: {
-                            type: "array",
-                            items: { type: "string" },
-                            minLength: 1,
-                        },
-                        [OPTION_WHITELIST_OPERATOR]: {
+                        [OPTION_WHITELIST]: {
                             type: "array",
                             items: { type: "string" },
                             minLength: 1,
@@ -120,8 +113,7 @@ export class Rule extends Lint.Rules.TypedRule {
 function parseArguments(args: any[]): Options {
     const options: Options = {
         ignoreStatic: false,
-        whitelistMethod: [],
-        whitelistOperator: [],
+        whitelist: [],
     };
 
     for (const arg of args) {
@@ -133,11 +125,8 @@ function parseArguments(args: any[]): Options {
             if (arg.hasOwnProperty(OPTION_IGNORE_STATIC)) {
                 options.ignoreStatic = arg[OPTION_IGNORE_STATIC];
             }
-            if (arg.hasOwnProperty(OPTION_WHITELIST_METHOD)) {
-                options.whitelistMethod.push(arg[OPTION_WHITELIST_METHOD]);
-            }
-            if (arg.hasOwnProperty(OPTION_WHITELIST_OPERATOR)) {
-                options.whitelistOperator.push(arg[OPTION_WHITELIST_OPERATOR]);
+            if (arg.hasOwnProperty(OPTION_WHITELIST)) {
+                options.whitelist = options.whitelist.concat(arg[OPTION_WHITELIST]);
             }
         }
     }

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -42,7 +42,7 @@ export class Rule extends Lint.Rules.TypedRule {
         optionsDescription: Lint.Utils.dedent`
             You may additionally pass "${OPTION_IGNORE_STATIC}" to ignore static methods, or an options object.
             
-            The object might have two properties:
+            The object may have two properties:
             
             * "${OPTION_IGNORE_STATIC}" - to ignore static methods.
             * "${OPTION_WHITELIST}" - list of method names and keywords where method reference should be ignored, e.g.

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -18,6 +18,7 @@
 import {
     hasModifier,
     isCallExpression,
+    isIdentifier,
     isPropertyAccessExpression,
     isTypeOfExpression,
 } from "tsutils";
@@ -230,8 +231,8 @@ function isWhitelisted(node: ts.Node, whitelist: Set<string>, allowTypeof: boole
     if (isTypeOfExpression(node.parent)) {
         return allowTypeof;
     }
-    if (isCallExpression(node.parent)) {
-        const expression = node.parent.expression as ts.Identifier;
+    if (isCallExpression(node.parent) && isIdentifier(node.parent.expression)) {
+        const expression = node.parent.expression;
         const callingMethodName = expression.text as string;
         return whitelist.has(callingMethodName);
     }

--- a/test/rules/no-unbound-method/whitelist/test.tsx.lint
+++ b/test/rules/no-unbound-method/whitelist/test.tsx.lint
@@ -1,0 +1,67 @@
+class C {
+    method(x: number) {}
+    property: () => void;
+    template(strs: TemplateStringsArray, x: any) {}
+}
+
+const c = new C();
+[0].forEach(c.method);
+            ~~~~~~~~ [0]
+[0].forEach(x => c.method(x));
+[0].forEach(c.property);
+
+c.template;
+~~~~~~~~~~ [0]
+c.template`foo${0}`;
+String.raw`${c.template}`;
+             ~~~~~~~~~~ [0]
+
+expect(c.method).toHaveBeenCalled();
+typeof c.method;
+
+test(c.method);
+     ~~~~~~~~ [0]
+
+interface I {
+    foo(): void;
+    bar: () => void;
+}
+declare var i: I;
+i.foo;
+~~~~~ [0]
+i.bar;
+
+c.method === i.foo;
+
+// OK in condition
+c.method ? 1 : 2;
+1 ? c.method : c.method;
+    ~~~~~~~~ [0]
+               ~~~~~~~~ [0]
+if (c.method) {}
+while (c.method) {}
+do {} while (c.method);
+for (c.method; c.method; c.method) {}
+
+
+[0].forEach(c.method || i.foo);
+            ~~~~~~~~ [0]
+                        ~~~~~ [0]
+[0].forEach(c.method.bind(c));
+
+<button onClick={c.method}>Click me!</button>;
+                 ~~~~~~~~ [0]
+
+class Validators {
+    static required() {
+        return null;
+    }
+    static compose(...args: Function[]) {}
+}
+
+Validators.compose(Validators.required);
+                   ~~~~~~~~~~~~~~~~~~~ [0]
+
+
+
+[0]: Avoid referencing unbound methods which may cause unintentional scoping of 'this'.

--- a/test/rules/no-unbound-method/whitelist/test.tsx.lint
+++ b/test/rules/no-unbound-method/whitelist/test.tsx.lint
@@ -62,6 +62,11 @@ class Validators {
 Validators.compose(Validators.required);
                    ~~~~~~~~~~~~~~~~~~~ [0]
 
-
+(condition ? expectA : expectB)(c.method);
+                                ~~~~~~~~ [0]
+(await someObject)(c.method);
+                   ~~~~~~~~ [0]
+(await someMethod())(c.method);
+                     ~~~~~~~~ [0]
 
 [0]: Avoid referencing unbound methods which may cause unintentional scoping of 'this'.

--- a/test/rules/no-unbound-method/whitelist/tsconfig.json
+++ b/test/rules/no-unbound-method/whitelist/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    }
+}

--- a/test/rules/no-unbound-method/whitelist/tslint.json
+++ b/test/rules/no-unbound-method/whitelist/tslint.json
@@ -3,6 +3,6 @@
     "typeCheck": true
   },
   "rules": {
-    "no-unbound-method": [true, { "whitelist": ["expect", "typeof"] }]
+    "no-unbound-method": [true, { "whitelist": ["expect"], "allow-typeof": true }]
   }
 }

--- a/test/rules/no-unbound-method/whitelist/tslint.json
+++ b/test/rules/no-unbound-method/whitelist/tslint.json
@@ -3,6 +3,6 @@
     "typeCheck": true
   },
   "rules": {
-    "no-unbound-method": [true, { "whitelist-method": "expect", "whitelist-operator": "typeof" }]
+    "no-unbound-method": [true, { "whitelist": ["expect", "typeof"] }]
   }
 }

--- a/test/rules/no-unbound-method/whitelist/tslint.json
+++ b/test/rules/no-unbound-method/whitelist/tslint.json
@@ -1,0 +1,8 @@
+{
+  "linterOptions": {
+    "typeCheck": true
+  },
+  "rules": {
+    "no-unbound-method": [true, { "whitelist-method": "expect", "whitelist-operator": "typeof" }]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3755 
- [x] Enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Added configuration option to whitelist methods and operators for `no-unbound-method` rule, so that it will not report errors in cases such as:

`expect(x.method).toHaveBeenCalled()`
`typeof x.method === 'function'`

#### Is there anything you'd like reviewers to focus on?

Please verify that options for this rule are backwards compatible.

<!-- optional -->

#### CHANGELOG.md entry:

[new-rule-option] Added `whitelist` option to `no-unbound-method`

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
