### PR TITLE
Fix Octokit import

### DIFF
--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -23,7 +23,7 @@
 
 // tslint:disable:no-console
 
-import * as Octokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4930

#### Overview of change:

Changed `import * as Octokit` to `import { Octokit }`  
