### PR TITLE
[deprecation] Only flag statement deprecated if all overloads are deprecated

### DIFF
--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -32,6 +32,7 @@ import {
     isVariableDeclarationList,
 } from "tsutils";
 import * as ts from "typescript";
+
 import * as Lint from "../index";
 
 export class Rule extends Lint.Rules.TypedRule {

--- a/src/rules/deprecationRule.ts
+++ b/src/rules/deprecationRule.ts
@@ -211,7 +211,8 @@ function getDeprecationFromDeclarations(declarations?: ts.Declaration[]): string
     const deprecations = declarations
         .map(declaration => getDeprecationFromDeclaration(getRootDeclaration(declaration)))
         .filter(deprecation => deprecation !== undefined);
-    const allDeclarationsDeprecated = deprecations.length === declarations.length;
+    const allDeclarationsDeprecated =
+        deprecations.length > 0 && deprecations.length === declarations.length;
     return allDeclarationsDeprecated ? deprecations.join(", ") : undefined;
 }
 

--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -1,7 +1,3 @@
-// don't show an error on imports, because they don't do any harm if not used
-import def, {other, other2 as foobar, notDeprecated, notDeprecated2} from './other.test';
-import * as namespaceImport from './other.test';
-import * as other2 from './other2.test';
 
 other;
 other();
@@ -169,6 +165,10 @@ let {f, g, h} = p;
                   ~ [errmsg % ('h', 'Use g instead.')]
 (function ({foo: {f, g}}: {foo: I}) {})
                   ~ [err % ('f')]
+
+/** comment */
+let x = undefined;
+x = null;
 
 [err]: %s is deprecated.
 [errmsg]: %s is deprecated: %s

--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -3,6 +3,7 @@ import def, {other, other2 as foobar, notDeprecated, notDeprecated2} from './oth
 import * as namespaceImport from './other.test';
 import * as other2 from './other2.test';
 
+other;
 other();
 ~~~~~ [errmsg % ('other', 'reason')]
 other(1);
@@ -14,6 +15,8 @@ other2;
 import tmp = namespaceImport.other;
 
 tmp;
+tmp(1);
+tmp();
 ~~~ [errmsg % ('tmp', 'reason')]
 
 declare interface D {
@@ -58,9 +61,7 @@ const A = 1, B = 2;
 
 A + B;
 ~     [err % ('A')]
-#if typescript < 2.6.1
     ~ [err % ('B')]
-#endif
 
 export default A;
 
@@ -75,7 +76,6 @@ fn<number>();
 fn(1);
 ~~ [err % ('fn')]
 fn;
-~~ [err % ('fn')]
 
 class TestClass {
     /** @deprecated */

--- a/test/rules/deprecation/test.ts.lint
+++ b/test/rules/deprecation/test.ts.lint
@@ -1,3 +1,7 @@
+// don't show an error on imports, because they don't do any harm if not used
+import def, {other, other2 as foobar, notDeprecated, notDeprecated2} from './other.test';
+import * as namespaceImport from './other.test';
+import * as other2 from './other2.test';
 
 other;
 other();
@@ -169,6 +173,11 @@ let {f, g, h} = p;
 /** comment */
 let x = undefined;
 x = null;
+
+/** @deprecated */
+let y = undefined;
+x = y;
+    ~ [err % ('y')]
 
 [err]: %s is deprecated.
 [errmsg]: %s is deprecated: %s


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4522
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

##### Old behavior
`deprecation` rule flags a statement as deprecated when at least one of the overloads is deprecated (see #4522).

##### New behavior
`deprecation` rule flags statement as deprecated when all overloads are deprecated (and TS can't infer which overload is being used).
