### PR TITLE
Add "cd tslint" to README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Prerequisites:
 
 ```bash
 git clone git@github.com:palantir/tslint.git --config core.autocrlf=input --config core.eol=lf
+cd tslint
 yarn
 yarn compile
 yarn test


### PR DESCRIPTION
This makes the entire block copy-pastable!

#### CHANGELOG.md entry:

[no-log]