### PR TITLE
docs: add missing colon after `[error]`

### DIFF
--- a/docs/develop/testing-rules/index.md
+++ b/docs/develop/testing-rules/index.md
@@ -111,7 +111,7 @@ const tree = 5;
       ~~~~      [error % ("plants")]
 const skyscraper = 100;
 
-[error] Variables named after %s are not allowed!
+[error]: Variables named after %s are not allowed!
 [no-animal]: error % ('animals')
 ```
 
@@ -136,7 +136,7 @@ const tree = 5;
       ~~~~      [error % ("plants", "tree")]
 const skyscraper = 100;
 
-[error] Variables named after %s are not allowed: '%s'
+[error]: Variables named after %s are not allowed: '%s'
 [no-animal]: error % ('animals')
 ```
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4894 
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Overview of change:

Add missing colon after `[error]` in `docs/develop/testing-rules/index.md`.

#### Is there anything you'd like reviewers to focus on?

These changes simply maintain the uniformity of the documentation. :)
