### PR TITLE
[quotemark] Exclude some cases from backtick rule

### DIFF
--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -30,7 +30,7 @@ export class Rule extends Lint.Rules.TypedRule {
         options: null,
         optionExamples: [true],
         rationale: Lint.Utils.dedent`
-            Prior to TypeScript 3.4, generic type parameters for functions and constructors are inferred as
+            Prior to TypeScript 3.5, generic type parameters for functions and constructors are inferred as
             \`{}\` (the empty object type) by default when no type parameter is explicitly supplied or when
             the compiler cannot infer a more specific type.
             This is often undesirable as the call is meant to be of a more specific type.

--- a/src/rules/noInferredEmptyObjectTypeRule.ts
+++ b/src/rules/noInferredEmptyObjectTypeRule.ts
@@ -30,7 +30,7 @@ export class Rule extends Lint.Rules.TypedRule {
         options: null,
         optionExamples: [true],
         rationale: Lint.Utils.dedent`
-            Prior to TypeScript 3.5, generic type parameters for functions and constructors are inferred as
+            Prior to TypeScript 3.4, generic type parameters for functions and constructors are inferred as
             \`{}\` (the empty object type) by default when no type parameter is explicitly supplied or when
             the compiler cannot infer a more specific type.
             This is often undesirable as the call is meant to be of a more specific type.

--- a/src/rules/quotemarkRule.ts
+++ b/src/rules/quotemarkRule.ts
@@ -259,7 +259,7 @@ function isNotValidToUseBackticksInNode(node: StringLiteralLike, sourceFile: ts.
         isEnumMember(node.parent) ||
         // Typescript converts old octal escape sequences to just the numbers therein
         containsOctalEscapeSequence(node, sourceFile) ||
-        // Typescript converts old octal escape sequences to just the numbers therein
+        // Use strict declarations have to be single or double quoted
         isUseStrictDeclaration(node) ||
         // Lookup type parameters must be single/double quoted
         isLookupTypeParameter(node)

--- a/test/rules/quotemark/backtick/test.ts.fix
+++ b/test/rules/quotemark/backtick/test.ts.fix
@@ -15,11 +15,13 @@ const octalEscapeSequence4 = '\377'
 const octalEscapeSequence5 = '\123'
 // Prefix (\47) is an octal escape sequence
 const octalEscapeSequence6 = '\477'
+const octalEscapeSequence7 = '\\77 \77 \\37 \\77'
 
 const notOctalEscapeSequence = `\877`
 const notOctalEscapeSequence2 = `\017`
 const notOctalEscapeSequence3 = `\t`
 const notOctalEscapeSequence4 = `\0`
+const notOctalEscapeSequence4 = `\\77 \\37 \\\\47 \\\\\\77`
 
 function strictFunction() {
     "use strict"

--- a/test/rules/quotemark/backtick/test.ts.fix
+++ b/test/rules/quotemark/backtick/test.ts.fix
@@ -1,5 +1,31 @@
+"use strict"
+
 import { Something } from "some-package"
 export { SomethingElse } from "another-package"
+
+enum Sides {
+    '<- Left',
+    'Right ->'
+}
+
+const octalEscapeSequence = '\1'
+const octalEscapeSequence2 = '\7'
+const octalEscapeSequence3 = '\77'
+const octalEscapeSequence4 = '\377'
+const octalEscapeSequence5 = '\123'
+// Prefix (\47) is an octal escape sequence
+const octalEscapeSequence6 = '\477'
+
+const notOctalEscapeSequence = `\877`
+const notOctalEscapeSequence2 = `\017`
+const notOctalEscapeSequence3 = `\t`
+const notOctalEscapeSequence4 = `\0`
+
+function strictFunction() {
+    "use strict"
+
+    const str = `use strict`
+}
 
 var single = `single`;
     var double = `married`;
@@ -21,6 +47,26 @@ function test<T extends "generic">() {
 
 function test<T extends ("generic" & number)>() {
 
+}
+
+declare var obj: {
+    helloWorldString: string
+}
+
+interface obj2 {
+    helloWorldString: string
+}
+
+type objHello = typeof obj["helloWorldString"]
+type objHello2 = obj2["helloWorldString"]
+let helloValue = obj[`helloWorldString`]
+
+helloValue = obj[`helloWorldString`]
+
+const obj3: {
+    value: typeof obj["helloWorldString"]
+} = {
+    value: obj[`helloWorldString`]
 }
 
 const callback = <U extends "generic">() => `hi` as number | string

--- a/test/rules/quotemark/backtick/test.ts.lint
+++ b/test/rules/quotemark/backtick/test.ts.lint
@@ -1,5 +1,36 @@
+"use strict"
+
 import { Something } from "some-package"
 export { SomethingElse } from "another-package"
+
+enum Sides {
+    '<- Left',
+    'Right ->'
+}
+
+const octalEscapeSequence = '\1'
+const octalEscapeSequence2 = '\7'
+const octalEscapeSequence3 = '\77'
+const octalEscapeSequence4 = '\377'
+const octalEscapeSequence5 = '\123'
+// Prefix (\47) is an octal escape sequence
+const octalEscapeSequence6 = '\477'
+
+const notOctalEscapeSequence = '\877'
+                               ~~~~~~ [single]
+const notOctalEscapeSequence2 = '\017'
+                                ~~~~~~ [single]
+const notOctalEscapeSequence3 = '\t'
+                                ~~~~ [single]
+const notOctalEscapeSequence4 = '\0'
+                                ~~~~ [single]
+
+function strictFunction() {
+    "use strict"
+
+    const str = "use strict"
+                ~~~~~~~~~~~~ [double]
+}
 
 var single = 'single';
              ~~~~~~~~  [single]
@@ -26,6 +57,29 @@ function test<T extends "generic">() {
 
 function test<T extends ("generic" & number)>() {
 
+}
+
+declare var obj: {
+    helloWorldString: string
+}
+
+interface obj2 {
+    helloWorldString: string
+}
+
+type objHello = typeof obj["helloWorldString"]
+type objHello2 = obj2["helloWorldString"]
+let helloValue = obj["helloWorldString"]
+                     ~~~~~~~~~~~~~~~~~~ [double]
+
+helloValue = obj["helloWorldString"]
+                 ~~~~~~~~~~~~~~~~~~ [double]
+
+const obj3: {
+    value: typeof obj["helloWorldString"]
+} = {
+    value: obj["helloWorldString"]
+               ~~~~~~~~~~~~~~~~~~ [double]
 }
 
 const callback = <U extends "generic">() => "hi" as number | string

--- a/test/rules/quotemark/backtick/test.ts.lint
+++ b/test/rules/quotemark/backtick/test.ts.lint
@@ -15,6 +15,7 @@ const octalEscapeSequence4 = '\377'
 const octalEscapeSequence5 = '\123'
 // Prefix (\47) is an octal escape sequence
 const octalEscapeSequence6 = '\477'
+const octalEscapeSequence7 = '\\77 \77 \\37 \\77'
 
 const notOctalEscapeSequence = '\877'
                                ~~~~~~ [single]
@@ -24,6 +25,8 @@ const notOctalEscapeSequence3 = '\t'
                                 ~~~~ [single]
 const notOctalEscapeSequence4 = '\0'
                                 ~~~~ [single]
+const notOctalEscapeSequence4 = '\\77 \\37 \\\\47 \\\\\\77'
+                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~ [single]
 
 function strictFunction() {
     "use strict"


### PR DESCRIPTION
This commit makes quotemark backtick ignore use strict declarations, enum members, lookup types, and strings containing octal escape sequences.

#### PR checklist

- [x] Addresses an existing issue: fixes #4692 
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

See description. Just ignore the cases mentioned in the bug.

#### Is there anything you'd like reviewers to focus on?

Make sure I captured all the variations of the said cases in the tests.

#### CHANGELOG.md entry:

[bugfix] Quotemark backtrack now ignores enum members, use strict declarations, lookup types, and strings containing octal escape sequences.