### PR TITLE
3810 prefer-switch: add missing cases

### DIFF
--- a/src/rules/preferSwitchRule.ts
+++ b/src/rules/preferSwitchRule.ts
@@ -113,7 +113,11 @@ function everyCondition(node: ts.Expression, test: (e: ts.Expression) => boolean
         case ts.SyntaxKind.BarBarToken:
             return everyCondition(left, test) && everyCondition(right, test);
         case ts.SyntaxKind.EqualsEqualsEqualsToken:
-            return isSimple(left) && isSimple(right) && test(left);
+            return (
+                isSimple(left) &&
+                isSimple(right) &&
+                ((isSwitchVariable(left) && test(left)) || (isSwitchVariable(right) && test(right)))
+            );
         default:
             return false;
     }
@@ -143,6 +147,25 @@ function isSimple(node: ts.Node): boolean {
         case ts.SyntaxKind.TrueKeyword:
         case ts.SyntaxKind.FalseKeyword:
         case ts.SyntaxKind.NullKeyword:
+            return true;
+        default:
+            return false;
+    }
+}
+
+function isUndefined(node: ts.Node): boolean {
+    return utils.isIdentifier(node) && node.text === "undefined";
+}
+
+function isSwitchVariable(node: ts.Node): boolean {
+    switch (node.kind) {
+        case ts.SyntaxKind.PropertyAccessExpression:
+        case ts.SyntaxKind.ThisKeyword:
+            return true;
+        case ts.SyntaxKind.Identifier:
+            if (isUndefined(node)) {
+                return false;
+            }
             return true;
         default:
             return false;

--- a/test/rules/prefer-switch/default/test.ts.lint
+++ b/test/rules/prefer-switch/default/test.ts.lint
@@ -15,5 +15,19 @@ if (x === 1 || x === 2 || x === false) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 if (x === 1 || x === 2 || x === `123`) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+if (x === 1 || x === 2 || null === x) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+if (x === 1 || x === 2 || true === x) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+if (x === 1 || false === x || x === 2) {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+if (null === 1 || null === 2 || null === 3) {}
+if (1 === null || 2 === null || 3 === null) {}
+if (null === 1 || 2 === null || null === 3) {}
+
+if (undefined === 1 || undefined === 2 || undefined === 3) {}
+if (1 === undefined || 2 === undefined || 3 === undefined) {}
+if (undefined === 1 || 2 === undefined || undefined === 3) {}
 
 [0]: Use a switch statement instead of using multiple '===' checks.

--- a/test/rules/prefer-switch/min-cases-2/test.ts.lint
+++ b/test/rules/prefer-switch/min-cases-2/test.ts.lint
@@ -25,4 +25,13 @@ if (x === f()) {} else if (x === g()) {}
 if (x.y.z === a.b) else if (x.y.z === c.d) {}
     ~~~~~~~~~~~~~ [0]
 
+if (null === 1 || null === 2 || null === 3) {}
+if (1 === null || 2 === null || 3 === null) {}
+if (null === 1 || 2 === null || null === 3) {}
+
+if (undefined === 1 || undefined === 2 || undefined === 3) {}
+if (1 === undefined || 2 === undefined || 3 === undefined) {}
+if (undefined === 1 || 2 === undefined || undefined === 3) {}
+
+
 [0]: Use a switch statement instead of using multiple '===' checks.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #3810
- [x] bugfix
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
check `leftNode` or `rightNode` if its a switch type variable.
