### PR TITLE
Prepare v5.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Change Log
 
+## v5.17.0
+
+- [bugfix] [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/) backtic option now ignores enum members, use strict declarations, lookup types, and strings containing octal escape sequences. (#4693)
+- [bugfix] [`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) no longer errors on `JSDocThisTag` (#4690)
+- [chore] Update devDependency mocha from v3.2.0 to v6.1.4 (#4669) (#4674)
+- [chore] Update devDependency js-yaml from ^3.13.0 to ^3.13.1 (#4663)
+- [chore] Update deprecated devDependency github to @octokit/rest (#4673)
+- [chore] Update devDependency nyc from v13.3.0 to v14.1.1 (#4699)
+- [deprecation] [`no-use-before-declare`](https://palantir.github.io/tslint/rules/no-use-before-declare/) rule for typescript >= 2.9.0 (#4695)
+- [documentation] Minor fix for [`variable-name`](https://palantir.github.io/tslint/rules/variable-name/) rule metadata (#4731)
+- [documentation] Fixed [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) argument count (#4683)
+- [enhancement] Allow const assertions in [`no-object-literal-type-assertion`](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/) (#4681)
+- [new-fixer] [`unnecessary-constructor`](https://palantir.github.io/tslint/rules/unnecessary-constructor/) (#4694)
+
+Thanks to our contributors!
+
+- Bjorn Stromberg
+- Vitaliy Agoshkov
+- knafteN
+- Bowen Ni
+- Waseem Ahmad
+- Åsmund Grammeltvedt
+- Eric Ferreira
+- Zhen Tian
+- Tom Lakesman
+- zachkirsch
+
+
 ## v5.16.0
 
 - [bugfix] Excuse more [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/) backtick edge cases and fix behavior for TS < 2.7.1 (#4642)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tslint",
-    "version": "5.16.0",
+    "version": "5.17.0",
     "description": "An extensible static analysis linter for the TypeScript language",
     "bin": {
         "tslint": "./bin/tslint"

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -25,15 +25,28 @@
 
 import * as Octokit from "@octokit/rest";
 import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 import { camelize } from "../lib/utils";
 
+// ignores TLS certificate error
+// process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+const tokenFile = path.join(os.homedir(), "github_token.txt");
+const authToken = fs
+    .readFileSync(tokenFile, "utf8")
+    .toString()
+    .trim();
+console.log(`Using OAuth token ${authToken}\n`);
+
 const octokit = new Octokit({
+    auth: authToken,
     host: "api.github.com",
     protocol: "https",
     request: {
-        timeout: 5000
-    }
+        timeout: 5000,
+    },
 });
 
 const repoInfo = {
@@ -45,7 +58,7 @@ const commitList: ICommit[] = [];
 octokit.repos
     .getLatestRelease(repoInfo)
     .then(({ data: { tag_name } }) => {
-        console.log("Getting commits " + tag_name + "..master");
+        console.log(`Getting commits ${tag_name}..master`);
         // get the commits between the most recent release and the head of master
         return octokit.repos.compareCommits({
             base: tag_name,
@@ -61,7 +74,7 @@ octokit.repos
                 fields: [],
                 sha: commitInfo.sha,
                 submitter:
-                    commitInfo.commit.author.name != null
+                    commitInfo.commit.author.name !== null
                         ? commitInfo.commit.author.name
                         : commitInfo.author.login,
                 title: commitInfo.commit.message,
@@ -88,7 +101,7 @@ octokit.repos
                                 if (fieldMatch) {
                                     commit.fields.push({
                                         tag: fieldMatch[1],
-                                        text: addLinks(line) + " (#" + commit.pushRequestNum + ")",
+                                        text: `${addLinks(line)} (#${commit.pushRequestNum})`,
                                     });
                                 }
                             }
@@ -114,28 +127,26 @@ octokit.repos
             }
             contributors.add(commit.submitter);
         }
-        entries.sort((a, b) => {
-            return a.tag.localeCompare(b.tag);
-        });
+        entries.sort((a, b) => a.tag.localeCompare(b.tag));
 
         console.log("\n---- formatted changelog entries: ----");
         for (const entry of entries) {
-            console.log("- " + entry.text);
+            console.log(`- ${entry.text}`);
         }
 
         console.log("\n---- PRs with missing changelog entries: ----");
         for (const missing of noFields) {
-            console.log("- " + missing.replace(/[\r\n]+/, "\r\n    "));
+            console.log(`- ${missing.replace(/[\r\n]+/, "\r\n    ")}`);
         }
 
         console.log("\n---- thanks ----");
         console.log("Thanks to our contributors!");
         contributors.forEach(contributor => {
-            console.log("- " + contributor);
+            console.log(`- ${contributor}`);
         });
     })
     .catch(error => {
-        console.log("Error:" + error);
+        console.log(`Error: ${error}`);
     });
 
 const cache = new Map<string, boolean>();
@@ -158,9 +169,9 @@ function addLinks(text: string): string {
     let match = regex.exec(text);
     while (match !== null) {
         if (isRule(match[1])) {
-            result +=
-                text.slice(lastIndex, match.index) +
-                `[${match[0]}](https://palantir.github.io/tslint/rules/${match[1]}/)`;
+            result += `${text.slice(lastIndex, match.index)}[${
+                match[0]
+            }](https://palantir.github.io/tslint/rules/${match[1]}/)`;
             lastIndex = regex.lastIndex;
         }
         match = regex.exec(text);

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -42,7 +42,7 @@ import { arrayify, dedent, flatMap, mapDefined } from "./utils";
  * Linter that can lint multiple files in consecutive runs.
  */
 export class Linter {
-    public static VERSION = "5.16.0";
+    public static VERSION = "5.17.0";
 
     public static findConfiguration = findConfiguration;
     public static findConfigurationPath = findConfigurationPath;

--- a/test/rules/no-inferred-empty-object-type/test.ts.lint
+++ b/test/rules/no-inferred-empty-object-type/test.ts.lint
@@ -1,4 +1,5 @@
-[typescript]: <=3.4.x
+[typescript]: <=3.4.5
+
 let s: string;
 let n: number;
 let o: Object;

--- a/tslint-vscode.json
+++ b/tslint-vscode.json
@@ -8,6 +8,9 @@
         "no-boolean-literal-compare": false,
         "no-floating-promises": false,
         "no-for-in-array": false,
+        "no-implicit-dependencies": {
+            "options": ["dev"]
+        },
         "no-inferred-empty-object-type": false,
         "no-restricted-globals": false,
         "no-unnecessary-type-assertion": false,


### PR DESCRIPTION
## v5.17.0

- [bugfix] [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/) backtic option now ignores enum members, use strict declarations, lookup types, and strings containing octal escape sequences. (#4693)
- [bugfix] [`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) no longer errors on `JSDocThisTag` (#4690)
- [chore] Update devDependency mocha from v3.2.0 to v6.1.4 (#4669) (#4674)
- [chore] Update devDependency js-yaml from ^3.13.0 to ^3.13.1 (#4663)
- [chore] Update deprecated devDependency github to @octokit/rest (#4673)
- [chore] Update devDependency nyc from v13.3.0 to v14.1.1 (#4699)
- [deprecation] [`no-use-before-declare`](https://palantir.github.io/tslint/rules/no-use-before-declare/) rule for typescript >= 2.9.0 (#4695)
- [documentation] Minor fix for [`variable-name`](https://palantir.github.io/tslint/rules/variable-name/) rule metadata (#4731)
- [documentation] Fixed [`no-unused-variable`](https://palantir.github.io/tslint/rules/no-unused-variable/) argument count (#4683)
- [enhancement] Allow const assertions in [`no-object-literal-type-assertion`](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/) (#4681)
- [new-fixer] [`unnecessary-constructor`](https://palantir.github.io/tslint/rules/unnecessary-constructor/) (#4694)
