### PR TITLE
ordered-imports: don't remove linebreaks if text contains non-whitespace characters

### DIFF
--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -538,7 +538,10 @@ class Walker extends Lint.AbstractWalker<Options> {
             if (index > 0) {
                 const prevItems = groupedDeclarations[index - 1];
                 const last = prevItems[prevItems.length - 1];
-                if (/[\r\n]+/.test(this.sourceFile.text.slice(last.nodeEndOffset, start))) {
+
+                const textFragment = this.sourceFile.text.slice(last.nodeEndOffset, start);
+                const isWhitespace = /[\r\n]+/.test(textFragment) && !/\S/.test(textFragment);
+                if (isWhitespace) {
                     // remove whitespace between blocks
                     start = last.nodeEndOffset;
                 }

--- a/src/rules/orderedImportsRule.ts
+++ b/src/rules/orderedImportsRule.ts
@@ -540,8 +540,7 @@ class Walker extends Lint.AbstractWalker<Options> {
                 const last = prevItems[prevItems.length - 1];
 
                 const textFragment = this.sourceFile.text.slice(last.nodeEndOffset, start);
-                const isWhitespace = /[\r\n]+/.test(textFragment) && !/\S/.test(textFragment);
-                if (isWhitespace) {
+                if (!/\S/.test(textFragment)) {
                     // remove whitespace between blocks
                     start = last.nodeEndOffset;
                 }

--- a/test/rules/ordered-imports/groups-complex/test.ts.fix
+++ b/test/rules/ordered-imports/groups-complex/test.ts.fix
@@ -17,6 +17,8 @@ import './baz'; // required
 
 import {bar} from '../bar';
 import {xbar} from '../xbar';
+x.fnCall();
+
 
 
 export class Test {}

--- a/test/rules/ordered-imports/groups-complex/test.ts.lint
+++ b/test/rules/ordered-imports/groups-complex/test.ts.lint
@@ -20,6 +20,7 @@ import {foo, afoo} from 'foo';
         ~~~~~~~~~              [Named imports must be alphabetized.]
 
 import x = require('y');
+x.fnCall();
 
 import './baz'; // required
 import './baa';


### PR DESCRIPTION
#### PR checklist

- [X] Addresses an existing issue: #4569

#### Overview of change:

Existing replacement code deletes lines around import declarations if they contain any line break. This means it deletes actual code in the case where a fragment of text has both line breaks and characters.

An ideal fix would be to keep the (previously deleted) code as close to the import it depends on...assuming it depends on an import at all. Of course, this ramps up the complexity, because any given line of code could use a combination of imports.

This fix results in the code just appearing below the import blocks in the order they were processed.

#### CHANGELOG.md entry:

[bugfix] fix linebreak handling in `ordered-imports`
