### PR TITLE
fix for #4518: (no-trailing-whitespace) flags leading empty line as error

### DIFF
--- a/src/rules/noTrailingWhitespaceRule.ts
+++ b/src/rules/noTrailingWhitespaceRule.ts
@@ -92,10 +92,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
         if (
             match !== null &&
             !(ctx.options.ignoreBlankLines && match.index === 0) &&
-            // See https://github.com/palantir/tslint/issues/4518
-            // and https://github.com/ajafff/tsutils/issues/94
-            // TODO: Remove this check once tsutils handles Byte Order Markers correctly.
-            match[0].charCodeAt(0) !== ZERO_WIDTH_NO_BREAK_SPACE
+            (match[0] !== String.fromCharCode(ZERO_WIDTH_NO_BREAK_SPACE))
         ) {
             possibleFailures.push({
                 end: line.pos + line.contentLength,

--- a/src/rules/noTrailingWhitespaceRule.ts
+++ b/src/rules/noTrailingWhitespaceRule.ts
@@ -92,7 +92,7 @@ function walk(ctx: Lint.WalkContext<Options>) {
         if (
             match !== null &&
             !(ctx.options.ignoreBlankLines && match.index === 0) &&
-            (match[0] !== String.fromCharCode(ZERO_WIDTH_NO_BREAK_SPACE))
+            match[0] !== String.fromCharCode(ZERO_WIDTH_NO_BREAK_SPACE)
         ) {
             possibleFailures.push({
                 end: line.pos + line.contentLength,

--- a/test/rules/no-trailing-whitespace/zero-width-no-break-space/test.ts.lint
+++ b/test/rules/no-trailing-whitespace/zero-width-no-break-space/test.ts.lint
@@ -1,0 +1,4 @@
+﻿
+// This file starts with a zero width no-break-space.
+// See http://www.fileformat.info/info/unicode/char/feff/index.htm
+const a = 3;

--- a/test/rules/no-trailing-whitespace/zero-width-no-break-space/test2.ts.lint
+++ b/test/rules/no-trailing-whitespace/zero-width-no-break-space/test2.ts.lint
@@ -1,0 +1,5 @@
+﻿ 
+~~ [trailing whitespace]
+// This file starts with a zero width no-break-space followed by a trailing space.
+// See http://www.fileformat.info/info/unicode/char/feff/index.htm
+const a = 3;

--- a/test/rules/no-trailing-whitespace/zero-width-no-break-space/tslint.json
+++ b/test/rules/no-trailing-whitespace/zero-width-no-break-space/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-trailing-whitespace": true
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #4518 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Temporary fix to handle files starting with a byte order mark (see https://github.com/ajafff/tsutils/issues/94).

#### CHANGELOG.md entry:

[bugfix] `no-trailing-whitespace` no longer flags files starting with a byte order mark
