### PR TITLE
Added an overloads option in completed-docs

### DIFF
--- a/src/rules/completed-docs/exclusions.ts
+++ b/src/rules/completed-docs/exclusions.ts
@@ -16,7 +16,7 @@
  */
 
 import { hasOwnProperty } from "../../utils";
-import { DESCRIPTOR_OVERLOADS_SEPARATE_DOCS, DocType } from "../completedDocsRule";
+import { DESCRIPTOR_OVERLOADS, DocType } from "../completedDocsRule";
 
 import { BlockExclusion, IBlockExclusionDescriptor } from "./blockExclusion";
 import { ClassExclusion, IClassExclusionDescriptor } from "./classExclusion";
@@ -63,8 +63,8 @@ const createRequirementsForDocType = (docType: DocType, descriptor: InputExclusi
     const requirements = [];
     let overloadsSeparateDocs = false;
 
-    if (typeof descriptor === "object" && DESCRIPTOR_OVERLOADS_SEPARATE_DOCS in descriptor) {
-        overloadsSeparateDocs = !!(descriptor as any)[DESCRIPTOR_OVERLOADS_SEPARATE_DOCS];
+    if (typeof descriptor === "object" && DESCRIPTOR_OVERLOADS in descriptor) {
+        overloadsSeparateDocs = !!(descriptor as any)[DESCRIPTOR_OVERLOADS];
     }
 
     if (docType === "methods" || docType === "properties") {

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -592,7 +592,7 @@ function getSiblings(node: ts.Node) {
         return [...parent.statements];
     }
 
-    return parent.getChildren()!;
+    return parent.getChildren();
 }
 
 function isGetAccessor(node: ts.Node): node is ts.GetAccessorDeclaration {

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -21,7 +21,7 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 
 import { IInputExclusionDescriptors } from "./completed-docs/exclusionDescriptors";
-import { constructExclusionsMap, ExclusionsMap } from "./completed-docs/exclusionFactory";
+import { constructExclusionsMap, ExclusionsMap } from "./completed-docs/exclusions";
 
 export const ALL = "all";
 
@@ -38,7 +38,7 @@ export const ARGUMENT_VARIABLES = "variables";
 
 export const DESCRIPTOR_TAGS = "tags";
 export const DESCRIPTOR_LOCATIONS = "locations";
-export const DESCRIPTOR_OVERLOADS_SEPARATE_DOCS = "overloads-separate-docs";
+export const DESCRIPTOR_OVERLOADS = "overloads";
 export const DESCRIPTOR_PRIVACIES = "privacies";
 export const DESCRIPTOR_VISIBILITIES = "visibilities";
 
@@ -163,7 +163,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static ARGUMENT_DESCRIPTOR_FUNCTION = {
         properties: {
             ...Rule.ARGUMENT_DESCRIPTOR_BLOCK.properties,
-            [DESCRIPTOR_OVERLOADS_SEPARATE_DOCS]: {
+            [DESCRIPTOR_OVERLOADS]: {
                 type: "boolean",
             },
         },
@@ -173,7 +173,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     public static ARGUMENT_DESCRIPTOR_METHOD = {
         properties: {
             ...Rule.ARGUMENT_DESCRIPTOR_CLASS.properties,
-            [DESCRIPTOR_OVERLOADS_SEPARATE_DOCS]: {
+            [DESCRIPTOR_OVERLOADS]: {
                 type: "boolean",
             },
         },
@@ -204,7 +204,7 @@ export class Rule extends Lint.Rules.AbstractRule {
                     * \`"${ALL}"\`
                     * \`"${VISIBILITY_EXPORTED}"\`
                     * \`"${VISIBILITY_INTERNAL}"\`
-                * \`"${ARGUMENT_FUNCTIONS}"\` \`"${ARGUMENT_METHODS}"\` may also specify \`"${DESCRIPTOR_OVERLOADS_SEPARATE_DOCS}"\`
+                * \`"${ARGUMENT_FUNCTIONS}"\` \`"${ARGUMENT_METHODS}"\` may also specify \`"${DESCRIPTOR_OVERLOADS}"\`
                   to indicate that each overload should have its own documentation, which is \`false\` by default.
                 * All types may also provide \`"${DESCRIPTOR_TAGS}"\`
                   with members specifying tags that allow the docs to not have a body.

--- a/src/rules/completedDocsRule.ts
+++ b/src/rules/completedDocsRule.ts
@@ -21,7 +21,7 @@ import * as ts from "typescript";
 import * as Lint from "../index";
 
 import { IInputExclusionDescriptors } from "./completed-docs/exclusionDescriptors";
-import { ExclusionFactory, ExclusionsMap } from "./completed-docs/exclusionFactory";
+import { constructExclusionsMap, ExclusionsMap } from "./completed-docs/exclusionFactory";
 
 export const ALL = "all";
 
@@ -38,6 +38,7 @@ export const ARGUMENT_VARIABLES = "variables";
 
 export const DESCRIPTOR_TAGS = "tags";
 export const DESCRIPTOR_LOCATIONS = "locations";
+export const DESCRIPTOR_OVERLOADS_SEPARATE_DOCS = "overloads-separate-docs";
 export const DESCRIPTOR_PRIVACIES = "privacies";
 export const DESCRIPTOR_VISIBILITIES = "visibilities";
 
@@ -159,6 +160,26 @@ export class Rule extends Lint.Rules.AbstractRule {
         type: "object",
     };
 
+    public static ARGUMENT_DESCRIPTOR_FUNCTION = {
+        properties: {
+            ...Rule.ARGUMENT_DESCRIPTOR_BLOCK.properties,
+            [DESCRIPTOR_OVERLOADS_SEPARATE_DOCS]: {
+                type: "boolean",
+            },
+        },
+        type: "object",
+    };
+
+    public static ARGUMENT_DESCRIPTOR_METHOD = {
+        properties: {
+            ...Rule.ARGUMENT_DESCRIPTOR_CLASS.properties,
+            [DESCRIPTOR_OVERLOADS_SEPARATE_DOCS]: {
+                type: "boolean",
+            },
+        },
+        type: "object",
+    };
+
     /* tslint:disable:object-literal-sort-keys */
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "completed-docs",
@@ -183,6 +204,8 @@ export class Rule extends Lint.Rules.AbstractRule {
                     * \`"${ALL}"\`
                     * \`"${VISIBILITY_EXPORTED}"\`
                     * \`"${VISIBILITY_INTERNAL}"\`
+                * \`"${ARGUMENT_FUNCTIONS}"\` \`"${ARGUMENT_METHODS}"\` may also specify \`"${DESCRIPTOR_OVERLOADS_SEPARATE_DOCS}"\`
+                  to indicate that each overload should have its own documentation, which is \`false\` by default.
                 * All types may also provide \`"${DESCRIPTOR_TAGS}"\`
                   with members specifying tags that allow the docs to not have a body.
                     * \`"${TAGS_FOR_CONTENT}"\`: Object mapping tags to \`RegExp\` bodies content allowed to count as complete docs.
@@ -224,9 +247,9 @@ export class Rule extends Lint.Rules.AbstractRule {
                             [ARGUMENT_CLASSES]: Rule.ARGUMENT_DESCRIPTOR_BLOCK,
                             [ARGUMENT_ENUMS]: Rule.ARGUMENT_DESCRIPTOR_BLOCK,
                             [ARGUMENT_ENUM_MEMBERS]: Rule.ARGUMENT_DESCRIPTOR_BLOCK,
-                            [ARGUMENT_FUNCTIONS]: Rule.ARGUMENT_DESCRIPTOR_BLOCK,
+                            [ARGUMENT_FUNCTIONS]: Rule.ARGUMENT_DESCRIPTOR_FUNCTION,
                             [ARGUMENT_INTERFACES]: Rule.ARGUMENT_DESCRIPTOR_BLOCK,
-                            [ARGUMENT_METHODS]: Rule.ARGUMENT_DESCRIPTOR_CLASS,
+                            [ARGUMENT_METHODS]: Rule.ARGUMENT_DESCRIPTOR_METHOD,
                             [ARGUMENT_NAMESPACES]: Rule.ARGUMENT_DESCRIPTOR_BLOCK,
                             [ARGUMENT_PROPERTIES]: Rule.ARGUMENT_DESCRIPTOR_CLASS,
                             [ARGUMENT_TYPES]: Rule.ARGUMENT_DESCRIPTOR_BLOCK,
@@ -264,15 +287,13 @@ export class Rule extends Lint.Rules.AbstractRule {
         rationale: Lint.Utils.dedent`
             Helps ensure important components are documented.
 
-            Note: use this rule sparingly. It's better to have self-documenting names on components with single, consice responsibilities.
+            Note: use this rule sparingly. It's better to have self-documenting names on components with single, concise responsibilities.
             Comments that only restate the names of variables add nothing to code, and can easily become outdated.
         `,
         type: "style",
         typescriptOnly: false,
     };
     /* tslint:enable:object-literal-sort-keys */
-
-    private readonly exclusionFactory = new ExclusionFactory();
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         const options = this.getOptions();
@@ -288,7 +309,7 @@ export class Rule extends Lint.Rules.AbstractRule {
             ruleArguments = [Rule.defaultArguments];
         }
 
-        return this.exclusionFactory.constructExclusionsMap(ruleArguments);
+        return constructExclusionsMap(ruleArguments);
     }
 }
 
@@ -364,7 +385,7 @@ function walk(context: Lint.WalkContext<ExclusionsMap>) {
             case ts.SyntaxKind.GetAccessor:
             case ts.SyntaxKind.SetAccessor:
                 if (node.parent.kind !== ts.SyntaxKind.ObjectLiteralExpression) {
-                    checkAccessorNode(node as ts.AccessorDeclaration);
+                    checkAccessorNode(node as ts.AccessorDeclaration, ARGUMENT_PROPERTIES);
                 }
         }
 
@@ -373,29 +394,29 @@ function walk(context: Lint.WalkContext<ExclusionsMap>) {
 
     function checkNode(
         node: ts.NamedDeclaration,
-        nodeType: DocType,
+        docType: DocType,
         requirementNode: ts.Node = node,
     ): void {
-        if (!nodeIsExcluded(node, nodeType, requirementNode) && !nodeHasDocs(node)) {
-            addDocumentationFailure(node, describeNode(nodeType), requirementNode);
+        if (!nodeIsExcluded(node, docType, requirementNode) && !nodeHasDocs(node, docType)) {
+            addDocumentationFailure(node, describeDocType(docType), requirementNode);
         }
     }
 
-    function checkAccessorNode(node: ts.AccessorDeclaration): void {
-        if (nodeIsExcluded(node, ARGUMENT_PROPERTIES, node) || nodeHasDocs(node)) {
+    function checkAccessorNode(node: ts.AccessorDeclaration, docType: DocType): void {
+        if (nodeIsExcluded(node, ARGUMENT_PROPERTIES, node) || nodeHasDocs(node, docType)) {
             return;
         }
 
         const correspondingAccessor = getCorrespondingAccessor(node);
 
-        if (correspondingAccessor === undefined || !nodeHasDocs(correspondingAccessor)) {
+        if (correspondingAccessor === undefined || !nodeHasDocs(correspondingAccessor, docType)) {
             addDocumentationFailure(node, ARGUMENT_PROPERTIES, node);
         }
     }
 
     function nodeIsExcluded(
         node: ts.NamedDeclaration,
-        nodeType: DocType,
+        docType: DocType,
         requirementNode: ts.Node,
     ): boolean {
         const { name } = node;
@@ -403,13 +424,13 @@ function walk(context: Lint.WalkContext<ExclusionsMap>) {
             return true;
         }
 
-        const exclusions = context.options.get(nodeType);
+        const exclusions = context.options.get(docType);
         if (exclusions === undefined) {
             return true;
         }
 
-        for (const exclusion of exclusions) {
-            if (exclusion.excludes(requirementNode)) {
+        for (const requirement of exclusions.requirements) {
+            if (requirement.excludes(requirementNode)) {
                 return true;
             }
         }
@@ -417,8 +438,8 @@ function walk(context: Lint.WalkContext<ExclusionsMap>) {
         return false;
     }
 
-    function nodeHasDocs(node: ts.Node): boolean {
-        const docs = getApparentJsDoc(node);
+    function nodeHasDocs(node: ts.Node, docType: DocType): boolean {
+        const docs = getApparentJsDoc(node, docType, context.sourceFile);
         if (docs === undefined) {
             return false;
         }
@@ -430,14 +451,80 @@ function walk(context: Lint.WalkContext<ExclusionsMap>) {
         return comments.length !== 0;
     }
 
+    /**
+     * @see https://github.com/ajafff/tsutils/issues/16
+     */
+    function getApparentJsDoc(
+        node: ts.Node,
+        docType: DocType,
+        sourceFile: ts.SourceFile,
+    ): ts.JSDoc[] | undefined {
+        if (ts.isVariableDeclaration(node)) {
+            if (variableIsAfterFirstInDeclarationList(node)) {
+                return undefined;
+            }
+
+            node = node.parent;
+        }
+
+        if (ts.isVariableDeclarationList(node)) {
+            node = node.parent;
+        }
+
+        const equivalentNodesForDocs: ts.Node[] = getEquivalentNodesForDocs(node, docType);
+
+        return equivalentNodesForDocs
+            .map(docsNode => tsutils.getJsDoc(docsNode, sourceFile))
+            .filter(nodeDocs => nodeDocs !== undefined)
+            .reduce((docs, moreDocs) => [...docs, ...moreDocs], []);
+    }
+
+    /**
+     * @see https://github.com/palantir/tslint/issues/4416
+     */
+    function getEquivalentNodesForDocs(node: ts.Node, docType: DocType): ts.Node[] {
+        const exclusions = context.options.get(docType);
+        if (exclusions === undefined || exclusions.overloadsSeparateDocs) {
+            return [node];
+        }
+
+        if (tsutils.isFunctionDeclaration(node) && node.name !== undefined) {
+            const functionName = node.name.text;
+
+            return getSiblings(node).filter(
+                child =>
+                    tsutils.isFunctionDeclaration(child) &&
+                    child.name !== undefined &&
+                    child.name.text === functionName,
+            );
+        }
+
+        if (
+            tsutils.isMethodDeclaration(node) &&
+            tsutils.isIdentifier(node.name) &&
+            tsutils.isClassDeclaration(node.parent)
+        ) {
+            const methodName = node.name.text;
+
+            return node.parent.members.filter(
+                member =>
+                    tsutils.isMethodDeclaration(member) &&
+                    tsutils.isIdentifier(member.name) &&
+                    member.name.text === methodName,
+            );
+        }
+
+        return [node];
+    }
+
     function addDocumentationFailure(
         node: ts.Node,
-        nodeType: string,
+        docType: string,
         requirementNode: ts.Node,
     ): void {
         const start = node.getStart();
         const width = node.getText().split(/\r|\n/g)[0].length;
-        const description = describeDocumentationFailure(requirementNode, nodeType);
+        const description = describeDocumentationFailure(requirementNode, docType);
 
         context.addFailureAt(start, width, description);
     }
@@ -466,25 +553,6 @@ function getCorrespondingAccessor(node: ts.AccessorDeclaration) {
     return undefined;
 }
 
-/**
- * @remarks See https://github.com/ajafff/tsutils/issues/16
- */
-function getApparentJsDoc(node: ts.Node): ts.JSDoc[] | undefined {
-    if (ts.isVariableDeclaration(node)) {
-        if (variableIsAfterFirstInDeclarationList(node)) {
-            return undefined;
-        }
-
-        node = node.parent;
-    }
-
-    if (ts.isVariableDeclarationList(node)) {
-        node = node.parent;
-    }
-
-    return tsutils.getJsDoc(node);
-}
-
 function variableIsAfterFirstInDeclarationList(node: ts.VariableDeclaration): boolean {
     const parent = node.parent;
     if (parent === undefined) {
@@ -494,7 +562,7 @@ function variableIsAfterFirstInDeclarationList(node: ts.VariableDeclaration): bo
     return ts.isVariableDeclarationList(parent) && node !== parent.declarations[0];
 }
 
-function describeDocumentationFailure(node: ts.Node, nodeType: string): string {
+function describeDocumentationFailure(node: ts.Node, docType: string): string {
     let description = Rule.FAILURE_STRING_EXIST;
 
     if (node.modifiers !== undefined) {
@@ -503,7 +571,7 @@ function describeDocumentationFailure(node: ts.Node, nodeType: string): string {
             .join(" ")} `;
     }
 
-    return `${description}${nodeType}.`;
+    return `${description}${docType}.`;
 }
 
 function describeModifier(kind: ts.SyntaxKind) {
@@ -512,8 +580,19 @@ function describeModifier(kind: ts.SyntaxKind) {
     return alias !== undefined ? alias : description;
 }
 
-function describeNode(nodeType: DocType): string {
-    return nodeType.replace("-", " ");
+function describeDocType(docType: DocType): string {
+    return docType.replace("-", " ");
+}
+
+function getSiblings(node: ts.Node) {
+    const { parent } = node;
+
+    // Source files nest their statements within a node for getChildren()
+    if (ts.isSourceFile(parent)) {
+        return [...parent.statements];
+    }
+
+    return parent.getChildren()!;
 }
 
 function isGetAccessor(node: ts.Node): node is ts.GetAccessorDeclaration {

--- a/test/rules/completed-docs/accessors-public/tsconfig.json
+++ b/test/rules/completed-docs/accessors-public/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/accessors/tsconfig.json
+++ b/test/rules/completed-docs/accessors/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/defaults/tsconfig.json
+++ b/test/rules/completed-docs/defaults/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/functions/overloads-separate-docs/default/test.ts.lint
+++ b/test/rules/completed-docs/functions/overloads-separate-docs/default/test.ts.lint
@@ -1,0 +1,8 @@
+function emit(event: string, data: number): void;
+
+function emit(event: string, data: string): void;
+
+/**
+ * Exists in one place
+ */
+function emit(event: string, data:any) { }

--- a/test/rules/completed-docs/functions/overloads-separate-docs/default/tslint.json
+++ b/test/rules/completed-docs/functions/overloads-separate-docs/default/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+      "functions": {
+        "privacies": ["all"]
+      }
+    }]
+  }
+}

--- a/test/rules/completed-docs/functions/overloads-separate-docs/false/test.ts.lint
+++ b/test/rules/completed-docs/functions/overloads-separate-docs/false/test.ts.lint
@@ -1,0 +1,8 @@
+function emit(event: string, data: number): void;
+
+function emit(event: string, data: string): void;
+
+/**
+ * Exists in one place
+ */
+function emit(event: string, data:any) { }

--- a/test/rules/completed-docs/functions/overloads-separate-docs/false/tslint.json
+++ b/test/rules/completed-docs/functions/overloads-separate-docs/false/tslint.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+      "functions": {
+        "overloads-separate-docs": false,
+        "privacies": ["all"]
+      }
+    }]
+  }
+}

--- a/test/rules/completed-docs/functions/overloads-separate-docs/false/tslint.json
+++ b/test/rules/completed-docs/functions/overloads-separate-docs/false/tslint.json
@@ -2,7 +2,7 @@
   "rules": {
     "completed-docs": [true, {
       "functions": {
-        "overloads-separate-docs": false,
+        "overloads": false,
         "privacies": ["all"]
       }
     }]

--- a/test/rules/completed-docs/functions/overloads-separate-docs/true/test.ts.lint
+++ b/test/rules/completed-docs/functions/overloads-separate-docs/true/test.ts.lint
@@ -1,0 +1,23 @@
+function emit(event: string, data: number): void;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Documentation must exist for functions.]
+
+function emit(event: string, data: string): void;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Documentation must exist for functions.]
+
+/**
+ * Exists in one place
+ */
+function emit(event: string, data:any) { }
+
+{
+    function a(event: string, data: number): void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Documentation must exist for functions.]
+
+    function b(event: string, data: string): void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Documentation must exist for functions.]
+
+    /**
+    * Exists in one place
+    */
+    function b(event: string, data:any) { }
+}

--- a/test/rules/completed-docs/functions/overloads-separate-docs/true/tslint.json
+++ b/test/rules/completed-docs/functions/overloads-separate-docs/true/tslint.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+      "functions": {
+        "overloads-separate-docs": true,
+        "privacies": ["all"]
+      }
+    }]
+  }
+}

--- a/test/rules/completed-docs/functions/overloads-separate-docs/true/tslint.json
+++ b/test/rules/completed-docs/functions/overloads-separate-docs/true/tslint.json
@@ -2,7 +2,7 @@
   "rules": {
     "completed-docs": [true, {
       "functions": {
-        "overloads-separate-docs": true,
+        "overloads": true,
         "privacies": ["all"]
       }
     }]

--- a/test/rules/completed-docs/interface-members/tsconfig.json
+++ b/test/rules/completed-docs/interface-members/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/locations/tsconfig.json
+++ b/test/rules/completed-docs/locations/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/methods/overloads-separate-docs/default/test.ts.lint
+++ b/test/rules/completed-docs/methods/overloads-separate-docs/default/test.ts.lint
@@ -1,0 +1,10 @@
+class Foo {
+    emit(event: string, data: number): void;
+
+    emit(event: string, data: string): void;
+ 
+    /**
+     * Exists in one place
+     */
+    emit(event: string, data:any) { }
+}

--- a/test/rules/completed-docs/methods/overloads-separate-docs/default/tslint.json
+++ b/test/rules/completed-docs/methods/overloads-separate-docs/default/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+      "methods": {
+        "privacies": ["all"]
+      }
+    }]
+  }
+}

--- a/test/rules/completed-docs/methods/overloads-separate-docs/false/test.ts.lint
+++ b/test/rules/completed-docs/methods/overloads-separate-docs/false/test.ts.lint
@@ -1,0 +1,10 @@
+class Foo {
+    emit(event: string, data: number): void;
+
+    emit(event: string, data: string): void;
+ 
+    /**
+     * Exists in one place
+     */
+    emit(event: string, data:any) { }
+}

--- a/test/rules/completed-docs/methods/overloads-separate-docs/false/tslint.json
+++ b/test/rules/completed-docs/methods/overloads-separate-docs/false/tslint.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+      "methods": {
+        "overloads-separate-docs": false,
+        "privacies": ["all"]
+      }
+    }]
+  }
+}

--- a/test/rules/completed-docs/methods/overloads-separate-docs/false/tslint.json
+++ b/test/rules/completed-docs/methods/overloads-separate-docs/false/tslint.json
@@ -2,7 +2,7 @@
   "rules": {
     "completed-docs": [true, {
       "methods": {
-        "overloads-separate-docs": false,
+        "overloads": false,
         "privacies": ["all"]
       }
     }]

--- a/test/rules/completed-docs/methods/overloads-separate-docs/true/test.ts.lint
+++ b/test/rules/completed-docs/methods/overloads-separate-docs/true/test.ts.lint
@@ -1,0 +1,12 @@
+class Foo {
+    emit(event: string, data: number): void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Documentation must exist for methods.]
+
+    emit(event: string, data: string): void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Documentation must exist for methods.]
+ 
+    /**
+     * Exists in one place
+     */
+    emit(event: string, data:any) { }
+}

--- a/test/rules/completed-docs/methods/overloads-separate-docs/true/tslint.json
+++ b/test/rules/completed-docs/methods/overloads-separate-docs/true/tslint.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+      "methods": {
+        "overloads-separate-docs": true,
+        "privacies": ["all"]
+      }
+    }]
+  }
+}

--- a/test/rules/completed-docs/methods/overloads-separate-docs/true/tslint.json
+++ b/test/rules/completed-docs/methods/overloads-separate-docs/true/tslint.json
@@ -2,7 +2,7 @@
   "rules": {
     "completed-docs": [true, {
       "methods": {
-        "overloads-separate-docs": true,
+        "overloads": true,
         "privacies": ["all"]
       }
     }]

--- a/test/rules/completed-docs/privacies-private/tsconfig.json
+++ b/test/rules/completed-docs/privacies-private/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/privacies-protected/tsconfig.json
+++ b/test/rules/completed-docs/privacies-protected/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/privacies-public/tsconfig.json
+++ b/test/rules/completed-docs/privacies-public/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/privacies/tsconfig.json
+++ b/test/rules/completed-docs/privacies/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/tags/content/tsconfig.json
+++ b/test/rules/completed-docs/tags/content/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/tags/existence/tsconfig.json
+++ b/test/rules/completed-docs/tags/existence/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/types/tsconfig.json
+++ b/test/rules/completed-docs/types/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/variables/tsconfig.json
+++ b/test/rules/completed-docs/variables/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/test/rules/completed-docs/visibilities/tsconfig.json
+++ b/test/rules/completed-docs/visibilities/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4416
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Opt-in (false by default) boolean flag that can be applied to functions and methods to require their overloads each receive their own documentation comment.

Also deleted a bunch of unnecessary `tsconfig.json` files that were still in the tests directory for completed-docs. I should have removed them when converting it to TypeScript.

#### CHANGELOG.md entry:

[new-rule-option] `completed-docs`: `overloads` option to enforce documentation of each overload signature
