### PR TITLE
Used checker.getTypeArguments in return-undefined rule when possible

### DIFF
--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -140,7 +140,7 @@ function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker) {
     }
 
     //
-    function getTypeArgumentsOfType(type: ts.Type): readonly ts.Type[] | undefined {
+    function getTypeArgumentsOfType(type: ts.Type) {
         if (!isTypeReference(type)) {
             return undefined;
         }

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -72,7 +72,7 @@ function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker) {
             return;
         }
 
-        const returnKindFromType = getReturnKindFromFunction(functionReturningFrom, checker);
+        const returnKindFromType = getReturnKindFromFunction(functionReturningFrom);
         if (returnKindFromType !== undefined && returnKindFromType !== actualReturnKind) {
             ctx.addFailureAtNode(
                 node,
@@ -81,6 +81,77 @@ function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker) {
                     : Rule.FAILURE_STRING_VALUE_RETURN,
             );
         }
+    }
+
+    function getReturnKindFromFunction(node: FunctionLike): ReturnKind | undefined {
+        switch (node.kind) {
+            case ts.SyntaxKind.Constructor:
+            case ts.SyntaxKind.SetAccessor:
+                return ReturnKind.Void;
+            case ts.SyntaxKind.GetAccessor:
+                return ReturnKind.Value;
+        }
+
+        // Handle generator functions/methods:
+        if (node.asteriskToken !== undefined) {
+            return ReturnKind.Void;
+        }
+
+        const contextual =
+            isFunctionExpressionLike(node) && node.type === undefined
+                ? tryGetReturnType(checker.getContextualType(node), checker)
+                : undefined;
+        const returnType =
+            contextual !== undefined
+                ? contextual
+                : tryGetReturnType(checker.getTypeAtLocation(node), checker);
+
+        if (returnType === undefined || isTypeFlagSet(returnType, ts.TypeFlags.Any)) {
+            return undefined;
+        }
+
+        const effectivelyVoidChecker = hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword)
+            ? isEffectivelyVoidPromise
+            : isEffectivelyVoid;
+
+        if (effectivelyVoidChecker(returnType)) {
+            return ReturnKind.Void;
+        }
+
+        return ReturnKind.Value;
+    }
+
+    /** True for `void`, `undefined`, Promise<void>, or `void | undefined | Promise<void>`. */
+    function isEffectivelyVoidPromise(type: ts.Type): boolean {
+        // Would need access to `checker.getPromisedTypeOfPromise` to do this properly.
+        // Assume that the return type is the global Promise (since this is an async function) and get its type argument.
+
+        // tslint:disable-next-line:no-bitwise
+        if (
+            isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
+            (isUnionType(type) && type.types.every(isEffectivelyVoidPromise))
+        ) {
+            return true;
+        }
+
+        const typeArguments = getTypeArgumentsOfType(type);
+        
+        return typeArguments !== undefined && typeArguments.length === 1 && isEffectivelyVoidPromise(typeArguments[0]);
+    }
+
+    function getTypeArgumentsOfType(type: ts.Type) {
+        if (!isTypeReference(type)) {
+            return undefined;
+        }
+
+        // Fixes for https://github.com/palantir/tslint/issues/4863
+        // type.typeArguments was replaced with checker.getTypeArguments:
+        // https://github.com/microsoft/TypeScript/commit/250d5a8229e17342f36fe52545bb68140db96a2e
+        if ((checker as any).getTypeArguments) {
+            return (checker as any).getTypeArguments(type) as readonly ts.Type[] | undefined;
+        }
+
+        return (type as any).typeArguments as readonly ts.Type[] | undefined;
     }
 }
 
@@ -107,63 +178,6 @@ type FunctionLike =
     | ts.ConstructorDeclaration
     | ts.GetAccessorDeclaration
     | ts.SetAccessorDeclaration;
-
-function getReturnKindFromFunction(
-    node: FunctionLike,
-    checker: ts.TypeChecker,
-): ReturnKind | undefined {
-    switch (node.kind) {
-        case ts.SyntaxKind.Constructor:
-        case ts.SyntaxKind.SetAccessor:
-            return ReturnKind.Void;
-        case ts.SyntaxKind.GetAccessor:
-            return ReturnKind.Value;
-    }
-
-    // Handle generator functions/methods:
-    if (node.asteriskToken !== undefined) {
-        return ReturnKind.Void;
-    }
-
-    const contextual =
-        isFunctionExpressionLike(node) && node.type === undefined
-            ? tryGetReturnType(checker.getContextualType(node), checker)
-            : undefined;
-    const returnType =
-        contextual !== undefined
-            ? contextual
-            : tryGetReturnType(checker.getTypeAtLocation(node), checker);
-
-    if (returnType === undefined || isTypeFlagSet(returnType, ts.TypeFlags.Any)) {
-        return undefined;
-    }
-
-    const effectivelyVoidChecker = hasModifier(node.modifiers, ts.SyntaxKind.AsyncKeyword)
-        ? isEffectivelyVoidPromise
-        : isEffectivelyVoid;
-
-    if (effectivelyVoidChecker(returnType)) {
-        return ReturnKind.Void;
-    }
-
-    return ReturnKind.Value;
-}
-
-/** True for `void`, `undefined`, Promise<void>, or `void | undefined | Promise<void>`. */
-function isEffectivelyVoidPromise(type: ts.Type): boolean {
-    // Would need access to `checker.getPromisedTypeOfPromise` to do this properly.
-    // Assume that the return type is the global Promise (since this is an async function) and get its type argument.
-
-    return (
-        // tslint:disable-next-line:no-bitwise
-        isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
-        (isUnionType(type) && type.types.every(isEffectivelyVoidPromise)) ||
-        (isTypeReference(type) &&
-            type.typeArguments !== undefined &&
-            type.typeArguments.length === 1 &&
-            isEffectivelyVoidPromise(type.typeArguments[0]))
-    );
-}
 
 /** True for `void`, `undefined`, or `void | undefined`. */
 function isEffectivelyVoid(type: ts.Type): boolean {

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -135,8 +135,12 @@ function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker) {
         }
 
         const typeArguments = getTypeArgumentsOfType(type);
-        
-        return typeArguments !== undefined && typeArguments.length === 1 && isEffectivelyVoidPromise(typeArguments[0]);
+
+        return (
+            typeArguments !== undefined &&
+            typeArguments.length === 1 &&
+            isEffectivelyVoidPromise(typeArguments[0])
+        );
     }
 
     function getTypeArgumentsOfType(type: ts.Type) {

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -126,8 +126,8 @@ function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker) {
         // Would need access to `checker.getPromisedTypeOfPromise` to do this properly.
         // Assume that the return type is the global Promise (since this is an async function) and get its type argument.
 
-        // tslint:disable-next-line:no-bitwise
         if (
+            // tslint:disable-next-line:no-bitwise
             isTypeFlagSet(type, ts.TypeFlags.Void | ts.TypeFlags.Undefined) ||
             (isUnionType(type) && type.types.every(isEffectivelyVoidPromise))
         ) {
@@ -139,19 +139,22 @@ function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker) {
         return typeArguments !== undefined && typeArguments.length === 1 && isEffectivelyVoidPromise(typeArguments[0]);
     }
 
-    function getTypeArgumentsOfType(type: ts.Type) {
+    //
+    function getTypeArgumentsOfType(type: ts.Type): readonly ts.Type[] | undefined {
         if (!isTypeReference(type)) {
             return undefined;
         }
 
+        // tslint:disable:no-unsafe-any
         // Fixes for https://github.com/palantir/tslint/issues/4863
         // type.typeArguments was replaced with checker.getTypeArguments:
         // https://github.com/microsoft/TypeScript/commit/250d5a8229e17342f36fe52545bb68140db96a2e
         if ((checker as any).getTypeArguments) {
-            return (checker as any).getTypeArguments(type) as readonly ts.Type[] | undefined;
+            return (checker as any).getTypeArguments(type) as ts.Type[] | undefined;
         }
 
-        return (type as any).typeArguments as readonly ts.Type[] | undefined;
+        return (type as any).typeArguments as ts.Type[] | undefined;
+        // tslint:enable:no-unsafe-any
     }
 }
 

--- a/src/rules/returnUndefinedRule.ts
+++ b/src/rules/returnUndefinedRule.ts
@@ -139,7 +139,6 @@ function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker) {
         return typeArguments !== undefined && typeArguments.length === 1 && isEffectivelyVoidPromise(typeArguments[0]);
     }
 
-    //
     function getTypeArgumentsOfType(type: ts.Type) {
         if (!isTypeReference(type)) {
             return undefined;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4863
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- ~[ ] Documentation update~

#### Overview of change:

TypeScript no longer guarantees a .typeArguments member on the Type object, as they're apparently capable of being lazily-defined (?). Instead we're to use a `checker.getTypeArguments` method.

Once 3.7 is out of beta/RC we'll be able to upgrade our dev dependency to rely on it.