### PR TITLE
[quotemark] Excuse more backtick edge cases

### DIFF
--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -324,7 +324,7 @@ function isNameInAssignment(node: ts.StringLiteral | ts.NoSubstitutionTemplateLi
 }
 
 function isTypeCheckWithOldTsc(node: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral) {
-    if (hasOldTscBacktickBehavior()) {
+    if (!hasOldTscBacktickBehavior()) {
         // This one only affects older typescript versions
         return false;
     }

--- a/test/rules/quotemark/backtick/test.ts.fix
+++ b/test/rules/quotemark/backtick/test.ts.fix
@@ -25,30 +25,8 @@ function test<T extends ("generic" & number)>() {
 
 const callback = <U extends "generic">() => `hi` as number | string
 
-const v = callback()
-
-if (typeof v === `string`) {}
-
-if (typeof `string` === `number`) {}
-
 var hello: `world`;
 `escaped'quotemark`;
 
 // "avoid-template" option is not set.
 `foo`;
-
-const object: {
-    "hello-kebab"
-    : number
-    "kebab-case": number
-    "optional-prop"?: `hello-optional`
-    "optional-function"?(): void
-    "another-kebab": `hello-value`
-} = {
-    "hello-kebab"
-    : 4
-    "kebab-case": 3,
-    "optional-kebab": undefined,
-    "optional-function"() {},
-    "another-kebab": `hello-value`
-};

--- a/test/rules/quotemark/backtick/test.ts.fix
+++ b/test/rules/quotemark/backtick/test.ts.fix
@@ -6,7 +6,31 @@ var single = `single`;
 var singleWithinDouble = `'singleWithinDouble'`;
 var doubleWithinSingle = `"doubleWithinSingle"`;
 var tabNewlineWithinSingle = `tab\tNewline\nWithinSingle`;
+
 var array: Array<"literal string"> = [];
+var arrayTwo: Array<"literal string" | number> = [];
+var arrayThree: Array<"literal string" | "hello world"> = [];
+var arrayFour: Array<"literal string" | "hello world" | "foo bar"> = [];
+var array: Array<"literal string"> = [];
+var arrayTwo: Array<"literal string" & number> = [];
+var arrayFour: Array<"literal string" | "hello world" & "foo bar"> = [];
+
+function test<T extends "generic">() {
+
+}
+
+function test<T extends ("generic" & number)>() {
+
+}
+
+const callback = <U extends "generic">() => `hi` as number | string
+
+const v = callback()
+
+if (typeof v === `string`) {}
+
+if (typeof `string` === `number`) {}
+
 var hello: `world`;
 `escaped'quotemark`;
 
@@ -17,10 +41,14 @@ const object: {
     "hello-kebab"
     : number
     "kebab-case": number
+    "optional-prop"?: `hello-optional`
+    "optional-function"?(): void
     "another-kebab": `hello-value`
 } = {
     "hello-kebab"
     : 4
     "kebab-case": 3,
+    "optional-kebab": undefined,
+    "optional-function"() {},
     "another-kebab": `hello-value`
 };

--- a/test/rules/quotemark/backtick/test.ts.lint
+++ b/test/rules/quotemark/backtick/test.ts.lint
@@ -31,15 +31,6 @@ function test<T extends ("generic" & number)>() {
 const callback = <U extends "generic">() => "hi" as number | string
                                             ~~~~ [double]
 
-const v = callback()
-
-if (typeof v === "string") {}
-                 ~~~~~~~~ [double]
-
-if (typeof "string" === 'number') {}
-           ~~~~~~~~ [double]
-                        ~~~~~~~~ [single]
-
 var hello: "world";
            ~~~~~~~ [double]
 'escaped\'quotemark';
@@ -47,23 +38,5 @@ var hello: "world";
 
 // "avoid-template" option is not set.
 `foo`;
-
-const object: {
-    "hello-kebab"
-    : number
-    "kebab-case": number
-    "optional-prop"?: `hello-optional`
-    "optional-function"?(): void
-    "another-kebab": "hello-value"
-                     ~~~~~~~~~~~~~ [double]
-} = {
-    "hello-kebab"
-    : 4
-    "kebab-case": 3,
-    "optional-kebab": undefined,
-    "optional-function"() {},
-    "another-kebab": "hello-value"
-                     ~~~~~~~~~~~~~ [double]
-};
 [single]: ' should be `
 [double]: " should be `

--- a/test/rules/quotemark/backtick/test.ts.lint
+++ b/test/rules/quotemark/backtick/test.ts.lint
@@ -2,20 +2,48 @@ import { Something } from "some-package"
 export { SomethingElse } from "another-package"
 
 var single = 'single';
-             ~~~~~~~~  [' should be `]
+             ~~~~~~~~  [single]
     var double = "married";
-                 ~~~~~~~~~ [" should be `]
+                 ~~~~~~~~~ [double]
 var singleWithinDouble = "'singleWithinDouble'";
-                         ~~~~~~~~~~~~~~~~~~~~~~ [" should be `]
+                         ~~~~~~~~~~~~~~~~~~~~~~ [double]
 var doubleWithinSingle = '"doubleWithinSingle"';
-                         ~~~~~~~~~~~~~~~~~~~~~~  [' should be `]
+                         ~~~~~~~~~~~~~~~~~~~~~~  [single]
 var tabNewlineWithinSingle = 'tab\tNewline\nWithinSingle';
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [' should be `]
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [single]
+
 var array: Array<"literal string"> = [];
+var arrayTwo: Array<"literal string" | number> = [];
+var arrayThree: Array<"literal string" | "hello world"> = [];
+var arrayFour: Array<"literal string" | "hello world" | "foo bar"> = [];
+var array: Array<"literal string"> = [];
+var arrayTwo: Array<"literal string" & number> = [];
+var arrayFour: Array<"literal string" | "hello world" & "foo bar"> = [];
+
+function test<T extends "generic">() {
+
+}
+
+function test<T extends ("generic" & number)>() {
+
+}
+
+const callback = <U extends "generic">() => "hi" as number | string
+                                            ~~~~ [double]
+
+const v = callback()
+
+if (typeof v === "string") {}
+                 ~~~~~~~~ [double]
+
+if (typeof "string" === 'number') {}
+           ~~~~~~~~ [double]
+                        ~~~~~~~~ [single]
+
 var hello: "world";
-           ~~~~~~~ [" should be `]
+           ~~~~~~~ [double]
 'escaped\'quotemark';
-~~~~~~~~~~~~~~~~~~~~ [' should be `]
+~~~~~~~~~~~~~~~~~~~~ [single]
 
 // "avoid-template" option is not set.
 `foo`;
@@ -24,12 +52,18 @@ const object: {
     "hello-kebab"
     : number
     "kebab-case": number
+    "optional-prop"?: `hello-optional`
+    "optional-function"?(): void
     "another-kebab": "hello-value"
-                     ~~~~~~~~~~~~~ [" should be `]
+                     ~~~~~~~~~~~~~ [double]
 } = {
     "hello-kebab"
     : 4
     "kebab-case": 3,
+    "optional-kebab": undefined,
+    "optional-function"() {},
     "another-kebab": "hello-value"
-                     ~~~~~~~~~~~~~ [" should be `]
+                     ~~~~~~~~~~~~~ [double]
 };
+[single]: ' should be `
+[double]: " should be `

--- a/test/rules/quotemark/backtick/test<2.7.1.ts.fix
+++ b/test/rules/quotemark/backtick/test<2.7.1.ts.fix
@@ -1,0 +1,11 @@
+if (typeof v === "string") {}
+
+if (typeof `string` === 'number') {}
+
+const object: {
+   "optional-prop"?: "hello-optional"
+   "another-kebab": "hello-value"
+} = {
+   "optional-prop": undefined,
+   "another-kebab": "hello-value"
+};

--- a/test/rules/quotemark/backtick/test<2.7.1.ts.lint
+++ b/test/rules/quotemark/backtick/test<2.7.1.ts.lint
@@ -1,0 +1,15 @@
+[typescript]: <2.7.1
+if (typeof v === "string") {}
+
+if (typeof "string" === 'number') {}
+           ~~~~~~~~ [double]
+
+const object: {
+   "optional-prop"?: "hello-optional"
+   "another-kebab": "hello-value"
+} = {
+   "optional-prop": undefined,
+   "another-kebab": "hello-value"
+};
+[single]: ' should be `
+[double]: " should be `

--- a/test/rules/quotemark/backtick/test>=2.7.1.ts.fix
+++ b/test/rules/quotemark/backtick/test>=2.7.1.ts.fix
@@ -1,0 +1,13 @@
+if (typeof v === `string`) {}
+
+if (typeof `string` === `number`) {}
+
+const object: {
+    "optional-prop"?: `hello-optional`
+    "optional-function"?(): void
+    "another-kebab": `hello-value`
+} = {
+    "optional-prop": undefined,
+    "optional-function"() {},
+    "another-kebab": `hello-value`
+};

--- a/test/rules/quotemark/backtick/test>=2.7.1.ts.lint
+++ b/test/rules/quotemark/backtick/test>=2.7.1.ts.lint
@@ -1,0 +1,21 @@
+[typescript]: >=2.7.1
+if (typeof v === "string") {}
+                 ~~~~~~~~ [double]
+
+if (typeof "string" === 'number') {}
+           ~~~~~~~~ [double]
+                        ~~~~~~~~ [single]
+
+const object: {
+    "optional-prop"?: `hello-optional`
+    "optional-function"?(): void
+    "another-kebab": "hello-value"
+                     ~~~~~~~~~~~~~ [double]
+} = {
+    "optional-prop": undefined,
+    "optional-function"() {},
+    "another-kebab": "hello-value"
+                     ~~~~~~~~~~~~~ [double]
+};
+[single]: ' should be `
+[double]: " should be `


### PR DESCRIPTION
This edge cases were previously flagged when they should be ignored, as changing them breaks typescript. This commit makes it so they are ignored. It also organizes a little better, using functions instead of multi-layered conditionals (it was getting confusing).

#### PR checklist

- [x] Addresses an existing issue: #4588, fixes #4645
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

I keep finding other edge cases that I previously missed. I *think* this is all of them now, but we shall see. Related to #4588.

#### Is there anything you'd like reviewers to focus on?

See if y'all find any other edge cases.

#### CHANGELOG.md entry:

[bugfix] Excuse more quotemark backtick edge cases