### PR TITLE
Change interface-name rule to check suffix and prefix

### DIFF
--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -52,7 +52,9 @@ export const rules = {
         options: ["spaces"],
     },
     "interface-name": {
-        options: ["always-prefix"],
+        options: {
+            "prefix-never": ["I"],
+        },
     },
     "interface-over-type-literal": true,
     "jsdoc-format": true,

--- a/test/files/tsconfig-extends-relative/tslint-ok.json
+++ b/test/files/tsconfig-extends-relative/tslint-ok.json
@@ -2,7 +2,9 @@
     "rules":{
         "interface-name": [
             true,
-            "always-prefix"
+            {
+                "prefix-needs": "I"
+            }
         ]
     }
 }

--- a/test/rules/interface-name/always-prefix/tslint.json
+++ b/test/rules/interface-name/always-prefix/tslint.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "interface-name": [true, "always-prefix"]
-  }
-}

--- a/test/rules/interface-name/default/test.ts.lint
+++ b/test/rules/interface-name/default/test.ts.lint
@@ -1,7 +1,0 @@
-interface IValidInterfaceName {
-
-}
-
-interface NotValidInterfaceName {
-          ~~~~~~~~~~~~~~~~~~~~~  [interface name must start with a capitalized I]
-}

--- a/test/rules/interface-name/default/tslint.json
+++ b/test/rules/interface-name/default/tslint.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "interface-name": true
-  }
-}

--- a/test/rules/interface-name/never-prefix/tslint.json
+++ b/test/rules/interface-name/never-prefix/tslint.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "interface-name": [true, "never-prefix"]
-  }
-}

--- a/test/rules/interface-name/prefix-needs-i/test.ts.lint
+++ b/test/rules/interface-name/prefix-needs-i/test.ts.lint
@@ -22,13 +22,13 @@ interface IS3Foobar {
 
 // invalid code
 interface Options {
-          ~~~~~~~   [interface name must start with a capitalized I]
+          ~~~~~~~   [interface name must start with specified prefix: I]
 }
 
 interface Incomplete {
-          ~~~~~~~~~~   [interface name must start with a capitalized I]
+          ~~~~~~~~~~   [interface name must start with specified prefix: I]
 }
 
 interface I18nService {
-          ~~~~~~~~~~~   [interface name must start with a capitalized I]
+          ~~~~~~~~~~~   [interface name must start with specified prefix: I]
 }

--- a/test/rules/interface-name/prefix-needs-i/tslint.json
+++ b/test/rules/interface-name/prefix-needs-i/tslint.json
@@ -1,0 +1,9 @@
+{
+    "rules": {
+        "interface-name": [true,
+            {
+                "prefix-needs": ["I"]
+            }
+        ]
+    }
+}

--- a/test/rules/interface-name/prefix-needs/test.ts.lint
+++ b/test/rules/interface-name/prefix-needs/test.ts.lint
@@ -1,0 +1,28 @@
+// valid code
+interface TypeOptions {
+}
+
+interface TypeSomething {
+}
+
+interface TypeFoo {
+}
+
+interface TypeBar {
+}
+
+interface TypeBaz {
+}
+
+// invalid code
+interface Options {
+          ~~~~~~~   [interface name must start with specified prefix: Type]
+}
+
+interface Incomplete {
+          ~~~~~~~~~~   [interface name must start with specified prefix: Type]
+}
+
+interface I18nService {
+          ~~~~~~~~~~~   [interface name must start with specified prefix: Type]
+}

--- a/test/rules/interface-name/prefix-needs/tslint.json
+++ b/test/rules/interface-name/prefix-needs/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "interface-name": [true,
+        {
+            "prefix-needs": ["Type"]
+        }
+    ]
+  }
+}

--- a/test/rules/interface-name/prefix-never-i/test.ts.lint
+++ b/test/rules/interface-name/prefix-never-i/test.ts.lint
@@ -31,5 +31,5 @@ interface ABC {
 
 // invalid code
 interface IOptions {
-          ~~~~~~~~   [interface name must not have an "I" prefix]
+          ~~~~~~~~   [interface name must not start with specified prefix: I]
 }

--- a/test/rules/interface-name/prefix-never-i/tslint.json
+++ b/test/rules/interface-name/prefix-never-i/tslint.json
@@ -1,7 +1,6 @@
 {
-    "rules":{
-        "interface-name": [
-            true,
+    "rules": {
+        "interface-name": [true,
             {
                 "prefix-never": ["I"]
             }

--- a/test/rules/interface-name/prefix-never/test.ts.lint
+++ b/test/rules/interface-name/prefix-never/test.ts.lint
@@ -1,0 +1,28 @@
+// valid code
+interface Options {
+}
+
+interface Something {
+}
+
+interface Foo {
+}
+
+interface Bar {
+}
+
+interface Baz {
+}
+
+// invalid code
+interface TypeOptions {
+          ~~~~~~~~~~~   [interface name must not start with specified prefix: Type]
+}
+
+interface TypeIncomplete {
+          ~~~~~~~~~~~~~~   [interface name must not start with specified prefix: Type]
+}
+
+interface TypeSomething {
+          ~~~~~~~~~~~~~   [interface name must not start with specified prefix: Type]
+}

--- a/test/rules/interface-name/prefix-never/tslint.json
+++ b/test/rules/interface-name/prefix-never/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "interface-name": [true,
+        {
+            "prefix-never": ["Type"]
+        }
+    ]
+  }
+}

--- a/test/rules/interface-name/suffix-needs/test.ts.lint
+++ b/test/rules/interface-name/suffix-needs/test.ts.lint
@@ -1,0 +1,28 @@
+// valid code
+interface OptionsContract {
+}
+
+interface SomethingContract {
+}
+
+interface FooContract {
+}
+
+interface BarContract {
+}
+
+interface BazContract {
+}
+
+// invalid code
+interface Options {
+          ~~~~~~~   [interface name must finish with specified suffix: Contract]
+}
+
+interface Incomplete {
+          ~~~~~~~~~~   [interface name must finish with specified suffix: Contract]
+}
+
+interface I18nService {
+          ~~~~~~~~~~~   [interface name must finish with specified suffix: Contract]
+}

--- a/test/rules/interface-name/suffix-needs/tslint.json
+++ b/test/rules/interface-name/suffix-needs/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "interface-name": [true,
+        {
+            "suffix-needs": ["Contract"]
+        }
+    ]
+  }
+}

--- a/test/rules/interface-name/suffix-never/test.ts.lint
+++ b/test/rules/interface-name/suffix-never/test.ts.lint
@@ -1,0 +1,28 @@
+// valid code
+interface Options {
+}
+
+interface Something {
+}
+
+interface Foo {
+}
+
+interface Bar {
+}
+
+interface Baz {
+}
+
+// invalid code
+interface OptionsContract {
+          ~~~~~~~~~~~~~~~   [interface name must not finish with specified suffix: Contract]
+}
+
+interface IncompleteContract {
+          ~~~~~~~~~~~~~~~~~~   [interface name must not finish with specified suffix: Contract]
+}
+
+interface SomethingContract {
+          ~~~~~~~~~~~~~~~~~   [interface name must not finish with specified suffix: Contract]
+}

--- a/test/rules/interface-name/suffix-never/tslint.json
+++ b/test/rules/interface-name/suffix-never/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "interface-name": [true,
+        {
+            "suffix-never": ["Contract"]
+        }
+    ]
+  }
+}


### PR DESCRIPTION
Thinking about the interface-name rule, it's very common discussions in the development world if developers prefer to use suffixes or prefixes specific to their interfaces, eg TypeSomething, SomethingContract or ISomething, I Realized that it would make more sense for developers to use the rule by defining whether they want a specific suffix or prefix, here are some examples:

Always interfaces prefix `Type`:
```json
{
  "rules": {
    "interface-name": [
        true,
        {
            "prefix-needs": ["Type"]
        }
    ]
  }
}
```

Always interfaces prefix `I` (keep with same older implementation):
```json
{
    "rules": {
        "interface-name": [true,
            {
                "prefix-needs": ["I"]
            }
        ]
    }
}
```

Never interfaces prefix `Type`:

```json
{
  "rules": {
    "interface-name": [true,
        {
            "prefix-never": ["Type"]
        }
    ]
  }
}
```

Never interfaces prefix `I` (keep with same older implementation):

```json
{
    "rules": {
        "interface-name": [true,
            {
                "prefix-never": ["I"]
            }
        ]
    }
}
```

Always interface suffix `Contract`:

```json
{
  "rules": {
    "interface-name": [true,
        {
            "suffix-needs": ["Contract"]
        }
    ]
  }
}
```

Never interface suffix `Contract`:

```json
{
  "rules": {
    "interface-name": [true,
        {
            "suffix-never": ["Contract"]
        }
    ]
  }
}
```

#### PR checklist

- [ ] Addresses an existing issue: fixes #0000
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests
- [ ] Documentation update
