### PR TITLE
fix(file-name-casing): ignore option works correctly

### DIFF
--- a/src/rules/fileNameCasingRule.ts
+++ b/src/rules/fileNameCasingRule.ts
@@ -25,7 +25,7 @@ import { isCamelCased, isKebabCased, isPascalCased, isSnakeCased } from "../util
 enum Casing {
     CamelCase = "camel-case",
     PascalCase = "pascal-case",
-    Ignored = "ignored",
+    Ignored = "ignore",
     KebabCase = "kebab-case",
     SnakeCase = "snake-case",
 }
@@ -40,7 +40,13 @@ type ValidationResult = Casing | undefined;
 
 type Validator<T extends Config> = (sourceFile: ts.SourceFile, casing: T) => ValidationResult;
 
-const rules = [Casing.CamelCase, Casing.PascalCase, Casing.KebabCase, Casing.SnakeCase];
+const rules = [
+    Casing.CamelCase,
+    Casing.Ignored,
+    Casing.PascalCase,
+    Casing.KebabCase,
+    Casing.SnakeCase,
+];
 
 const validCasingOptions = new Set(rules);
 

--- a/test/rules/file-name-casing/complex/tslint.json
+++ b/test/rules/file-name-casing/complex/tslint.json
@@ -1,9 +1,9 @@
 {
   "rules": {
     "file-name-casing": [true, {
-      ".component.ts": "pascal-case",
-      ".tsx": "pascal-case",
-      ".ts": "camel-case"
+      ".component.ts$": "pascal-case",
+      ".tsx$": "pascal-case",
+      ".ts$": "camel-case"
     }]
   }
 }

--- a/test/rules/file-name-casing/ignore/tslint.json
+++ b/test/rules/file-name-casing/ignore/tslint.json
@@ -1,8 +1,8 @@
 {
     "rules": {
         "file-name-casing": [true, {
-            ".ts": "ignore",
-            ".tsx": "pascal-case"
+            ".ts$": "ignore",
+            ".tsx$": "pascal-case"
         }]
     }
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4836
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update


#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

[bugfix] 'ignore' option for `file-name-casing` rule works correctly
