### PR TITLE
4746: fix weird failures in strict-boolean-expressions for 'ignore-rhs' option

### DIFF
--- a/src/rules/strictBooleanExpressionsRule.ts
+++ b/src/rules/strictBooleanExpressionsRule.ts
@@ -153,7 +153,7 @@ function walk(ctx: Lint.WalkContext<Options>, checker: ts.TypeChecker): void {
                     // on the left side because it will be checked well enough on its own.  However,
                     // if ignore-rhs is on, we have to analyze the overall result of the left
                     // side no matter what, because its right side might not follow the rules.
-                    if (options.ignoreRhs || !isBooleanBinaryExpression(left)) {
+                    if (!isBooleanBinaryExpression(left)) {
                         checkExpression(left, b);
                     }
                     // If ignore-rhs is on, we don't have to analyze the right hand side

--- a/test/rules/strict-boolean-expressions/default/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/default/test.ts.lint
@@ -190,3 +190,46 @@ if (trueOrDate) {}
 declare var a: any;
 // Allow 'any'
 if (a) {}
+
+let bool1:boolean = true
+let bool2:boolean = true
+let obj:{}|undefined = {}
+
+  bool1 && obj && bool2
+           ~~~          [This type is not allowed in the operand for the '&&' operator because it could be undefined. Only booleans are allowed.]
+  bool1 && bool2 && obj
+                    ~~~ [This type is not allowed in the operand for the '&&' operator because it could be undefined. Only booleans are allowed.]
+  boolExpr && numType || strType;
+              ~~~~~~~             [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
+                         ~~~~~~~  [This type is not allowed in the operand for the '||' operator because it is a string. Only booleans are allowed.]
+  boolExpr || numType || strType;
+              ~~~~~~~             [This type is not allowed in the operand for the '||' operator because it is a number. Only booleans are allowed.]
+                         ~~~~~~~  [This type is not allowed in the operand for the '||' operator because it is a string. Only booleans are allowed.]
+  boolExpr || numType && strType;
+              ~~~~~~~             [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
+                         ~~~~~~~  [This type is not allowed in the operand for the '&&' operator because it is a string. Only booleans are allowed.]
+  boolExpr && numType && strType;
+              ~~~~~~~             [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
+                         ~~~~~~~  [This type is not allowed in the operand for the '&&' operator because it is a string. Only booleans are allowed.]
+  boolExpr || boolType && strType;
+                          ~~~~~~~  [This type is not allowed in the operand for the '&&' operator because it is a string. Only booleans are allowed.]
+  boolExpr || boolType || strType;
+                          ~~~~~~~  [This type is not allowed in the operand for the '||' operator because it is a string. Only booleans are allowed.]
+  boolExpr && boolType || strType;
+                          ~~~~~~~  [This type is not allowed in the operand for the '||' operator because it is a string. Only booleans are allowed.]
+
+  bool1 && obj && bool2
+           ~~~          [This type is not allowed in the operand for the '&&' operator because it could be undefined. Only booleans are allowed.]
+
+  obj && bool2 && obj
+  ~~~                 [This type is not allowed in the operand for the '&&' operator because it could be undefined. Only booleans are allowed.]
+                  ~~~ [This type is not allowed in the operand for the '&&' operator because it could be undefined. Only booleans are allowed.]
+
+  obj || bool2 || obj
+  ~~~                 [This type is not allowed in the operand for the '||' operator because it could be undefined. Only booleans are allowed.]
+                  ~~~ [This type is not allowed in the operand for the '||' operator because it could be undefined. Only booleans are allowed.]
+
+  obj || bool2 && obj
+  ~~~                 [This type is not allowed in the operand for the '||' operator because it could be undefined. Only booleans are allowed.]
+                  ~~~ [This type is not allowed in the operand for the '&&' operator because it could be undefined. Only booleans are allowed.]
+

--- a/test/rules/strict-boolean-expressions/ignore-rhs/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/ignore-rhs/test.ts.lint
@@ -25,10 +25,16 @@ anyType && boolType;
 numType && boolType;
 ~~~~~~~ [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
 boolType && strType;
+
 boolType && objType && enumType;
-#if typescript < 2.2.0
-~~~~~~~~~~~~~~~~~~~              [This type is not allowed in the operand for the '&&' operator because it is always truthy. Only booleans are allowed.]
-#endif
+
+boolType && objType || enumType;
+
+boolType || objType && enumType;
+            ~~~~~~~              [This type is not allowed in the operand for the '&&' operator because it is always truthy. Only booleans are allowed.]
+
+boolType || objType || enumType;
+
 bwrapType && boolType;
 ~~~~~~~~~              [This type is not allowed in the operand for the '&&' operator because it is always truthy. Only booleans are allowed.]
 

--- a/test/rules/strict-boolean-expressions/ignore-rhs/test.ts.lint
+++ b/test/rules/strict-boolean-expressions/ignore-rhs/test.ts.lint
@@ -35,18 +35,38 @@ bwrapType && boolType;
 boolType || classType;
 boolType || anyType;
 boolType || numType;
+
 strType || boolType;
 ~~~~~~~              [This type is not allowed in the operand for the '||' operator because it is a string. Only booleans are allowed.]
+
 bwrapType || boolType;
 ~~~~~~~~~              [This type is not allowed in the operand for the '||' operator because it is always truthy. Only booleans are allowed.]
+
 objType || boolType || enumType;
 ~~~~~~~                          [This type is not allowed in the operand for the '||' operator because it is always truthy. Only booleans are allowed.]
-~~~~~~~~~~~~~~~~~~~              [This type is not allowed in the operand for the '||' operator because it is always truthy. Only booleans are allowed.]
+
 boolExpr && strType;
+
 numType || boolExpr;
 ~~~~~~~              [This type is not allowed in the operand for the '||' operator because it is a number. Only booleans are allowed.]
+
 numType && boolExpr || strType;
 ~~~~~~~                         [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
-~~~~~~~~~~~~~~~~~~~             [This type is not allowed in the operand for the '||' operator because it could be a number. Only booleans are allowed.]
+
 bwrapType || boolExpr && bwrapType;
 ~~~~~~~~~                           [This type is not allowed in the operand for the '||' operator because it is always truthy. Only booleans are allowed.]
+
+let bool1:boolean = true
+let bool2:boolean = true
+let obj:{}|undefined = {}
+
+bool1 && obj && bool2
+bool1 && bool2 && obj
+boolExpr && numType || strType;
+boolExpr || numType || strType;
+boolExpr || numType && strType;
+            ~~~~~~~             [This type is not allowed in the operand for the '&&' operator because it is a number. Only booleans are allowed.]
+boolExpr && numType && strType;
+boolExpr || boolType && strType;
+boolExpr || boolType || strType;
+boolExpr && boolType || strType;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4746 
- [x] bugfix
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
check expression only if `left` node is not a `BooleanBinaryExpression`