### PR TITLE
Internalized isPrivateIdentifier helper

### DIFF
--- a/src/language/utils.ts
+++ b/src/language/utils.ts
@@ -582,9 +582,3 @@ export function isWhiteSpace(ch: number): boolean {
     // tslint:disable-next-line
     return (ts.isWhiteSpaceLike || (ts as any).isWhiteSpace)(ch);
 }
-
-/** Wrapper for compatability with typescript@<3.8.2 */
-export function isPrivateIdentifier(node: ts.Node): node is ts.PrivateIdentifier {
-    // tslint:disable-next-line
-    return ts.isPrivateIdentifier ? ts.isPrivateIdentifier(node) : false;
-}

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -154,7 +154,7 @@ function tryGetAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Sym
 }
 
 /** Wrapper for compatability with typescript@<3.8.2 */
-export function isPrivateIdentifier(node: ts.Node): node is ts.PrivateIdentifier {
+function isPrivateIdentifier(node: ts.Node): node is ts.PrivateIdentifier {
     // tslint:disable-next-line
     return ts.isPrivateIdentifier ? ts.isPrivateIdentifier(node) : false;
 }

--- a/src/rules/noUnnecessaryQualifierRule.ts
+++ b/src/rules/noUnnecessaryQualifierRule.ts
@@ -64,7 +64,7 @@ function walk(ctx: Lint.WalkContext, checker: ts.TypeChecker): void {
 
             case ts.SyntaxKind.PropertyAccessExpression:
                 const { expression, name } = node as ts.PropertyAccessExpression;
-                if (utils.isEntityNameExpression(expression) && !Lint.isPrivateIdentifier(name)) {
+                if (utils.isEntityNameExpression(expression) && !isPrivateIdentifier(name)) {
                     visitNamespaceAccess(node, expression, name);
                     break;
                 }
@@ -151,4 +151,10 @@ function tryGetAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Sym
     return utils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)
         ? checker.getAliasedSymbol(symbol)
         : undefined;
+}
+
+/** Wrapper for compatability with typescript@<3.8.2 */
+export function isPrivateIdentifier(node: ts.Node): node is ts.PrivateIdentifier {
+    // tslint:disable-next-line
+    return ts.isPrivateIdentifier ? ts.isPrivateIdentifier(node) : false;
 }


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4929
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Overview of change:

Moving it into just the file that uses it fixes the issue of it being exported in the public `.d.ts` files.

#### CHANGELOG.md entry:

[bugfix] Internalized isPrivateIdentifier to fix TS<3.8 compiles
