### PR TITLE
Add whitespace rule for ExportDeclaration

### DIFF
--- a/src/rules/whitespaceRule.ts
+++ b/src/rules/whitespaceRule.ts
@@ -170,6 +170,22 @@ function walk(ctx: Lint.WalkContext<Options>) {
                 }
                 break;
 
+            case ts.SyntaxKind.ExportDeclaration:
+                const { exportClause } = node as ts.ExportDeclaration;
+                if (options.module && exportClause !== undefined) {
+                    exportClause.elements.forEach((element, idx, arr) => {
+                        if (idx === arr.length - 1) {
+                            const token = exportClause.getLastToken()!;
+                            checkForTrailingWhitespace(token.getFullStart());
+                        }
+                        if (idx === 0) {
+                            const startPos = element.getStart() - 1;
+                            checkForTrailingWhitespace(startPos, startPos + 1);
+                        }
+                    });
+                }
+                break;
+
             case ts.SyntaxKind.FunctionType:
                 checkEqualsGreaterThanTokenInNode(node);
                 break;

--- a/test/rules/whitespace/all/test.ts.fix
+++ b/test/rules/whitespace/all/test.ts.fix
@@ -84,8 +84,12 @@ export function each(obj, iterator, context) {
     //
 }
 
-export {each as forEach};
+export { each as forEach };
 import "libE";
+
+const E = 123;
+const F = 123;
+export { E, F };
 
 function foobar() {}
 

--- a/test/rules/whitespace/all/test.ts.lint
+++ b/test/rules/whitespace/all/test.ts.lint
@@ -144,7 +144,16 @@ export function each(obj, iterator, context) {
 }
 
 export {each as forEach};
+        ~ [missing whitespace]
+                       ~ [missing whitespace]
 import "libE";
+
+const E = 123;
+const F = 123;
+export {E,F};
+        ~ [missing whitespace]
+          ~ [missing whitespace]
+           ~ [missing whitespace]
 
 function foobar(){}
                  ~ [missing whitespace]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4014 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Adds a case to handle ExportDeclaration, to properly lint and fix statements such as:
```ts
export { A, B };
```

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[bugfix] Lint export statements with `whitespace` rule