### PR TITLE
Add prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "tabWidth": 4,
+  "trailingComma": "all"
+}

--- a/tslint.json
+++ b/tslint.json
@@ -6,13 +6,7 @@
     ],
     "rules": {
         // Formatting rules
-        "prettier": {
-            "options": {
-                "printWidth": 100,
-                "tabWidth": 4,
-                "trailingComma": "all"
-            }
-        },
+        "prettier": true,
 
         // Don't want these
         "cyclomatic-complexity": false,


### PR DESCRIPTION
#### Overview of change:

Use prettierrc instead of a config in tslint.json
User with prettier have now a correct auto-formatting of the project