### PR TITLE
Fix #4556 - False positive: No void expression

### DIFF
--- a/src/rules/noVoidExpressionRule.ts
+++ b/src/rules/noVoidExpressionRule.ts
@@ -104,6 +104,10 @@ function walk(ctx: Lint.WalkContext<Options>, checker: ts.TypeChecker): void {
             // Something like "x && console.log(x)".
             case ts.SyntaxKind.BinaryExpression:
                 return isParentAllowedVoid(node.parent);
+
+            // Something like "!!cond ? console.log(true) : console.log(false)"
+            case ts.SyntaxKind.ConditionalExpression:
+                return true;
             default:
                 return false;
         }

--- a/test/rules/no-void-expression/default/test.ts.lint
+++ b/test/rules/no-void-expression/default/test.ts.lint
@@ -24,4 +24,6 @@ declare function doIt(): void;
 declare function doAsync(): Promise<void>;
 declare function print(strs: TemplateStringsArray): void;
 
+!!data ? console.info(message, data) : console.info(message);
+
 [0]: Expression has type `void`. Put it on its own line as a statement.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4556 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Allow void expressions in conditional expressions.

#### Is there anything you'd like reviewers to focus on?

Any extra test cases you would like me to cover?

#### CHANGELOG.md entry:

[bugfix] `no-void-expression` now allows conditional expressions