### PR TITLE
Arrow return shorthand rule is breaking casted map

### DIFF
--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -133,7 +133,7 @@ function createFix(
 
     function isParenthesisNeeded(node: ts.Node): boolean {
 		if (node.kind === ts.SyntaxKind.AsExpression) {
-			return isParenthesisNeeded(node.expression);
+			return isParenthesisNeeded((node as ts.AsExpression).expression);
 		}
         return node.kind === ts.SyntaxKind.ObjectLiteralExpression;
     }

--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -116,8 +116,8 @@ function createFix(
     return anyComments
         ? undefined
         : [
-              // Object literal must be wrapped in `()`
-              ...(expr.kind === ts.SyntaxKind.ObjectLiteralExpression
+              // Some expressions must be wrapped in `()`
+              ...(isParenthesisNeeded(expr)
                   ? [
                         Lint.Replacement.appendText(expr.getStart(), "("),
                         Lint.Replacement.appendText(expr.getEnd(), ")"),
@@ -130,6 +130,13 @@ function createFix(
               // " }" (may include semicolon)
               Lint.Replacement.deleteFromTo(expr.end, closeBrace.end),
           ];
+
+    function isParenthesisNeeded(node) {
+		if (node.kind === ts.SyntaxKind.AsExpression) {
+			return isParenthesisNeeded(node.expression);
+		}
+        return node.kind === ts.SyntaxKind.ObjectLiteralExpression;
+    }
 
     function hasComments(node: ts.Node): boolean {
         return hasCommentAfterPosition(text, node.getEnd());

--- a/src/rules/arrowReturnShorthandRule.ts
+++ b/src/rules/arrowReturnShorthandRule.ts
@@ -131,7 +131,7 @@ function createFix(
               Lint.Replacement.deleteFromTo(expr.end, closeBrace.end),
           ];
 
-    function isParenthesisNeeded(node) {
+    function isParenthesisNeeded(node: ts.Node): boolean {
 		if (node.kind === ts.SyntaxKind.AsExpression) {
 			return isParenthesisNeeded(node.expression);
 		}


### PR DESCRIPTION
#### PR checklist

- [ ] Addresses an existing issue: fixes #0000
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
**Given**
```TypeScript
() => {return {} as MyClass;}
```

**When**
Applying _Arrow return shorthand rule_...

**Actual**
```TypeScript
() => {} as MyClass
```

**Expected**
```TypeScript
() => ({} as MyClass)
```

#### Is there anything you'd like reviewers to focus on?

<!-- optional -->

#### CHANGELOG.md entry:

<!-- optional (example: "[new-rule] `arrow-return-shorthand`") -->
<!-- suggested tags: [new-rule], [new-rule-option], [new-fixer], [bugfix], [enhancement], [api], [rule-change], [no-log] -->
