### PR TITLE
[new-rule] Add no-unnecessary-type-check rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Prerequisites:
 
 ```bash
 git clone git@github.com:palantir/tslint.git --config core.autocrlf=input --config core.eol=lf
+cd tslint
 yarn
 yarn compile
 yarn test

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -221,6 +221,7 @@ export const rules = {
     "no-unnecessary-initializer": true,
     "no-unnecessary-qualifier": true,
     "no-unnecessary-type-assertion": true,
+    "no-unnecessary-type-check": true,
     "number-literal-format": true,
     "object-literal-key-quotes": { options: "consistent-as-needed" },
     "object-literal-shorthand": true,

--- a/src/rules/noUnnecessaryTypeCheckRule.ts
+++ b/src/rules/noUnnecessaryTypeCheckRule.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2017 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as utils from "tsutils";
+import { isUnionType } from "tsutils";
+import * as ts from "typescript";
+
+import * as Lint from "../index";
+
+type Side = "right" | "left";
+type Overlap = "always" | "never";
+interface UnnecessaryTypeCheck {
+    atNode: ts.Expression;
+    failingSide: Side;
+    overlapType: Overlap;
+    comparingTo: string;
+}
+
+export class Rule extends Lint.Rules.TypedRule {
+    /* tslint:disable:object-literal-sort-keys */
+    public static metadata: Lint.IRuleMetadata = {
+        ruleName: "no-unnecessary-type-check",
+        description:
+            "Warns on comparison against `null` or `undefined` (`x !== undefined`) if the result is always true or always false",
+        hasFix: false,
+        optionsDescription: "Not configurable.",
+        options: null,
+        optionExamples: [true],
+        rationale: Lint.Utils.dedent`
+            Checking against null or undefined unnecessarily can be a symptom of incorrect typings.
+            If it's possible that a value can be null or undefined, its type should reflect that.
+        `,
+        type: "typescript",
+        typescriptOnly: true,
+        requiresTypeInfo: true,
+    };
+    /* tslint:enable:object-literal-sort-keys */
+
+    public static FAILURE_STRING(failure: UnnecessaryTypeCheck) {
+        const { failingSide, overlapType, comparingTo } = failure;
+        return `This comparison is unnecessary because the ${failingSide} side is ${overlapType} ${comparingTo}`;
+    }
+
+    public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
+    }
+}
+
+function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker): void {
+    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
+        if (utils.isBinaryExpression(node)) {
+            const failure = getUnnecessaryTypeCheck(node, checker);
+            if (failure !== undefined) {
+                ctx.addFailureAtNode(failure.atNode, Rule.FAILURE_STRING(failure));
+            }
+        }
+        return ts.forEachChild(node, cb);
+    });
+}
+
+interface Identifier {
+    kind: ts.SyntaxKind;
+    typeFlag: ts.TypeFlags;
+    label: string;
+}
+
+const comparisonsToCheck: Identifier[] = [
+    {
+        kind: ts.SyntaxKind.UndefinedKeyword,
+        typeFlag: ts.TypeFlags.Undefined,
+        label: "undefined",
+    },
+    {
+        kind: ts.SyntaxKind.NullKeyword,
+        typeFlag: ts.TypeFlags.Null,
+        label: "null",
+    },
+];
+
+function getUnnecessaryTypeCheck(
+    node: ts.BinaryExpression,
+    tc: ts.TypeChecker,
+): UnnecessaryTypeCheck | undefined {
+    const { left, operatorToken, right } = node;
+    const eq = Lint.getEqualsKind(operatorToken);
+    if (eq === undefined) {
+        return undefined;
+    }
+
+    for (const identifier of comparisonsToCheck) {
+        const failure = getUnnecessaryTypeCheckForIdentifier(tc, left, right, identifier);
+        if (failure) {
+            return failure;
+        }
+    }
+
+    return undefined;
+}
+
+function getUnnecessaryTypeCheckForIdentifier(
+    tc: ts.TypeChecker,
+    left: ts.Expression,
+    right: ts.Expression,
+    identifier: Identifier,
+): UnnecessaryTypeCheck | undefined {
+    const failureDetails = (overlapType: Overlap, failingSide: Side) => ({
+        atNode: failingSide === "right" ? right : left,
+        failingSide,
+        overlapType,
+        comparingTo: identifier.label,
+    });
+
+    const alwaysOverlaps = (exp: ts.Expression) =>
+        tc.getTypeAtLocation(exp).getFlags() === identifier.typeFlag;
+
+    const neverOverlaps = (exp: ts.Expression) =>
+        !containsType(tc.getTypeAtLocation(exp), identifier.typeFlag);
+
+    if (expressionIsIdentifier(left, identifier.kind)) {
+        if (alwaysOverlaps(right)) {
+            return failureDetails("always", "right");
+        }
+        if (neverOverlaps(right)) {
+            return failureDetails("never", "right");
+        }
+    }
+
+    if (expressionIsIdentifier(right, identifier.kind)) {
+        if (alwaysOverlaps(left)) {
+            return failureDetails("always", "left");
+        }
+        if (neverOverlaps(left)) {
+            return failureDetails("never", "left");
+        }
+    }
+
+    return undefined;
+}
+
+function expressionIsIdentifier(exp: ts.Expression, identifier: ts.SyntaxKind) {
+    if (ts.isIdentifier(exp)) {
+        return exp.originalKeywordKind === identifier;
+    }
+    return exp.kind === identifier;
+}
+
+function containsType(haystack: ts.Type | undefined, needle: ts.TypeFlags): boolean {
+    if (haystack === undefined) {
+        return false;
+    }
+
+    if (isUnionType(haystack)) {
+        return haystack.types.some(subType => containsType(subType, needle));
+    }
+
+    return haystack.getFlags() === needle;
+}

--- a/src/rules/noUnnecessaryTypeCheckRule.ts
+++ b/src/rules/noUnnecessaryTypeCheckRule.ts
@@ -16,7 +16,6 @@
  */
 
 import * as utils from "tsutils";
-import { isUnionType } from "tsutils";
 import * as ts from "typescript";
 
 import * as Lint from "../index";
@@ -163,7 +162,7 @@ function containsType(haystack: ts.Type | undefined, needle: ts.TypeFlags): bool
         return false;
     }
 
-    if (isUnionType(haystack)) {
+    if (utils.isUnionType(haystack)) {
         return haystack.types.some(subType => containsType(subType, needle));
     }
 

--- a/src/rules/noUnnecessaryTypeCheckRule.ts
+++ b/src/rules/noUnnecessaryTypeCheckRule.ts
@@ -155,14 +155,9 @@ function expressionIsIdentifier(exp: ts.Expression, identifier: ts.SyntaxKind) {
     return exp.kind === identifier;
 }
 
-function containsType(haystack: ts.Type | undefined, needle: ts.TypeFlags): boolean {
-    if (haystack === undefined) {
-        return false;
-    }
-
+function containsType(haystack: ts.Type, needle: ts.TypeFlags): boolean {
     if (utils.isUnionType(haystack)) {
         return haystack.types.some(subType => containsType(subType, needle));
     }
-
     return haystack.getFlags() === needle;
 }

--- a/src/rules/noUnnecessaryTypeCheckRule.ts
+++ b/src/rules/noUnnecessaryTypeCheckRule.ts
@@ -96,13 +96,13 @@ interface Identifier {
 const comparisonsToCheck: Identifier[] = [
     {
         kind: ts.SyntaxKind.UndefinedKeyword,
-        typeFlag: ts.TypeFlags.Undefined,
         label: "undefined",
+        typeFlag: ts.TypeFlags.Undefined,
     },
     {
         kind: ts.SyntaxKind.NullKeyword,
-        typeFlag: ts.TypeFlags.Null,
         label: "null",
+        typeFlag: ts.TypeFlags.Null,
     },
 ];
 
@@ -128,7 +128,7 @@ function getUnnecessaryTypeCheck(
             { expression: right, side: "right" },
             identifier,
         );
-        if (failure) {
+        if (failure !== undefined) {
             return failure;
         }
     }
@@ -148,9 +148,9 @@ function getUnnecessaryTypeCheckForIdentifier(
         failingSide: Side,
     ): UnnecessaryTypeCheck => ({
         atNode,
+        comparingTo: identifier.label,
         failingSide,
         overlapType,
-        comparingTo: identifier.label,
     });
 
     const alwaysOverlaps = (exp: ts.Expression) =>
@@ -171,6 +171,7 @@ function getUnnecessaryTypeCheckForIdentifier(
         return undefined;
     };
 
+    // tslint:disable-next-line:strict-boolean-expressions
     return getFailure(left.expression, right) || getFailure(right.expression, left);
 }
 

--- a/test/rules/no-unnecessary-type-check/test.ts.lint
+++ b/test/rules/no-unnecessary-type-check/test.ts.lint
@@ -1,3 +1,8 @@
+42 === undefined;
+~~                [This comparison is unnecessary because the left side is never undefined]
+
+
+
 declare const alwaysUndefined: boolean | undefined = undefined;
 declare const sometimesUndefined: boolean | undefined;
 declare const neverUndefined: boolean | undefined = true;
@@ -21,6 +26,7 @@ undefined === sometimesUndefined;
 
 undefined === neverUndefined;
               ~~~~~~~~~~~~~~  [This comparison is unnecessary because the right side is never undefined]
+
 
 
 declare const alwaysNull: boolean | null = null;

--- a/test/rules/no-unnecessary-type-check/test.ts.lint
+++ b/test/rules/no-unnecessary-type-check/test.ts.lint
@@ -1,0 +1,29 @@
+declare const alwaysUndefined: boolean | undefined = undefined;
+declare const sometimesUndefined: boolean | undefined;
+declare const neverUndefined: boolean | undefined = true;
+
+alwaysUndefined === undefined;
+~~~~~~~~~~~~~~~                [This comparison is unnecessary because the left side is always undefined]
+
+sometimesUndefined === undefined;
+if (sometimesUndefined !== undefined) {
+    sometimesUndefined === undefined;
+    ~~~~~~~~~~~~~~~~~~                [This comparison is unnecessary because the left side is never undefined]
+}
+
+neverUndefined === undefined;
+~~~~~~~~~~~~~~                [This comparison is unnecessary because the left side is never undefined]
+
+undefined === alwaysUndefined;
+              ~~~~~~~~~~~~~~~  [This comparison is unnecessary because the right side is always undefined]
+
+undefined === sometimesUndefined;
+
+undefined === neverUndefined;
+              ~~~~~~~~~~~~~~  [This comparison is unnecessary because the right side is never undefined]
+
+
+declare const alwaysNull: boolean | null = null;
+
+alwaysNull === null;
+~~~~~~~~~~          [This comparison is unnecessary because the left side is always null]

--- a/test/rules/no-unnecessary-type-check/test.ts.lint
+++ b/test/rules/no-unnecessary-type-check/test.ts.lint
@@ -26,8 +26,8 @@ undefined === neverUndefined;
 
 declare const neverNull: boolean = false;
 
-alwaysNull === null;
-~~~~~~~~~~          [LEFT_NEVER_NULL]
+neverNull === null;
+~~~~~~~~~           [LEFT_NEVER_NULL]
 
 
 

--- a/test/rules/no-unnecessary-type-check/test.ts.lint
+++ b/test/rules/no-unnecessary-type-check/test.ts.lint
@@ -1,35 +1,43 @@
-42 === undefined;
-~~                [This comparison is unnecessary because the left side is never undefined]
-
-
-
 declare const alwaysUndefined: boolean | undefined = undefined;
 declare const sometimesUndefined: boolean | undefined;
 declare const neverUndefined: boolean | undefined = true;
 
 alwaysUndefined === undefined;
-~~~~~~~~~~~~~~~                [This comparison is unnecessary because the left side is always undefined]
+~~~~~~~~~~~~~~~                [LEFT_ALWAYS_UNDEFINED]
 
 sometimesUndefined === undefined;
 if (sometimesUndefined !== undefined) {
     sometimesUndefined === undefined;
-    ~~~~~~~~~~~~~~~~~~                [This comparison is unnecessary because the left side is never undefined]
+    ~~~~~~~~~~~~~~~~~~                [LEFT_NEVER_UNDEFINED]
 }
 
 neverUndefined === undefined;
-~~~~~~~~~~~~~~                [This comparison is unnecessary because the left side is never undefined]
+~~~~~~~~~~~~~~                [LEFT_NEVER_UNDEFINED]
 
 undefined === alwaysUndefined;
-              ~~~~~~~~~~~~~~~  [This comparison is unnecessary because the right side is always undefined]
+              ~~~~~~~~~~~~~~~  [RIGHT_ALWAYS_UNDEFINED]
 
 undefined === sometimesUndefined;
 
 undefined === neverUndefined;
-              ~~~~~~~~~~~~~~  [This comparison is unnecessary because the right side is never undefined]
+              ~~~~~~~~~~~~~~  [RIGHT_NEVER_UNDEFINED]
 
 
 
-declare const alwaysNull: boolean | null = null;
+declare const neverNull: boolean = false;
 
 alwaysNull === null;
-~~~~~~~~~~          [This comparison is unnecessary because the left side is always null]
+~~~~~~~~~~          [LEFT_NEVER_NULL]
+
+
+
+42 === undefined;
+~~                [LEFT_NEVER_UNDEFINED]
+
+
+
+[LEFT_ALWAYS_UNDEFINED]:  This comparison is unnecessary because the left side is always undefined
+[LEFT_NEVER_UNDEFINED]:   This comparison is unnecessary because the left side is never undefined
+[RIGHT_ALWAYS_UNDEFINED]: This comparison is unnecessary because the right side is always undefined
+[RIGHT_NEVER_UNDEFINED]:  This comparison is unnecessary because the right side is never undefined
+[LEFT_NEVER_NULL]:        This comparison is unnecessary because the left side is never null

--- a/test/rules/no-unnecessary-type-check/tsconfig.json
+++ b/test/rules/no-unnecessary-type-check/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strictNullChecks": true
+    }
+}

--- a/test/rules/no-unnecessary-type-check/tslint.json
+++ b/test/rules/no-unnecessary-type-check/tslint.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "no-unnecessary-type-check": true
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4733
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Adds the rule `no-unnecessary-type-check` (see https://github.com/palantir/tslint/issues/4733 for more details)

#### Is there anything you'd like reviewers to focus on?

- Not sure how to add documentation - is there a command or is it manual?
- `yarn verify` is failing because there are some places in this repo where this rule fails (see below for example). Should I try to fix all these cases or just add a `disable-line` for this rule where the errors occur?
```
/Users/zkirsch/Documents/tslint/src/configuration.ts
This comparison is unnecessary because the left side is never undefined (no-unnecessary-type-check)
  151 |     inputFilePath?: string,
  152 | ): string | undefined {
> 153 |     if (suppliedConfigFilePath != undefined) {
      |        ^
  154 |         if (!fs.existsSync(suppliedConfigFilePath)) {
  155 |             throw new FatalError(
  156 |                 `Could not find config file at: ${path.resolve(suppliedConfigFilePath)}`,
```
- This is my first time working the TSLint or anything to do with the TS compiler so please let me know if I did anything incorrectly or there's a corner case I didn't consider.

#### CHANGELOG.md entry:

[new-rule] `no-unnecessary-type-check`