### PR TITLE
fix identifer to identifier typo - note missing (i)

### DIFF
--- a/docs/develop/custom-rules/index.md
+++ b/docs/develop/custom-rules/index.md
@@ -6,7 +6,7 @@ permalink: "/develop/custom-rules/"
 
 TSLint ships with a set of core rules that can be configured. However, users are also allowed to write their own rules, which allows them to enforce specific behavior not covered by the core of TSLint. TSLint's internal rules are itself written to be pluggable, so adding a new rule is as simple as creating a new rule file named by convention. New rules can be written in either TypeScript or JavaScript; if written in TypeScript, the code must be compiled to JavaScript before invoking TSLint.
 
-Let us take the example of how to write a new rule to forbid all import statements (you know, *for science*). Let us name the rule file `noImportsRule.ts`. Rules are referenced in `tslint.json` with their kebab-cased identifer, so `"no-imports": true` would configure the rule.
+Let us take the example of how to write a new rule to forbid all import statements (you know, *for science*). Let us name the rule file `noImportsRule.ts`. Rules are referenced in `tslint.json` with their kebab-cased identifier, so `"no-imports": true` would configure the rule.
 
 __Important conventions__:
 

--- a/src/rules/radixRule.ts
+++ b/src/rules/radixRule.ts
@@ -59,25 +59,25 @@ function isPropertyAccessParseInt(
 
 function isPropertyAccessOfIdentifier(
     expression: ts.LeftHandSideExpression,
-    identifers: string[],
+    identifiers: string[],
 ): expression is ts.PropertyAccessExpression {
     return (
         isPropertyAccessExpression(expression) &&
         isIdentifier(expression.expression) &&
-        identifers.some(identifer => (expression.expression as ts.Identifier).text === identifer)
+        identifiers.some(identifier => (expression.expression as ts.Identifier).text === identifier)
     );
 }
 
 function isPropertyAccessOfProperty(
     expression: ts.LeftHandSideExpression,
-    identifers: string[],
+    identifiers: string[],
 ): expression is ts.PropertyAccessExpression {
     return (
         isPropertyAccessExpression(expression) &&
         isPropertyAccessExpression(expression.expression) &&
-        identifers.some(
-            identifer =>
-                (expression.expression as ts.PropertyAccessExpression).name.text === identifer,
+        identifiers.some(
+            identifier =>
+                (expression.expression as ts.PropertyAccessExpression).name.text === identifier,
         )
     );
 }


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: fixes #0000
- [ ] New feature, bugfix, or enhancement
- [ ] Includes tests
- [x] Documentation update

#### Overview of change:
This should have no functional impact, just fixing a typo in code and documentation

#### Is there anything you'd like reviewers to focus on?

The parameter name is limited to the scope of the function in which it is used, and therefore it is not possible to have a side effect with this change. Please confirm my understanding.

#### CHANGELOG.md entry:
[new-fixer]
