### PR TITLE
Check for non-public modifiers in constructors (#4511)

### DIFF
--- a/test/rules/unnecessary-constructor/test.ts.lint
+++ b/test/rules/unnecessary-constructor/test.ts.lint
@@ -10,12 +10,10 @@ class PublicConstructor {
 
 class ProtectedConstructor {
     protected constructor() { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~       [0]
 }
 
 class PrivateConstructor {
     private constructor() { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~       [0]
 }
 
 class SameLine { constructor() { } }
@@ -53,6 +51,14 @@ class CallsSuper extends PublicConstructor {
 class ContainsParameter {
     constructor(x: number) { }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+}
+
+class PrivateContainsParameter {
+    private constructor(x: number) { }
+}
+
+class ProtectedContainsParameter {
+    protected constructor(x: number) { }
 }
 
 class ContainsParameterDeclaration {


### PR DESCRIPTION
This commit checks the modifiers of each constructor declaration. If it has any modifier that isn't `public`, then it is actually necessary and shouldn't be flagged.

#### PR checklist

- [x] Addresses an existing issue: fixes #4511 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Iterate through the modifiers of each constructor declaration. If it has any modifiers that isn't `public`, keep it.

#### CHANGELOG.md entry:

[bugfix] unnecessary-constructor: don't flag constructors that are actually necessary
