### PR TITLE
Fixes "no-redundant-jsdoc" exception on this tag

### DIFF
--- a/src/rules/noRedundantJsdocRule.ts
+++ b/src/rules/noRedundantJsdocRule.ts
@@ -79,6 +79,7 @@ function walk(ctx: Lint.WalkContext): void {
                 break;
 
             case ts.SyntaxKind.JSDocClassTag:
+            case ts.SyntaxKind.JSDocThisTag:
             case ts.SyntaxKind.JSDocTypeTag:
             case ts.SyntaxKind.JSDocTypedefTag:
             case ts.SyntaxKind.JSDocPropertyTag:

--- a/test/rules/no-redundant-jsdoc/test.ts.lint
+++ b/test/rules/no-redundant-jsdoc/test.ts.lint
@@ -1,8 +1,11 @@
 /** @typedef {number} T */
      ~~~~~~~ [tag % ('typedef')]
 
-/** @function */
+/** @function
      ~~~~~~~~ [tag % ('function')]
+ *  @this
+     ~~~~ [tag % ('this')]
+ */
 function f() {}
 
 /** @type number */
@@ -12,6 +15,8 @@ const x = 0;
 /**
  * @class
     ~~~~~ [tag % ('class')]
+ * @this {}
+    ~~~~ [tag % ('this')]
  * @param {number} x Is a number
           ~~~~~~~~ [type]
  * @param y
@@ -26,10 +31,16 @@ const x = 0;
 declare function g(x: number, y: number, z: number): number;
 
 /**
+ * @this {SomeClass}
+    ~~~~ [tag % ('this')]
+ */
+declare function h();
+
+/**
  * @param x Useful comment
  * @returns Useful comment
  */
-declare function h(x: number): number;
+declare function i(x: number): number;
 
 /**
  * @template T, U
@@ -38,7 +49,7 @@ declare function h(x: number): number;
 #endif
  * @template V Some additional information
  */
-declare function i<T, U, V>(x: T, y: V): U;
+declare function j<T, U, V>(x: T, y: V): U;
 
 [tag]: JSDoc tag '@%s' is redundant in TypeScript code.
 [type]: Type annotation in JSDoc is redundant in TypeScript code.


### PR DESCRIPTION
```
The 'no-redundant-jsdoc' rule threw an error in 'some-file.ts':
Error: Unexpected tag kind: JSDocThisTag
```

This appears to be similar to #3413

#### PR checklist

- [ ] Addresses an existing issue: fixes #0000
- [ x ] New feature, bugfix, or enhancement
  - [ x ] Includes tests
- [ ] Documentation update

#### Overview of change:

Adds `JSDocThisTag` to the redundant cases.

#### Is there anything you'd like reviewers to focus on?

I appreciate this is my first contribution to this project so feel free to point me in the direction of any contribution guidelines that I've overlooked.

#### CHANGELOG.md entry:
[bugfix] `no-redundant-jsdoc` no longer errors on `JSDocThisTag`
