### PR TITLE
Add fixer for no-void-expression

### DIFF
--- a/src/rules/noVoidExpressionRule.ts
+++ b/src/rules/noVoidExpressionRule.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import { isTypeFlagSet } from "tsutils";
+import {isNodeFlagSet, isTypeFlagSet} from 'tsutils';
 import * as ts from "typescript";
-
 import * as Lint from "../index";
+
 
 const OPTION_IGNORE_ARROW_FUNCTION_SHORTHAND = "ignore-arrow-function-shorthand";
 
@@ -27,6 +27,7 @@ export class Rule extends Lint.Rules.TypedRule {
     public static metadata: Lint.IRuleMetadata = {
         ruleName: "no-void-expression",
         description: "Requires expressions of type `void` to appear in statement position.",
+        hasFix: true,
         optionsDescription: Lint.Utils.dedent`
             If \`${OPTION_IGNORE_ARROW_FUNCTION_SHORTHAND}\` is provided, \`() => returnsVoid()\` will be allowed.
             Otherwise, it must be written as \`() => { returnsVoid(); }\`.`,
@@ -87,9 +88,9 @@ function walk(ctx: Lint.WalkContext<Options>, checker: ts.TypeChecker): void {
         if (
             isPossiblyVoidExpression(node) &&
             !isParentAllowedVoid(node) &&
-            isTypeFlagSet(checker.getTypeAtLocation(node), ts.TypeFlags.Void)
+            isVoidExpression(node, checker)
         ) {
-            ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING, fix(node));
         }
         return ts.forEachChild(node, cb);
     });
@@ -121,6 +122,62 @@ function isPossiblyVoidExpression(node: ts.Node): boolean {
         case ts.SyntaxKind.TaggedTemplateExpression:
             return true;
         default:
-            return false;
+            return ts.isArrowFunction(node.parent) &&
+                isNodeFlagSet(node.parent, ts.NodeFlags.HasImplicitReturn);
     }
+}
+
+function fix(node: ts.Node): Lint.Fix | undefined {
+    let text: string;
+    switch (node.parent.kind) {
+        case ts.SyntaxKind.ReturnStatement:
+            text = `${node.getText()}; return;`;
+            node = node.parent;
+            break;
+        case ts.SyntaxKind.ArrowFunction:
+            text = `{ ${node.getText()}; }`;
+            break;
+        default:
+            return undefined;
+    }
+    return new Lint.Replacement(node.getStart(), node.getWidth(), text);
+}
+
+function isVoidExpression(node: ts.Node, checker: ts.TypeChecker) {
+    if (isTypeFlagSet(checker.getTypeAtLocation(node), ts.TypeFlags.Void)) return true;
+
+    // Detect an arrow function that is up-casted to return void by looking at
+    // the parameter declarations of the function or constructor.
+    // Arrow functions that already have a body wrapped in a block are ignored.
+    if (ts.isArrowFunction(node.parent) &&
+        node.parent.body === node &&
+        !ts.isBlock(node) &&
+        ts.isCallOrNewExpression(node.parent.parent)
+    ) {
+        if (!node.parent.parent.arguments) return false;
+        const idx = node.parent.parent.arguments.findIndex(n => n === node.parent);
+        if (idx === -1) return false;
+        const signature = checker.getResolvedSignature(node.parent.parent)
+        if (!signature) return false;
+        const params = signature.getParameters();
+        if (!params.length) return false;
+        const param = params[idx] || params[params.length - 1];
+        if (!ts.isParameter(param.valueDeclaration) || !param.valueDeclaration.type) return false;
+        let returnType: ts.TypeNode|undefined;
+        // Param is variadic
+        if (param.valueDeclaration.dotDotDotToken &&
+            ts.isTypeReferenceNode(param.valueDeclaration.type) &&
+            param.valueDeclaration.type.typeName.getText() === "Array" &&
+            param.valueDeclaration.type.typeArguments &&
+            param.valueDeclaration.type.typeArguments[0] &&
+            ts.isFunctionTypeNode(param.valueDeclaration.type.typeArguments[0])
+        ) {
+            returnType = (param.valueDeclaration.type.typeArguments[0] as ts.FunctionTypeNode).type
+        } else if (ts.isFunctionTypeNode(param.valueDeclaration.type)) {
+            returnType = param.valueDeclaration.type.type
+        }
+        if(!returnType) return false;
+        return isTypeFlagSet(checker.getTypeFromTypeNode(returnType), ts.TypeFlags.Void);
+    }
+    return false;
 }

--- a/test/rules/no-void-expression/default/test.ts.fix
+++ b/test/rules/no-void-expression/default/test.ts.fix
@@ -1,0 +1,38 @@
+function doIt() {}
+async function doAsync() {}
+function print(strs) {}
+
+[].forEach(x => { console.log(x); });
+
+[].forEach(x => {
+    console.log(x);
+});
+
+[].forEach(x => { x && console.log(x); });
+
+async function f(): Promise<void> {
+    const x = doIt();
+    console.log(await doAsync());
+    print``; return;
+}
+
+true && console.log(0);
+false || console.log(0);
+
+runner(() => { "x"; });
+runner(() => { ({x: "x"}); });
+listRunner(() => { "x"; });
+listRunner(() => { "x"; }, stringer, console.log, () => { "x"; });
+maybeRunner(() => { "x"; });
+runner(stringer);
+
+declare function doIt(): void;
+declare function doAsync(): Promise<void>;
+declare function print(strs: TemplateStringsArray): void;
+declare function runner(x: () => void): void;
+declare function listRunner(...x: Array<() => void>): void;
+declare function maybeRunner(x?: () => void): void;
+declare function stringer(): string;
+
+!!data ? console.info(message, data) : console.info(message);
+

--- a/test/rules/no-void-expression/default/test.ts.lint
+++ b/test/rules/no-void-expression/default/test.ts.lint
@@ -5,7 +5,12 @@ function print(strs) {}
 [].forEach(x => console.log(x));
                 ~~~~~~~~~~~~~~ [0]
 
+[].forEach(x => {
+    console.log(x);
+});
+
 [].forEach(x => x && console.log(x));
+                ~~~~~~~~~~~~~~~~~~~ [0]
                      ~~~~~~~~~~~~~~ [0]
 
 async function f(): Promise<void> {
@@ -20,9 +25,26 @@ async function f(): Promise<void> {
 true && console.log(0);
 false || console.log(0);
 
+runner(() => "x");
+             ~~~  [0]
+runner(() => ({x: "x"}));
+             ~~~~~~~~~~  [0]
+listRunner(() => "x");
+                 ~~~  [0]
+listRunner(() => "x", stringer, console.log, () => "x");
+                 ~~~  [0]
+                                                   ~~~  [0]
+maybeRunner(() => "x");
+                  ~~~  [0]
+runner(stringer);
+
 declare function doIt(): void;
 declare function doAsync(): Promise<void>;
 declare function print(strs: TemplateStringsArray): void;
+declare function runner(x: () => void): void;
+declare function listRunner(...x: Array<() => void>): void;
+declare function maybeRunner(x?: () => void): void;
+declare function stringer(): string;
 
 !!data ? console.info(message, data) : console.info(message);
 

--- a/test/rules/no-void-expression/default/tsconfig.json
+++ b/test/rules/no-void-expression/default/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "target": "es6",
-        "allowJs": true
+        "allowJs": true,
+        "strictFunctionTypes": true,
     }
 }

--- a/test/rules/no-void-expression/ignore-arrow-function-shorthand/test.ts.fix
+++ b/test/rules/no-void-expression/ignore-arrow-function-shorthand/test.ts.fix
@@ -7,8 +7,6 @@
 });
 
 [].forEach(x => {
-    return console.log(x);
-           ~~~~~~~~~~~~~~  [0]
+    console.log(x); return;
 });
 
-[0]: Expression has type `void`. Put it on its own line as a statement.


### PR DESCRIPTION
Fixer only fixes short-hand arrow functions and return statements.

#### PR checklist

- [x] Addresses an existing issue: fixes #4753
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:
```ts
// before
x(() => console.log());
x(console.log());
return console.log();
// after
x(() => { console.log(); });
x(console.log()); // still an error but no autofix, too semantic
console.log(); return;
```

#### Is there anything you'd like reviewers to focus on?

Is there a way to format the fixer or is this OK?

#### CHANGELOG.md entry:
[new-fixer] `no-void-expression` Fixes shorthand arrow functions and return statements. Using as argument or as value still raises a lint error, but no fix is provided in those cases.
<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
