### PR TITLE
[prefer-switch]: Allow if-else statement with mulitple OR

### DIFF
--- a/src/rules/preferSwitchRule.ts
+++ b/src/rules/preferSwitchRule.ts
@@ -77,6 +77,13 @@ function walk(ctx: Lint.WalkContext<number>): void {
 function check(node: ts.IfStatement, sourceFile: ts.SourceFile, minCases: number): boolean {
     let switchVariable: ts.Expression | undefined;
     let casesSeen = 0;
+
+    const { elseStatement } = node;
+
+    if (elseStatement === undefined) {
+        return false;
+    }
+
     const couldBeSwitch = everyCase(node, expr => {
         casesSeen++;
         if (switchVariable !== undefined) {

--- a/test/rules/prefer-switch/default/test.ts.lint
+++ b/test/rules/prefer-switch/default/test.ts.lint
@@ -1,19 +1,79 @@
 if (x === 1 || x === 2) {}
 
 if (x === 1 || x === 2 || x === 3) {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 
 if (x === 1 || x === 2 || x === 3) {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 if (x === 1 || x === 2 || x === -3) {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 if (x === 1 || x === 2 || x === null) {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 if (x === 1 || x === 2 || x === true) {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 if (x === 1 || x === 2 || x === false) {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 if (x === 1 || x === 2 || x === `123`) {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+if (x === 1 || x === 2 && x === `123`) {}
+
+if (x === 1) {}
+    ~~~~~~~ [0]
+else if (x === 2) {}
+else if (x === 3) {}
+
+if (x === 1) {}
+    ~~~~~~~ [0]
+else if (x === 2) {}
+else if (x === 3) {}
+else {}
+
+if (x === 1 || x === 2) {}
+    ~~~~~~~~~~~~~~~~~~ [0]
+else if (x === 3) {}
+
+if (x === 1 || x === 2) {}
+else {}
+
+if (x === 1 || x === 2 || && x === 3) {}
+else if (x === 4) {}
+else if (x === 5) {}
+else {}
+
+if (x === 1 && x === 2) {}
+else if (x === 3) {}
+else if (x === 4) {}
+
+if (x === 1 && x === 2) {}
+else if (x === 3) {}
+else if (x === 4) {}
+else {}
+
+
+if (x === 1 || y === 2) {}
+else if (x === 3) {}
+else if (x === 4) {}
+else {}
+
+
+if (x === 1 && y === 2) {}
+else if (x === 3) {}
+else if (x === 4 && x === 5) {}
+else {}
+
+if (x === 1 && y === 2) {}
+else if (x === 3) {}
+else if (x === 4 && x === 5) {}
+
+export enum ItemType {
+    FIRST = "FIRST",
+    SECOND = "SECOND",
+    THIRD = "THIRD",
+}
+
+if (
+    item.type === ItemType.FIRST ||
+    item.type === ItemType.SECOND ||
+    item.type === ItemType.THIRD
+) {}
 
 [0]: Use a switch statement instead of using multiple '===' checks.

--- a/test/rules/prefer-switch/min-cases-2/test.ts.lint
+++ b/test/rules/prefer-switch/min-cases-2/test.ts.lint
@@ -10,7 +10,19 @@ if (x === 1) {} else if (x === 2) {}
 
 // Works with `||`
 if (this === 1 || this === 2) {}
-    ~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
+if (this === 1 || this === 2 || this === 3) {}
+
+
+if (x === 1) {}
+    ~~~~~~~ [0]
+else if (x === 2) {}
+else if (x === 3) {}
+
+if (x === 1) {}
+    ~~~~~~~ [0]
+else if (x === 2) {}
+
 
 // Default minumum of 2 cases.
 if (x === 1) {} else {}
@@ -24,5 +36,17 @@ if (x === f()) {} else if (x === g()) {}
 // Allow properties
 if (x.y.z === a.b) else if (x.y.z === c.d) {}
     ~~~~~~~~~~~~~ [0]
+
+export enum ItemType {
+    FIRST = "FIRST",
+    SECOND = "SECOND",
+    THIRD = "THIRD",
+}
+
+if (
+    item.type === ItemType.FIRST ||
+    item.type === ItemType.SECOND ||
+    item.type === ItemType.THIRD
+) {}
 
 [0]: Use a switch statement instead of using multiple '===' checks.


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #3719 
- [x] bugfix
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Check if `elseStatement` is undefined

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->

[enhancement]: `prefer-switch` is more lenient with `if` statements containing multiple OR conditions without any `else` clause
