### PR TITLE
Deprecate no-use-before-declare rule for typescript 2.9+

### DIFF
--- a/src/rules/noUseBeforeDeclareRule.ts
+++ b/src/rules/noUseBeforeDeclareRule.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as semver from "semver";
 import { isBindingElement } from "tsutils";
 import * as ts from "typescript";
 
@@ -42,6 +43,9 @@ export class Rule extends Lint.Rules.TypedRule {
         typescriptOnly: false,
         requiresTypeInfo: true,
         codeExamples,
+        deprecationMessage: semver.gte(ts.version, "2.9.0-dev.0")
+            ? "Since TypeScript 2.9. Please use the built-in compiler checks instead."
+            : undefined,
     };
     /* tslint:enable:object-literal-sort-keys */
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4666
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
deprecate no-use-before-declare for TS 2.9+

