### PR TITLE
fix[file-header]: fix enforce-trailing-newline option

### DIFF
--- a/src/rules/fileHeaderRule.ts
+++ b/src/rules/fileHeaderRule.ts
@@ -244,9 +244,7 @@ export class Rule extends Lint.Rules.AbstractRule {
         );
 
         const NEW_LINE_FOLLOWING_HEADER = /^.*((\r)?\n){2,}$/gm;
-        return (
-            entireComment !== undefined && NEW_LINE_FOLLOWING_HEADER.test(entireComment) !== null
-        );
+        return entireComment !== undefined && !NEW_LINE_FOLLOWING_HEADER.test(entireComment);
     }
 
     private getFileHeaderText(

--- a/test/rules/file-header/good-newline/test.ts.lint
+++ b/test/rules/file-header/good-newline/test.ts.lint
@@ -1,0 +1,3 @@
+/* Copyright 2019 */
+
+class Foo {}

--- a/test/rules/file-header/good-newline/tslint.json
+++ b/test/rules/file-header/good-newline/tslint.json
@@ -1,0 +1,10 @@
+{
+    "rules": {
+        "file-header": [
+            true,
+            "Copyright \\d{4}",
+            "Copyright 2019",
+            "enforce-trailing-newline"
+        ]
+    }
+}


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4640 
- [x] bugfix
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Remove `null` check from `Regex` test

<!-- optional -->

#### CHANGELOG.md entry:
[bugfix] fix `enforce-trailing-newline` option in `file-header` rule
<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
