### PR TITLE
Added fixer for newline-before-return rule

### DIFF
--- a/src/rules/curlyRule.ts
+++ b/src/rules/curlyRule.ts
@@ -19,6 +19,7 @@ import { isBlock, isIfStatement, isIterationStatement, isSameLine } from "tsutil
 import * as ts from "typescript";
 
 import * as Lint from "../index";
+import { newLineWithIndentation } from "../utils";
 
 import { codeExamples } from "./code-examples/curly.examples";
 
@@ -172,29 +173,10 @@ class CurlyWalker extends Lint.AbstractWalker<Options> {
                 Lint.Replacement.appendText(statement.end, " }"),
             ];
         } else {
-            const match = /\n([\t ])/.exec(node.getFullText(this.sourceFile)); // determine which character to use (tab or space)
-            const indentation =
-                match === null
-                    ? ""
-                    : // indentation should match start of statement
-                      match[1].repeat(
-                          ts.getLineAndCharacterOfPosition(
-                              this.sourceFile,
-                              node.getStart(this.sourceFile),
-                          ).character,
-                      );
-
-            const maybeCarriageReturn =
-                this.sourceFile.text[this.sourceFile.getLineEndOfPosition(node.pos) - 1] === "\r"
-                    ? "\r"
-                    : "";
-
+            const newLine = newLineWithIndentation(node, this.sourceFile);
             return [
                 Lint.Replacement.appendText(statement.pos, " {"),
-                Lint.Replacement.appendText(
-                    statement.end,
-                    `${maybeCarriageReturn}\n${indentation}}`,
-                ),
+                Lint.Replacement.appendText(statement.end, `${newLine}}`),
             ];
         }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -295,6 +295,31 @@ function tryResolveSync(packageName: string, relativeTo?: string): string | unde
 }
 
 /**
+ * Gets the full indentation of the provided node
+ */
+export function getIndentation(node: ts.Node, sourceFile: ts.SourceFile): string {
+    const text = sourceFile.text.substr(node.pos, node.getStart() - node.pos);
+    const matches = text.match(/([ \t]*)$/);
+    return matches !== null ? matches[1] : "";
+}
+
+/**
+ * Creates x new lines with a proper indentation at the last one based on the provided node
+ */
+export function newLineWithIndentation(
+    node: ts.Node,
+    sourceFile: ts.SourceFile,
+    linesCount: number = 1,
+) {
+    const maybeCarriageReturn =
+        sourceFile.text[sourceFile.getLineEndOfPosition(node.pos) - 1] === "\r" ? "\r" : "";
+
+    const indentation = getIndentation(node, sourceFile);
+
+    return `${`${maybeCarriageReturn}\n`.repeat(linesCount)}${indentation}`;
+}
+
+/**
  * @deprecated Copied from tsutils 2.27.2. This will be removed once TSLint requires tsutils > 3.0.
  */
 export function isFunctionScopeBoundary(node: ts.Node): boolean {

--- a/test/rules/newline-before-return/default/test.ts.fix
+++ b/test/rules/newline-before-return/default/test.ts.fix
@@ -1,0 +1,114 @@
+function foo(bar) {
+    if (!bar) {
+        return;
+    }
+
+    return bar;
+}
+
+function foo(bar) {
+    if (!bar) {
+        var statement = '';
+
+        return statement;
+    }
+
+    return bar;
+}
+
+function foo(bar) {
+    if (!bar) {
+        return;
+    }
+
+    /* multi-line
+    comment */
+    return bar;
+}
+
+var fn = () => null;
+function foo() {
+    fn();
+
+    return;
+}
+
+function foo(fn) {
+    fn();
+
+    return;
+}
+
+function foo() {
+    return;
+}
+
+function foo() {
+
+    return;
+}
+
+function foo(bar) {
+    if (!bar) return;
+}
+
+function foo(bar) {
+    let someCall;
+    if (!bar) return;
+}
+
+function foo(bar) {
+    if (!bar) { return };
+}
+
+function foo(bar) {
+    if (!bar) {
+        return;
+    }
+}
+
+function foo(bar) {
+    if (!bar) {
+        return;
+    }
+
+    return bar;
+}
+
+function foo(bar) {
+    if (!bar) {
+
+        return;
+    }
+}
+
+function foo() {
+
+    // comment
+    return;
+}
+
+function test() {
+    console.log("Any statement");
+    // Any comment
+
+    return;
+}
+
+function foo() {
+    fn();
+    // comment
+
+    // comment
+    return;
+}
+
+function bar() {
+    "some statement";
+
+    //comment
+    //comment
+    //comment
+    return;
+}
+

--- a/test/rules/newline-before-return/default/test.ts.fix
+++ b/test/rules/newline-before-return/default/test.ts.fix
@@ -39,6 +39,18 @@ function foo(fn) {
     return;
 }
 
+function foo(fn) {
+    fn();
+
+    return;
+}
+
+function foo(fn) {
+    fn();
+
+    return;
+}
+
 function foo() {
     return;
 }

--- a/test/rules/newline-before-return/default/test.ts.lint
+++ b/test/rules/newline-before-return/default/test.ts.lint
@@ -38,6 +38,16 @@ function foo(fn) {
           ~nil [0]
 }
 
+function foo(fn) {
+    fn();   return;
+            ~nil [0]
+}
+
+function foo(fn) {
+    fn();          return;
+                   ~nil [0]
+}
+
 function foo() {
     return;
 }

--- a/test/rules/newline-before-return/default/test.tsx.fix
+++ b/test/rules/newline-before-return/default/test.tsx.fix
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+<div>{ [].map((child: any) => {
+    let i = 0;
+
+    return <span />;
+}) }</div>
+
+<div>{ [].map((child: any) => {
+    return <span />;
+}) }</div>
+
+<div>{ [].map((child: any) =>
+    <span />;
+) }</div>
+
+


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
I've realized that **newline-before-return** didn't have a fixer which seems to be quite straightforward. Here are my two cents. 

I've added tests and everything seems OK.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

[new-fixer] added fixer for **newline-before-return** rule