### PR TITLE
fix: writeFileSync can not write to temp files on macOS 10.15

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -257,7 +257,7 @@ export class Linter {
                 const oldSource = fs.readFileSync(filePath, "utf-8");
                 fileNewSource = Replacement.applyFixes(oldSource, fileFixes);
             }
-            fs.writeFileSync(filePath, fileNewSource);
+            fs.writeFileSync(path.resolve(filePath), fileNewSource);
             this.updateProgram(filePath);
         });
 

--- a/test/executable/executableTests.ts
+++ b/test/executable/executableTests.ts
@@ -337,7 +337,7 @@ describe("Executable", function(this: Mocha.Suite) {
         it("fixes multiple rules without overwriting each other", async () => {
             const tempFile = path.relative(process.cwd(), createTempFile("ts"));
             fs.writeFileSync(
-                tempFile,
+                path.resolve(tempFile),
                 'import * as x from "b"\nimport * as y from "a_long_module";\n',
             );
             const result = await execRunnerWithOutput({
@@ -348,7 +348,7 @@ describe("Executable", function(this: Mocha.Suite) {
             const content = fs.readFileSync(tempFile, "utf8");
             // compare against file name which will be returned by formatter (used in TypeScript)
             const denormalizedFileName = denormalizeWinPath(tempFile);
-            fs.unlinkSync(tempFile);
+            fs.unlinkSync(path.resolve(tempFile));
             assert.equal(result.status, Status.Ok, "process should exit without an error");
             assert.strictEqual(
                 content,


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4880
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- ~~[ ] Documentation update~~

#### Overview of change:
Add `path.resolve` when`fs.writeFileSync` called with temp file path.

Credits for the idea hot to fix the issue goes to @dhleong https://github.com/palantir/tslint/issues/4880#issue-509605076

#### Is there anything you'd like reviewers to focus on?
Actually tests were failing on macOS Catalina before this fix.
