### PR TITLE
Implement 4201: add option to ignore shadowed underscore

### DIFF
--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -63,8 +63,8 @@ export class Rule extends Lint.Rules.AbstractRule {
         `,
         optionsDescription: Lint.Utils.dedent`
             You can optionally pass an object to disable checking for certain kinds of declarations.
-            Possible keys are \`"class"\`, \`"enum"\`, \`"function"\`, \`"import"\`, \`"interface"\`, \`"namespace"\`, \`"typeAlias"\`
-            and \`"typeParameter"\`. Just set the value to \`false\` for the check you want to disable.
+            Possible keys are \`"class"\`, \`"enum"\`, \`"function"\`, \`"import"\`, \`"interface"\`, \`"namespace"\`, \`"typeAlias"\`,
+            \`"typeParameter"\` and \`"underscore"\`. Just set the value to \`false\` for the check you want to disable.
             All checks default to \`true\`, i.e. are enabled by default.
             Note that you cannot disable variables and parameters.
 
@@ -101,6 +101,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                 typeAlias: { type: "boolean" },
                 typeParameter: { type: "boolean" },
                 temporalDeadZone: { type: "boolean" },
+                underscore: { type: "boolean" },
             },
         },
         optionExamples: [
@@ -115,6 +116,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                     namespace: true,
                     typeAlias: false,
                     typeParameter: false,
+                    underscore: false,
                 },
             ],
         ],
@@ -147,7 +149,8 @@ type Kind =
     | "namespace"
     | "typeParameter"
     | "typeAlias"
-    | "temporalDeadZone";
+    | "temporalDeadZone"
+    | "underscore";
 type Options = Record<Kind, boolean>;
 
 function parseOptions(option: Partial<Options> | undefined): Options {
@@ -161,6 +164,7 @@ function parseOptions(option: Partial<Options> | undefined): Options {
         temporalDeadZone: true,
         typeAlias: true,
         typeParameter: true,
+        underscore: true,
         ...option,
     };
 }
@@ -402,7 +406,8 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
                         declarationsInScope.some(
                             declaration =>
                                 !declaration.tdz || declaration.identifier.pos < identifier.pos,
-                        ))
+                        )) &&
+                    (this.options.underscore || identifier.getText() !== "_")
                 ) {
                     this.addFailureAtNode(identifier, Rule.FAILURE_STRING_FACTORY(name));
                 } else if (parent !== undefined) {

--- a/src/rules/noShadowedVariableRule.ts
+++ b/src/rules/noShadowedVariableRule.ts
@@ -63,8 +63,9 @@ export class Rule extends Lint.Rules.AbstractRule {
         `,
         optionsDescription: Lint.Utils.dedent`
             You can optionally pass an object to disable checking for certain kinds of declarations.
-            Possible keys are \`"class"\`, \`"enum"\`, \`"function"\`, \`"import"\`, \`"interface"\`, \`"namespace"\`, \`"typeAlias"\`,
-            \`"typeParameter"\` and \`"underscore"\`. Just set the value to \`false\` for the check you want to disable.
+            Possible keys are \`"class"\`, \`"enum"\`, \`"function"\`, \`"import"\`, \`"interface"\`, \`"namespace"\`, \`"typeAlias"\`
+            and \`"typeParameter"\`. You can also pass \`"underscore\`" to ignore variable names that begin with \`_\`.
+            Just set the value to \`false\` for the check you want to disable.
             All checks default to \`true\`, i.e. are enabled by default.
             Note that you cannot disable variables and parameters.
 
@@ -407,7 +408,7 @@ class NoShadowedVariableWalker extends Lint.AbstractWalker<Options> {
                             declaration =>
                                 !declaration.tdz || declaration.identifier.pos < identifier.pos,
                         )) &&
-                    (this.options.underscore || identifier.getText() !== "_")
+                    (this.options.underscore || !identifier.getText().startsWith("_"))
                 ) {
                     this.addFailureAtNode(identifier, Rule.FAILURE_STRING_FACTORY(name));
                 } else if (parent !== undefined) {

--- a/test/rules/no-shadowed-variable/default/test.ts.lint
+++ b/test/rules/no-shadowed-variable/default/test.ts.lint
@@ -2,6 +2,7 @@ import { Foo } from './foo';
 import * as Bar from '.bar';
 import Baz from './baz';
 import Bas = require('./bas');
+import _ = require('lodash');
 {
     const Foo = 'bar';
           ~~~ [err % ('Foo')]
@@ -11,6 +12,8 @@ import Bas = require('./bas');
           ~~~ [err % ('Baz')]
     const Bas = Baz;
           ~~~ [err % ('Bas')]
+    const _ = _;
+          ~ [err % ('_')]
 }
 function letTesting() {
     var a = 1;

--- a/test/rules/no-shadowed-variable/ignore-underscore/test.ts.lint
+++ b/test/rules/no-shadowed-variable/ignore-underscore/test.ts.lint
@@ -3,3 +3,8 @@ import _ = require('lodash');
 function foo(_) {
     console.log(_);
 }
+
+function foo(_1, _2) {
+    // Allow shadowing of multiple unused parameters
+    [].map((_1, _2) => undefined);
+}

--- a/test/rules/no-shadowed-variable/ignore-underscore/test.ts.lint
+++ b/test/rules/no-shadowed-variable/ignore-underscore/test.ts.lint
@@ -1,0 +1,5 @@
+import _ = require('lodash');
+
+function foo(_) {
+    console.log(_);
+}

--- a/test/rules/no-shadowed-variable/ignore-underscore/tslint.json
+++ b/test/rules/no-shadowed-variable/ignore-underscore/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "no-shadowed-variable": [true, {"underscore": false}]
+    }
+  }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4201
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Add option to ignore shadowed underscore.

**Usage**

```json
{
  "rules": {
    "no-shadowed-variable": [true, {"underscore": false}]
  }
}
```

**Before**

```javascript
import _ = require('lodash');
function foo(_) {
             ~ [Shadowed name: '_']
    console.log(_);
}
```

**After**

```javascript
import _ = require('lodash');
function foo(_) {
    // No lint error
    console.log(_);
}
```

#### Is there anything you'd like reviewers to focus on?

Have I made all the necessary changes to documentation?

#### CHANGELOG.md entry:

[enhancement]: added option to `no-shadowed-variable` to ignore shadowed underscores