### PR TITLE
Fix incorrect error when variable is assigned in a destructuring pattern

### DIFF
--- a/src/rules/preferReadonlyRule.ts
+++ b/src/rules/preferReadonlyRule.ts
@@ -156,6 +156,12 @@ function walk(context: Lint.WalkContext<Options>, typeChecker: ts.TypeChecker) {
 
     function handlePropertyAccessExpression(node: ts.PropertyAccessExpression, parent: ts.Node) {
         switch (parent.kind) {
+            case ts.SyntaxKind.ArrayLiteralExpression:
+                const grandParent = parent.parent;
+                handleParentArrayLiteralExpression(
+                    node, parent as ts.ArrayLiteralExpression,
+                    grandParent as ts.BinaryExpression);
+                break;
             case ts.SyntaxKind.BinaryExpression:
                 handleParentBinaryExpression(node, parent as ts.BinaryExpression);
                 break;
@@ -172,6 +178,16 @@ function walk(context: Lint.WalkContext<Options>, typeChecker: ts.TypeChecker) {
         }
 
         ts.forEachChild(node, visitNode);
+    }
+
+    function handleParentArrayLiteralExpression(
+      node: ts.PropertyAccessExpression, parent: ts.ArrayLiteralExpression,
+      grandParent: ts.BinaryExpression,
+    ) {
+        if (grandParent != null && grandParent.left === parent &&
+            utils.isAssignmentKind(grandParent.operatorToken.kind)) {
+          scope.addVariableModification(node);
+        }
     }
 
     function handleParentBinaryExpression(

--- a/src/rules/preferReadonlyRule.ts
+++ b/src/rules/preferReadonlyRule.ts
@@ -159,8 +159,10 @@ function walk(context: Lint.WalkContext<Options>, typeChecker: ts.TypeChecker) {
             case ts.SyntaxKind.ArrayLiteralExpression:
                 const grandParent = parent.parent;
                 handleParentArrayLiteralExpression(
-                    node, parent as ts.ArrayLiteralExpression,
-                    grandParent as ts.BinaryExpression);
+                    node,
+                    parent as ts.ArrayLiteralExpression,
+                    grandParent as ts.BinaryExpression,
+                );
                 break;
             case ts.SyntaxKind.BinaryExpression:
                 handleParentBinaryExpression(node, parent as ts.BinaryExpression);
@@ -181,12 +183,16 @@ function walk(context: Lint.WalkContext<Options>, typeChecker: ts.TypeChecker) {
     }
 
     function handleParentArrayLiteralExpression(
-      node: ts.PropertyAccessExpression, parent: ts.ArrayLiteralExpression,
-      grandParent: ts.BinaryExpression,
+        node: ts.PropertyAccessExpression,
+        parent: ts.ArrayLiteralExpression,
+        grandParent: ts.BinaryExpression,
     ) {
-        if (grandParent != null && grandParent.left === parent &&
-            utils.isAssignmentKind(grandParent.operatorToken.kind)) {
-          scope.addVariableModification(node);
+        if (
+            grandParent !== null &&
+            grandParent.left === parent &&
+            utils.isAssignmentKind(grandParent.operatorToken.kind)
+        ) {
+            scope.addVariableModification(node);
         }
     }
 


### PR DESCRIPTION
…ng pattern

The linter fails to recognize an assignment to a variable and complains that the variable is not marked readonly.
For example:
...
private background = new Color(0, 1, 255);
private foreground = new Color(0, 0, 255);
[this.background, this.foreground] =
        this.calibrator.step(n === this.currentNumber);
...

#### PR checklist

- [ ] Addresses an existing issue: fixes #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:


#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
