### PR TITLE
Fix align rule throwing error when encountering literal array type in a template type argument

### DIFF
--- a/src/rules/alignRule.ts
+++ b/src/rules/alignRule.ts
@@ -192,7 +192,7 @@ class AlignWalker extends Lint.AbstractWalker<Options> {
     }
 
     private checkAlignment(nodes: ReadonlyArray<ts.Node>, kind: string) {
-        if (nodes.length <= 1) {
+        if (!nodes || nodes.length <= 1) {
             return;
         }
         const sourceFile = this.sourceFile;


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #4949 

#### Overview of change:
adds 9 characters to fix the issue I was seeing. As I'm using Angular, `ng lint` wants TSLint, even in Angular's latest version. So I'd like it to work - I understand the project is dead and I look forward to the day I can switch to ESLint, but that day isn't today. I was hoping you'd change your mind since it's such a small, innocuous change and I did it myself.

#### Is there anything you'd like reviewers to focus on?

#### CHANGELOG.md entry:
