### PR TITLE
Excuse edge cases in quotemark backtick (#4588)

### DIFF
--- a/src/rules/noNullUndefinedUnionRule.ts
+++ b/src/rules/noNullUndefinedUnionRule.ts
@@ -55,7 +55,7 @@ export class Rule extends Lint.Rules.TypedRule {
     }
 }
 
-function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker): void {
+function walk(ctx: Lint.WalkContext, tc: ts.TypeChecker): void {
     return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
         const type = getType(node, tc);
         if (type !== undefined && isNullUndefinedUnion(type)) {

--- a/test/rules/quotemark/backtick/test.ts.fix
+++ b/test/rules/quotemark/backtick/test.ts.fix
@@ -1,13 +1,26 @@
 import { Something } from "some-package"
+export { SomethingElse } from "another-package"
 
 var single = `single`;
     var double = `married`;
 var singleWithinDouble = `'singleWithinDouble'`;
 var doubleWithinSingle = `"doubleWithinSingle"`;
 var tabNewlineWithinSingle = `tab\tNewline\nWithinSingle`;
+var array: Array<"literal string"> = [];
+var hello: `world`;
 `escaped'quotemark`;
 
 // "avoid-template" option is not set.
 `foo`;
 
-const object = { "kebab-case": 3 }
+const object: {
+    "hello-kebab"
+    : number
+    "kebab-case": number
+    "another-kebab": `hello-value`
+} = {
+    "hello-kebab"
+    : 4
+    "kebab-case": 3,
+    "another-kebab": `hello-value`
+};

--- a/test/rules/quotemark/backtick/test.ts.lint
+++ b/test/rules/quotemark/backtick/test.ts.lint
@@ -1,4 +1,5 @@
 import { Something } from "some-package"
+export { SomethingElse } from "another-package"
 
 var single = 'single';
              ~~~~~~~~  [' should be `]
@@ -10,10 +11,25 @@ var doubleWithinSingle = '"doubleWithinSingle"';
                          ~~~~~~~~~~~~~~~~~~~~~~  [' should be `]
 var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [' should be `]
+var array: Array<"literal string"> = [];
+var hello: "world";
+           ~~~~~~~ [" should be `]
 'escaped\'quotemark';
 ~~~~~~~~~~~~~~~~~~~~ [' should be `]
 
 // "avoid-template" option is not set.
 `foo`;
 
-const object = { "kebab-case": 3 }
+const object: {
+    "hello-kebab"
+    : number
+    "kebab-case": number
+    "another-kebab": "hello-value"
+                     ~~~~~~~~~~~~~ [" should be `]
+} = {
+    "hello-kebab"
+    : 4
+    "kebab-case": 3,
+    "another-kebab": "hello-value"
+                     ~~~~~~~~~~~~~ [" should be `]
+};


### PR DESCRIPTION
This commit fixes the cases where export statements, string literal type as generic type parameter, and string literals in object literal property assignments were incorrectly flagged. This also fixes a small lint error (specifying a type parameter same as default).

#### PR checklist

- [x] Addresses an existing issue: fixes #4588 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

This commit fixes the cases where export statements, string literal type as generic type parameter, and string literals in object literal property assignments were incorrectly flagged. This also fixes a small lint error (specifying a type parameter same as default).

#### Is there anything you'd like reviewers to focus on?

Make sure the tests capture all the use cases.

#### CHANGELOG.md entry:

[bugfix] quotemark: backtick should no longer flag strings that require single/double quotes