### PR TITLE
Address 2637: Relax promise-function-async for short arrow functions

### DIFF
--- a/src/rules/promiseFunctionAsyncRule.ts
+++ b/src/rules/promiseFunctionAsyncRule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { hasModifier } from "tsutils";
+import { hasModifier, isCallExpression } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -103,10 +103,11 @@ function walk(ctx: Lint.WalkContext<EnabledSyntaxKinds>, tc: ts.TypeChecker) {
     const { sourceFile, options } = ctx;
     return ts.forEachChild(sourceFile, function cb(node): void {
         if (options.has(node.kind)) {
+            const declaration = node as ts.FunctionLikeDeclaration;
             switch (node.kind) {
                 case ts.SyntaxKind.MethodDeclaration:
                 case ts.SyntaxKind.FunctionDeclaration:
-                    if ((node as ts.FunctionLikeDeclaration).body === undefined) {
+                    if (declaration.body === undefined) {
                         break;
                     }
                 // falls through
@@ -114,7 +115,8 @@ function walk(ctx: Lint.WalkContext<EnabledSyntaxKinds>, tc: ts.TypeChecker) {
                 case ts.SyntaxKind.ArrowFunction:
                     if (
                         !hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword) &&
-                        returnsPromise(node as ts.FunctionLikeDeclaration, tc)
+                        returnsPromise(declaration, tc) &&
+                        !isCallExpression(declaration.body as ts.Expression)
                     ) {
                         ctx.addFailure(
                             node.getStart(sourceFile),

--- a/test/rules/promise-function-async/test.ts.lint
+++ b/test/rules/promise-function-async/test.ts.lint
@@ -62,6 +62,9 @@ class Test {
     public nonAsyncNonPromiseMethod(n: number) {
         return n;
     }
+
+    // single statement lamda functions that delegate to another promise-returning function are allowed
+    public delegatingMethod = () => this.asyncPromiseMethodB(1);
 }
 
 [0]: functions that return promises must be async


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #2637 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Single statement lamda functions that delegate to another promise-returning function are allowed.

**Configuration**

```json
{
  "rules": {
    "promise-function-async": true
  }
}
```

**Before**

```typescript
public async asyncPromiseMethodB() {
    return new Promise<void>();
}

public delegatingMethod = () => this.asyncPromiseMethodB(1);
                          ~~~~~ [functions that return promises must be async]
```

**After**

```typescript
public async asyncPromiseMethodB() {
    return new Promise<void>();
}

public delegatingMethod = () => this.asyncPromiseMethodB(1);
                          // No lint error
```

#### CHANGELOG.md entry:

[enhancement] `promise-function-async` now allows single statement lamda functions that delegate to another promise-returning function
