### PR TITLE
Fix behavior of jsRules:true to include explicitly disabled rules.

### DIFF
--- a/docs/usage/configuration/index.md
+++ b/docs/usage/configuration/index.md
@@ -31,7 +31,7 @@ configure which rules get run and each of their options.
     -   Legacy: A boolean value may be specified instead of the above object, and is equivalent to setting no options with default severity.
     -   Any rules specified in this block will override those configured in any base configuration being extended.
     -   [Check out the full rules list here][3].
--   `jsRules?: any | boolean`: Same format as `rules` or explicit `true` to copy all valid active rules from rules. These rules are applied to `.js` and `.jsx` files.
+-   `jsRules?: any | boolean`: Same format as `rules` or explicit `true` to copy all rule configurations for JS-compatible rules from `rules`. These rules are applied to `.js` and `.jsx` files.
 -   `defaultSeverity?: "error" | "warning" | "off"`: The severity level that is applied to rules in this config file as well as rules in any inherited config files which have their severity set to "default". If undefined, "error" is used as the defaultSeverity.
 -   `linterOptions?: { exclude?: string[] }`:
     -   `exclude: string[]`: An array of globs. Any file matching these globs will not be linted. All exclude patterns are relative to the configuration file they were specified in.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -592,14 +592,12 @@ export function parseConfigFile(
         const validJsRules = new Map<string, Partial<IOptions>>();
         if (copyRulestoJsRules) {
             rules.forEach((ruleOptions, ruleName) => {
-                if (ruleOptions.ruleSeverity !== "off") {
-                    const Rule = findRule(ruleName, rulesDirectory);
-                    if (
-                        Rule !== undefined &&
-                        (Rule.metadata === undefined || !Rule.metadata.typescriptOnly)
-                    ) {
-                        validJsRules.set(ruleName, ruleOptions);
-                    }
+                const Rule = findRule(ruleName, rulesDirectory);
+                if (
+                    Rule !== undefined &&
+                    (Rule.metadata === undefined || !Rule.metadata.typescriptOnly)
+                ) {
+                    validJsRules.set(ruleName, ruleOptions);
                 }
             });
         }

--- a/test/configurationTests.ts
+++ b/test/configurationTests.ts
@@ -141,6 +141,7 @@ describe("Configuration", () => {
             rawConfig = {
                 jsRules: true,
                 rules: {
+                    // valid rule for JS
                     eofline: true,
                 },
             };
@@ -151,7 +152,9 @@ describe("Configuration", () => {
             rawConfig = {
                 jsRules: true,
                 rules: {
-                    eofline: true,
+                    // valid rule for JS, disabled (should be copied over)
+                    eofline: false,
+                    // non-valid rule for JS (should NOT be copied over)
                     typedef: true,
                 },
             };


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4513
- [x] bugfix
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Changed behavior of `jsRules:true` to copy over ALL rule configurations that are compatible with JS, including any that are explicitly disabled.

#### Is there anything you'd like reviewers to focus on?

The original PR (https://github.com/palantir/tslint/pull/3641) that added `jsRules:true` functionality seemed to make a point to describe its desired/implemented behavior to copy over all "active" rules that are valid for JS. Does the term "active" mean something special that is not simply "those that are not disabled"? Is there still some kind of rule configurations that I should be skipping over?

#### CHANGELOG.md entry:
[bugfix] Explicit disabling of rules is now copied over to jsRules when using jsRules:true
