### PR TITLE
no-angle-bracket-type-assertion: check only for binary expression

### DIFF
--- a/src/rules/noAngleBracketTypeAssertionRule.ts
+++ b/src/rules/noAngleBracketTypeAssertionRule.ts
@@ -51,7 +51,7 @@ function walk(ctx: Lint.WalkContext) {
         if (isTypeAssertion(node)) {
             let { expression } = node;
             const start = node.getStart(ctx.sourceFile);
-            const addParens = needsParens(node);
+            const addParens = isBinaryExpression(node.parent);
             let replaceText = ` as ${node.type.getText(ctx.sourceFile)}${addParens ? ")" : ""}`;
             while (isTypeAssertion(expression)) {
                 replaceText = ` as ${expression.type.getText(ctx.sourceFile)}${replaceText}`;
@@ -69,13 +69,4 @@ function walk(ctx: Lint.WalkContext) {
         }
         return ts.forEachChild(node, cb);
     });
-}
-
-function needsParens(node: ts.TypeAssertion): boolean {
-    const parent = node.parent;
-    return (
-        isBinaryExpression(parent) &&
-        (parent.operatorToken.kind === ts.SyntaxKind.AmpersandToken ||
-            parent.operatorToken.kind === ts.SyntaxKind.BarToken)
-    );
 }

--- a/test/rules/no-angle-bracket-type-assertion/test.ts.fix
+++ b/test/rules/no-angle-bracket-type-assertion/test.ts.fix
@@ -15,3 +15,38 @@ let g = a as any as A;
 
 let h = a as any as AsyncIterableIterator;
 
+interface Action {
+    payload: number | false;
+}
+
+const action: Action = {
+    payload: 5,
+}
+
+const booleanAction: Action = {
+    payload: false,
+}
+
+const a = 5 + (action.payload as number);
+
+const a = 5 - (action.payload as number);
+
+const a = 5 * (action.payload as number);
+
+const a = 5 / (action.payload as number);
+
+const a = 5 % (action.payload as number);
+
+const a = 5 && (action.payload as number);
+
+const a = 5 || (action.payload as number);
+
+const a = 5 % (action.payload as any as number);
+
+const a = 5 && (action.payload as any as number);
+
+const a = 5 || (action.payload as any as number);
+
+const a = true || (booleanAction.payload as boolean);
+
+const a = false && (booleanAction.payload as boolean);

--- a/test/rules/no-angle-bracket-type-assertion/test.ts.lint
+++ b/test/rules/no-angle-bracket-type-assertion/test.ts.lint
@@ -23,4 +23,51 @@ let g = <A><any>a;
 let h = <AsyncIterableIterator><any>a;
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 
+interface Action {
+    payload: number | false;
+}
+
+const action: Action = {
+    payload: 5,
+}
+
+const booleanAction: Action = {
+    payload: false,
+}
+
+const a = 5 + <number>action.payload;
+              ~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 - <number>action.payload;
+              ~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 * <number>action.payload;
+              ~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 / <number>action.payload;
+              ~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 % <number>action.payload;
+              ~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 && <number>action.payload;
+               ~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 || <number>action.payload;
+               ~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 % <number><any>action.payload;
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 && <number><any>action.payload;
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = 5 || <number><any>action.payload;
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = true || <boolean>booleanAction.payload;
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+const a = false && <boolean>booleanAction.payload;
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 [0]: Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4805 
- [x] bugfix
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
check only for binary expression in the parent.