### PR TITLE
Fix interfaceName rule

### DIFF
--- a/src/rules/interfaceNameRule.ts
+++ b/src/rules/interfaceNameRule.ts
@@ -75,19 +75,17 @@ function walk(ctx: Lint.WalkContext<{ never: boolean }>): void {
 }
 
 function hasPrefixI(name: string): boolean {
-    return (
-        name.length >= 3 && name[0] === "I" && /^[A-Z]*$/.test(name[1]) && !/^[A-Z]*$/.test(name[2])
-    );
+    return name.length >= 3 && name[0] === "I" && /^[A-Z]*$/.test(name[1]);
 }
 
 function cantDecide(name: string): boolean {
     return (
         // Case ID
         (name.length === 2 && name[0] === "I" && /^[A-Z]*$/.test(name[1])) ||
-        // Case IDB
+        // Case IDB or ID42
         (name.length >= 2 &&
             name[0] === "I" &&
             /^[A-Z]*$/.test(name[1]) &&
-            /^[A-Z]*$/.test(name[2]))
+            !/^[a-z]*$/.test(name[2]))
     );
 }

--- a/test/rules/interface-name/always-prefix/test.ts.lint
+++ b/test/rules/interface-name/always-prefix/test.ts.lint
@@ -14,6 +14,12 @@ interface IDBFactory {
 interface II18nService {
 }
 
+interface IIS3Foobar {
+}
+
+interface IS3Foobar {
+}
+
 // invalid code
 interface Options {
           ~~~~~~~   [interface name must start with a capitalized I]
@@ -21,4 +27,8 @@ interface Options {
 
 interface Incomplete {
           ~~~~~~~~~~   [interface name must start with a capitalized I]
+}
+
+interface I18nService {
+          ~~~~~~~~~~~   [interface name must start with a capitalized I]
 }

--- a/test/rules/interface-name/never-prefix/test.ts.lint
+++ b/test/rules/interface-name/never-prefix/test.ts.lint
@@ -17,6 +17,15 @@ interface IDBFactory {
 interface I18nFactory {
 }
 
+interface II18nFactory {
+}
+
+interface IS3Foobar {
+}
+
+interface IIS3Foobar {
+}
+
 interface ABC {
 }
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes https://github.com/palantir/tslint/pull/4486#issuecomment-481882311
- [x] bugfix
  - [x] Includes tests

#### Overview of change:

More edge case for this rule.

#### Is there anything you'd like reviewers to focus on?

Theses cases are considered valid in both `always`  and `never`.

IS
IIS3Foobar
IS3Foobar -> This one is fixed now
IISFoobar
ISFoobar

#### CHANGELOG.md entry:

"[bugfix] `interface-name`"