### PR TITLE
Add `allow-delete` option to `no-unbound-method` rule

### DIFF
--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -66,6 +66,7 @@ export class Rule extends Lint.Rules.TypedRule {
             The object may have three properties:
             
             * "${OPTION_IGNORE_STATIC}" - to ignore static methods.
+            * "${OPTION_ALLOW_DELETE}" - ignore methods referenced in a delete expression.
             * "${OPTION_ALLOW_TYPEOF}" - ignore methods referenced in a typeof expression.
             * "${OPTION_WHITELIST}" - ignore method references in parameters of specifed function calls.
             
@@ -79,6 +80,7 @@ export class Rule extends Lint.Rules.TypedRule {
                 {
                     type: "object",
                     properties: {
+                        [OPTION_ALLOW_DELETE]: { type: "boolean" },
                         [OPTION_ALLOW_TYPEOF]: { type: "boolean" },
                         [OPTION_IGNORE_STATIC]: { type: "boolean" },
                         [OPTION_WHITELIST]: {

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -18,6 +18,7 @@
 import {
     hasModifier,
     isCallExpression,
+    isDeleteExpression,
     isIdentifier,
     isPropertyAccessExpression,
     isTypeOfExpression,
@@ -232,7 +233,10 @@ function isSafeUse(node: ts.Node): boolean {
 }
 
 function isWhitelisted(node: ts.Node, options: Options): boolean {
-    const { whitelist, allowTypeof } = options;
+    const { whitelist, allowTypeof, allowDelete } = options;
+    if (isDeleteExpression(node.parent)) {
+        return allowDelete;
+    }
     if (isTypeOfExpression(node.parent)) {
         return allowTypeof;
     }

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -174,9 +174,7 @@ function walk(ctx: Lint.WalkContext<Options>, tc: ts.TypeChecker) {
 
             const isMethodAccess =
                 declaration !== undefined && isMethod(declaration, ctx.options.ignoreStatic);
-            const shouldBeReported =
-                isMethodAccess &&
-                !isWhitelisted(node, ctx.options.whitelist, ctx.options.allowTypeof);
+            const shouldBeReported = isMethodAccess && !isWhitelisted(node, ctx.options);
             if (shouldBeReported) {
                 ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
             }
@@ -228,7 +226,8 @@ function isSafeUse(node: ts.Node): boolean {
     }
 }
 
-function isWhitelisted(node: ts.Node, whitelist: Set<string>, allowTypeof: boolean): boolean {
+function isWhitelisted(node: ts.Node, options: Options): boolean {
+    const { whitelist, allowTypeof } = options;
     if (isTypeOfExpression(node.parent)) {
         return allowTypeof;
     }

--- a/src/rules/noUnboundMethodRule.ts
+++ b/src/rules/noUnboundMethodRule.ts
@@ -29,6 +29,7 @@ import * as Lint from "../index";
 const OPTION_IGNORE_STATIC = "ignore-static";
 const OPTION_WHITELIST = "whitelist";
 const OPTION_ALLOW_TYPEOF = "allow-typeof";
+const OPTION_ALLOW_DELETE = "allow-delete";
 
 const OPTION_WHITELIST_EXAMPLE = [
     true,
@@ -40,12 +41,14 @@ const OPTION_WHITELIST_EXAMPLE = [
 ];
 
 interface Options {
+    allowDelete: boolean;
     allowTypeof: boolean;
     ignoreStatic: boolean;
     whitelist: Set<string>;
 }
 
 interface OptionsInput {
+    [OPTION_ALLOW_DELETE]?: boolean;
     [OPTION_ALLOW_TYPEOF]?: boolean;
     [OPTION_IGNORE_STATIC]?: boolean;
     [OPTION_WHITELIST]?: string[];
@@ -146,6 +149,7 @@ export class Rule extends Lint.Rules.TypedRule {
 
 function parseArguments(args: Array<string | OptionsInput>): Options {
     const options: Options = {
+        allowDelete: false,
         allowTypeof: false,
         ignoreStatic: false,
         whitelist: new Set(),
@@ -157,6 +161,7 @@ function parseArguments(args: Array<string | OptionsInput>): Options {
                 options.ignoreStatic = true;
             }
         } else {
+            options.allowDelete = arg[OPTION_ALLOW_DELETE] || false;
             options.allowTypeof = arg[OPTION_ALLOW_TYPEOF] || false;
             options.ignoreStatic = arg[OPTION_IGNORE_STATIC] || false;
             options.whitelist = new Set(arg[OPTION_WHITELIST]);

--- a/test/rules/no-unbound-method/default/test.tsx.lint
+++ b/test/rules/no-unbound-method/default/test.tsx.lint
@@ -56,4 +56,13 @@ class Validators {
 Validators.compose(Validators.required);
                    ~~~~~~~~~~~~~~~~~~~ [0]
 
+const a = {
+    getText() {
+        return 'text';
+    }
+};
+
+delete a.getText;
+       ~~~~~~~~~ [0]
+
 [0]: Avoid referencing unbound methods which may cause unintentional scoping of 'this'.

--- a/test/rules/no-unbound-method/whitelist/test.tsx.lint
+++ b/test/rules/no-unbound-method/whitelist/test.tsx.lint
@@ -69,4 +69,12 @@ Validators.compose(Validators.required);
 (await someMethod())(c.method);
                      ~~~~~~~~ [0]
 
+const a = {
+  getText() {
+    return 'text';
+  }
+};
+
+delete a.getText;
+
 [0]: Avoid referencing unbound methods which may cause unintentional scoping of 'this'.

--- a/test/rules/no-unbound-method/whitelist/tslint.json
+++ b/test/rules/no-unbound-method/whitelist/tslint.json
@@ -3,6 +3,6 @@
     "typeCheck": true
   },
   "rules": {
-    "no-unbound-method": [true, { "whitelist": ["expect"], "allow-typeof": true }]
+    "no-unbound-method": [true, { "whitelist": ["expect"], "allow-typeof": true, "allow-delete": true }]
   }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: #3801
- [x] enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Added configuration option to `no-unbound-method` that does allows not reporting errors in `delete` statements `delete obj.method;`

#### Is there anything you'd like reviewers to focus on?

#### CHANGELOG.md entry:

[new-rule-option] Added `allow-delete` option to `no-unbound-method` rule
