### PR TITLE
Understand import aliases for ordered-imports.

### DIFF
--- a/test/rules/ordered-imports/groups-import-alias/test.ts.fix
+++ b/test/rules/ordered-imports/groups-import-alias/test.ts.fix
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+/* Test a more complex set of split up groups. */
+
+// comment outside of imports
+import {app_f} from 'app/foo';
+
+import MyAlias = SomeModule.SomeType;
+
+export class Test {}

--- a/test/rules/ordered-imports/groups-import-alias/test.ts.lint
+++ b/test/rules/ordered-imports/groups-import-alias/test.ts.lint
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/* Test a more complex set of split up groups. */
+
+// comment outside of imports
+import MyAlias = SomeModule.SomeType;
+import {app_f} from 'app/foo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Imports from this module are not allowed in this group.  The expected groups (in order) are: /^app/, /.*=.*/.]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import sources within a group must be alphabetized.]
+
+export class Test {}

--- a/test/rules/ordered-imports/groups-import-alias/tslint.json
+++ b/test/rules/ordered-imports/groups-import-alias/tslint.json
@@ -1,0 +1,16 @@
+{
+    "rules": {
+        "ordered-imports": [
+            true,
+            {
+                "import-sources-order": "case-insensitive",
+                "named-imports-order": "case-insensitive",
+                "grouped-imports": true,
+                "groups": [
+                    { "match": "^app", "order": 10 },
+                    { "match": ".*=.*", "order": 20 }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes https://github.com/palantir/tslint/issues/4591
  - [x] Includes tests
- [x] Documentation update -- nothing to add I think

#### Overview of change:

This enhances the behavior of `ordered-imports` to also lint import aliases such as `import X = Module.X`.
Without this, code bases having import aliases in them cannot be automatically linted/fixed by the current `ordered-imports` rule.


#### CHANGELOG.md entry:

[enhancement], [rule-change]
<!-- suggested tags: [enhancement], [rule-change] -->
