### PR TITLE
Allow suppressing unnecessary null type asserts.

### DIFF
--- a/src/rules/noUnnecessaryTypeAssertionRule.ts
+++ b/src/rules/noUnnecessaryTypeAssertionRule.ts
@@ -32,7 +32,7 @@ export class Rule extends Lint.Rules.TypedRule {
                 items: { type: "string" },
             },
         },
-        optionsDescription: "A list of whitelisted assertion types to ignore",
+        optionsDescription: `A list of whitelisted assertion types to ignore (use ! for null assertions)`,
         type: "typescript",
         hasFix: true,
         typescriptOnly: true,
@@ -76,7 +76,7 @@ class Walker extends Lint.AbstractWalker<string[]> {
         const cb = (node: ts.Node): void => {
             switch (node.kind) {
                 case ts.SyntaxKind.NonNullExpression:
-                    if (this.strictNullChecks) {
+                    if (this.strictNullChecks && this.options.indexOf("!") === -1) {
                         this.checkNonNullAssertion(node as ts.NonNullExpression);
                     }
                     break;

--- a/test/rules/no-unnecessary-type-assertion/whitelistNull/test.ts.lint
+++ b/test/rules/no-unnecessary-type-assertion/whitelistNull/test.ts.lint
@@ -1,0 +1,3 @@
+const nonNullValue: string = 'a';
+// The "!" assertion below is unnecessary, but ignored due to "!" being whitelisted.
+const alsoNotNull: string = nonNullValue!;

--- a/test/rules/no-unnecessary-type-assertion/whitelistNull/tsconfig.json
+++ b/test/rules/no-unnecessary-type-assertion/whitelistNull/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "strictNullChecks": true,
+  }
+}

--- a/test/rules/no-unnecessary-type-assertion/whitelistNull/tslint.json
+++ b/test/rules/no-unnecessary-type-assertion/whitelistNull/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unnecessary-type-assertion": [true, "!"]
+  }
+}


### PR DESCRIPTION
#### PR checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Overview of change:

Previously, `noUnnecessaryTypeAssertionRule` could only suppress
specific types to cast to, but not `!`. This change adds a specific
check and branch to allow `!` assertions.

#### CHANGELOG.md entry:

[enhancement] `no-unnecessary-type-assertion` can now ignore `!` assertions.
