### PR TITLE
Fix #4514: [quotemark: backtick] Incorrectly flags string literals that must use single/double quotes

### DIFF
--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isNoSubstitutionTemplateLiteral, isSameLine, isStringLiteral } from "tsutils";
+import { isNoSubstitutionTemplateLiteral, isSameLine, isStringLiteral, isImportDeclaration, isPropertyAssignment } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -121,6 +121,14 @@ function walk(ctx: Lint.WalkContext<Options>) {
                     ? options.jsxQuotemark
                     : options.quotemark;
             const actualQuotemark = sourceFile.text[node.end - 1];
+
+            // Don't use backticks when it breaks TypeScript syntax.
+            if (expectedQuotemark === '`' &&
+                (isImportDeclaration(node.parent) ||
+                    isPropertyAssignment(node.parent))
+            ) {
+                return;
+            }
 
             if (actualQuotemark === expectedQuotemark) {
                 return;

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -122,7 +122,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
                     : options.quotemark;
             const actualQuotemark = sourceFile.text[node.end - 1];
 
-            // Don't use backticks when it breaks TypeScript syntax.
+            // Don't use backticks instead of single/double quotes when it breaks TypeScript syntax.
             if (expectedQuotemark === '`' &&
                 (isImportDeclaration(node.parent) ||
                     isPropertyAssignment(node.parent))

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -14,8 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { isNoSubstitutionTemplateLiteral, isSameLine, isStringLiteral, isImportDeclaration, isPropertyAssignment } from "tsutils";
+import {
+    isImportDeclaration,
+    isNoSubstitutionTemplateLiteral,
+    isPropertyAssignment,
+    isSameLine,
+    isStringLiteral,
+} from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -123,9 +128,9 @@ function walk(ctx: Lint.WalkContext<Options>) {
             const actualQuotemark = sourceFile.text[node.end - 1];
 
             // Don't use backticks instead of single/double quotes when it breaks TypeScript syntax.
-            if (expectedQuotemark === '`' &&
-                (isImportDeclaration(node.parent) ||
-                    isPropertyAssignment(node.parent))
+            if (
+                expectedQuotemark === "`" &&
+                (isImportDeclaration(node.parent) || isPropertyAssignment(node.parent))
             ) {
                 return;
             }

--- a/test/rules/quotemark/backtick/test.ts.fix
+++ b/test/rules/quotemark/backtick/test.ts.fix
@@ -1,3 +1,5 @@
+import { Something } from "some-package"
+
 var single = `single`;
     var double = `married`;
 var singleWithinDouble = `'singleWithinDouble'`;
@@ -7,3 +9,5 @@ var tabNewlineWithinSingle = `tab\tNewline\nWithinSingle`;
 
 // "avoid-template" option is not set.
 `foo`;
+
+const object = { "kebab-case": 3 }

--- a/test/rules/quotemark/backtick/test.ts.lint
+++ b/test/rules/quotemark/backtick/test.ts.lint
@@ -1,3 +1,5 @@
+import { Something } from "some-package"
+
 var single = 'single';
              ~~~~~~~~  [' should be `]
     var double = "married";
@@ -13,3 +15,5 @@ var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
 
 // "avoid-template" option is not set.
 `foo`;
+
+const object = { "kebab-case": 3 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4514 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Don't use backticks instead of single/double quotes when it breaks TypeScript syntax.

#### Is there anything you'd like reviewers to focus on?

Any other edge cases.

#### CHANGELOG.md entry:

[bugfix] `quotemark: backtick` no longer incorrectly flags string literals that must use single/double quotes
