### PR TITLE
[enhancement] Update babel-code-frame to @babel/code-frame

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "coverage": "rimraf coverage .nyc_output && nyc npm test"
     },
     "dependencies": {
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
@@ -47,7 +47,7 @@
         "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
     },
     "devDependencies": {
-        "@types/babel-code-frame": "^6.20.0",
+        "@types/babel__code-frame": "^7.0.1",
         "@types/chai": "^3.5.0",
         "@types/diff": "^3.2.0",
         "@types/glob": "^5.0.30",

--- a/src/formatters/codeFrameFormatter.ts
+++ b/src/formatters/codeFrameFormatter.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import codeFrame = require("babel-code-frame");
+import { codeFrameColumns } from "@babel/code-frame";
 import chalk from "chalk";
 
 import { AbstractFormatter } from "../language/formatter/abstractFormatter";
@@ -76,11 +76,10 @@ export class Formatter extends AbstractFormatter {
             ruleName = chalk.gray(`(${ruleName})`);
 
             // Frame
-            const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
-            const frame = codeFrame(
+            const { character: column, line } = failure.getStartPosition().getLineAndCharacter();
+            const frame = codeFrameColumns(
                 failure.getRawLines(),
-                lineAndCharacter.line + 1, // babel-code-frame is 1 index
-                lineAndCharacter.character,
+                { start: { line: line + 1, column } }, // babel-code-frame is 1 index
                 {
                     forceColor: chalk.enabled,
                     highlightCode: true,

--- a/test/formatters/codeFrameFormatterTests.ts
+++ b/test/formatters/codeFrameFormatterTests.ts
@@ -27,6 +27,7 @@ describe("CodeFrame Formatter", () => {
     let sourceFile: ts.SourceFile;
     let formatter: IFormatter;
     let colorsEnabled: boolean;
+
     before(() => {
         colorsEnabled = chalk.enabled;
         const Formatter = TestUtils.getFormatter("codeFrame");
@@ -35,11 +36,11 @@ describe("CodeFrame Formatter", () => {
     });
 
     after(() => {
-        (chalk as any).enabled = colorsEnabled;
+        chalk.enabled = colorsEnabled;
     });
 
     it("formats failures with colors", () => {
-        (chalk as any).enabled = true;
+        chalk.enabled = true;
         const maxPosition = sourceFile.getFullWidth();
 
         const failures = [
@@ -84,36 +85,36 @@ describe("CodeFrame Formatter", () => {
 
         const expectedResultColored = `formatters/codeFrameFormatter.test.ts
             \u001b[31mfirst failure\u001b[39m \u001b[90m(first-name)\u001b[39m
-            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {
-            \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {
-            \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m
-            \u001b[90m 4 | \u001b[39m\u001b[0m
+            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {\u001b[0m
+            \u001b[0m \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {\u001b[0m
+            \u001b[0m \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m\u001b[0m
+            \u001b[0m \u001b[90m 4 | \u001b[39m\u001b[0m
 
             \u001b[31mfull failure\u001b[39m \u001b[90m(full-name)\u001b[39m
-            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {
-            \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {
-            \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m
-            \u001b[90m 4 | \u001b[39m\u001b[0m
+            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {\u001b[0m
+            \u001b[0m \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {\u001b[0m
+            \u001b[0m \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m\u001b[0m
+            \u001b[0m \u001b[90m 4 | \u001b[39m\u001b[0m
 
             \u001b[33mwarning failure\u001b[39m \u001b[90m(warning-name)\u001b[39m
-            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {
-            \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {
-            \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m
-            \u001b[90m 4 | \u001b[39m\u001b[0m
+            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {\u001b[0m
+            \u001b[0m \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {\u001b[0m
+            \u001b[0m \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m\u001b[0m
+            \u001b[0m \u001b[90m 4 | \u001b[39m\u001b[0m
 
-            \u001b[31m&<>'\" should be escaped\u001b[39m \u001b[90m(escape)\u001b[39m
-            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {
-            \u001b[90m   | \u001b[39m \u001b[31m\u001b[1m^\u001b[22m\u001b[39m
-            \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {
-            \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m
-            \u001b[90m 4 | \u001b[39m\u001b[0m
+            \u001b[31m&<>\'" should be escaped\u001b[39m \u001b[90m(escape)\u001b[39m
+            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 1 | \u001b[39mmodule \u001b[33mCodeFrameModule\u001b[39m {\u001b[0m
+            \u001b[0m \u001b[90m   | \u001b[39m \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m
+            \u001b[0m \u001b[90m 2 | \u001b[39m    \u001b[36mexport\u001b[39m \u001b[36mclass\u001b[39m \u001b[33mCodeFrameClass\u001b[39m {\u001b[0m
+            \u001b[0m \u001b[90m 3 | \u001b[39m        private name\u001b[33m:\u001b[39m string\u001b[33m;\u001b[39m\u001b[0m
+            \u001b[0m \u001b[90m 4 | \u001b[39m\u001b[0m
 
             \u001b[31mlast failure\u001b[39m \u001b[90m(last-name)\u001b[39m
-            \u001b[0m \u001b[90m  7 | \u001b[39m        }
-            \u001b[90m  8 | \u001b[39m    }
-            \u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  9 | \u001b[39m}
-            \u001b[90m    | \u001b[39m\u001b[31m\u001b[1m^\u001b[22m\u001b[39m
-            \u001b[90m 10 | \u001b[39m\u001b[0m
+            \u001b[0m \u001b[90m  7 | \u001b[39m        }\u001b[0m
+            \u001b[0m \u001b[90m  8 | \u001b[39m    }\u001b[0m
+            \u001b[0m\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m  9 | \u001b[39m}\u001b[0m
+            \u001b[0m \u001b[90m    | \u001b[39m\u001b[31m\u001b[1m^\u001b[22m\u001b[39m\u001b[0m
+            \u001b[0m \u001b[90m 10 | \u001b[39m\u001b[0m
 
         `;
 


### PR DESCRIPTION
#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Overview of change:
[babel-code-frame](https://www.npmjs.com/package/babel-code-frame) is deprecated and future updates will be published under the babel npm organization as [@babel/code-frame](https://www.npmjs.com/package/@babel/code-frame).

Updated `babel-code-frame` v6.22.0 to `@babel/code-frame` v7.0.0
Updated `@types/babel-code-frame` v6.20.0 to `@types/babel__code-frame` v7.0.1

`chalk` now has types so we don't need to cast as any in the test.

#### Is there anything you'd like reviewers to focus on?

The test used old code-frame behavior:
```
first failure (first-name)
> 1 | module CodeFrameModule {
 2 |     export class CodeFrameClass {
 3 |         private name: string;
 4 | 

full failure (full-name)
> 1 | module CodeFrameModule {
 2 |     export class CodeFrameClass {
 3 |         private name: string;
 4 | 

warning failure (warning-name)
> 1 | module CodeFrameModule {
 2 |     export class CodeFrameClass {
 3 |         private name: string;
 4 | 

&<>'" should be escaped (escape)
> 1 | module CodeFrameModule {
   |  ^
 2 |     export class CodeFrameClass {
 3 |         private name: string;
 4 | 

last failure (last-name)
   7 |         }
  8 |     }
>  9 | }
    | ^
 10 | 
```

The new one looks much better:
```
first failure (first-name)
> 1 | module CodeFrameModule {
  2 |     export class CodeFrameClass {
  3 |         private name: string;
  4 | 

full failure (full-name)
> 1 | module CodeFrameModule {
  2 |     export class CodeFrameClass {
  3 |         private name: string;
  4 | 

warning failure (warning-name)
> 1 | module CodeFrameModule {
  2 |     export class CodeFrameClass {
  3 |         private name: string;
  4 | 

&<>'" should be escaped (escape)
> 1 | module CodeFrameModule {
    |  ^
  2 |     export class CodeFrameClass {
  3 |         private name: string;
  4 | 

last failure (last-name)
   7 |         }
   8 |     }
>  9 | }
     | ^
  10 | 
```

#### CHANGELOG.md entry:

[enhancement] `Update babel-code-frame to @babel/code-frame`
