### PR TITLE
4696: remove semicolons from callable-types rule suggestions

### DIFF
--- a/src/rules/callableTypesRule.ts
+++ b/src/rules/callableTypesRule.ts
@@ -119,7 +119,7 @@ function renderSuggestion(
             return `type ${parent.name.text} = ${suggestion}`;
         }
     }
-    return suggestion.endsWith(";") ? suggestion.slice(0, -1) : suggestion;
+    return suggestion.replace(";", "");
 }
 
 function shouldWrapSuggestion(parent: ts.Node) {

--- a/test/rules/callable-types/test.ts.fix
+++ b/test/rules/callable-types/test.ts.fix
@@ -8,6 +8,8 @@ type L<T> = () => T
 
 type T = () => void;
 
+type T = T2 & (() => void)
+
 type U = <T>(t: T) => T
 
 var fn: () => void;
@@ -31,4 +33,6 @@ export type I0 = () => void;
 export type I1 = new () => void;
 
 export type T = () => void
+
+export type T = T2 & (() => void)
 

--- a/test/rules/callable-types/test.ts.lint
+++ b/test/rules/callable-types/test.ts.lint
@@ -23,6 +23,11 @@ type T = {
     ~~~~~~~~~ [type % ('() => void')]
 };
 
+type T = T2 & {
+    (): void;
+    ~~~~~~~~~ [type % ('(() => void)')]
+}
+
 type U = {
     <T>(t: T): T;
     ~~~~~~~~~~~~~ [type % ('<T>(t: T) => T')]
@@ -67,6 +72,11 @@ export interface I1 {
 export type T = {
     (): void;
     ~~~~~~~~~ [type % ('() => void')]
+}
+
+export type T = T2 & {
+    (): void;
+    ~~~~~~~~~ [type % ('(() => void)')]
 }
 
 [_base]: %s has only a call signature — use `%s` instead.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4696
- [x] Bugfix
  - [x] Includes tests
- [ ] Documentation update (no)

#### Overview of change:

Remove semicolons (;) from suggestions of the callable-types rule.
