### PR TITLE
Fix false positive for simple parenthesized array types with array-simple (#4844)

### DIFF
--- a/src/rules/arrayTypeRule.ts
+++ b/src/rules/arrayTypeRule.ts
@@ -164,6 +164,8 @@ function isSimpleType(nodeType: ts.TypeNode): boolean {
         case ts.SyntaxKind.ThisType:
         case ts.SyntaxKind.UnknownKeyword:
             return true;
+        case ts.SyntaxKind.ParenthesizedType:
+            return isSimpleType((nodeType as ts.ParenthesizedTypeNode).type);
         case ts.SyntaxKind.TypeReference:
             // TypeReferences must be non-generic or be another Array with a simple type
             const { typeName, typeArguments } = nodeType as ts.TypeReferenceNode;

--- a/test/rules/array-type/array-simple/test.ts.fix
+++ b/test/rules/array-type/array-simple/test.ts.fix
@@ -10,6 +10,8 @@ let yy: number[][] = [[4, 5], [6]];
 let ya = [[1, "2"]] as Array<[number, string]>;
 
 type Arr<T> = T[];
+type ParenthesisArr<T> = (T)[];
+type DoubleParenthesisArr<T> = ((T))[];
 
 // Ignore user defined aliases
 let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];
@@ -38,9 +40,11 @@ let barVar: Array<(c: number) => number>;
 
 type fooUnion = Array<string|number|boolean>;
 type barUnion = Array<string|number|boolean>;
+type bazUnion = Array<(string|number|boolean)>;
 
 type fooIntersection = Array<string & number>;
 type barIntersection = Array<string & number>;
+type bazIntersection = Array<(string & number)>;
 
 namespace fooName {
     type BarType = { bar: string };

--- a/test/rules/array-type/array-simple/test.ts.lint
+++ b/test/rules/array-type/array-simple/test.ts.lint
@@ -19,6 +19,8 @@ let ya = [[1, "2"]] as[number, string][];
 
 type Arr<T> = Array<T>;
               ~~~~~~~~  [0]
+type ParenthesisArr<T> = (T)[];
+type DoubleParenthesisArr<T> = ((T))[];
 
 // Ignore user defined aliases
 let yyyy: Arr<Array<Arr<string>>[]> = [[[["2"]]]];
@@ -52,10 +54,14 @@ let barVar: ((c: number) => number)[];
 type fooUnion = Array<string|number|boolean>;
 type barUnion = (string|number|boolean)[];
                 ~~~~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
+type bazUnion = ((string|number|boolean))[];
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
 
 type fooIntersection = Array<string & number>;
 type barIntersection = (string & number)[];
                        ~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
+type bazIntersection = ((string & number))[];
+                       ~~~~~~~~~~~~~~~~~~~~~  [Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.]
 
 namespace fooName {
     type BarType = { bar: string };


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4844
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:
`(T)` is now considered a simple type if `T` is a simple type.

#### Is there anything you'd like reviewers to focus on?

#### CHANGELOG.md entry:
[bugfix] Fix false positive for simple parenthesized array types with array-simple (#4844)