### PR TITLE
Add junit output for files which are successfully linted.

### DIFF
--- a/src/formatters/junitFormatter.ts
+++ b/src/formatters/junitFormatter.ts
@@ -76,20 +76,20 @@ export class Formatter extends AbstractFormatter {
             }
         }
 
-        if(fileNames && fileNames.length !== 0) {
+        if (fileNames !== undefined && fileNames.length !== 0) {
             // Filter out files which have had a failure associated with them.
-            const filteredFileNames = fileNames.filter((fileName) => {
-                for(const failure of failures) {
-                    if(fileName === failure.getFileName()) {
+            const filteredFileNames = fileNames.filter(fileName => {
+                for (const failure of failures) {
+                    if (fileName === failure.getFileName()) {
                         return false;
                     }
                 }
                 return true;
             });
 
-            for(const fileName of filteredFileNames) {
+            for (const fileName of filteredFileNames) {
                 output += `<testsuite name="${this.escapeXml(fileName)}" errors="0">`;
-                output += `<testcase name="${this.escapeXml(fileName)}" />`
+                output += `<testcase name="${this.escapeXml(fileName)}" />`;
                 output += `</testsuite>`;
             }
         }

--- a/src/formatters/junitFormatter.ts
+++ b/src/formatters/junitFormatter.ts
@@ -41,7 +41,7 @@ export class Formatter extends AbstractFormatter {
     };
     /* tslint:enable:object-literal-sort-keys */
 
-    public format(failures: RuleFailure[]): string {
+    public format(failures: RuleFailure[], _fixes?: RuleFailure[], fileNames?: string[]): string {
         let output = '<?xml version="1.0" encoding="utf-8"?><testsuites package="tslint">';
 
         if (failures.length !== 0) {
@@ -73,6 +73,24 @@ export class Formatter extends AbstractFormatter {
             }
             if (previousFilename !== null) {
                 output += "</testsuite>";
+            }
+        }
+
+        if(fileNames && fileNames.length !== 0) {
+            // Filter out files which have had a failure associated with them.
+            const filteredFileNames = fileNames.filter((fileName) => {
+                for(const failure of failures) {
+                    if(fileName === failure.getFileName()) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+
+            for(const fileName of filteredFileNames) {
+                output += `<testsuite name="${this.escapeXml(fileName)}" errors="0">`;
+                output += `<testcase name="${this.escapeXml(fileName)}" />`
+                output += `</testsuite>`;
             }
         }
 

--- a/src/formatters/junitFormatter.ts
+++ b/src/formatters/junitFormatter.ts
@@ -44,7 +44,7 @@ export class Formatter extends AbstractFormatter {
     public format(failures: RuleFailure[], _fixes?: RuleFailure[], fileNames?: string[]): string {
         let output = '<?xml version="1.0" encoding="utf-8"?><testsuites package="tslint">';
 
-        const failureFileNames: Set<string> = new Set<string>();
+        const failureFileNames: Set<string> = new Set([...failures.map(f => f.getFileName())]);
 
         if (failures.length !== 0) {
             const failuresSorted = failures.sort((a, b) =>
@@ -52,9 +52,6 @@ export class Formatter extends AbstractFormatter {
             );
             let previousFilename: string | null = null;
             for (const failure of failuresSorted) {
-                if (!failureFileNames.has(failure.getFileName())) {
-                    failureFileNames.add(failure.getFileName());
-                }
                 const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
                 const message = this.escapeXml(failure.getFailure());
                 const rule = this.escapeXml(failure.getRuleName());

--- a/test/formatters/junitFormatterTests.ts
+++ b/test/formatters/junitFormatterTests.ts
@@ -106,14 +106,24 @@ describe("JUnit Formatter", () => {
                 </testsuite>
             </testsuites>`.replace(/>\s+/g, ">"); // Remove whitespace between tags;
 
-        assert.equal(formatter.format(failures), expectedResult);
+        assert.equal(formatter.format(failures, [], [TEST_FILE_1, TEST_FILE_2]), expectedResult);
     });
 
     it("handles no failures", () => {
-        const result = formatter.format([]);
-        assert.deepEqual(
-            result,
-            '<?xml version="1.0" encoding="utf-8"?><testsuites package="tslint"></testsuites>',
-        );
+        const result = formatter.format([], [], ["test1.ts", "test2.ts", "test3.ts"]);
+        const expectedResult = `<?xml version="1.0" encoding="utf-8"?>
+            <testsuites package="tslint">
+                <testsuite name="test1.ts" errors="0">
+                    <testcase name="test1.ts" />
+                </testsuite>
+                <testsuite name="test2.ts" errors="0">
+                    <testcase name="test2.ts" />
+                </testsuite>
+                <testsuite name="test3.ts" errors="0">
+                    <testcase name="test3.ts" />
+                </testsuite>
+            </testsuites>`.replace(/>\s+/g, ">");
+
+        assert.equal(result, expectedResult);
     });
 });

--- a/test/formatters/junitFormatterTests.ts
+++ b/test/formatters/junitFormatterTests.ts
@@ -126,4 +126,55 @@ describe("JUnit Formatter", () => {
 
         assert.equal(result, expectedResult);
     });
+
+    it("handles a mixture of failures and successes", () => {
+        const maxPosition1 = sourceFile1.getFullWidth();
+
+        const failures = [
+            createFailure(sourceFile1, 0, 1, "first failure", "first-name", undefined, "error"),
+            createFailure(
+                sourceFile1,
+                2,
+                3,
+                "&<>'\" should be escaped",
+                "escape",
+                undefined,
+                "error",
+            ),
+            createFailure(
+                sourceFile1,
+                maxPosition1 - 1,
+                maxPosition1,
+                "last failure",
+                "last-name",
+                undefined,
+                "error",
+            ),
+        ];
+
+        const expectedResult = `<?xml version="1.0" encoding="utf-8"?>
+        <testsuites package="tslint">
+            <testsuite name="formatters/jsonFormatter.test.ts">
+                <testcase name="first-name" classname="formatters/jsonFormatter.test.ts">
+                    <failure type="error">first failure Line 1, Column 1</failure>
+                </testcase>
+                <testcase name="escape" classname="formatters/jsonFormatter.test.ts">
+                    <failure type="error">&amp;&lt;&gt;&#39;&quot; should be escaped Line 1, Column 3</failure>
+                </testcase>
+                <testcase name="last-name" classname="formatters/jsonFormatter.test.ts">
+                    <failure type="error">last failure Line 6, Column 3</failure>
+                </testcase>
+            </testsuite>
+            <testsuite name="test1.ts" errors="0">
+                <testcase name="test1.ts" />
+            </testsuite>
+            <testsuite name="test2.ts" errors="0">
+                <testcase name="test2.ts" />
+            </testsuite>
+        </testsuites>`.replace(/>\s+/g, ">");
+
+        const result = formatter.format(failures, [], [TEST_FILE_1, "test1.ts", "test2.ts"]);
+
+        assert.equal(result, expectedResult);
+    });
 });


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #3744 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
This fixes an issue with the junit formatter. Successful test cases are now output when files are linted without error.
