### PR TITLE
Prepare release v5.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Change Log
 
+## v5.18.0
+
+- [feature] New `--print-config` CLI flag (#4744)
+- [bugfix] [`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) no longer flags `x!` non-null assertions if `--strictNullChecks` is not enabled (#3724)
+- [bugfix] [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/) handles unbalanced quotes more gracefully without crashing (#4344)
+- [docs] Add tslint-playground link to README and bug report template (#4150)
+- [enhancement] [`no-magic-numbers`](https://palantir.github.io/tslint/rules/no-magic-numbers/) rule ignores arguments passed into default Number methods (#3668)
+- [new-fixer] [`comment-format`](https://palantir.github.io/tslint/rules/comment-format/) (#3583)
+- [new-rule-option] `"allow-trailing-lowercase"` option for [`comment-format`](https://palantir.github.io/tslint/rules/comment-format/) rule (#3583)
+- [new-rule-option] `"ignore-accessors"` for [`adjacent-overload-signatures`](https://palantir.github.io/tslint/rules/adjacent-overload-signatures/) to ignore getters / setters overloads (#3718)
+- [new-rule] [`no-async-without-await`](https://palantir.github.io/tslint/rules/no-async-without-await/) (#3945)
+- [new-rule] [`strict-comparisons`](https://palantir.github.io/tslint/rules/strict-comparisons/) (#4519)
+
+Thanks to our contributors!
+
+- Josh Goldberg
+- smoehrle
+- Mateusz Witkowski
+- Andy Hanson
+- John Wiseheart
+- Eran Shabi
+- Tibor Blenessy
+- AndreasGassmann
+- Ryan Waskiewicz
+- Isabelle
+
+
 ## v5.17.0
 
 - [bugfix] [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/) backtic option now ignores enum members, use strict declarations, lookup types, and strings containing octal escape sequences. (#4693)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tslint",
-    "version": "5.17.0",
+    "version": "5.18.0",
     "description": "An extensible static analysis linter for the TypeScript language",
     "bin": {
         "tslint": "./bin/tslint"
@@ -44,7 +44,7 @@
         "tsutils": "^2.29.0"
     },
     "peerDependencies": {
-        "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
+        "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev"
     },
     "devDependencies": {
         "@octokit/rest": "^16.24.3",

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -42,7 +42,7 @@ import { arrayify, dedent, flatMap, mapDefined } from "./utils";
  * Linter that can lint multiple files in consecutive runs.
  */
 export class Linter {
-    public static VERSION = "5.17.0";
+    public static VERSION = "5.18.0";
 
     public static findConfiguration = findConfiguration;
     public static findConfigurationPath = findConfigurationPath;


### PR DESCRIPTION
Fixes #4106 

## v5.18.0

 - [feature] New `--print-config` CLI flag (#4744)
- [bugfix] [`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/) no longer flags `x!` non-null assertions if `--strictNullChecks` is not enabled (#3724)
- [bugfix] [`quotemark`](https://palantir.github.io/tslint/rules/quotemark/) handles unbalanced quotes more gracefully without crashing (#4344)
- [docs] Add tslint-playground link to README and bug report template (#4150)
- [enhancement] [`no-magic-numbers`](https://palantir.github.io/tslint/rules/no-magic-numbers/) rule ignores arguments passed into default Number methods (#3668)
- [new-fixer] [`comment-format`](https://palantir.github.io/tslint/rules/comment-format/) (#3583)
- [new-rule-option] `"allow-trailing-lowercase"` option for [`comment-format`](https://palantir.github.io/tslint/rules/comment-format/) rule (#3583)
- [new-rule-option] `"ignore-accessors"` for [`adjacent-overload-signatures`](https://palantir.github.io/tslint/rules/adjacent-overload-signatures/) to ignore getters / setters overloads (#3718)
- [new-rule] [`no-async-without-await`](https://palantir.github.io/tslint/rules/no-async-without-await/) (#3945)
- [new-rule] [`strict-comparisons`](https://palantir.github.io/tslint/rules/strict-comparisons/) (#4519)
