### PR TITLE
Improve typedef for callback used as parameter

### DIFF
--- a/src/rules/typedefRule.ts
+++ b/src/rules/typedefRule.ts
@@ -148,7 +148,7 @@ class TypedefWalker extends Lint.AbstractWalker<Options> {
     }
 
     private checkArrowFunction({ parent, parameters, type }: ts.ArrowFunction): void {
-        if (parent.kind !== ts.SyntaxKind.CallExpression && !isTypedPropertyDeclaration(parent)) {
+        if (!isTypedPropertyDeclaration(parent)) {
             this.checkTypeAnnotation("arrow-call-signature", parameters, type);
         }
     }

--- a/test/rules/typedef/all/test.ts.lint
+++ b/test/rules/typedef/all/test.ts.lint
@@ -76,12 +76,15 @@ class TsLint {
 }
 
 setTimeout(() => {}, 1000);
+           ~~            [expected arrow-call-signature to have a typedef]
 setTimeout(function() {}, 1000);
                    ~~            [expected call-signature to have a typedef]
 
 someFunc(n => n+1);
+        ~~~            [expected arrow-call-signature to have a typedef]
          ~        [expected arrow-parameter: 'n' to have a typedef]
 someFunc(n => {});
+        ~~~            [expected arrow-call-signature to have a typedef]
          ~        [expected arrow-parameter: 'n' to have a typedef]
 
 class A {

--- a/test/rules/typedef/arrow-call-signature/test.ts.lint
+++ b/test/rules/typedef/arrow-call-signature/test.ts.lint
@@ -18,7 +18,13 @@ var obj = {
 }
 
 setTimeout(() => {}, 1000);
+           ~~       [expected arrow-call-signature to have a typedef]
 setTimeout(function() {}, 1000);
 
+const foo = n => n+1
+          ~~~~       [expected arrow-call-signature to have a typedef]
+
 someFunc(n => n+1);
+        ~~~       [expected arrow-call-signature to have a typedef]
 someFunc(n => {});
+        ~~~       [expected arrow-call-signature to have a typedef]

--- a/test/rules/typedef/arrow-parameter/test.ts.lint
+++ b/test/rules/typedef/arrow-parameter/test.ts.lint
@@ -3,3 +3,11 @@ var NoTypesFn = function (a, b) {}
 var NoTypesArrowFn = (a, b) => {}
                       ~ [expected arrow-parameter: 'a' to have a typedef]
                          ~ [expected arrow-parameter: 'b' to have a typedef]
+
+someFunc(n => n+1);
+         ~ [expected arrow-parameter: 'n' to have a typedef]
+someFunc((n) => n+1);
+          ~ [expected arrow-parameter: 'n' to have a typedef]
+someFunc((n,m) => n+m);
+          ~ [expected arrow-parameter: 'n' to have a typedef]
+            ~ [expected arrow-parameter: 'm' to have a typedef]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #227 ; #2000
- [x] Includes tests

#### Overview of change:
Typedef `arrow-call-signature` now return error for
```
someFunc(() => {});
```

#### Is there anything you'd like reviewers to focus on?
Actually, with all typedef rules actives.
```
const A = () => {} // error (return type)
someFunc(() => {}); // no error
someFunc((n) => {}); // error (param type)
setTimeout(function() {}, 1000); // error (return type)
```
After the PR, error everywhere ; for consistency.

Here https://github.com/palantir/tslint/issues/2000#issuecomment-435629910, a suggestion is a `child-arrow-call-signature`. That's a possibility, but we have to (for consistency) add a `child-arrow-parameter` too, which is also a suggestion here https://github.com/palantir/tslint/issues/813.
We, then, have to decide before if we want also a `child-parameter` and a `child-call-signature`.

I can do it if you prefer. 
Personally I don't think all these options are necessary. The typedef is a _style rule_ for people who want to type the code (more like a documentation) even if it's not necessary thanks to inference. If you don't want to be redundant and infer as much type you can, just use the `noImplicitAny` option in `tsconfig`.


#### CHANGELOG.md entry:

[enhancement] `typedef` rule `arrow-call-signature` option is more consistent in reporting errors on lambdas and will flag more violations that were missed in the previous rule implementation.