### PR TITLE
[no-inferred-empty-object-type] Skip test in TS > 3.4.x

### DIFF
--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -30,8 +30,9 @@ export class Rule extends Lint.Rules.TypedRule {
         options: null,
         optionExamples: [true],
         rationale: Lint.Utils.dedent`
-            When function or constructor may be called with a type parameter but one isn't supplied or inferrable,
-            TypeScript sometimes defaults to \`{}\`.
+            Prior to TypeScript 3.4, generic type parameters for functions and constructors are inferred as
+            \`{}\` (the empty object type) by default when no type parameter is explicitly supplied or when
+            the compiler cannot infer a more specific type.
             This is often undesirable as the call is meant to be of a more specific type.
         `,
         type: "functionality",

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -31,7 +31,7 @@ export class Rule extends Lint.Rules.TypedRule {
         optionExamples: [true],
         rationale: Lint.Utils.dedent`
             When function or constructor may be called with a type parameter but one isn't supplied or inferrable,
-            TypeScript defaults to \`{}\`.
+            TypeScript sometimes defaults to \`{}\`.
             This is often undesirable as the call is meant to be of a more specific type.
         `,
         type: "functionality",

--- a/test/rules/no-inferred-empty-object-type/test.ts.lint
+++ b/test/rules/no-inferred-empty-object-type/test.ts.lint
@@ -1,3 +1,4 @@
+[typescript]: <=3.4.x
 let s: string;
 let n: number;
 let o: Object;


### PR DESCRIPTION
As the generic parameters are inferred as `unknown` in newer TS versions (> 3.4.x), this rule no longer applies in those versions, and those places that would have previously thrown an error, as seen in the tests, no longer should throw as they are no longer inferred as `{}`.

#### PR checklist

- [x] Addresses an existing issue: fixes #4644
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

TS above 3.4.x infers the types to `unknown` instead of `{}`, so the tests no longer apply.

#### CHANGELOG.md entry:

[no-log]