### PR TITLE
Add a fixer for "unnecessary-constructor" rule.

### DIFF
--- a/src/rules/unnecessaryConstructorRule.ts
+++ b/src/rules/unnecessaryConstructorRule.ts
@@ -56,12 +56,16 @@ const isAccessRestrictingConstructor = (node: ts.ConstructorDeclaration): boolea
     // If this has any modifier that isn't public, it's doing something
     node.modifiers.some(modifier => modifier.kind !== ts.SyntaxKind.PublicKeyword);
 
+const containsDecorator = (node: ts.ConstructorDeclaration): boolean =>
+    node.parameters.some(p => p.decorators !== undefined);
+
 function walk(context: Lint.WalkContext) {
     const callback = (node: ts.Node): void => {
         if (
             isConstructorDeclaration(node) &&
             isEmptyConstructor(node) &&
             !containsConstructorParameter(node) &&
+            !containsDecorator(node) &&
             !isAccessRestrictingConstructor(node)
         ) {
             const replacements = [];

--- a/test/rules/unnecessary-constructor/test.ts.fix
+++ b/test/rules/unnecessary-constructor/test.ts.fix
@@ -1,0 +1,65 @@
+export class ExportedClass {
+}
+
+class PublicConstructor {
+}
+
+class ProtectedConstructor {
+    protected constructor() { }
+}
+
+class PrivateConstructor {
+    private constructor() { }
+}
+
+class SameLine { }
+
+class WithPrecedingMember {
+    public member: string;
+}
+
+class WithFollowingMethod {
+    public method() {}
+}
+
+const classExpression = class {
+}
+
+class ContainsContents {
+    constructor() {
+        console.log("Hello!");
+    }
+}
+
+class CallsSuper extends PublicConstructor {
+    constructor() {
+        super();
+    }
+}
+
+class ContainsParameter {
+}
+
+class PrivateContainsParameter {
+    private constructor(x: number) { }
+}
+
+class ProtectedContainsParameter {
+    protected constructor(x: number) { }
+}
+
+class ContainsParameterDeclaration {
+    constructor(public x: number) { }
+}
+
+class ContainsParameterAndParameterDeclaration {
+    constructor(x: number, public y: number) { }
+}
+
+class ConstructorOverload {
+}
+
+interface IConstructorSignature {
+    new(): {};
+}
+

--- a/test/rules/unnecessary-constructor/test.ts.fix
+++ b/test/rules/unnecessary-constructor/test.ts.fix
@@ -63,3 +63,7 @@ interface IConstructorSignature {
     new(): {};
 }
 
+class DecoratedParameters {
+    constructor(@Optional x: number) {}
+}
+

--- a/test/rules/unnecessary-constructor/test.ts.lint
+++ b/test/rules/unnecessary-constructor/test.ts.lint
@@ -79,4 +79,8 @@ interface IConstructorSignature {
     new(): {};
 }
 
+class DecoratedParameters {
+    constructor(@Optional x: number) {}
+}
+
 [0]: Remove unnecessary empty constructor.


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: fixes #0000
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Add a fixer for "unnecessary-constructor" rule.
Also don't flag constructors with decorated parameters since the parameter decorator can have side effects.

#### Is there anything you'd like reviewers to focus on?
This was added in the initial commit of "unnecessary-constructor" rule but [removed later](https://github.com/palantir/tslint/pull/3647/commits/56ac48a9ebe6680a33c795091874b17a3126b862). What are the concerns?
I ran this fixer across Google's mono repo. The fixes produced are legit to me.

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
