### PR TITLE
Remove unnecessary break in switchDefault example

### DIFF
--- a/src/rules/code-examples/switchDefault.examples.ts
+++ b/src/rules/code-examples/switchDefault.examples.ts
@@ -35,7 +35,6 @@ export const codeExamples = [
                     break;
                 default:
                     console.log('default');
-                    break;
             }
         `,
         fail: Lint.Utils.dedent`
@@ -46,7 +45,6 @@ export const codeExamples = [
                     break;
                 case 2:
                     doSomething2();
-                    break;
             }
         `,
     },


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: fixes #0000
- [ ] New feature, bugfix, or enhancement
- [ ] Includes tests
- [x] Documentation update

#### Overview of change:
Last switch case does not need a break statement as the switch will already end after it. This way this example will also ensure following the rule switchFinalBreakRule which it does not at the moment. 

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
