### PR TITLE
Fix regression in CheckstyleFormatter backwards compatibility

### DIFF
--- a/src/formatters/checkstyleFormatter.ts
+++ b/src/formatters/checkstyleFormatter.ts
@@ -38,8 +38,8 @@ export class Formatter extends AbstractFormatter {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public format(failures: RuleFailure[], _fixes: RuleFailure[], fileNames: string[]): string {
-        const groupedFailures: { [k: string]: RuleFailure[] } = {};
+    public format(failures: RuleFailure[], _fixes?: RuleFailure[], fileNames?: string[]): string {
+        const groupedFailures: { [fileName: string]: RuleFailure[] } = {};
         for (const failure of failures) {
             const fileName = failure.getFileName();
             if (groupedFailures[fileName] !== undefined) {
@@ -47,6 +47,10 @@ export class Formatter extends AbstractFormatter {
             } else {
                 groupedFailures[fileName] = [failure];
             }
+        }
+
+        if (fileNames === undefined) {
+            fileNames = Object.keys(groupedFailures);
         }
 
         const formattedFiles = fileNames.map(fileName => {

--- a/src/language/formatter/abstractFormatter.ts
+++ b/src/language/formatter/abstractFormatter.ts
@@ -23,8 +23,8 @@ export abstract class AbstractFormatter implements IFormatter {
     public static metadata: IFormatterMetadata;
     public abstract format(
         failures: RuleFailure[],
-        fixes: RuleFailure[],
-        fileNames: string[],
+        fixes?: RuleFailure[],
+        fileNames?: string[],
     ): string;
 
     protected sortFailures(failures: RuleFailure[]): RuleFailure[] {


### PR DESCRIPTION
Fixes #4555 

#### CHANGELOG.md entry:

[bugfix] Fixed regression in CheckstyleFormatter backwards compatibility

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
