### PR TITLE
Handle I18n case

### DIFF
--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -19,7 +19,7 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { isUpperCase } from "../utils";
+import { isLowerCase } from "../utils";
 
 const OPTION_ALWAYS = "always-prefix";
 const OPTION_NEVER = "never-prefix";
@@ -74,10 +74,10 @@ function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
 }
 
 function hasPrefixI(name: string): boolean {
-    return name.length >= 2 && name[0] === "I" && isUpperCase(name[1]) && !isSpecialCase(name);
+    return name.length >= 2 && name[0] === "I" && !isLowerCase(name[1]) && !isSpecialCase(name);
 }
 
 function isSpecialCase(name: string): boolean {
-    // Allow IndexedDB and I18n interfaces
-    return name.startsWith("IDB") || name.startsWith("I18n");
+    // Allow IndexedDB
+    return name.startsWith("IDB");
 }

--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -19,7 +19,7 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { isLowerCase } from "../utils";
+import { isLowerCase, isUpperCase } from "../utils";
 
 const OPTION_ALWAYS = "always-prefix";
 const OPTION_NEVER = "never-prefix";
@@ -74,10 +74,5 @@ function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
 }
 
 function hasPrefixI(name: string): boolean {
-    return name.length >= 2 && name[0] === "I" && !isLowerCase(name[1]) && !isSpecialCase(name);
-}
-
-function isSpecialCase(name: string): boolean {
-    // Allow IndexedDB
-    return name.startsWith("IDB");
+    return name.length >= 3 && name[0] === "I" && !isLowerCase(name[1]) && !isUpperCase(name[2]);
 }

--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -62,10 +62,12 @@ function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         if (utils.isInterfaceDeclaration(node)) {
             const { name } = node;
-            if (never && hasPrefixI(name.text)) {
-                ctx.addFailureAtNode(name, Rule.FAILURE_STRING_NO_PREFIX);
-            } else if (!never && !hasPrefixI(name.text) && !isEdgeCase(name.text)) {
-                ctx.addFailureAtNode(name, Rule.FAILURE_STRING);
+            if (!cantDecide(name.text)) {
+                if (never && hasPrefixI(name.text)) {
+                    ctx.addFailureAtNode(name, Rule.FAILURE_STRING_NO_PREFIX);
+                } else if (!never && !hasPrefixI(name.text)) {
+                    ctx.addFailureAtNode(name, Rule.FAILURE_STRING);
+                }
             }
         } else {
             return ts.forEachChild(node, cb);
@@ -77,6 +79,9 @@ function hasPrefixI(name: string): boolean {
     return name.length >= 3 && name[0] === "I" && !isLowerCase(name[1]) && !isUpperCase(name[2]);
 }
 
-function isEdgeCase(name: string): boolean {
-    return name.length === 2 && name[0] === "I" && !isLowerCase(name[1]);
+function cantDecide(name: string): boolean {
+    return (
+        (name.length === 2 && name[0] === "I" && !isLowerCase(name[1])) ||
+        (name.length >= 2 && name[0] === "I" && !isLowerCase(name[1]) && !isLowerCase(name[2]))
+    );
 }

--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -64,7 +64,7 @@ function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
             const { name } = node;
             if (never && hasPrefixI(name.text)) {
                 ctx.addFailureAtNode(name, Rule.FAILURE_STRING_NO_PREFIX);
-            } else if (!never && name.text[0] !== "I") {
+            } else if (!never && !hasPrefixI(name.text) && !isEdgeCase(name.text)) {
                 ctx.addFailureAtNode(name, Rule.FAILURE_STRING);
             }
         } else {
@@ -75,4 +75,8 @@ function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
 
 function hasPrefixI(name: string): boolean {
     return name.length >= 3 && name[0] === "I" && !isLowerCase(name[1]) && !isUpperCase(name[2]);
+}
+
+function isEdgeCase(name: string): boolean {
+    return name.length === 2 && name[0] === "I" && !isLowerCase(name[1]);
 }

--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -74,6 +74,10 @@ function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
 }
 
 function hasPrefixI(name: string): boolean {
-    // Allow IndexedDB interfaces
-    return name.length >= 2 && name[0] === "I" && isUpperCase(name[1]) && !name.startsWith("IDB");
+    return name.length >= 2 && name[0] === "I" && isUpperCase(name[1]) && !isSpecialCase(name);
+}
+
+function isSpecialCase(name: string): boolean {
+    // Allow IndexedDB and I18n interfaces
+    return name.startsWith("IDB") || name.startsWith("I18n");
 }

--- a/test/rules/interface-name/always-prefix/test.ts.lint
+++ b/test/rules/interface-name/always-prefix/test.ts.lint
@@ -2,7 +2,20 @@
 interface IOptions {
 }
 
+interface ID {
+}
+
+interface IABC {
+}
+
+interface IDBFactory {
+}
+
 // invalid code
 interface Options {
           ~~~~~~~   [interface name must start with a capitalized I]
+}
+
+interface Incomplete {
+          ~~~~~~~~~~   [interface name must start with a capitalized I]
 }

--- a/test/rules/interface-name/never-prefix/test.ts.lint
+++ b/test/rules/interface-name/never-prefix/test.ts.lint
@@ -8,6 +8,9 @@ interface I {
 interface IDBFactory {
 }
 
+interface I18nFactory {
+}
+
 interface ABC {
 }
 

--- a/test/rules/interface-name/never-prefix/test.ts.lint
+++ b/test/rules/interface-name/never-prefix/test.ts.lint
@@ -5,6 +5,12 @@ interface Index {
 interface I {
 }
 
+interface ID {
+}
+
+interface IABC {
+}
+
 interface IDBFactory {
 }
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4476
- [x] New feature, bugfix, or enhancement
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Interface name (never-prefix) doesn't return error for I18nSomething

#### CHANGELOG.md entry:

[bugfix] `interface-name` now handles interface starting with "I18n" correctly
