### PR TITLE
Allow const assertions in no-object-literal-type-assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "tslint-config-prettier": "^1.18.0",
         "tslint-plugin-prettier": "^2.0.1",
         "tslint-test-config-non-relative": "file:test/external/tslint-test-config-non-relative",
-        "typescript": "~3.1.6",
+        "typescript": "~3.4.0",
         "yarn-deduplicate": "^1.1.1"
     },
     "engines": {

--- a/src/rules/noObjectLiteralTypeAssertionRule.ts
+++ b/src/rules/noObjectLiteralTypeAssertionRule.ts
@@ -86,6 +86,12 @@ function walk(ctx: Lint.WalkContext<Options>): void {
         if (
             isAssertionExpression(node) &&
             node.type.kind !== ts.SyntaxKind.AnyKeyword &&
+            // If using TS >=3.4, allow const assertions
+            !(
+                (ts as any).isConstTypeReference &&
+                node.type.kind === ts.SyntaxKind.TypeReference &&
+                (ts as any).isConstTypeReference(node.type)
+            ) &&
             // Compare with UnknownKeyword if using TS 3.0 or above
             (!!(ts.SyntaxKind as any).UnknownKeyword
                 ? node.type.kind !== (ts.SyntaxKind as any).UnknownKeyword

--- a/src/rules/noObjectLiteralTypeAssertionRule.ts
+++ b/src/rules/noObjectLiteralTypeAssertionRule.ts
@@ -88,9 +88,9 @@ function walk(ctx: Lint.WalkContext<Options>): void {
             node.type.kind !== ts.SyntaxKind.AnyKeyword &&
             // If using TS >=3.4, allow const assertions
             !(
-                (ts as any).isConstTypeReference &&
                 node.type.kind === ts.SyntaxKind.TypeReference &&
-                (ts as any).isConstTypeReference(node.type)
+                ts.isConstTypeReference !== undefined &&
+                ts.isConstTypeReference(node.type)
             ) &&
             // Compare with UnknownKeyword if using TS 3.0 or above
             (!!(ts.SyntaxKind as any).UnknownKeyword

--- a/src/rules/noObjectLiteralTypeAssertionRule.ts
+++ b/src/rules/noObjectLiteralTypeAssertionRule.ts
@@ -48,7 +48,9 @@ export class Rule extends Lint.Rules.AbstractRule {
             The type assertion in the latter case is either unnecessary or hides an error.
             The compiler will warn for excess properties with this syntax, but not missing required fields.
             For example: \`const x: { foo: number } = {}\` will fail to compile, but
-            \`const x = {} as { foo: number }\` will succeed.`,
+            \`const x = {} as { foo: number }\` will succeed.
+            Additionally, the const assertion \`const x = { foo: 1 } as const\`,
+            introduced in TypeScript 3.4, is considered beneficial and is ignored by this rule.`,
         optionsDescription: Lint.Utils.dedent`
             One option may be configured:
 
@@ -87,12 +89,7 @@ function walk(ctx: Lint.WalkContext<Options>): void {
             isAssertionExpression(node) &&
             node.type.kind !== ts.SyntaxKind.AnyKeyword &&
             // Allow const assertions, introduced in TS 3.4
-            !(
-                node.type.kind === ts.SyntaxKind.TypeReference &&
-                (ts.isConstTypeReference !== undefined
-                    ? ts.isConstTypeReference(node.type)
-                    : node.type.getText(ctx.sourceFile) === "const")
-            ) &&
+            !(ts.isConstTypeReference !== undefined && ts.isConstTypeReference(node.type)) &&
             // Compare with UnknownKeyword if using TS 3.0 or above
             (!!(ts.SyntaxKind as any).UnknownKeyword
                 ? node.type.kind !== (ts.SyntaxKind as any).UnknownKeyword

--- a/src/rules/noObjectLiteralTypeAssertionRule.ts
+++ b/src/rules/noObjectLiteralTypeAssertionRule.ts
@@ -86,11 +86,12 @@ function walk(ctx: Lint.WalkContext<Options>): void {
         if (
             isAssertionExpression(node) &&
             node.type.kind !== ts.SyntaxKind.AnyKeyword &&
-            // If using TS >=3.4, allow const assertions
+            // Allow const assertions, introduced in TS 3.4
             !(
                 node.type.kind === ts.SyntaxKind.TypeReference &&
-                ts.isConstTypeReference !== undefined &&
-                ts.isConstTypeReference(node.type)
+                (ts.isConstTypeReference !== undefined
+                    ? ts.isConstTypeReference(node.type)
+                    : node.type.getText(ctx.sourceFile) === "const")
             ) &&
             // Compare with UnknownKeyword if using TS 3.0 or above
             (!!(ts.SyntaxKind as any).UnknownKeyword

--- a/test/rules/no-object-literal-type-assertion/default/test.ts.lint
+++ b/test/rules/no-object-literal-type-assertion/default/test.ts.lint
@@ -16,9 +16,11 @@ x as T;
 {} as unknown;
 <unknown> {};
 
+#if typescript >= 3.4.0
 // Allow const assertion
 ({}) as const;
 <const> ({});
+#endif
 
 foo({} as T);
     ~~~~~~~ [0]

--- a/test/rules/no-object-literal-type-assertion/default/test.ts.lint
+++ b/test/rules/no-object-literal-type-assertion/default/test.ts.lint
@@ -16,6 +16,10 @@ x as T;
 {} as unknown;
 <unknown> {};
 
+// Allow const assertion
+({}) as const;
+<const> ({});
+
 foo({} as T);
     ~~~~~~~ [0]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,10 +1851,10 @@ type-detect@^1.0.0:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
   integrity sha1-diIXzAbbJY7EiQihKY6LlRIejqI=
 
-typescript@~3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@~3.4.0:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 uglify-js@^3.1.4:
   version "3.5.4"


### PR DESCRIPTION
These are not normal type assertions and asserting that literal objects
are immutable is a normal usage pattern.

#### PR checklist

- [x] Addresses an existing issue: fixes #4628
- [x] enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Allow const assertions in no-object-literal-type-assertion. These are not equivalent to normal type assertions, and using them on literal objects is expected behavior.

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
[enhancement] Allow const assertions in no-object-literal-type-assertion
