### PR TITLE
[complete-doc]: add support for constuctor doc

### DIFF
--- a/src/rules/completed-docs/constructorExclusion.ts
+++ b/src/rules/completed-docs/constructorExclusion.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2019 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { hasModifier } from "tsutils";
+import * as ts from "typescript";
+
+import {
+    ALL,
+    Privacy,
+    PRIVACY_PRIVATE,
+    PRIVACY_PROTECTED,
+    PRIVACY_PUBLIC,
+} from "../completedDocsRule";
+
+import { Exclusion } from "./exclusion";
+
+export interface IConstructorExclusionDescriptor {
+    privacies?: Privacy[];
+}
+
+export class ConstructorExclusion extends Exclusion<IConstructorExclusionDescriptor> {
+    public readonly privacies: Set<Privacy> = this.createSet(this.descriptor.privacies);
+
+    public excludes(node: ts.Node) {
+        return !this.shouldPrivacyBeDocumented(node);
+    }
+
+    private shouldPrivacyBeDocumented(node: ts.Node) {
+        if (this.privacies.has(ALL)) {
+            return true;
+        }
+
+        if (hasModifier(node.modifiers, ts.SyntaxKind.PrivateKeyword)) {
+            return this.privacies.has(PRIVACY_PRIVATE);
+        }
+
+        if (hasModifier(node.modifiers, ts.SyntaxKind.ProtectedKeyword)) {
+            return this.privacies.has(PRIVACY_PROTECTED);
+        }
+
+        return this.privacies.has(PRIVACY_PUBLIC);
+    }
+}

--- a/src/rules/completed-docs/exclusions.ts
+++ b/src/rules/completed-docs/exclusions.ts
@@ -19,6 +19,7 @@ import { DESCRIPTOR_OVERLOADS, DocType } from "../completedDocsRule";
 
 import { BlockExclusion, IBlockExclusionDescriptor } from "./blockExclusion";
 import { ClassExclusion, IClassExclusionDescriptor } from "./classExclusion";
+import { ConstructorExclusion, IConstructorExclusionDescriptor } from "./constructorExclusion";
 import { Exclusion } from "./exclusion";
 import { IInputExclusionDescriptors, InputExclusionDescriptor } from "./exclusionDescriptors";
 import { ITagExclusionDescriptor, TagExclusion } from "./tagExclusion";
@@ -64,10 +65,18 @@ const createRequirementsForDocType = (docType: DocType, descriptor: InputExclusi
         overloadsSeparateDocs = !!(descriptor as any)[DESCRIPTOR_OVERLOADS];
     }
 
-    if (docType === "methods" || docType === "properties") {
-        requirements.push(new ClassExclusion(descriptor as IClassExclusionDescriptor));
-    } else {
-        requirements.push(new BlockExclusion(descriptor as IBlockExclusionDescriptor));
+    switch (docType) {
+        case "constructors":
+            requirements.push(
+                new ConstructorExclusion(descriptor as IConstructorExclusionDescriptor),
+            );
+            break;
+        case "methods":
+        case "properties":
+            requirements.push(new ClassExclusion(descriptor as IClassExclusionDescriptor));
+            break;
+        default:
+            requirements.push(new BlockExclusion(descriptor as IBlockExclusionDescriptor));
     }
 
     if ((descriptor as ITagExclusionDescriptor).tags !== undefined) {

--- a/test/rules/completed-docs/constructors/overloads/default/test.ts.lint
+++ b/test/rules/completed-docs/constructors/overloads/default/test.ts.lint
@@ -1,0 +1,31 @@
+class Foo {
+    constructor(i: number);
+
+    /**
+     * Exists in one place
+     */
+    constructor(o: any) {}
+}
+
+class Foo {
+    public constructor(i: number);
+
+    /**
+     * Exists in one place
+     */
+    public constructor(o: any) {}
+}
+
+class Foo {
+    private constructor(i: number);
+
+    /**
+     * Exists in one place
+     */
+    private constructor(o: any) {}
+}
+
+class Foo {
+    protected constructor(i: number);
+    protected constructor(o: any) {}
+}

--- a/test/rules/completed-docs/constructors/overloads/default/tslint.json
+++ b/test/rules/completed-docs/constructors/overloads/default/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+        "constructors": {
+            "privacies": ["public", "private"]
+        }
+    }]
+  }
+}

--- a/test/rules/completed-docs/constructors/overloads/true/test.ts.lint
+++ b/test/rules/completed-docs/constructors/overloads/true/test.ts.lint
@@ -1,0 +1,35 @@
+class Foo {
+    constructor(i: number);
+    ~~~~~~~~~~~~~~~~~~~~~~~ [default]
+    /**
+     * Exists in one place
+     */
+    constructor(o: any) {}
+}
+
+class Foo {
+    public constructor(i: number);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [public]
+    /**
+     * Exists in one place
+     */
+    public constructor(o: any) {}
+}
+
+class Foo {
+    private constructor(i: number);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [private]
+    /**
+     * Exists in one place
+     */
+    private constructor(o: any) {}
+}
+
+class Foo {
+    protected constructor(i: number);
+    protected constructor(o: any) {}
+}
+
+[default]: Documentation must exist for constructors.
+[public]: Documentation must exist for public constructors.
+[private]: Documentation must exist for private constructors.

--- a/test/rules/completed-docs/constructors/overloads/true/tslint.json
+++ b/test/rules/completed-docs/constructors/overloads/true/tslint.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+        "constructors": {
+            "overloads": true,
+            "privacies": ["public", "private"]
+        }
+    }]
+  }
+}

--- a/test/rules/completed-docs/constructors/privacies/test.ts.lint
+++ b/test/rules/completed-docs/constructors/privacies/test.ts.lint
@@ -1,0 +1,99 @@
+class Foo {
+    constructor() {}
+    ~~~~~~~~~~~~~~~~ [default]
+}
+
+class Foo {
+    public constructor() {}
+    ~~~~~~~~~~~~~~~~~~~~~~~ [public]
+}
+
+class Foo {
+    private constructor() {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~ [private]
+}
+
+class Foo {
+    protected constructor() {}
+}
+
+class Foo {
+    /** ... */
+    constructor() {}
+}
+
+class Foo {
+    /** content */
+    constructor() {}
+}
+
+class Foo {
+    /** */
+    constructor() {}
+    ~~~~~~~~~~~~~~~~ [default]
+}
+
+class Foo {
+    /** ... */
+    public constructor() {}
+}
+
+class Foo {
+    /** content */
+    public constructor() {}
+}
+
+class Foo {
+    /** */
+    public constructor() {}
+    ~~~~~~~~~~~~~~~~~~~~~~~ [public]
+}
+
+class Foo {
+    /** ... */
+    private constructor() {}
+}
+
+class Foo {
+    /** content */
+    private constructor() {}
+}
+
+class Foo {
+    /** */
+    private constructor() {}
+    ~~~~~~~~~~~~~~~~~~~~~~~~ [private]
+}
+
+
+class Foo {
+    /**
+     * ...
+     */
+    constructor() {}
+}
+
+class Foo {
+    /**
+     * ...
+     */
+    public constructor() {}
+}
+
+class Foo {
+    /**
+     * ...
+     */
+    private constructor() {}
+}
+
+class Foo {
+    /**
+     * ...
+     */
+    protected constructor() {}
+}
+
+[default]: Documentation must exist for constructors.
+[public]: Documentation must exist for public constructors.
+[private]: Documentation must exist for private constructors.

--- a/test/rules/completed-docs/constructors/privacies/tslint.json
+++ b/test/rules/completed-docs/constructors/privacies/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "completed-docs": [true, {
+        "constructors": {
+            "privacies": ["public", "private"]
+        }
+    }]
+  }
+}

--- a/test/rules/completed-docs/constructors/tags/test.ts.lint
+++ b/test/rules/completed-docs/constructors/tags/test.ts.lint
@@ -1,0 +1,30 @@
+class Foo {
+    /**
+     * ...
+     */
+    constructor() {}
+}
+
+class Foo {
+    /**
+     * @see
+     */
+    public constructor() {}
+    ~~~~~~~~~~~~~~~~~~~~~~~ [public]
+}
+
+class Foo {
+    /**
+     * ...
+     */
+    private constructor() {}
+}
+
+class Foo {
+    /**
+     * @see #123
+     */
+    protected constructor() {}
+}
+
+[public]: Documentation must exist for public constructors.

--- a/test/rules/completed-docs/constructors/tags/tslint.json
+++ b/test/rules/completed-docs/constructors/tags/tslint.json
@@ -1,0 +1,13 @@
+{
+    "rules": {
+        "completed-docs": [true, {
+            "constructors": {
+                "tags": {
+                    "content": {
+                        "see": "^(\\s*)#(\\d+)(\\s*)$"
+                    }
+                }
+            }
+        }]
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4781 
- [x] enhancement
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Added new doctype => ARGUMENT_CONSTRUCTORS = "constructors"

Below is the descriptor

```javascript
    public static ARGUMENT_DESCRIPTOR_CONSTRUCTOR = {
        properties: {
            [DESCRIPTOR_TAGS]: {
                properties: {
                    [TAGS_FOR_CONTENT]: {
                        items: {
                            type: "string",
                        },
                        type: "object",
                    },
                    [TAGS_FOR_EXISTENCE]: {
                        items: {
                            type: "string",
                        },
                        type: "array",
                    },
                },
            },
            [DESCRIPTOR_PRIVACIES]: {
                enum: [ALL, PRIVACY_PRIVATE, PRIVACY_PROTECTED, PRIVACY_PUBLIC],
                type: "string",
            },
            [DESCRIPTOR_OVERLOADS]: {
                type: "boolean",
            },
        },
        type: "object",
    };
```
