### PR TITLE
Fix typo

### DIFF
--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -66,7 +66,7 @@ export class Rule extends Lint.Rules.TypedRule {
               - Also allows \`true | false | undefined\`.
               - Does not allow \`false | undefined\`.
               - This option is a subset of \`${OPTION_ALLOW_UNDEFINED_UNION}\`, so you don't need to enable both options at the same time.
-            * \`${OPTION_IGNORE_RHS}\` ignores the right-hand operand of \`&&\` and \`||\'
+            * \`${OPTION_IGNORE_RHS}\` ignores the right-hand operand of \`&&\` and \`||\`.
         `,
         options: {
             type: "array",


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: #0000
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

Fixes a simple typo that resulted in a broken layout of the `ignore-rhs` item:

![grafik](https://user-images.githubusercontent.com/2145092/54600362-e317ed00-4a3c-11e9-9566-077b20ce137a.png)
