### PR TITLE
Match eslint case fall through comment

### DIFF
--- a/src/rules/noSwitchCaseFallThroughRule.ts
+++ b/src/rules/noSwitchCaseFallThroughRule.ts
@@ -100,7 +100,7 @@ export class NoSwitchCaseFallThroughWalker extends Lint.AbstractWalker {
         return (
             comments !== undefined &&
             comments.some(comment =>
-                /^\s*falls through\b/i.test(
+                /^\s*falls?\s?through\b/i.test(
                     this.sourceFile.text.slice(comment.pos + 2, comment.end),
                 ),
             )


### PR DESCRIPTION

#### PR checklist

- [ ] ~~Addresses an existing issue: fixes #0000~~ Maybe?
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests - minor change
- [ ] Documentation update - TODO

#### Overview of change:
As I was used to using the special comment "fallthrough" from using eslint, and other users are probably in the same boat, this change uses the [same regex rule as eslint](https://eslint.org/docs/rules/no-fallthrough).

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
[enhancement] Match eslint case fall through special comment format - `/falls?\s?through/i`
