### PR TITLE
Allowed new 'AsyncGenerator' name for await-promise async iterables

### DIFF
--- a/src/rules/awaitPromiseRule.ts
+++ b/src/rules/awaitPromiseRule.ts
@@ -111,5 +111,7 @@ function containsType(type: ts.Type, predicate: (name: string) => boolean): bool
 }
 
 function isAsyncIterable(name: string) {
-    return name === "AsyncIterable" || name === "AsyncIterableIterator";
+    return (
+        name === "AsyncIterable" || name === "AsyncIterableIterator" || name === "AsyncGenerator"
+    );
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4784
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- ~[ ] Documentation update~

#### Overview of change:

Allows the new `AsyncGenerator` type introduced in https://github.com/microsoft/TypeScript/pull/30790 as one of the hardcoded names for async iterables.

#### Is there anything you'd like reviewers to focus on?

Is this the right approach? I think so, but 🤷‍♂ hard to tell with these kind-of-sort-of breaking changes.

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
