### PR TITLE
fix file-header rule option "enforce-trailing-newline" (#4640)

### DIFF
--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -244,9 +244,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         );
 
         const NEW_LINE_FOLLOWING_HEADER = /^.*((\r)?\n){2,}$/gm;
-        return (
-            entireComment !== undefined && NEW_LINE_FOLLOWING_HEADER.test(entireComment) !== null
-        );
+        return entireComment !== undefined && !NEW_LINE_FOLLOWING_HEADER.test(entireComment);
     }
 
     private getFileHeaderText(

--- a/test/rules/file-header/good-newline/test.ts.lint
+++ b/test/rules/file-header/good-newline/test.ts.lint
@@ -1,0 +1,11 @@
+/*
+ * Good header
+ */
+
+export class A {
+    public x = 1;
+
+    public B() {
+        return 2;
+    }
+}

--- a/test/rules/file-header/good-newline/tslint.json
+++ b/test/rules/file-header/good-newline/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "file-header": [true, "Good header", "Good header", "enforce-trailing-newline"]
+    }
+}


### PR DESCRIPTION
- [x] Addresses an existing issue: fixes #4640 
- [x] bugfix
  - [x] Includes tests

#### Overview of change:
add tests that identify the bug,
remove null check for the regex test since `RegExp.prototype.test()` returns a boolean (in contrast to `String.prototype.match()`)

#### CHANGELOG.md entry:
[bugfix] fix file-header rule option "enforce-trailing-newline" (#4640)