### PR TITLE
Issue 4894 fix: Added missing colon in docs

### DIFF
--- a/docs/develop/testing-rules/index.md
+++ b/docs/develop/testing-rules/index.md
@@ -111,7 +111,7 @@ const tree = 5;
       ~~~~      [error % ("plants")]
 const skyscraper = 100;
 
-[error] Variables named after %s are not allowed!
+[error]: Variables named after %s are not allowed!
 [no-animal]: error % ('animals')
 ```
 
@@ -136,7 +136,7 @@ const tree = 5;
       ~~~~      [error % ("plants", "tree")]
 const skyscraper = 100;
 
-[error] Variables named after %s are not allowed: '%s'
+[error]: Variables named after %s are not allowed: '%s'
 [no-animal]: error % ('animals')
 ```
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4894 
- [x] Documentation update

#### Overview of change:

According to Issue 4894 (https://github.com/palantir/tslint/issues/4894) documentation has two missing colons. Those colons have been added.

#### Is there anything you'd like reviewers to focus on?

The thing to review would be if the change reflects the real world scenario and if it's needed to fix

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
I'm not sure what this refers to, so I didn't complete this section
