### PR TITLE
Fix typo in rule docs generation

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -36,4 +36,4 @@ _These rules enforce consistent style across your codebase_:
 
 _These rules enforce consistent use of whitespace and punctuation_:
 
-{% include rule_list.html ruleType="format" %}
+{% include rule_list.html ruleType="formatting" %}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4620
- [ ] New feature, bugfix, or enhancement (N/A)
  - [ ] Includes tests (N/A)
- [x] Documentation update

#### Overview of change:

An incorrect rule type selector in rules documentation page (docs/rules/index.md) was omitting the following rules:

* `align`
* `arrow-parens`
* `eofline`
* `import-spacing`
* `indent`
* `jsdoc-format`
* `linebreak-style`
* `max-line-length`
* `newline-before-return`
* `new-parens`
* `no-consecutive-blank-lines`
* `no-irregular-whitespace`
* `no-trailing-whitespace`
* `number-literal-format`
* `quotemark`
* `semicolon`
* `trailing-comma`
* `typedef-whitespace`
* `whitespace`