### PR TITLE
Defaulted formatter to stylish

### DIFF
--- a/docs/usage/cli/index.md
+++ b/docs/usage/cli/index.md
@@ -44,7 +44,7 @@ Options:
 --print-config                         print resolved configuration for a file
 -r, --rules-dir [rules-dir]            rules directory
 -s, --formatters-dir [formatters-dir]  formatters directory
--t, --format [format]                  output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)
+-t, --format [format]                  output format (json, stylish, verbose, pmd, prose, msbuild, checkstyle, vso, fileslist, codeFrame)
 -q, --quiet                            hide non "error" severity linting errors from output
 --test                                 test that tslint produces the correct output for the specified directory
 -p, --project [project]                tsconfig.json file
@@ -113,11 +113,12 @@ tslint accepts the following command-line options:
 -t, --format:
     The formatter to use to format the results of the linter before
     outputting it to stdout or the file passed in --out. The core
-    formatters are prose (human readable), json (machine readable)
-    and verbose. prose is the default if this option is not used.
+    formatters are stylish (colored and human readable), json (machine
+    readable), and verbose (human readable).
+    stylish is the default if this option is not used.
     Other built-in options include pmd, msbuild, checkstyle, and vso.
     Additional formatters can be added and used if the --formatters-dir
-    option is set.
+    option is set.`,
 
 -q, --quiet
     Hide non "error" severity linting errors from output. This can be

--- a/src/formatters/verboseFormatter.ts
+++ b/src/formatters/verboseFormatter.ts
@@ -25,7 +25,7 @@ export class Formatter extends AbstractFormatter {
         formatterName: "verbose",
         description: "The human-readable formatter which includes the rule name in messages.",
         descriptionDetails:
-            "The output is the same as the prose formatter with the rule name included",
+            "Basic formatter which outputs simple human-readable messages",
         sample: "ERROR: (semicolon) myFile.ts[1, 14]: Missing semicolon",
         consumer: "human",
     };

--- a/src/formatters/verboseFormatter.ts
+++ b/src/formatters/verboseFormatter.ts
@@ -24,8 +24,7 @@ export class Formatter extends AbstractFormatter {
     public static metadata: IFormatterMetadata = {
         formatterName: "verbose",
         description: "The human-readable formatter which includes the rule name in messages.",
-        descriptionDetails:
-            "Basic formatter which outputs simple human-readable messages",
+        descriptionDetails: "Basic formatter which outputs simple human-readable messages",
         sample: "ERROR: (semicolon) myFile.ts[1, 14]: Missing semicolon",
         consumer: "human",
     };

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -184,7 +184,7 @@ export class Linter {
         const failures = this.options.quiet ? errors : this.failures;
 
         const formatterName =
-            this.options.formatter !== undefined ? this.options.formatter : "prose";
+            this.options.formatter !== undefined ? this.options.formatter : "stylish";
         const Formatter = findFormatter(formatterName, this.options.formattersDirectory);
         if (Formatter === undefined) {
             throw new Error(`formatter '${String(formatterName)}' not found`);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -232,7 +232,7 @@ async function doLinting(
         formatter =
             configFile && configFile.linterOptions && configFile.linterOptions.format
                 ? configFile.linterOptions.format
-                : "prose";
+                : "stylish";
     }
 
     const linter = new Linter(

--- a/src/tslintCli.ts
+++ b/src/tslintCli.ts
@@ -161,13 +161,14 @@ const options: Option[] = [
         name: "format",
         type: "string",
         describe:
-            "output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)",
+            "output format (json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame)",
         description: dedent`
             The formatter to use to format the results of the linter before
             outputting it to stdout or the file passed in --out. The core
-            formatters are prose (human readable), json (machine readable)
-            and verbose. prose is the default if this option is not used.
-            Other built-in options include pmd, msbuild, checkstyle, and vso.
+            formatters are stylish (colored and human readable), json (machine
+            readable), and verbose (human readable).
+            stylish is the default if this option is not used.
+            Other built-in options include pmd, prose, msbuild, checkstyle, and vso.
             Additional formatters can be added and used if the --formatters-dir
             option is set.`,
     },

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -775,7 +775,7 @@ function execRunnerWithOutput(options: Partial<Options>) {
 
 // tslint:disable-next-line:promise-function-async
 function execRunner(options: Partial<Options>, logger: Logger = dummyLogger) {
-    return run({ exclude: [], files: [], ...options }, logger);
+    return run({ exclude: [], files: [], format: "prose", ...options }, logger);
 }
 
 // tslint:disable-next-line:ban-types

--- a/test/runner/runnerTests.ts
+++ b/test/runner/runnerTests.ts
@@ -22,6 +22,7 @@ const customRulesOptions: Options = {
     config: "./test/config/tslint-custom-rules.json",
     exclude: [],
     files: ["src/test.ts"],
+    format: "prose",
     rulesDirectory: "./test/files/custom-rules",
 };
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #2228, fixes #3460
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

#### Overview of change:

Removes the `prose` formatter and its associated tests.

#### Is there anything you'd like reviewers to focus on?

The `prose` formatter also printed details on file fixes, which was used in some tests. I ended up keeping it in and just deprioritizing it in the docs. It feels like changing the default formatter to `stylish` will serve the purpose of improving the general CLI output by default?

#### CHANGELOG.md entry:

[api] Changed default formatter to stylish
