### PR TITLE
Fix interface name rule

### DIFF
--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -19,7 +19,6 @@ import * as utils from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
-import { isLowerCase, isUpperCase } from "../utils";
 
 const OPTION_ALWAYS = "always-prefix";
 const OPTION_NEVER = "never-prefix";
@@ -76,12 +75,19 @@ function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
 }
 
 function hasPrefixI(name: string): boolean {
-    return name.length >= 3 && name[0] === "I" && !isLowerCase(name[1]) && !isUpperCase(name[2]);
+    return (
+        name.length >= 3 && name[0] === "I" && /^[A-Z]*$/.test(name[1]) && !/^[A-Z]*$/.test(name[2])
+    );
 }
 
 function cantDecide(name: string): boolean {
     return (
-        (name.length === 2 && name[0] === "I" && !isLowerCase(name[1])) ||
-        (name.length >= 2 && name[0] === "I" && !isLowerCase(name[1]) && !isLowerCase(name[2]))
+        // Case ID
+        (name.length === 2 && name[0] === "I" && /^[A-Z]*$/.test(name[1])) ||
+        // Case IDB
+        (name.length >= 2 &&
+            name[0] === "I" &&
+            /^[A-Z]*$/.test(name[1]) &&
+            /^[A-Z]*$/.test(name[2]))
     );
 }

--- a/test/rules/interface-name/always-prefix/test.ts.lint
+++ b/test/rules/interface-name/always-prefix/test.ts.lint
@@ -11,6 +11,9 @@ interface IABC {
 interface IDBFactory {
 }
 
+interface II18nService {
+}
+
 // invalid code
 interface Options {
           ~~~~~~~   [interface name must start with a capitalized I]


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4624
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Overview of change:
I stoped to use isLowerCase or isUpperCase to use a real regex. These functions was buggy with numbers.

#### Is there anything you'd like reviewers to focus on?

I add a better support for prettier too.

#### CHANGELOG.md entry:

 [bugfix] `interface-name` now correctly handle numeric characters
