### PR TITLE
Fix up variable-name rule metadata

### DIFF
--- a/src/language/rule/rule.ts
+++ b/src/language/rule/rule.ts
@@ -73,7 +73,7 @@ export interface IRuleMetadata {
      * Examples of what a standard config for the rule might look like.
      * Using a string[] here is deprecated. Write the options as a JSON object instead.
      */
-    optionExamples?: Array<true | any[]> | string[];
+    optionExamples?: Array<true | any[]> | string[] | Array<{ options: any }>;
 
     /**
      * An explanation of why the rule is useful.

--- a/test/rules/no-null-undefined-union/test.ts.lint
+++ b/test/rules/no-null-undefined-union/test.ts.lint
@@ -1,4 +1,4 @@
-[typescript]: >= 2.4.0
+[typescript]: >= 2.4.0 < 3.5.0
 
 // Catches explicit union types.
 

--- a/test/rules/no-null-undefined-union/ts350.ts.lint
+++ b/test/rules/no-null-undefined-union/ts350.ts.lint
@@ -1,0 +1,12 @@
+[typescript]: >= 3.5.0
+
+type SomeType =
+
+    | null
+    ~~~~~~
+    | undefined
+~~~~~~~~~~~~~~~
+    | boolean;
+~~~~~~~~~~~~~ [0]
+
+[0]: Union type cannot include both 'null' and 'undefined'.

--- a/tslint-vscode.json
+++ b/tslint-vscode.json
@@ -9,6 +9,7 @@
         "no-floating-promises": false,
         "no-for-in-array": false,
         "no-inferred-empty-object-type": false,
+        "no-restricted-globals": false,
         "no-unnecessary-type-assertion": false,
         "no-unsafe-any": false,
         "prefer-readonly": false,


### PR DESCRIPTION
Related to #4677 

#### CHANGELOG.md entry:

[documentation] Minor fix for `variable-name` rule metadata
